### PR TITLE
Add historical target calculation code, results

### DIFF
--- a/scores/target-multivals.csv
+++ b/scores/target-multivals.csv
@@ -1,0 +1,18330 @@
+Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
+2010,40,2010/2011,40,US National,Season onset,51
+2010,40,2010/2011,40,US National,Season peak week,5
+2010,40,2010/2011,40,US National,Season peak week,7
+2010,40,2010/2011,40,US National,Season peak percentage,4.6
+2010,40,2010/2011,40,US National,1 wk ahead,1.2
+2010,40,2010/2011,40,US National,2 wk ahead,1.3
+2010,40,2010/2011,40,US National,3 wk ahead,1.3
+2010,40,2010/2011,40,US National,4 wk ahead,1.4
+2010,40,2010/2011,40,HHS Region 1,Season onset,4
+2010,40,2010/2011,40,HHS Region 1,Season peak week,7
+2010,40,2010/2011,40,HHS Region 1,Season peak week,8
+2010,40,2010/2011,40,HHS Region 1,Season peak percentage,2.3
+2010,40,2010/2011,40,HHS Region 1,1 wk ahead,0.6
+2010,40,2010/2011,40,HHS Region 1,2 wk ahead,0.6
+2010,40,2010/2011,40,HHS Region 1,3 wk ahead,0.6
+2010,40,2010/2011,40,HHS Region 1,4 wk ahead,0.6
+2010,40,2010/2011,40,HHS Region 2,Season onset,49
+2010,40,2010/2011,40,HHS Region 2,Season peak week,52
+2010,40,2010/2011,40,HHS Region 2,Season peak percentage,4.5
+2010,40,2010/2011,40,HHS Region 2,1 wk ahead,1.3
+2010,40,2010/2011,40,HHS Region 2,2 wk ahead,1.2
+2010,40,2010/2011,40,HHS Region 2,3 wk ahead,1.4
+2010,40,2010/2011,40,HHS Region 2,4 wk ahead,1.2
+2010,40,2010/2011,40,HHS Region 3,Season onset,3
+2010,40,2010/2011,40,HHS Region 3,Season peak week,5
+2010,40,2010/2011,40,HHS Region 3,Season peak percentage,4.4
+2010,40,2010/2011,40,HHS Region 3,1 wk ahead,1.3
+2010,40,2010/2011,40,HHS Region 3,2 wk ahead,1.1
+2010,40,2010/2011,40,HHS Region 3,3 wk ahead,1.1
+2010,40,2010/2011,40,HHS Region 3,4 wk ahead,1.2
+2010,40,2010/2011,40,HHS Region 4,Season onset,50
+2010,40,2010/2011,40,HHS Region 4,Season peak week,5
+2010,40,2010/2011,40,HHS Region 4,Season peak percentage,5.5
+2010,40,2010/2011,40,HHS Region 4,1 wk ahead,1.1
+2010,40,2010/2011,40,HHS Region 4,2 wk ahead,1
+2010,40,2010/2011,40,HHS Region 4,3 wk ahead,1.2
+2010,40,2010/2011,40,HHS Region 4,4 wk ahead,1.4
+2010,40,2010/2011,40,HHS Region 5,Season onset,3
+2010,40,2010/2011,40,HHS Region 5,Season peak week,5
+2010,40,2010/2011,40,HHS Region 5,Season peak percentage,3.8
+2010,40,2010/2011,40,HHS Region 5,1 wk ahead,0.8
+2010,40,2010/2011,40,HHS Region 5,2 wk ahead,0.9
+2010,40,2010/2011,40,HHS Region 5,3 wk ahead,0.9
+2010,40,2010/2011,40,HHS Region 5,4 wk ahead,1
+2010,40,2010/2011,40,HHS Region 6,Season onset,3
+2010,40,2010/2011,40,HHS Region 6,Season peak week,7
+2010,40,2010/2011,40,HHS Region 6,Season peak percentage,7.9
+2010,40,2010/2011,40,HHS Region 6,1 wk ahead,1.9
+2010,40,2010/2011,40,HHS Region 6,2 wk ahead,2
+2010,40,2010/2011,40,HHS Region 6,3 wk ahead,2
+2010,40,2010/2011,40,HHS Region 6,4 wk ahead,2.2
+2010,40,2010/2011,40,HHS Region 7,Season onset,4
+2010,40,2010/2011,40,HHS Region 7,Season peak week,8
+2010,40,2010/2011,40,HHS Region 7,Season peak percentage,4.7
+2010,40,2010/2011,40,HHS Region 7,1 wk ahead,1.1
+2010,40,2010/2011,40,HHS Region 7,2 wk ahead,1.1
+2010,40,2010/2011,40,HHS Region 7,3 wk ahead,0.8
+2010,40,2010/2011,40,HHS Region 7,4 wk ahead,0.7
+2010,40,2010/2011,40,HHS Region 8,Season onset,5
+2010,40,2010/2011,40,HHS Region 8,Season peak week,7
+2010,40,2010/2011,40,HHS Region 8,Season peak percentage,2.7
+2010,40,2010/2011,40,HHS Region 8,1 wk ahead,0.5
+2010,40,2010/2011,40,HHS Region 8,2 wk ahead,0.6
+2010,40,2010/2011,40,HHS Region 8,3 wk ahead,0.7
+2010,40,2010/2011,40,HHS Region 8,4 wk ahead,0.8
+2010,40,2010/2011,40,HHS Region 9,Season onset,6
+2010,40,2010/2011,40,HHS Region 9,Season peak week,7
+2010,40,2010/2011,40,HHS Region 9,Season peak week,8
+2010,40,2010/2011,40,HHS Region 9,Season peak percentage,4.7
+2010,40,2010/2011,40,HHS Region 9,1 wk ahead,1.9
+2010,40,2010/2011,40,HHS Region 9,2 wk ahead,2
+2010,40,2010/2011,40,HHS Region 9,3 wk ahead,1.8
+2010,40,2010/2011,40,HHS Region 9,4 wk ahead,2.3
+2010,40,2010/2011,40,HHS Region 10,Season onset,5
+2010,40,2010/2011,40,HHS Region 10,Season peak week,7
+2010,40,2010/2011,40,HHS Region 10,Season peak percentage,3.9
+2010,40,2010/2011,40,HHS Region 10,1 wk ahead,1
+2010,40,2010/2011,40,HHS Region 10,2 wk ahead,0.8
+2010,40,2010/2011,40,HHS Region 10,3 wk ahead,0.9
+2010,40,2010/2011,40,HHS Region 10,4 wk ahead,0.9
+2010,41,2010/2011,41,US National,Season onset,51
+2010,41,2010/2011,41,US National,Season peak week,5
+2010,41,2010/2011,41,US National,Season peak week,7
+2010,41,2010/2011,41,US National,Season peak percentage,4.6
+2010,41,2010/2011,41,US National,1 wk ahead,1.3
+2010,41,2010/2011,41,US National,2 wk ahead,1.3
+2010,41,2010/2011,41,US National,3 wk ahead,1.4
+2010,41,2010/2011,41,US National,4 wk ahead,1.5
+2010,41,2010/2011,41,HHS Region 1,Season onset,4
+2010,41,2010/2011,41,HHS Region 1,Season peak week,7
+2010,41,2010/2011,41,HHS Region 1,Season peak week,8
+2010,41,2010/2011,41,HHS Region 1,Season peak percentage,2.3
+2010,41,2010/2011,41,HHS Region 1,1 wk ahead,0.6
+2010,41,2010/2011,41,HHS Region 1,2 wk ahead,0.6
+2010,41,2010/2011,41,HHS Region 1,3 wk ahead,0.6
+2010,41,2010/2011,41,HHS Region 1,4 wk ahead,0.6
+2010,41,2010/2011,41,HHS Region 2,Season onset,49
+2010,41,2010/2011,41,HHS Region 2,Season peak week,52
+2010,41,2010/2011,41,HHS Region 2,Season peak percentage,4.5
+2010,41,2010/2011,41,HHS Region 2,1 wk ahead,1.2
+2010,41,2010/2011,41,HHS Region 2,2 wk ahead,1.4
+2010,41,2010/2011,41,HHS Region 2,3 wk ahead,1.2
+2010,41,2010/2011,41,HHS Region 2,4 wk ahead,1.4
+2010,41,2010/2011,41,HHS Region 3,Season onset,3
+2010,41,2010/2011,41,HHS Region 3,Season peak week,5
+2010,41,2010/2011,41,HHS Region 3,Season peak percentage,4.4
+2010,41,2010/2011,41,HHS Region 3,1 wk ahead,1.1
+2010,41,2010/2011,41,HHS Region 3,2 wk ahead,1.1
+2010,41,2010/2011,41,HHS Region 3,3 wk ahead,1.2
+2010,41,2010/2011,41,HHS Region 3,4 wk ahead,1.3
+2010,41,2010/2011,41,HHS Region 4,Season onset,50
+2010,41,2010/2011,41,HHS Region 4,Season peak week,5
+2010,41,2010/2011,41,HHS Region 4,Season peak percentage,5.5
+2010,41,2010/2011,41,HHS Region 4,1 wk ahead,1
+2010,41,2010/2011,41,HHS Region 4,2 wk ahead,1.2
+2010,41,2010/2011,41,HHS Region 4,3 wk ahead,1.4
+2010,41,2010/2011,41,HHS Region 4,4 wk ahead,1.6
+2010,41,2010/2011,41,HHS Region 5,Season onset,3
+2010,41,2010/2011,41,HHS Region 5,Season peak week,5
+2010,41,2010/2011,41,HHS Region 5,Season peak percentage,3.8
+2010,41,2010/2011,41,HHS Region 5,1 wk ahead,0.9
+2010,41,2010/2011,41,HHS Region 5,2 wk ahead,0.9
+2010,41,2010/2011,41,HHS Region 5,3 wk ahead,1
+2010,41,2010/2011,41,HHS Region 5,4 wk ahead,0.9
+2010,41,2010/2011,41,HHS Region 6,Season onset,3
+2010,41,2010/2011,41,HHS Region 6,Season peak week,7
+2010,41,2010/2011,41,HHS Region 6,Season peak percentage,7.9
+2010,41,2010/2011,41,HHS Region 6,1 wk ahead,2
+2010,41,2010/2011,41,HHS Region 6,2 wk ahead,2
+2010,41,2010/2011,41,HHS Region 6,3 wk ahead,2.2
+2010,41,2010/2011,41,HHS Region 6,4 wk ahead,2.4
+2010,41,2010/2011,41,HHS Region 7,Season onset,4
+2010,41,2010/2011,41,HHS Region 7,Season peak week,8
+2010,41,2010/2011,41,HHS Region 7,Season peak percentage,4.7
+2010,41,2010/2011,41,HHS Region 7,1 wk ahead,1.1
+2010,41,2010/2011,41,HHS Region 7,2 wk ahead,0.8
+2010,41,2010/2011,41,HHS Region 7,3 wk ahead,0.7
+2010,41,2010/2011,41,HHS Region 7,4 wk ahead,1.2
+2010,41,2010/2011,41,HHS Region 8,Season onset,5
+2010,41,2010/2011,41,HHS Region 8,Season peak week,7
+2010,41,2010/2011,41,HHS Region 8,Season peak percentage,2.7
+2010,41,2010/2011,41,HHS Region 8,1 wk ahead,0.6
+2010,41,2010/2011,41,HHS Region 8,2 wk ahead,0.7
+2010,41,2010/2011,41,HHS Region 8,3 wk ahead,0.8
+2010,41,2010/2011,41,HHS Region 8,4 wk ahead,0.7
+2010,41,2010/2011,41,HHS Region 9,Season onset,6
+2010,41,2010/2011,41,HHS Region 9,Season peak week,7
+2010,41,2010/2011,41,HHS Region 9,Season peak week,8
+2010,41,2010/2011,41,HHS Region 9,Season peak percentage,4.7
+2010,41,2010/2011,41,HHS Region 9,1 wk ahead,2
+2010,41,2010/2011,41,HHS Region 9,2 wk ahead,1.8
+2010,41,2010/2011,41,HHS Region 9,3 wk ahead,2.3
+2010,41,2010/2011,41,HHS Region 9,4 wk ahead,2.3
+2010,41,2010/2011,41,HHS Region 10,Season onset,5
+2010,41,2010/2011,41,HHS Region 10,Season peak week,7
+2010,41,2010/2011,41,HHS Region 10,Season peak percentage,3.9
+2010,41,2010/2011,41,HHS Region 10,1 wk ahead,0.8
+2010,41,2010/2011,41,HHS Region 10,2 wk ahead,0.9
+2010,41,2010/2011,41,HHS Region 10,3 wk ahead,0.9
+2010,41,2010/2011,41,HHS Region 10,4 wk ahead,1
+2010,42,2010/2011,42,US National,Season onset,51
+2010,42,2010/2011,42,US National,Season peak week,5
+2010,42,2010/2011,42,US National,Season peak week,7
+2010,42,2010/2011,42,US National,Season peak percentage,4.6
+2010,42,2010/2011,42,US National,1 wk ahead,1.3
+2010,42,2010/2011,42,US National,2 wk ahead,1.4
+2010,42,2010/2011,42,US National,3 wk ahead,1.5
+2010,42,2010/2011,42,US National,4 wk ahead,1.6
+2010,42,2010/2011,42,HHS Region 1,Season onset,4
+2010,42,2010/2011,42,HHS Region 1,Season peak week,7
+2010,42,2010/2011,42,HHS Region 1,Season peak week,8
+2010,42,2010/2011,42,HHS Region 1,Season peak percentage,2.3
+2010,42,2010/2011,42,HHS Region 1,1 wk ahead,0.6
+2010,42,2010/2011,42,HHS Region 1,2 wk ahead,0.6
+2010,42,2010/2011,42,HHS Region 1,3 wk ahead,0.6
+2010,42,2010/2011,42,HHS Region 1,4 wk ahead,0.7
+2010,42,2010/2011,42,HHS Region 2,Season onset,49
+2010,42,2010/2011,42,HHS Region 2,Season peak week,52
+2010,42,2010/2011,42,HHS Region 2,Season peak percentage,4.5
+2010,42,2010/2011,42,HHS Region 2,1 wk ahead,1.4
+2010,42,2010/2011,42,HHS Region 2,2 wk ahead,1.2
+2010,42,2010/2011,42,HHS Region 2,3 wk ahead,1.4
+2010,42,2010/2011,42,HHS Region 2,4 wk ahead,1.4
+2010,42,2010/2011,42,HHS Region 3,Season onset,3
+2010,42,2010/2011,42,HHS Region 3,Season peak week,5
+2010,42,2010/2011,42,HHS Region 3,Season peak percentage,4.4
+2010,42,2010/2011,42,HHS Region 3,1 wk ahead,1.1
+2010,42,2010/2011,42,HHS Region 3,2 wk ahead,1.2
+2010,42,2010/2011,42,HHS Region 3,3 wk ahead,1.3
+2010,42,2010/2011,42,HHS Region 3,4 wk ahead,1.3
+2010,42,2010/2011,42,HHS Region 4,Season onset,50
+2010,42,2010/2011,42,HHS Region 4,Season peak week,5
+2010,42,2010/2011,42,HHS Region 4,Season peak percentage,5.5
+2010,42,2010/2011,42,HHS Region 4,1 wk ahead,1.2
+2010,42,2010/2011,42,HHS Region 4,2 wk ahead,1.4
+2010,42,2010/2011,42,HHS Region 4,3 wk ahead,1.6
+2010,42,2010/2011,42,HHS Region 4,4 wk ahead,1.8
+2010,42,2010/2011,42,HHS Region 5,Season onset,3
+2010,42,2010/2011,42,HHS Region 5,Season peak week,5
+2010,42,2010/2011,42,HHS Region 5,Season peak percentage,3.8
+2010,42,2010/2011,42,HHS Region 5,1 wk ahead,0.9
+2010,42,2010/2011,42,HHS Region 5,2 wk ahead,1
+2010,42,2010/2011,42,HHS Region 5,3 wk ahead,0.9
+2010,42,2010/2011,42,HHS Region 5,4 wk ahead,0.9
+2010,42,2010/2011,42,HHS Region 6,Season onset,3
+2010,42,2010/2011,42,HHS Region 6,Season peak week,7
+2010,42,2010/2011,42,HHS Region 6,Season peak percentage,7.9
+2010,42,2010/2011,42,HHS Region 6,1 wk ahead,2
+2010,42,2010/2011,42,HHS Region 6,2 wk ahead,2.2
+2010,42,2010/2011,42,HHS Region 6,3 wk ahead,2.4
+2010,42,2010/2011,42,HHS Region 6,4 wk ahead,2.4
+2010,42,2010/2011,42,HHS Region 7,Season onset,4
+2010,42,2010/2011,42,HHS Region 7,Season peak week,8
+2010,42,2010/2011,42,HHS Region 7,Season peak percentage,4.7
+2010,42,2010/2011,42,HHS Region 7,1 wk ahead,0.8
+2010,42,2010/2011,42,HHS Region 7,2 wk ahead,0.7
+2010,42,2010/2011,42,HHS Region 7,3 wk ahead,1.2
+2010,42,2010/2011,42,HHS Region 7,4 wk ahead,1.1
+2010,42,2010/2011,42,HHS Region 8,Season onset,5
+2010,42,2010/2011,42,HHS Region 8,Season peak week,7
+2010,42,2010/2011,42,HHS Region 8,Season peak percentage,2.7
+2010,42,2010/2011,42,HHS Region 8,1 wk ahead,0.7
+2010,42,2010/2011,42,HHS Region 8,2 wk ahead,0.8
+2010,42,2010/2011,42,HHS Region 8,3 wk ahead,0.7
+2010,42,2010/2011,42,HHS Region 8,4 wk ahead,0.7
+2010,42,2010/2011,42,HHS Region 9,Season onset,6
+2010,42,2010/2011,42,HHS Region 9,Season peak week,7
+2010,42,2010/2011,42,HHS Region 9,Season peak week,8
+2010,42,2010/2011,42,HHS Region 9,Season peak percentage,4.7
+2010,42,2010/2011,42,HHS Region 9,1 wk ahead,1.8
+2010,42,2010/2011,42,HHS Region 9,2 wk ahead,2.3
+2010,42,2010/2011,42,HHS Region 9,3 wk ahead,2.3
+2010,42,2010/2011,42,HHS Region 9,4 wk ahead,2.5
+2010,42,2010/2011,42,HHS Region 10,Season onset,5
+2010,42,2010/2011,42,HHS Region 10,Season peak week,7
+2010,42,2010/2011,42,HHS Region 10,Season peak percentage,3.9
+2010,42,2010/2011,42,HHS Region 10,1 wk ahead,0.9
+2010,42,2010/2011,42,HHS Region 10,2 wk ahead,0.9
+2010,42,2010/2011,42,HHS Region 10,3 wk ahead,1
+2010,42,2010/2011,42,HHS Region 10,4 wk ahead,1.2
+2010,43,2010/2011,43,US National,Season onset,51
+2010,43,2010/2011,43,US National,Season peak week,5
+2010,43,2010/2011,43,US National,Season peak week,7
+2010,43,2010/2011,43,US National,Season peak percentage,4.6
+2010,43,2010/2011,43,US National,1 wk ahead,1.4
+2010,43,2010/2011,43,US National,2 wk ahead,1.5
+2010,43,2010/2011,43,US National,3 wk ahead,1.6
+2010,43,2010/2011,43,US National,4 wk ahead,1.8
+2010,43,2010/2011,43,HHS Region 1,Season onset,4
+2010,43,2010/2011,43,HHS Region 1,Season peak week,7
+2010,43,2010/2011,43,HHS Region 1,Season peak week,8
+2010,43,2010/2011,43,HHS Region 1,Season peak percentage,2.3
+2010,43,2010/2011,43,HHS Region 1,1 wk ahead,0.6
+2010,43,2010/2011,43,HHS Region 1,2 wk ahead,0.6
+2010,43,2010/2011,43,HHS Region 1,3 wk ahead,0.7
+2010,43,2010/2011,43,HHS Region 1,4 wk ahead,0.8
+2010,43,2010/2011,43,HHS Region 2,Season onset,49
+2010,43,2010/2011,43,HHS Region 2,Season peak week,52
+2010,43,2010/2011,43,HHS Region 2,Season peak percentage,4.5
+2010,43,2010/2011,43,HHS Region 2,1 wk ahead,1.2
+2010,43,2010/2011,43,HHS Region 2,2 wk ahead,1.4
+2010,43,2010/2011,43,HHS Region 2,3 wk ahead,1.4
+2010,43,2010/2011,43,HHS Region 2,4 wk ahead,1.7
+2010,43,2010/2011,43,HHS Region 3,Season onset,3
+2010,43,2010/2011,43,HHS Region 3,Season peak week,5
+2010,43,2010/2011,43,HHS Region 3,Season peak percentage,4.4
+2010,43,2010/2011,43,HHS Region 3,1 wk ahead,1.2
+2010,43,2010/2011,43,HHS Region 3,2 wk ahead,1.3
+2010,43,2010/2011,43,HHS Region 3,3 wk ahead,1.3
+2010,43,2010/2011,43,HHS Region 3,4 wk ahead,1.5
+2010,43,2010/2011,43,HHS Region 4,Season onset,50
+2010,43,2010/2011,43,HHS Region 4,Season peak week,5
+2010,43,2010/2011,43,HHS Region 4,Season peak percentage,5.5
+2010,43,2010/2011,43,HHS Region 4,1 wk ahead,1.4
+2010,43,2010/2011,43,HHS Region 4,2 wk ahead,1.6
+2010,43,2010/2011,43,HHS Region 4,3 wk ahead,1.8
+2010,43,2010/2011,43,HHS Region 4,4 wk ahead,2.2
+2010,43,2010/2011,43,HHS Region 5,Season onset,3
+2010,43,2010/2011,43,HHS Region 5,Season peak week,5
+2010,43,2010/2011,43,HHS Region 5,Season peak percentage,3.8
+2010,43,2010/2011,43,HHS Region 5,1 wk ahead,1
+2010,43,2010/2011,43,HHS Region 5,2 wk ahead,0.9
+2010,43,2010/2011,43,HHS Region 5,3 wk ahead,0.9
+2010,43,2010/2011,43,HHS Region 5,4 wk ahead,1
+2010,43,2010/2011,43,HHS Region 6,Season onset,3
+2010,43,2010/2011,43,HHS Region 6,Season peak week,7
+2010,43,2010/2011,43,HHS Region 6,Season peak percentage,7.9
+2010,43,2010/2011,43,HHS Region 6,1 wk ahead,2.2
+2010,43,2010/2011,43,HHS Region 6,2 wk ahead,2.4
+2010,43,2010/2011,43,HHS Region 6,3 wk ahead,2.4
+2010,43,2010/2011,43,HHS Region 6,4 wk ahead,2.6
+2010,43,2010/2011,43,HHS Region 7,Season onset,4
+2010,43,2010/2011,43,HHS Region 7,Season peak week,8
+2010,43,2010/2011,43,HHS Region 7,Season peak percentage,4.7
+2010,43,2010/2011,43,HHS Region 7,1 wk ahead,0.7
+2010,43,2010/2011,43,HHS Region 7,2 wk ahead,1.2
+2010,43,2010/2011,43,HHS Region 7,3 wk ahead,1.1
+2010,43,2010/2011,43,HHS Region 7,4 wk ahead,1
+2010,43,2010/2011,43,HHS Region 8,Season onset,5
+2010,43,2010/2011,43,HHS Region 8,Season peak week,7
+2010,43,2010/2011,43,HHS Region 8,Season peak percentage,2.7
+2010,43,2010/2011,43,HHS Region 8,1 wk ahead,0.8
+2010,43,2010/2011,43,HHS Region 8,2 wk ahead,0.7
+2010,43,2010/2011,43,HHS Region 8,3 wk ahead,0.7
+2010,43,2010/2011,43,HHS Region 8,4 wk ahead,0.7
+2010,43,2010/2011,43,HHS Region 9,Season onset,6
+2010,43,2010/2011,43,HHS Region 9,Season peak week,7
+2010,43,2010/2011,43,HHS Region 9,Season peak week,8
+2010,43,2010/2011,43,HHS Region 9,Season peak percentage,4.7
+2010,43,2010/2011,43,HHS Region 9,1 wk ahead,2.3
+2010,43,2010/2011,43,HHS Region 9,2 wk ahead,2.3
+2010,43,2010/2011,43,HHS Region 9,3 wk ahead,2.5
+2010,43,2010/2011,43,HHS Region 9,4 wk ahead,2.8
+2010,43,2010/2011,43,HHS Region 10,Season onset,5
+2010,43,2010/2011,43,HHS Region 10,Season peak week,7
+2010,43,2010/2011,43,HHS Region 10,Season peak percentage,3.9
+2010,43,2010/2011,43,HHS Region 10,1 wk ahead,0.9
+2010,43,2010/2011,43,HHS Region 10,2 wk ahead,1
+2010,43,2010/2011,43,HHS Region 10,3 wk ahead,1.2
+2010,43,2010/2011,43,HHS Region 10,4 wk ahead,1.7
+2010,44,2010/2011,44,US National,Season onset,51
+2010,44,2010/2011,44,US National,Season peak week,5
+2010,44,2010/2011,44,US National,Season peak week,7
+2010,44,2010/2011,44,US National,Season peak percentage,4.6
+2010,44,2010/2011,44,US National,1 wk ahead,1.5
+2010,44,2010/2011,44,US National,2 wk ahead,1.6
+2010,44,2010/2011,44,US National,3 wk ahead,1.8
+2010,44,2010/2011,44,US National,4 wk ahead,1.7
+2010,44,2010/2011,44,HHS Region 1,Season onset,4
+2010,44,2010/2011,44,HHS Region 1,Season peak week,7
+2010,44,2010/2011,44,HHS Region 1,Season peak week,8
+2010,44,2010/2011,44,HHS Region 1,Season peak percentage,2.3
+2010,44,2010/2011,44,HHS Region 1,1 wk ahead,0.6
+2010,44,2010/2011,44,HHS Region 1,2 wk ahead,0.7
+2010,44,2010/2011,44,HHS Region 1,3 wk ahead,0.8
+2010,44,2010/2011,44,HHS Region 1,4 wk ahead,0.7
+2010,44,2010/2011,44,HHS Region 2,Season onset,49
+2010,44,2010/2011,44,HHS Region 2,Season peak week,52
+2010,44,2010/2011,44,HHS Region 2,Season peak percentage,4.5
+2010,44,2010/2011,44,HHS Region 2,1 wk ahead,1.4
+2010,44,2010/2011,44,HHS Region 2,2 wk ahead,1.4
+2010,44,2010/2011,44,HHS Region 2,3 wk ahead,1.7
+2010,44,2010/2011,44,HHS Region 2,4 wk ahead,2.2
+2010,44,2010/2011,44,HHS Region 3,Season onset,3
+2010,44,2010/2011,44,HHS Region 3,Season peak week,5
+2010,44,2010/2011,44,HHS Region 3,Season peak percentage,4.4
+2010,44,2010/2011,44,HHS Region 3,1 wk ahead,1.3
+2010,44,2010/2011,44,HHS Region 3,2 wk ahead,1.3
+2010,44,2010/2011,44,HHS Region 3,3 wk ahead,1.5
+2010,44,2010/2011,44,HHS Region 3,4 wk ahead,1.5
+2010,44,2010/2011,44,HHS Region 4,Season onset,50
+2010,44,2010/2011,44,HHS Region 4,Season peak week,5
+2010,44,2010/2011,44,HHS Region 4,Season peak percentage,5.5
+2010,44,2010/2011,44,HHS Region 4,1 wk ahead,1.6
+2010,44,2010/2011,44,HHS Region 4,2 wk ahead,1.8
+2010,44,2010/2011,44,HHS Region 4,3 wk ahead,2.2
+2010,44,2010/2011,44,HHS Region 4,4 wk ahead,1.9
+2010,44,2010/2011,44,HHS Region 5,Season onset,3
+2010,44,2010/2011,44,HHS Region 5,Season peak week,5
+2010,44,2010/2011,44,HHS Region 5,Season peak percentage,3.8
+2010,44,2010/2011,44,HHS Region 5,1 wk ahead,0.9
+2010,44,2010/2011,44,HHS Region 5,2 wk ahead,0.9
+2010,44,2010/2011,44,HHS Region 5,3 wk ahead,1
+2010,44,2010/2011,44,HHS Region 5,4 wk ahead,0.9
+2010,44,2010/2011,44,HHS Region 6,Season onset,3
+2010,44,2010/2011,44,HHS Region 6,Season peak week,7
+2010,44,2010/2011,44,HHS Region 6,Season peak percentage,7.9
+2010,44,2010/2011,44,HHS Region 6,1 wk ahead,2.4
+2010,44,2010/2011,44,HHS Region 6,2 wk ahead,2.4
+2010,44,2010/2011,44,HHS Region 6,3 wk ahead,2.6
+2010,44,2010/2011,44,HHS Region 6,4 wk ahead,2.5
+2010,44,2010/2011,44,HHS Region 7,Season onset,4
+2010,44,2010/2011,44,HHS Region 7,Season peak week,8
+2010,44,2010/2011,44,HHS Region 7,Season peak percentage,4.7
+2010,44,2010/2011,44,HHS Region 7,1 wk ahead,1.2
+2010,44,2010/2011,44,HHS Region 7,2 wk ahead,1.1
+2010,44,2010/2011,44,HHS Region 7,3 wk ahead,1
+2010,44,2010/2011,44,HHS Region 7,4 wk ahead,1.4
+2010,44,2010/2011,44,HHS Region 8,Season onset,5
+2010,44,2010/2011,44,HHS Region 8,Season peak week,7
+2010,44,2010/2011,44,HHS Region 8,Season peak percentage,2.7
+2010,44,2010/2011,44,HHS Region 8,1 wk ahead,0.7
+2010,44,2010/2011,44,HHS Region 8,2 wk ahead,0.7
+2010,44,2010/2011,44,HHS Region 8,3 wk ahead,0.7
+2010,44,2010/2011,44,HHS Region 8,4 wk ahead,0.7
+2010,44,2010/2011,44,HHS Region 9,Season onset,6
+2010,44,2010/2011,44,HHS Region 9,Season peak week,7
+2010,44,2010/2011,44,HHS Region 9,Season peak week,8
+2010,44,2010/2011,44,HHS Region 9,Season peak percentage,4.7
+2010,44,2010/2011,44,HHS Region 9,1 wk ahead,2.3
+2010,44,2010/2011,44,HHS Region 9,2 wk ahead,2.5
+2010,44,2010/2011,44,HHS Region 9,3 wk ahead,2.8
+2010,44,2010/2011,44,HHS Region 9,4 wk ahead,2.4
+2010,44,2010/2011,44,HHS Region 10,Season onset,5
+2010,44,2010/2011,44,HHS Region 10,Season peak week,7
+2010,44,2010/2011,44,HHS Region 10,Season peak percentage,3.9
+2010,44,2010/2011,44,HHS Region 10,1 wk ahead,1
+2010,44,2010/2011,44,HHS Region 10,2 wk ahead,1.2
+2010,44,2010/2011,44,HHS Region 10,3 wk ahead,1.7
+2010,44,2010/2011,44,HHS Region 10,4 wk ahead,1
+2010,45,2010/2011,45,US National,Season onset,51
+2010,45,2010/2011,45,US National,Season peak week,5
+2010,45,2010/2011,45,US National,Season peak week,7
+2010,45,2010/2011,45,US National,Season peak percentage,4.6
+2010,45,2010/2011,45,US National,1 wk ahead,1.6
+2010,45,2010/2011,45,US National,2 wk ahead,1.8
+2010,45,2010/2011,45,US National,3 wk ahead,1.7
+2010,45,2010/2011,45,US National,4 wk ahead,1.9
+2010,45,2010/2011,45,HHS Region 1,Season onset,4
+2010,45,2010/2011,45,HHS Region 1,Season peak week,7
+2010,45,2010/2011,45,HHS Region 1,Season peak week,8
+2010,45,2010/2011,45,HHS Region 1,Season peak percentage,2.3
+2010,45,2010/2011,45,HHS Region 1,1 wk ahead,0.7
+2010,45,2010/2011,45,HHS Region 1,2 wk ahead,0.8
+2010,45,2010/2011,45,HHS Region 1,3 wk ahead,0.7
+2010,45,2010/2011,45,HHS Region 1,4 wk ahead,0.8
+2010,45,2010/2011,45,HHS Region 2,Season onset,49
+2010,45,2010/2011,45,HHS Region 2,Season peak week,52
+2010,45,2010/2011,45,HHS Region 2,Season peak percentage,4.5
+2010,45,2010/2011,45,HHS Region 2,1 wk ahead,1.4
+2010,45,2010/2011,45,HHS Region 2,2 wk ahead,1.7
+2010,45,2010/2011,45,HHS Region 2,3 wk ahead,2.2
+2010,45,2010/2011,45,HHS Region 2,4 wk ahead,2.5
+2010,45,2010/2011,45,HHS Region 3,Season onset,3
+2010,45,2010/2011,45,HHS Region 3,Season peak week,5
+2010,45,2010/2011,45,HHS Region 3,Season peak percentage,4.4
+2010,45,2010/2011,45,HHS Region 3,1 wk ahead,1.3
+2010,45,2010/2011,45,HHS Region 3,2 wk ahead,1.5
+2010,45,2010/2011,45,HHS Region 3,3 wk ahead,1.5
+2010,45,2010/2011,45,HHS Region 3,4 wk ahead,1.5
+2010,45,2010/2011,45,HHS Region 4,Season onset,50
+2010,45,2010/2011,45,HHS Region 4,Season peak week,5
+2010,45,2010/2011,45,HHS Region 4,Season peak percentage,5.5
+2010,45,2010/2011,45,HHS Region 4,1 wk ahead,1.8
+2010,45,2010/2011,45,HHS Region 4,2 wk ahead,2.2
+2010,45,2010/2011,45,HHS Region 4,3 wk ahead,1.9
+2010,45,2010/2011,45,HHS Region 4,4 wk ahead,2.2
+2010,45,2010/2011,45,HHS Region 5,Season onset,3
+2010,45,2010/2011,45,HHS Region 5,Season peak week,5
+2010,45,2010/2011,45,HHS Region 5,Season peak percentage,3.8
+2010,45,2010/2011,45,HHS Region 5,1 wk ahead,0.9
+2010,45,2010/2011,45,HHS Region 5,2 wk ahead,1
+2010,45,2010/2011,45,HHS Region 5,3 wk ahead,0.9
+2010,45,2010/2011,45,HHS Region 5,4 wk ahead,1
+2010,45,2010/2011,45,HHS Region 6,Season onset,3
+2010,45,2010/2011,45,HHS Region 6,Season peak week,7
+2010,45,2010/2011,45,HHS Region 6,Season peak percentage,7.9
+2010,45,2010/2011,45,HHS Region 6,1 wk ahead,2.4
+2010,45,2010/2011,45,HHS Region 6,2 wk ahead,2.6
+2010,45,2010/2011,45,HHS Region 6,3 wk ahead,2.5
+2010,45,2010/2011,45,HHS Region 6,4 wk ahead,2.3
+2010,45,2010/2011,45,HHS Region 7,Season onset,4
+2010,45,2010/2011,45,HHS Region 7,Season peak week,8
+2010,45,2010/2011,45,HHS Region 7,Season peak percentage,4.7
+2010,45,2010/2011,45,HHS Region 7,1 wk ahead,1.1
+2010,45,2010/2011,45,HHS Region 7,2 wk ahead,1
+2010,45,2010/2011,45,HHS Region 7,3 wk ahead,1.4
+2010,45,2010/2011,45,HHS Region 7,4 wk ahead,1.3
+2010,45,2010/2011,45,HHS Region 8,Season onset,5
+2010,45,2010/2011,45,HHS Region 8,Season peak week,7
+2010,45,2010/2011,45,HHS Region 8,Season peak percentage,2.7
+2010,45,2010/2011,45,HHS Region 8,1 wk ahead,0.7
+2010,45,2010/2011,45,HHS Region 8,2 wk ahead,0.7
+2010,45,2010/2011,45,HHS Region 8,3 wk ahead,0.7
+2010,45,2010/2011,45,HHS Region 8,4 wk ahead,0.8
+2010,45,2010/2011,45,HHS Region 9,Season onset,6
+2010,45,2010/2011,45,HHS Region 9,Season peak week,7
+2010,45,2010/2011,45,HHS Region 9,Season peak week,8
+2010,45,2010/2011,45,HHS Region 9,Season peak percentage,4.7
+2010,45,2010/2011,45,HHS Region 9,1 wk ahead,2.5
+2010,45,2010/2011,45,HHS Region 9,2 wk ahead,2.8
+2010,45,2010/2011,45,HHS Region 9,3 wk ahead,2.4
+2010,45,2010/2011,45,HHS Region 9,4 wk ahead,2.9
+2010,45,2010/2011,45,HHS Region 10,Season onset,5
+2010,45,2010/2011,45,HHS Region 10,Season peak week,7
+2010,45,2010/2011,45,HHS Region 10,Season peak percentage,3.9
+2010,45,2010/2011,45,HHS Region 10,1 wk ahead,1.2
+2010,45,2010/2011,45,HHS Region 10,2 wk ahead,1.7
+2010,45,2010/2011,45,HHS Region 10,3 wk ahead,1
+2010,45,2010/2011,45,HHS Region 10,4 wk ahead,1.1
+2010,46,2010/2011,46,US National,Season onset,51
+2010,46,2010/2011,46,US National,Season peak week,5
+2010,46,2010/2011,46,US National,Season peak week,7
+2010,46,2010/2011,46,US National,Season peak percentage,4.6
+2010,46,2010/2011,46,US National,1 wk ahead,1.8
+2010,46,2010/2011,46,US National,2 wk ahead,1.7
+2010,46,2010/2011,46,US National,3 wk ahead,1.9
+2010,46,2010/2011,46,US National,4 wk ahead,2.3
+2010,46,2010/2011,46,HHS Region 1,Season onset,4
+2010,46,2010/2011,46,HHS Region 1,Season peak week,7
+2010,46,2010/2011,46,HHS Region 1,Season peak week,8
+2010,46,2010/2011,46,HHS Region 1,Season peak percentage,2.3
+2010,46,2010/2011,46,HHS Region 1,1 wk ahead,0.8
+2010,46,2010/2011,46,HHS Region 1,2 wk ahead,0.7
+2010,46,2010/2011,46,HHS Region 1,3 wk ahead,0.8
+2010,46,2010/2011,46,HHS Region 1,4 wk ahead,0.8
+2010,46,2010/2011,46,HHS Region 2,Season onset,49
+2010,46,2010/2011,46,HHS Region 2,Season peak week,52
+2010,46,2010/2011,46,HHS Region 2,Season peak percentage,4.5
+2010,46,2010/2011,46,HHS Region 2,1 wk ahead,1.7
+2010,46,2010/2011,46,HHS Region 2,2 wk ahead,2.2
+2010,46,2010/2011,46,HHS Region 2,3 wk ahead,2.5
+2010,46,2010/2011,46,HHS Region 2,4 wk ahead,3
+2010,46,2010/2011,46,HHS Region 3,Season onset,3
+2010,46,2010/2011,46,HHS Region 3,Season peak week,5
+2010,46,2010/2011,46,HHS Region 3,Season peak percentage,4.4
+2010,46,2010/2011,46,HHS Region 3,1 wk ahead,1.5
+2010,46,2010/2011,46,HHS Region 3,2 wk ahead,1.5
+2010,46,2010/2011,46,HHS Region 3,3 wk ahead,1.5
+2010,46,2010/2011,46,HHS Region 3,4 wk ahead,1.6
+2010,46,2010/2011,46,HHS Region 4,Season onset,50
+2010,46,2010/2011,46,HHS Region 4,Season peak week,5
+2010,46,2010/2011,46,HHS Region 4,Season peak percentage,5.5
+2010,46,2010/2011,46,HHS Region 4,1 wk ahead,2.2
+2010,46,2010/2011,46,HHS Region 4,2 wk ahead,1.9
+2010,46,2010/2011,46,HHS Region 4,3 wk ahead,2.2
+2010,46,2010/2011,46,HHS Region 4,4 wk ahead,3.3
+2010,46,2010/2011,46,HHS Region 5,Season onset,3
+2010,46,2010/2011,46,HHS Region 5,Season peak week,5
+2010,46,2010/2011,46,HHS Region 5,Season peak percentage,3.8
+2010,46,2010/2011,46,HHS Region 5,1 wk ahead,1
+2010,46,2010/2011,46,HHS Region 5,2 wk ahead,0.9
+2010,46,2010/2011,46,HHS Region 5,3 wk ahead,1
+2010,46,2010/2011,46,HHS Region 5,4 wk ahead,1.1
+2010,46,2010/2011,46,HHS Region 6,Season onset,3
+2010,46,2010/2011,46,HHS Region 6,Season peak week,7
+2010,46,2010/2011,46,HHS Region 6,Season peak percentage,7.9
+2010,46,2010/2011,46,HHS Region 6,1 wk ahead,2.6
+2010,46,2010/2011,46,HHS Region 6,2 wk ahead,2.5
+2010,46,2010/2011,46,HHS Region 6,3 wk ahead,2.3
+2010,46,2010/2011,46,HHS Region 6,4 wk ahead,2.9
+2010,46,2010/2011,46,HHS Region 7,Season onset,4
+2010,46,2010/2011,46,HHS Region 7,Season peak week,8
+2010,46,2010/2011,46,HHS Region 7,Season peak percentage,4.7
+2010,46,2010/2011,46,HHS Region 7,1 wk ahead,1
+2010,46,2010/2011,46,HHS Region 7,2 wk ahead,1.4
+2010,46,2010/2011,46,HHS Region 7,3 wk ahead,1.3
+2010,46,2010/2011,46,HHS Region 7,4 wk ahead,1.6
+2010,46,2010/2011,46,HHS Region 8,Season onset,5
+2010,46,2010/2011,46,HHS Region 8,Season peak week,7
+2010,46,2010/2011,46,HHS Region 8,Season peak percentage,2.7
+2010,46,2010/2011,46,HHS Region 8,1 wk ahead,0.7
+2010,46,2010/2011,46,HHS Region 8,2 wk ahead,0.7
+2010,46,2010/2011,46,HHS Region 8,3 wk ahead,0.8
+2010,46,2010/2011,46,HHS Region 8,4 wk ahead,0.8
+2010,46,2010/2011,46,HHS Region 9,Season onset,6
+2010,46,2010/2011,46,HHS Region 9,Season peak week,7
+2010,46,2010/2011,46,HHS Region 9,Season peak week,8
+2010,46,2010/2011,46,HHS Region 9,Season peak percentage,4.7
+2010,46,2010/2011,46,HHS Region 9,1 wk ahead,2.8
+2010,46,2010/2011,46,HHS Region 9,2 wk ahead,2.4
+2010,46,2010/2011,46,HHS Region 9,3 wk ahead,2.9
+2010,46,2010/2011,46,HHS Region 9,4 wk ahead,3.4
+2010,46,2010/2011,46,HHS Region 10,Season onset,5
+2010,46,2010/2011,46,HHS Region 10,Season peak week,7
+2010,46,2010/2011,46,HHS Region 10,Season peak percentage,3.9
+2010,46,2010/2011,46,HHS Region 10,1 wk ahead,1.7
+2010,46,2010/2011,46,HHS Region 10,2 wk ahead,1
+2010,46,2010/2011,46,HHS Region 10,3 wk ahead,1.1
+2010,46,2010/2011,46,HHS Region 10,4 wk ahead,1
+2010,47,2010/2011,47,US National,Season onset,51
+2010,47,2010/2011,47,US National,Season peak week,5
+2010,47,2010/2011,47,US National,Season peak week,7
+2010,47,2010/2011,47,US National,Season peak percentage,4.6
+2010,47,2010/2011,47,US National,1 wk ahead,1.7
+2010,47,2010/2011,47,US National,2 wk ahead,1.9
+2010,47,2010/2011,47,US National,3 wk ahead,2.3
+2010,47,2010/2011,47,US National,4 wk ahead,3
+2010,47,2010/2011,47,HHS Region 1,Season onset,4
+2010,47,2010/2011,47,HHS Region 1,Season peak week,7
+2010,47,2010/2011,47,HHS Region 1,Season peak week,8
+2010,47,2010/2011,47,HHS Region 1,Season peak percentage,2.3
+2010,47,2010/2011,47,HHS Region 1,1 wk ahead,0.7
+2010,47,2010/2011,47,HHS Region 1,2 wk ahead,0.8
+2010,47,2010/2011,47,HHS Region 1,3 wk ahead,0.8
+2010,47,2010/2011,47,HHS Region 1,4 wk ahead,1
+2010,47,2010/2011,47,HHS Region 2,Season onset,49
+2010,47,2010/2011,47,HHS Region 2,Season peak week,52
+2010,47,2010/2011,47,HHS Region 2,Season peak percentage,4.5
+2010,47,2010/2011,47,HHS Region 2,1 wk ahead,2.2
+2010,47,2010/2011,47,HHS Region 2,2 wk ahead,2.5
+2010,47,2010/2011,47,HHS Region 2,3 wk ahead,3
+2010,47,2010/2011,47,HHS Region 2,4 wk ahead,4.2
+2010,47,2010/2011,47,HHS Region 3,Season onset,3
+2010,47,2010/2011,47,HHS Region 3,Season peak week,5
+2010,47,2010/2011,47,HHS Region 3,Season peak percentage,4.4
+2010,47,2010/2011,47,HHS Region 3,1 wk ahead,1.5
+2010,47,2010/2011,47,HHS Region 3,2 wk ahead,1.5
+2010,47,2010/2011,47,HHS Region 3,3 wk ahead,1.6
+2010,47,2010/2011,47,HHS Region 3,4 wk ahead,2.2
+2010,47,2010/2011,47,HHS Region 4,Season onset,50
+2010,47,2010/2011,47,HHS Region 4,Season peak week,5
+2010,47,2010/2011,47,HHS Region 4,Season peak percentage,5.5
+2010,47,2010/2011,47,HHS Region 4,1 wk ahead,1.9
+2010,47,2010/2011,47,HHS Region 4,2 wk ahead,2.2
+2010,47,2010/2011,47,HHS Region 4,3 wk ahead,3.3
+2010,47,2010/2011,47,HHS Region 4,4 wk ahead,4.4
+2010,47,2010/2011,47,HHS Region 5,Season onset,3
+2010,47,2010/2011,47,HHS Region 5,Season peak week,5
+2010,47,2010/2011,47,HHS Region 5,Season peak percentage,3.8
+2010,47,2010/2011,47,HHS Region 5,1 wk ahead,0.9
+2010,47,2010/2011,47,HHS Region 5,2 wk ahead,1
+2010,47,2010/2011,47,HHS Region 5,3 wk ahead,1.1
+2010,47,2010/2011,47,HHS Region 5,4 wk ahead,1.4
+2010,47,2010/2011,47,HHS Region 6,Season onset,3
+2010,47,2010/2011,47,HHS Region 6,Season peak week,7
+2010,47,2010/2011,47,HHS Region 6,Season peak percentage,7.9
+2010,47,2010/2011,47,HHS Region 6,1 wk ahead,2.5
+2010,47,2010/2011,47,HHS Region 6,2 wk ahead,2.3
+2010,47,2010/2011,47,HHS Region 6,3 wk ahead,2.9
+2010,47,2010/2011,47,HHS Region 6,4 wk ahead,3.8
+2010,47,2010/2011,47,HHS Region 7,Season onset,4
+2010,47,2010/2011,47,HHS Region 7,Season peak week,8
+2010,47,2010/2011,47,HHS Region 7,Season peak percentage,4.7
+2010,47,2010/2011,47,HHS Region 7,1 wk ahead,1.4
+2010,47,2010/2011,47,HHS Region 7,2 wk ahead,1.3
+2010,47,2010/2011,47,HHS Region 7,3 wk ahead,1.6
+2010,47,2010/2011,47,HHS Region 7,4 wk ahead,2
+2010,47,2010/2011,47,HHS Region 8,Season onset,5
+2010,47,2010/2011,47,HHS Region 8,Season peak week,7
+2010,47,2010/2011,47,HHS Region 8,Season peak percentage,2.7
+2010,47,2010/2011,47,HHS Region 8,1 wk ahead,0.7
+2010,47,2010/2011,47,HHS Region 8,2 wk ahead,0.8
+2010,47,2010/2011,47,HHS Region 8,3 wk ahead,0.8
+2010,47,2010/2011,47,HHS Region 8,4 wk ahead,0.9
+2010,47,2010/2011,47,HHS Region 9,Season onset,6
+2010,47,2010/2011,47,HHS Region 9,Season peak week,7
+2010,47,2010/2011,47,HHS Region 9,Season peak week,8
+2010,47,2010/2011,47,HHS Region 9,Season peak percentage,4.7
+2010,47,2010/2011,47,HHS Region 9,1 wk ahead,2.4
+2010,47,2010/2011,47,HHS Region 9,2 wk ahead,2.9
+2010,47,2010/2011,47,HHS Region 9,3 wk ahead,3.4
+2010,47,2010/2011,47,HHS Region 9,4 wk ahead,4.2
+2010,47,2010/2011,47,HHS Region 10,Season onset,5
+2010,47,2010/2011,47,HHS Region 10,Season peak week,7
+2010,47,2010/2011,47,HHS Region 10,Season peak percentage,3.9
+2010,47,2010/2011,47,HHS Region 10,1 wk ahead,1
+2010,47,2010/2011,47,HHS Region 10,2 wk ahead,1.1
+2010,47,2010/2011,47,HHS Region 10,3 wk ahead,1
+2010,47,2010/2011,47,HHS Region 10,4 wk ahead,1.3
+2010,48,2010/2011,48,US National,Season onset,51
+2010,48,2010/2011,48,US National,Season peak week,5
+2010,48,2010/2011,48,US National,Season peak week,7
+2010,48,2010/2011,48,US National,Season peak percentage,4.6
+2010,48,2010/2011,48,US National,1 wk ahead,1.9
+2010,48,2010/2011,48,US National,2 wk ahead,2.3
+2010,48,2010/2011,48,US National,3 wk ahead,3
+2010,48,2010/2011,48,US National,4 wk ahead,3.1
+2010,48,2010/2011,48,HHS Region 1,Season onset,4
+2010,48,2010/2011,48,HHS Region 1,Season peak week,7
+2010,48,2010/2011,48,HHS Region 1,Season peak week,8
+2010,48,2010/2011,48,HHS Region 1,Season peak percentage,2.3
+2010,48,2010/2011,48,HHS Region 1,1 wk ahead,0.8
+2010,48,2010/2011,48,HHS Region 1,2 wk ahead,0.8
+2010,48,2010/2011,48,HHS Region 1,3 wk ahead,1
+2010,48,2010/2011,48,HHS Region 1,4 wk ahead,1.1
+2010,48,2010/2011,48,HHS Region 2,Season onset,49
+2010,48,2010/2011,48,HHS Region 2,Season peak week,52
+2010,48,2010/2011,48,HHS Region 2,Season peak percentage,4.5
+2010,48,2010/2011,48,HHS Region 2,1 wk ahead,2.5
+2010,48,2010/2011,48,HHS Region 2,2 wk ahead,3
+2010,48,2010/2011,48,HHS Region 2,3 wk ahead,4.2
+2010,48,2010/2011,48,HHS Region 2,4 wk ahead,4.5
+2010,48,2010/2011,48,HHS Region 3,Season onset,3
+2010,48,2010/2011,48,HHS Region 3,Season peak week,5
+2010,48,2010/2011,48,HHS Region 3,Season peak percentage,4.4
+2010,48,2010/2011,48,HHS Region 3,1 wk ahead,1.5
+2010,48,2010/2011,48,HHS Region 3,2 wk ahead,1.6
+2010,48,2010/2011,48,HHS Region 3,3 wk ahead,2.2
+2010,48,2010/2011,48,HHS Region 3,4 wk ahead,2.6
+2010,48,2010/2011,48,HHS Region 4,Season onset,50
+2010,48,2010/2011,48,HHS Region 4,Season peak week,5
+2010,48,2010/2011,48,HHS Region 4,Season peak percentage,5.5
+2010,48,2010/2011,48,HHS Region 4,1 wk ahead,2.2
+2010,48,2010/2011,48,HHS Region 4,2 wk ahead,3.3
+2010,48,2010/2011,48,HHS Region 4,3 wk ahead,4.4
+2010,48,2010/2011,48,HHS Region 4,4 wk ahead,4
+2010,48,2010/2011,48,HHS Region 5,Season onset,3
+2010,48,2010/2011,48,HHS Region 5,Season peak week,5
+2010,48,2010/2011,48,HHS Region 5,Season peak percentage,3.8
+2010,48,2010/2011,48,HHS Region 5,1 wk ahead,1
+2010,48,2010/2011,48,HHS Region 5,2 wk ahead,1.1
+2010,48,2010/2011,48,HHS Region 5,3 wk ahead,1.4
+2010,48,2010/2011,48,HHS Region 5,4 wk ahead,1.7
+2010,48,2010/2011,48,HHS Region 6,Season onset,3
+2010,48,2010/2011,48,HHS Region 6,Season peak week,7
+2010,48,2010/2011,48,HHS Region 6,Season peak percentage,7.9
+2010,48,2010/2011,48,HHS Region 6,1 wk ahead,2.3
+2010,48,2010/2011,48,HHS Region 6,2 wk ahead,2.9
+2010,48,2010/2011,48,HHS Region 6,3 wk ahead,3.8
+2010,48,2010/2011,48,HHS Region 6,4 wk ahead,3.8
+2010,48,2010/2011,48,HHS Region 7,Season onset,4
+2010,48,2010/2011,48,HHS Region 7,Season peak week,8
+2010,48,2010/2011,48,HHS Region 7,Season peak percentage,4.7
+2010,48,2010/2011,48,HHS Region 7,1 wk ahead,1.3
+2010,48,2010/2011,48,HHS Region 7,2 wk ahead,1.6
+2010,48,2010/2011,48,HHS Region 7,3 wk ahead,2
+2010,48,2010/2011,48,HHS Region 7,4 wk ahead,2.3
+2010,48,2010/2011,48,HHS Region 8,Season onset,5
+2010,48,2010/2011,48,HHS Region 8,Season peak week,7
+2010,48,2010/2011,48,HHS Region 8,Season peak percentage,2.7
+2010,48,2010/2011,48,HHS Region 8,1 wk ahead,0.8
+2010,48,2010/2011,48,HHS Region 8,2 wk ahead,0.8
+2010,48,2010/2011,48,HHS Region 8,3 wk ahead,0.9
+2010,48,2010/2011,48,HHS Region 8,4 wk ahead,1
+2010,48,2010/2011,48,HHS Region 9,Season onset,6
+2010,48,2010/2011,48,HHS Region 9,Season peak week,7
+2010,48,2010/2011,48,HHS Region 9,Season peak week,8
+2010,48,2010/2011,48,HHS Region 9,Season peak percentage,4.7
+2010,48,2010/2011,48,HHS Region 9,1 wk ahead,2.9
+2010,48,2010/2011,48,HHS Region 9,2 wk ahead,3.4
+2010,48,2010/2011,48,HHS Region 9,3 wk ahead,4.2
+2010,48,2010/2011,48,HHS Region 9,4 wk ahead,4.2
+2010,48,2010/2011,48,HHS Region 10,Season onset,5
+2010,48,2010/2011,48,HHS Region 10,Season peak week,7
+2010,48,2010/2011,48,HHS Region 10,Season peak percentage,3.9
+2010,48,2010/2011,48,HHS Region 10,1 wk ahead,1.1
+2010,48,2010/2011,48,HHS Region 10,2 wk ahead,1
+2010,48,2010/2011,48,HHS Region 10,3 wk ahead,1.3
+2010,48,2010/2011,48,HHS Region 10,4 wk ahead,2.4
+2010,49,2010/2011,49,US National,Season onset,51
+2010,49,2010/2011,49,US National,Season peak week,5
+2010,49,2010/2011,49,US National,Season peak week,7
+2010,49,2010/2011,49,US National,Season peak percentage,4.6
+2010,49,2010/2011,49,US National,1 wk ahead,2.3
+2010,49,2010/2011,49,US National,2 wk ahead,3
+2010,49,2010/2011,49,US National,3 wk ahead,3.1
+2010,49,2010/2011,49,US National,4 wk ahead,2.5
+2010,49,2010/2011,49,HHS Region 1,Season onset,4
+2010,49,2010/2011,49,HHS Region 1,Season peak week,7
+2010,49,2010/2011,49,HHS Region 1,Season peak week,8
+2010,49,2010/2011,49,HHS Region 1,Season peak percentage,2.3
+2010,49,2010/2011,49,HHS Region 1,1 wk ahead,0.8
+2010,49,2010/2011,49,HHS Region 1,2 wk ahead,1
+2010,49,2010/2011,49,HHS Region 1,3 wk ahead,1.1
+2010,49,2010/2011,49,HHS Region 1,4 wk ahead,1
+2010,49,2010/2011,49,HHS Region 2,Season onset,49
+2010,49,2010/2011,49,HHS Region 2,Season peak week,52
+2010,49,2010/2011,49,HHS Region 2,Season peak percentage,4.5
+2010,49,2010/2011,49,HHS Region 2,1 wk ahead,3
+2010,49,2010/2011,49,HHS Region 2,2 wk ahead,4.2
+2010,49,2010/2011,49,HHS Region 2,3 wk ahead,4.5
+2010,49,2010/2011,49,HHS Region 2,4 wk ahead,3.3
+2010,49,2010/2011,49,HHS Region 3,Season onset,3
+2010,49,2010/2011,49,HHS Region 3,Season peak week,5
+2010,49,2010/2011,49,HHS Region 3,Season peak percentage,4.4
+2010,49,2010/2011,49,HHS Region 3,1 wk ahead,1.6
+2010,49,2010/2011,49,HHS Region 3,2 wk ahead,2.2
+2010,49,2010/2011,49,HHS Region 3,3 wk ahead,2.6
+2010,49,2010/2011,49,HHS Region 3,4 wk ahead,2.2
+2010,49,2010/2011,49,HHS Region 4,Season onset,50
+2010,49,2010/2011,49,HHS Region 4,Season peak week,5
+2010,49,2010/2011,49,HHS Region 4,Season peak percentage,5.5
+2010,49,2010/2011,49,HHS Region 4,1 wk ahead,3.3
+2010,49,2010/2011,49,HHS Region 4,2 wk ahead,4.4
+2010,49,2010/2011,49,HHS Region 4,3 wk ahead,4
+2010,49,2010/2011,49,HHS Region 4,4 wk ahead,3.3
+2010,49,2010/2011,49,HHS Region 5,Season onset,3
+2010,49,2010/2011,49,HHS Region 5,Season peak week,5
+2010,49,2010/2011,49,HHS Region 5,Season peak percentage,3.8
+2010,49,2010/2011,49,HHS Region 5,1 wk ahead,1.1
+2010,49,2010/2011,49,HHS Region 5,2 wk ahead,1.4
+2010,49,2010/2011,49,HHS Region 5,3 wk ahead,1.7
+2010,49,2010/2011,49,HHS Region 5,4 wk ahead,1.5
+2010,49,2010/2011,49,HHS Region 6,Season onset,3
+2010,49,2010/2011,49,HHS Region 6,Season peak week,7
+2010,49,2010/2011,49,HHS Region 6,Season peak percentage,7.9
+2010,49,2010/2011,49,HHS Region 6,1 wk ahead,2.9
+2010,49,2010/2011,49,HHS Region 6,2 wk ahead,3.8
+2010,49,2010/2011,49,HHS Region 6,3 wk ahead,3.8
+2010,49,2010/2011,49,HHS Region 6,4 wk ahead,3.3
+2010,49,2010/2011,49,HHS Region 7,Season onset,4
+2010,49,2010/2011,49,HHS Region 7,Season peak week,8
+2010,49,2010/2011,49,HHS Region 7,Season peak percentage,4.7
+2010,49,2010/2011,49,HHS Region 7,1 wk ahead,1.6
+2010,49,2010/2011,49,HHS Region 7,2 wk ahead,2
+2010,49,2010/2011,49,HHS Region 7,3 wk ahead,2.3
+2010,49,2010/2011,49,HHS Region 7,4 wk ahead,1.7
+2010,49,2010/2011,49,HHS Region 8,Season onset,5
+2010,49,2010/2011,49,HHS Region 8,Season peak week,7
+2010,49,2010/2011,49,HHS Region 8,Season peak percentage,2.7
+2010,49,2010/2011,49,HHS Region 8,1 wk ahead,0.8
+2010,49,2010/2011,49,HHS Region 8,2 wk ahead,0.9
+2010,49,2010/2011,49,HHS Region 8,3 wk ahead,1
+2010,49,2010/2011,49,HHS Region 8,4 wk ahead,0.7
+2010,49,2010/2011,49,HHS Region 9,Season onset,6
+2010,49,2010/2011,49,HHS Region 9,Season peak week,7
+2010,49,2010/2011,49,HHS Region 9,Season peak week,8
+2010,49,2010/2011,49,HHS Region 9,Season peak percentage,4.7
+2010,49,2010/2011,49,HHS Region 9,1 wk ahead,3.4
+2010,49,2010/2011,49,HHS Region 9,2 wk ahead,4.2
+2010,49,2010/2011,49,HHS Region 9,3 wk ahead,4.2
+2010,49,2010/2011,49,HHS Region 9,4 wk ahead,3.2
+2010,49,2010/2011,49,HHS Region 10,Season onset,5
+2010,49,2010/2011,49,HHS Region 10,Season peak week,7
+2010,49,2010/2011,49,HHS Region 10,Season peak percentage,3.9
+2010,49,2010/2011,49,HHS Region 10,1 wk ahead,1
+2010,49,2010/2011,49,HHS Region 10,2 wk ahead,1.3
+2010,49,2010/2011,49,HHS Region 10,3 wk ahead,2.4
+2010,49,2010/2011,49,HHS Region 10,4 wk ahead,1.4
+2010,50,2010/2011,50,US National,Season onset,51
+2010,50,2010/2011,50,US National,Season peak week,5
+2010,50,2010/2011,50,US National,Season peak week,7
+2010,50,2010/2011,50,US National,Season peak percentage,4.6
+2010,50,2010/2011,50,US National,1 wk ahead,3
+2010,50,2010/2011,50,US National,2 wk ahead,3.1
+2010,50,2010/2011,50,US National,3 wk ahead,2.5
+2010,50,2010/2011,50,US National,4 wk ahead,2.9
+2010,50,2010/2011,50,HHS Region 1,Season onset,4
+2010,50,2010/2011,50,HHS Region 1,Season peak week,7
+2010,50,2010/2011,50,HHS Region 1,Season peak week,8
+2010,50,2010/2011,50,HHS Region 1,Season peak percentage,2.3
+2010,50,2010/2011,50,HHS Region 1,1 wk ahead,1
+2010,50,2010/2011,50,HHS Region 1,2 wk ahead,1.1
+2010,50,2010/2011,50,HHS Region 1,3 wk ahead,1
+2010,50,2010/2011,50,HHS Region 1,4 wk ahead,1.2
+2010,50,2010/2011,50,HHS Region 2,Season onset,49
+2010,50,2010/2011,50,HHS Region 2,Season peak week,52
+2010,50,2010/2011,50,HHS Region 2,Season peak percentage,4.5
+2010,50,2010/2011,50,HHS Region 2,1 wk ahead,4.2
+2010,50,2010/2011,50,HHS Region 2,2 wk ahead,4.5
+2010,50,2010/2011,50,HHS Region 2,3 wk ahead,3.3
+2010,50,2010/2011,50,HHS Region 2,4 wk ahead,3.8
+2010,50,2010/2011,50,HHS Region 3,Season onset,3
+2010,50,2010/2011,50,HHS Region 3,Season peak week,5
+2010,50,2010/2011,50,HHS Region 3,Season peak percentage,4.4
+2010,50,2010/2011,50,HHS Region 3,1 wk ahead,2.2
+2010,50,2010/2011,50,HHS Region 3,2 wk ahead,2.6
+2010,50,2010/2011,50,HHS Region 3,3 wk ahead,2.2
+2010,50,2010/2011,50,HHS Region 3,4 wk ahead,2.5
+2010,50,2010/2011,50,HHS Region 4,Season onset,50
+2010,50,2010/2011,50,HHS Region 4,Season peak week,5
+2010,50,2010/2011,50,HHS Region 4,Season peak percentage,5.5
+2010,50,2010/2011,50,HHS Region 4,1 wk ahead,4.4
+2010,50,2010/2011,50,HHS Region 4,2 wk ahead,4
+2010,50,2010/2011,50,HHS Region 4,3 wk ahead,3.3
+2010,50,2010/2011,50,HHS Region 4,4 wk ahead,3.6
+2010,50,2010/2011,50,HHS Region 5,Season onset,3
+2010,50,2010/2011,50,HHS Region 5,Season peak week,5
+2010,50,2010/2011,50,HHS Region 5,Season peak percentage,3.8
+2010,50,2010/2011,50,HHS Region 5,1 wk ahead,1.4
+2010,50,2010/2011,50,HHS Region 5,2 wk ahead,1.7
+2010,50,2010/2011,50,HHS Region 5,3 wk ahead,1.5
+2010,50,2010/2011,50,HHS Region 5,4 wk ahead,1.7
+2010,50,2010/2011,50,HHS Region 6,Season onset,3
+2010,50,2010/2011,50,HHS Region 6,Season peak week,7
+2010,50,2010/2011,50,HHS Region 6,Season peak percentage,7.9
+2010,50,2010/2011,50,HHS Region 6,1 wk ahead,3.8
+2010,50,2010/2011,50,HHS Region 6,2 wk ahead,3.8
+2010,50,2010/2011,50,HHS Region 6,3 wk ahead,3.3
+2010,50,2010/2011,50,HHS Region 6,4 wk ahead,4.4
+2010,50,2010/2011,50,HHS Region 7,Season onset,4
+2010,50,2010/2011,50,HHS Region 7,Season peak week,8
+2010,50,2010/2011,50,HHS Region 7,Season peak percentage,4.7
+2010,50,2010/2011,50,HHS Region 7,1 wk ahead,2
+2010,50,2010/2011,50,HHS Region 7,2 wk ahead,2.3
+2010,50,2010/2011,50,HHS Region 7,3 wk ahead,1.7
+2010,50,2010/2011,50,HHS Region 7,4 wk ahead,1.7
+2010,50,2010/2011,50,HHS Region 8,Season onset,5
+2010,50,2010/2011,50,HHS Region 8,Season peak week,7
+2010,50,2010/2011,50,HHS Region 8,Season peak percentage,2.7
+2010,50,2010/2011,50,HHS Region 8,1 wk ahead,0.9
+2010,50,2010/2011,50,HHS Region 8,2 wk ahead,1
+2010,50,2010/2011,50,HHS Region 8,3 wk ahead,0.7
+2010,50,2010/2011,50,HHS Region 8,4 wk ahead,1.4
+2010,50,2010/2011,50,HHS Region 9,Season onset,6
+2010,50,2010/2011,50,HHS Region 9,Season peak week,7
+2010,50,2010/2011,50,HHS Region 9,Season peak week,8
+2010,50,2010/2011,50,HHS Region 9,Season peak percentage,4.7
+2010,50,2010/2011,50,HHS Region 9,1 wk ahead,4.2
+2010,50,2010/2011,50,HHS Region 9,2 wk ahead,4.2
+2010,50,2010/2011,50,HHS Region 9,3 wk ahead,3.2
+2010,50,2010/2011,50,HHS Region 9,4 wk ahead,3.4
+2010,50,2010/2011,50,HHS Region 10,Season onset,5
+2010,50,2010/2011,50,HHS Region 10,Season peak week,7
+2010,50,2010/2011,50,HHS Region 10,Season peak percentage,3.9
+2010,50,2010/2011,50,HHS Region 10,1 wk ahead,1.3
+2010,50,2010/2011,50,HHS Region 10,2 wk ahead,2.4
+2010,50,2010/2011,50,HHS Region 10,3 wk ahead,1.4
+2010,50,2010/2011,50,HHS Region 10,4 wk ahead,1.5
+2010,51,2010/2011,51,US National,Season onset,51
+2010,51,2010/2011,51,US National,Season peak week,5
+2010,51,2010/2011,51,US National,Season peak week,7
+2010,51,2010/2011,51,US National,Season peak percentage,4.6
+2010,51,2010/2011,51,US National,1 wk ahead,3.1
+2010,51,2010/2011,51,US National,2 wk ahead,2.5
+2010,51,2010/2011,51,US National,3 wk ahead,2.9
+2010,51,2010/2011,51,US National,4 wk ahead,3.4
+2010,51,2010/2011,51,HHS Region 1,Season onset,4
+2010,51,2010/2011,51,HHS Region 1,Season peak week,7
+2010,51,2010/2011,51,HHS Region 1,Season peak week,8
+2010,51,2010/2011,51,HHS Region 1,Season peak percentage,2.3
+2010,51,2010/2011,51,HHS Region 1,1 wk ahead,1.1
+2010,51,2010/2011,51,HHS Region 1,2 wk ahead,1
+2010,51,2010/2011,51,HHS Region 1,3 wk ahead,1.2
+2010,51,2010/2011,51,HHS Region 1,4 wk ahead,1.2
+2010,51,2010/2011,51,HHS Region 2,Season onset,49
+2010,51,2010/2011,51,HHS Region 2,Season peak week,52
+2010,51,2010/2011,51,HHS Region 2,Season peak percentage,4.5
+2010,51,2010/2011,51,HHS Region 2,1 wk ahead,4.5
+2010,51,2010/2011,51,HHS Region 2,2 wk ahead,3.3
+2010,51,2010/2011,51,HHS Region 2,3 wk ahead,3.8
+2010,51,2010/2011,51,HHS Region 2,4 wk ahead,3.7
+2010,51,2010/2011,51,HHS Region 3,Season onset,3
+2010,51,2010/2011,51,HHS Region 3,Season peak week,5
+2010,51,2010/2011,51,HHS Region 3,Season peak percentage,4.4
+2010,51,2010/2011,51,HHS Region 3,1 wk ahead,2.6
+2010,51,2010/2011,51,HHS Region 3,2 wk ahead,2.2
+2010,51,2010/2011,51,HHS Region 3,3 wk ahead,2.5
+2010,51,2010/2011,51,HHS Region 3,4 wk ahead,3.3
+2010,51,2010/2011,51,HHS Region 4,Season onset,50
+2010,51,2010/2011,51,HHS Region 4,Season peak week,5
+2010,51,2010/2011,51,HHS Region 4,Season peak percentage,5.5
+2010,51,2010/2011,51,HHS Region 4,1 wk ahead,4
+2010,51,2010/2011,51,HHS Region 4,2 wk ahead,3.3
+2010,51,2010/2011,51,HHS Region 4,3 wk ahead,3.6
+2010,51,2010/2011,51,HHS Region 4,4 wk ahead,4.2
+2010,51,2010/2011,51,HHS Region 5,Season onset,3
+2010,51,2010/2011,51,HHS Region 5,Season peak week,5
+2010,51,2010/2011,51,HHS Region 5,Season peak percentage,3.8
+2010,51,2010/2011,51,HHS Region 5,1 wk ahead,1.7
+2010,51,2010/2011,51,HHS Region 5,2 wk ahead,1.5
+2010,51,2010/2011,51,HHS Region 5,3 wk ahead,1.7
+2010,51,2010/2011,51,HHS Region 5,4 wk ahead,2.4
+2010,51,2010/2011,51,HHS Region 6,Season onset,3
+2010,51,2010/2011,51,HHS Region 6,Season peak week,7
+2010,51,2010/2011,51,HHS Region 6,Season peak percentage,7.9
+2010,51,2010/2011,51,HHS Region 6,1 wk ahead,3.8
+2010,51,2010/2011,51,HHS Region 6,2 wk ahead,3.3
+2010,51,2010/2011,51,HHS Region 6,3 wk ahead,4.4
+2010,51,2010/2011,51,HHS Region 6,4 wk ahead,5.7
+2010,51,2010/2011,51,HHS Region 7,Season onset,4
+2010,51,2010/2011,51,HHS Region 7,Season peak week,8
+2010,51,2010/2011,51,HHS Region 7,Season peak percentage,4.7
+2010,51,2010/2011,51,HHS Region 7,1 wk ahead,2.3
+2010,51,2010/2011,51,HHS Region 7,2 wk ahead,1.7
+2010,51,2010/2011,51,HHS Region 7,3 wk ahead,1.7
+2010,51,2010/2011,51,HHS Region 7,4 wk ahead,2
+2010,51,2010/2011,51,HHS Region 8,Season onset,5
+2010,51,2010/2011,51,HHS Region 8,Season peak week,7
+2010,51,2010/2011,51,HHS Region 8,Season peak percentage,2.7
+2010,51,2010/2011,51,HHS Region 8,1 wk ahead,1
+2010,51,2010/2011,51,HHS Region 8,2 wk ahead,0.7
+2010,51,2010/2011,51,HHS Region 8,3 wk ahead,1.4
+2010,51,2010/2011,51,HHS Region 8,4 wk ahead,1.4
+2010,51,2010/2011,51,HHS Region 9,Season onset,6
+2010,51,2010/2011,51,HHS Region 9,Season peak week,7
+2010,51,2010/2011,51,HHS Region 9,Season peak week,8
+2010,51,2010/2011,51,HHS Region 9,Season peak percentage,4.7
+2010,51,2010/2011,51,HHS Region 9,1 wk ahead,4.2
+2010,51,2010/2011,51,HHS Region 9,2 wk ahead,3.2
+2010,51,2010/2011,51,HHS Region 9,3 wk ahead,3.4
+2010,51,2010/2011,51,HHS Region 9,4 wk ahead,3.8
+2010,51,2010/2011,51,HHS Region 10,Season onset,5
+2010,51,2010/2011,51,HHS Region 10,Season peak week,7
+2010,51,2010/2011,51,HHS Region 10,Season peak percentage,3.9
+2010,51,2010/2011,51,HHS Region 10,1 wk ahead,2.4
+2010,51,2010/2011,51,HHS Region 10,2 wk ahead,1.4
+2010,51,2010/2011,51,HHS Region 10,3 wk ahead,1.5
+2010,51,2010/2011,51,HHS Region 10,4 wk ahead,1.5
+2010,52,2010/2011,52,US National,Season onset,51
+2010,52,2010/2011,52,US National,Season peak week,5
+2010,52,2010/2011,52,US National,Season peak week,7
+2010,52,2010/2011,52,US National,Season peak percentage,4.6
+2010,52,2010/2011,52,US National,1 wk ahead,2.5
+2010,52,2010/2011,52,US National,2 wk ahead,2.9
+2010,52,2010/2011,52,US National,3 wk ahead,3.4
+2010,52,2010/2011,52,US National,4 wk ahead,4.2
+2010,52,2010/2011,52,HHS Region 1,Season onset,4
+2010,52,2010/2011,52,HHS Region 1,Season peak week,7
+2010,52,2010/2011,52,HHS Region 1,Season peak week,8
+2010,52,2010/2011,52,HHS Region 1,Season peak percentage,2.3
+2010,52,2010/2011,52,HHS Region 1,1 wk ahead,1
+2010,52,2010/2011,52,HHS Region 1,2 wk ahead,1.2
+2010,52,2010/2011,52,HHS Region 1,3 wk ahead,1.2
+2010,52,2010/2011,52,HHS Region 1,4 wk ahead,1.4
+2010,52,2010/2011,52,HHS Region 2,Season onset,49
+2010,52,2010/2011,52,HHS Region 2,Season peak week,52
+2010,52,2010/2011,52,HHS Region 2,Season peak percentage,4.5
+2010,52,2010/2011,52,HHS Region 2,1 wk ahead,3.3
+2010,52,2010/2011,52,HHS Region 2,2 wk ahead,3.8
+2010,52,2010/2011,52,HHS Region 2,3 wk ahead,3.7
+2010,52,2010/2011,52,HHS Region 2,4 wk ahead,3.9
+2010,52,2010/2011,52,HHS Region 3,Season onset,3
+2010,52,2010/2011,52,HHS Region 3,Season peak week,5
+2010,52,2010/2011,52,HHS Region 3,Season peak percentage,4.4
+2010,52,2010/2011,52,HHS Region 3,1 wk ahead,2.2
+2010,52,2010/2011,52,HHS Region 3,2 wk ahead,2.5
+2010,52,2010/2011,52,HHS Region 3,3 wk ahead,3.3
+2010,52,2010/2011,52,HHS Region 3,4 wk ahead,4
+2010,52,2010/2011,52,HHS Region 4,Season onset,50
+2010,52,2010/2011,52,HHS Region 4,Season peak week,5
+2010,52,2010/2011,52,HHS Region 4,Season peak percentage,5.5
+2010,52,2010/2011,52,HHS Region 4,1 wk ahead,3.3
+2010,52,2010/2011,52,HHS Region 4,2 wk ahead,3.6
+2010,52,2010/2011,52,HHS Region 4,3 wk ahead,4.2
+2010,52,2010/2011,52,HHS Region 4,4 wk ahead,5
+2010,52,2010/2011,52,HHS Region 5,Season onset,3
+2010,52,2010/2011,52,HHS Region 5,Season peak week,5
+2010,52,2010/2011,52,HHS Region 5,Season peak percentage,3.8
+2010,52,2010/2011,52,HHS Region 5,1 wk ahead,1.5
+2010,52,2010/2011,52,HHS Region 5,2 wk ahead,1.7
+2010,52,2010/2011,52,HHS Region 5,3 wk ahead,2.4
+2010,52,2010/2011,52,HHS Region 5,4 wk ahead,3.3
+2010,52,2010/2011,52,HHS Region 6,Season onset,3
+2010,52,2010/2011,52,HHS Region 6,Season peak week,7
+2010,52,2010/2011,52,HHS Region 6,Season peak percentage,7.9
+2010,52,2010/2011,52,HHS Region 6,1 wk ahead,3.3
+2010,52,2010/2011,52,HHS Region 6,2 wk ahead,4.4
+2010,52,2010/2011,52,HHS Region 6,3 wk ahead,5.7
+2010,52,2010/2011,52,HHS Region 6,4 wk ahead,6.9
+2010,52,2010/2011,52,HHS Region 7,Season onset,4
+2010,52,2010/2011,52,HHS Region 7,Season peak week,8
+2010,52,2010/2011,52,HHS Region 7,Season peak percentage,4.7
+2010,52,2010/2011,52,HHS Region 7,1 wk ahead,1.7
+2010,52,2010/2011,52,HHS Region 7,2 wk ahead,1.7
+2010,52,2010/2011,52,HHS Region 7,3 wk ahead,2
+2010,52,2010/2011,52,HHS Region 7,4 wk ahead,3.3
+2010,52,2010/2011,52,HHS Region 8,Season onset,5
+2010,52,2010/2011,52,HHS Region 8,Season peak week,7
+2010,52,2010/2011,52,HHS Region 8,Season peak percentage,2.7
+2010,52,2010/2011,52,HHS Region 8,1 wk ahead,0.7
+2010,52,2010/2011,52,HHS Region 8,2 wk ahead,1.4
+2010,52,2010/2011,52,HHS Region 8,3 wk ahead,1.4
+2010,52,2010/2011,52,HHS Region 8,4 wk ahead,1.5
+2010,52,2010/2011,52,HHS Region 9,Season onset,6
+2010,52,2010/2011,52,HHS Region 9,Season peak week,7
+2010,52,2010/2011,52,HHS Region 9,Season peak week,8
+2010,52,2010/2011,52,HHS Region 9,Season peak percentage,4.7
+2010,52,2010/2011,52,HHS Region 9,1 wk ahead,3.2
+2010,52,2010/2011,52,HHS Region 9,2 wk ahead,3.4
+2010,52,2010/2011,52,HHS Region 9,3 wk ahead,3.8
+2010,52,2010/2011,52,HHS Region 9,4 wk ahead,4.2
+2010,52,2010/2011,52,HHS Region 10,Season onset,5
+2010,52,2010/2011,52,HHS Region 10,Season peak week,7
+2010,52,2010/2011,52,HHS Region 10,Season peak percentage,3.9
+2010,52,2010/2011,52,HHS Region 10,1 wk ahead,1.4
+2010,52,2010/2011,52,HHS Region 10,2 wk ahead,1.5
+2010,52,2010/2011,52,HHS Region 10,3 wk ahead,1.5
+2010,52,2010/2011,52,HHS Region 10,4 wk ahead,2.1
+2011,1,2010/2011,53,US National,Season onset,51
+2011,1,2010/2011,53,US National,Season peak week,5
+2011,1,2010/2011,53,US National,Season peak week,7
+2011,1,2010/2011,53,US National,Season peak percentage,4.6
+2011,1,2010/2011,53,US National,1 wk ahead,2.9
+2011,1,2010/2011,53,US National,2 wk ahead,3.4
+2011,1,2010/2011,53,US National,3 wk ahead,4.2
+2011,1,2010/2011,53,US National,4 wk ahead,4.6
+2011,1,2010/2011,53,HHS Region 1,Season onset,4
+2011,1,2010/2011,53,HHS Region 1,Season peak week,7
+2011,1,2010/2011,53,HHS Region 1,Season peak week,8
+2011,1,2010/2011,53,HHS Region 1,Season peak percentage,2.3
+2011,1,2010/2011,53,HHS Region 1,1 wk ahead,1.2
+2011,1,2010/2011,53,HHS Region 1,2 wk ahead,1.2
+2011,1,2010/2011,53,HHS Region 1,3 wk ahead,1.4
+2011,1,2010/2011,53,HHS Region 1,4 wk ahead,1.9
+2011,1,2010/2011,53,HHS Region 2,Season onset,49
+2011,1,2010/2011,53,HHS Region 2,Season peak week,52
+2011,1,2010/2011,53,HHS Region 2,Season peak percentage,4.5
+2011,1,2010/2011,53,HHS Region 2,1 wk ahead,3.8
+2011,1,2010/2011,53,HHS Region 2,2 wk ahead,3.7
+2011,1,2010/2011,53,HHS Region 2,3 wk ahead,3.9
+2011,1,2010/2011,53,HHS Region 2,4 wk ahead,4.1
+2011,1,2010/2011,53,HHS Region 3,Season onset,3
+2011,1,2010/2011,53,HHS Region 3,Season peak week,5
+2011,1,2010/2011,53,HHS Region 3,Season peak percentage,4.4
+2011,1,2010/2011,53,HHS Region 3,1 wk ahead,2.5
+2011,1,2010/2011,53,HHS Region 3,2 wk ahead,3.3
+2011,1,2010/2011,53,HHS Region 3,3 wk ahead,4
+2011,1,2010/2011,53,HHS Region 3,4 wk ahead,4.4
+2011,1,2010/2011,53,HHS Region 4,Season onset,50
+2011,1,2010/2011,53,HHS Region 4,Season peak week,5
+2011,1,2010/2011,53,HHS Region 4,Season peak percentage,5.5
+2011,1,2010/2011,53,HHS Region 4,1 wk ahead,3.6
+2011,1,2010/2011,53,HHS Region 4,2 wk ahead,4.2
+2011,1,2010/2011,53,HHS Region 4,3 wk ahead,5
+2011,1,2010/2011,53,HHS Region 4,4 wk ahead,5.5
+2011,1,2010/2011,53,HHS Region 5,Season onset,3
+2011,1,2010/2011,53,HHS Region 5,Season peak week,5
+2011,1,2010/2011,53,HHS Region 5,Season peak percentage,3.8
+2011,1,2010/2011,53,HHS Region 5,1 wk ahead,1.7
+2011,1,2010/2011,53,HHS Region 5,2 wk ahead,2.4
+2011,1,2010/2011,53,HHS Region 5,3 wk ahead,3.3
+2011,1,2010/2011,53,HHS Region 5,4 wk ahead,3.8
+2011,1,2010/2011,53,HHS Region 6,Season onset,3
+2011,1,2010/2011,53,HHS Region 6,Season peak week,7
+2011,1,2010/2011,53,HHS Region 6,Season peak percentage,7.9
+2011,1,2010/2011,53,HHS Region 6,1 wk ahead,4.4
+2011,1,2010/2011,53,HHS Region 6,2 wk ahead,5.7
+2011,1,2010/2011,53,HHS Region 6,3 wk ahead,6.9
+2011,1,2010/2011,53,HHS Region 6,4 wk ahead,7.6
+2011,1,2010/2011,53,HHS Region 7,Season onset,4
+2011,1,2010/2011,53,HHS Region 7,Season peak week,8
+2011,1,2010/2011,53,HHS Region 7,Season peak percentage,4.7
+2011,1,2010/2011,53,HHS Region 7,1 wk ahead,1.7
+2011,1,2010/2011,53,HHS Region 7,2 wk ahead,2
+2011,1,2010/2011,53,HHS Region 7,3 wk ahead,3.3
+2011,1,2010/2011,53,HHS Region 7,4 wk ahead,4.3
+2011,1,2010/2011,53,HHS Region 8,Season onset,5
+2011,1,2010/2011,53,HHS Region 8,Season peak week,7
+2011,1,2010/2011,53,HHS Region 8,Season peak percentage,2.7
+2011,1,2010/2011,53,HHS Region 8,1 wk ahead,1.4
+2011,1,2010/2011,53,HHS Region 8,2 wk ahead,1.4
+2011,1,2010/2011,53,HHS Region 8,3 wk ahead,1.5
+2011,1,2010/2011,53,HHS Region 8,4 wk ahead,2.2
+2011,1,2010/2011,53,HHS Region 9,Season onset,6
+2011,1,2010/2011,53,HHS Region 9,Season peak week,7
+2011,1,2010/2011,53,HHS Region 9,Season peak week,8
+2011,1,2010/2011,53,HHS Region 9,Season peak percentage,4.7
+2011,1,2010/2011,53,HHS Region 9,1 wk ahead,3.4
+2011,1,2010/2011,53,HHS Region 9,2 wk ahead,3.8
+2011,1,2010/2011,53,HHS Region 9,3 wk ahead,4.2
+2011,1,2010/2011,53,HHS Region 9,4 wk ahead,4
+2011,1,2010/2011,53,HHS Region 10,Season onset,5
+2011,1,2010/2011,53,HHS Region 10,Season peak week,7
+2011,1,2010/2011,53,HHS Region 10,Season peak percentage,3.9
+2011,1,2010/2011,53,HHS Region 10,1 wk ahead,1.5
+2011,1,2010/2011,53,HHS Region 10,2 wk ahead,1.5
+2011,1,2010/2011,53,HHS Region 10,3 wk ahead,2.1
+2011,1,2010/2011,53,HHS Region 10,4 wk ahead,2.6
+2011,2,2010/2011,54,US National,Season onset,51
+2011,2,2010/2011,54,US National,Season peak week,5
+2011,2,2010/2011,54,US National,Season peak week,7
+2011,2,2010/2011,54,US National,Season peak percentage,4.6
+2011,2,2010/2011,54,US National,1 wk ahead,3.4
+2011,2,2010/2011,54,US National,2 wk ahead,4.2
+2011,2,2010/2011,54,US National,3 wk ahead,4.6
+2011,2,2010/2011,54,US National,4 wk ahead,4.5
+2011,2,2010/2011,54,HHS Region 1,Season onset,4
+2011,2,2010/2011,54,HHS Region 1,Season peak week,7
+2011,2,2010/2011,54,HHS Region 1,Season peak week,8
+2011,2,2010/2011,54,HHS Region 1,Season peak percentage,2.3
+2011,2,2010/2011,54,HHS Region 1,1 wk ahead,1.2
+2011,2,2010/2011,54,HHS Region 1,2 wk ahead,1.4
+2011,2,2010/2011,54,HHS Region 1,3 wk ahead,1.9
+2011,2,2010/2011,54,HHS Region 1,4 wk ahead,2
+2011,2,2010/2011,54,HHS Region 2,Season onset,49
+2011,2,2010/2011,54,HHS Region 2,Season peak week,52
+2011,2,2010/2011,54,HHS Region 2,Season peak percentage,4.5
+2011,2,2010/2011,54,HHS Region 2,1 wk ahead,3.7
+2011,2,2010/2011,54,HHS Region 2,2 wk ahead,3.9
+2011,2,2010/2011,54,HHS Region 2,3 wk ahead,4.1
+2011,2,2010/2011,54,HHS Region 2,4 wk ahead,4.1
+2011,2,2010/2011,54,HHS Region 3,Season onset,3
+2011,2,2010/2011,54,HHS Region 3,Season peak week,5
+2011,2,2010/2011,54,HHS Region 3,Season peak percentage,4.4
+2011,2,2010/2011,54,HHS Region 3,1 wk ahead,3.3
+2011,2,2010/2011,54,HHS Region 3,2 wk ahead,4
+2011,2,2010/2011,54,HHS Region 3,3 wk ahead,4.4
+2011,2,2010/2011,54,HHS Region 3,4 wk ahead,4.1
+2011,2,2010/2011,54,HHS Region 4,Season onset,50
+2011,2,2010/2011,54,HHS Region 4,Season peak week,5
+2011,2,2010/2011,54,HHS Region 4,Season peak percentage,5.5
+2011,2,2010/2011,54,HHS Region 4,1 wk ahead,4.2
+2011,2,2010/2011,54,HHS Region 4,2 wk ahead,5
+2011,2,2010/2011,54,HHS Region 4,3 wk ahead,5.5
+2011,2,2010/2011,54,HHS Region 4,4 wk ahead,5.2
+2011,2,2010/2011,54,HHS Region 5,Season onset,3
+2011,2,2010/2011,54,HHS Region 5,Season peak week,5
+2011,2,2010/2011,54,HHS Region 5,Season peak percentage,3.8
+2011,2,2010/2011,54,HHS Region 5,1 wk ahead,2.4
+2011,2,2010/2011,54,HHS Region 5,2 wk ahead,3.3
+2011,2,2010/2011,54,HHS Region 5,3 wk ahead,3.8
+2011,2,2010/2011,54,HHS Region 5,4 wk ahead,3.3
+2011,2,2010/2011,54,HHS Region 6,Season onset,3
+2011,2,2010/2011,54,HHS Region 6,Season peak week,7
+2011,2,2010/2011,54,HHS Region 6,Season peak percentage,7.9
+2011,2,2010/2011,54,HHS Region 6,1 wk ahead,5.7
+2011,2,2010/2011,54,HHS Region 6,2 wk ahead,6.9
+2011,2,2010/2011,54,HHS Region 6,3 wk ahead,7.6
+2011,2,2010/2011,54,HHS Region 6,4 wk ahead,7.8
+2011,2,2010/2011,54,HHS Region 7,Season onset,4
+2011,2,2010/2011,54,HHS Region 7,Season peak week,8
+2011,2,2010/2011,54,HHS Region 7,Season peak percentage,4.7
+2011,2,2010/2011,54,HHS Region 7,1 wk ahead,2
+2011,2,2010/2011,54,HHS Region 7,2 wk ahead,3.3
+2011,2,2010/2011,54,HHS Region 7,3 wk ahead,4.3
+2011,2,2010/2011,54,HHS Region 7,4 wk ahead,3.7
+2011,2,2010/2011,54,HHS Region 8,Season onset,5
+2011,2,2010/2011,54,HHS Region 8,Season peak week,7
+2011,2,2010/2011,54,HHS Region 8,Season peak percentage,2.7
+2011,2,2010/2011,54,HHS Region 8,1 wk ahead,1.4
+2011,2,2010/2011,54,HHS Region 8,2 wk ahead,1.5
+2011,2,2010/2011,54,HHS Region 8,3 wk ahead,2.2
+2011,2,2010/2011,54,HHS Region 8,4 wk ahead,2.5
+2011,2,2010/2011,54,HHS Region 9,Season onset,6
+2011,2,2010/2011,54,HHS Region 9,Season peak week,7
+2011,2,2010/2011,54,HHS Region 9,Season peak week,8
+2011,2,2010/2011,54,HHS Region 9,Season peak percentage,4.7
+2011,2,2010/2011,54,HHS Region 9,1 wk ahead,3.8
+2011,2,2010/2011,54,HHS Region 9,2 wk ahead,4.2
+2011,2,2010/2011,54,HHS Region 9,3 wk ahead,4
+2011,2,2010/2011,54,HHS Region 9,4 wk ahead,4.5
+2011,2,2010/2011,54,HHS Region 10,Season onset,5
+2011,2,2010/2011,54,HHS Region 10,Season peak week,7
+2011,2,2010/2011,54,HHS Region 10,Season peak percentage,3.9
+2011,2,2010/2011,54,HHS Region 10,1 wk ahead,1.5
+2011,2,2010/2011,54,HHS Region 10,2 wk ahead,2.1
+2011,2,2010/2011,54,HHS Region 10,3 wk ahead,2.6
+2011,2,2010/2011,54,HHS Region 10,4 wk ahead,2.5
+2011,3,2010/2011,55,US National,Season onset,51
+2011,3,2010/2011,55,US National,Season peak week,5
+2011,3,2010/2011,55,US National,Season peak week,7
+2011,3,2010/2011,55,US National,Season peak percentage,4.6
+2011,3,2010/2011,55,US National,1 wk ahead,4.2
+2011,3,2010/2011,55,US National,2 wk ahead,4.6
+2011,3,2010/2011,55,US National,3 wk ahead,4.5
+2011,3,2010/2011,55,US National,4 wk ahead,4.6
+2011,3,2010/2011,55,HHS Region 1,Season onset,4
+2011,3,2010/2011,55,HHS Region 1,Season peak week,7
+2011,3,2010/2011,55,HHS Region 1,Season peak week,8
+2011,3,2010/2011,55,HHS Region 1,Season peak percentage,2.3
+2011,3,2010/2011,55,HHS Region 1,1 wk ahead,1.4
+2011,3,2010/2011,55,HHS Region 1,2 wk ahead,1.9
+2011,3,2010/2011,55,HHS Region 1,3 wk ahead,2
+2011,3,2010/2011,55,HHS Region 1,4 wk ahead,2.3
+2011,3,2010/2011,55,HHS Region 2,Season onset,49
+2011,3,2010/2011,55,HHS Region 2,Season peak week,52
+2011,3,2010/2011,55,HHS Region 2,Season peak percentage,4.5
+2011,3,2010/2011,55,HHS Region 2,1 wk ahead,3.9
+2011,3,2010/2011,55,HHS Region 2,2 wk ahead,4.1
+2011,3,2010/2011,55,HHS Region 2,3 wk ahead,4.1
+2011,3,2010/2011,55,HHS Region 2,4 wk ahead,4.3
+2011,3,2010/2011,55,HHS Region 3,Season onset,3
+2011,3,2010/2011,55,HHS Region 3,Season peak week,5
+2011,3,2010/2011,55,HHS Region 3,Season peak percentage,4.4
+2011,3,2010/2011,55,HHS Region 3,1 wk ahead,4
+2011,3,2010/2011,55,HHS Region 3,2 wk ahead,4.4
+2011,3,2010/2011,55,HHS Region 3,3 wk ahead,4.1
+2011,3,2010/2011,55,HHS Region 3,4 wk ahead,4
+2011,3,2010/2011,55,HHS Region 4,Season onset,50
+2011,3,2010/2011,55,HHS Region 4,Season peak week,5
+2011,3,2010/2011,55,HHS Region 4,Season peak percentage,5.5
+2011,3,2010/2011,55,HHS Region 4,1 wk ahead,5
+2011,3,2010/2011,55,HHS Region 4,2 wk ahead,5.5
+2011,3,2010/2011,55,HHS Region 4,3 wk ahead,5.2
+2011,3,2010/2011,55,HHS Region 4,4 wk ahead,4.8
+2011,3,2010/2011,55,HHS Region 5,Season onset,3
+2011,3,2010/2011,55,HHS Region 5,Season peak week,5
+2011,3,2010/2011,55,HHS Region 5,Season peak percentage,3.8
+2011,3,2010/2011,55,HHS Region 5,1 wk ahead,3.3
+2011,3,2010/2011,55,HHS Region 5,2 wk ahead,3.8
+2011,3,2010/2011,55,HHS Region 5,3 wk ahead,3.3
+2011,3,2010/2011,55,HHS Region 5,4 wk ahead,3.3
+2011,3,2010/2011,55,HHS Region 6,Season onset,3
+2011,3,2010/2011,55,HHS Region 6,Season peak week,7
+2011,3,2010/2011,55,HHS Region 6,Season peak percentage,7.9
+2011,3,2010/2011,55,HHS Region 6,1 wk ahead,6.9
+2011,3,2010/2011,55,HHS Region 6,2 wk ahead,7.6
+2011,3,2010/2011,55,HHS Region 6,3 wk ahead,7.8
+2011,3,2010/2011,55,HHS Region 6,4 wk ahead,7.9
+2011,3,2010/2011,55,HHS Region 7,Season onset,4
+2011,3,2010/2011,55,HHS Region 7,Season peak week,8
+2011,3,2010/2011,55,HHS Region 7,Season peak percentage,4.7
+2011,3,2010/2011,55,HHS Region 7,1 wk ahead,3.3
+2011,3,2010/2011,55,HHS Region 7,2 wk ahead,4.3
+2011,3,2010/2011,55,HHS Region 7,3 wk ahead,3.7
+2011,3,2010/2011,55,HHS Region 7,4 wk ahead,4.5
+2011,3,2010/2011,55,HHS Region 8,Season onset,5
+2011,3,2010/2011,55,HHS Region 8,Season peak week,7
+2011,3,2010/2011,55,HHS Region 8,Season peak percentage,2.7
+2011,3,2010/2011,55,HHS Region 8,1 wk ahead,1.5
+2011,3,2010/2011,55,HHS Region 8,2 wk ahead,2.2
+2011,3,2010/2011,55,HHS Region 8,3 wk ahead,2.5
+2011,3,2010/2011,55,HHS Region 8,4 wk ahead,2.7
+2011,3,2010/2011,55,HHS Region 9,Season onset,6
+2011,3,2010/2011,55,HHS Region 9,Season peak week,7
+2011,3,2010/2011,55,HHS Region 9,Season peak week,8
+2011,3,2010/2011,55,HHS Region 9,Season peak percentage,4.7
+2011,3,2010/2011,55,HHS Region 9,1 wk ahead,4.2
+2011,3,2010/2011,55,HHS Region 9,2 wk ahead,4
+2011,3,2010/2011,55,HHS Region 9,3 wk ahead,4.5
+2011,3,2010/2011,55,HHS Region 9,4 wk ahead,4.7
+2011,3,2010/2011,55,HHS Region 10,Season onset,5
+2011,3,2010/2011,55,HHS Region 10,Season peak week,7
+2011,3,2010/2011,55,HHS Region 10,Season peak percentage,3.9
+2011,3,2010/2011,55,HHS Region 10,1 wk ahead,2.1
+2011,3,2010/2011,55,HHS Region 10,2 wk ahead,2.6
+2011,3,2010/2011,55,HHS Region 10,3 wk ahead,2.5
+2011,3,2010/2011,55,HHS Region 10,4 wk ahead,3.9
+2011,4,2010/2011,56,US National,Season onset,51
+2011,4,2010/2011,56,US National,Season peak week,5
+2011,4,2010/2011,56,US National,Season peak week,7
+2011,4,2010/2011,56,US National,Season peak percentage,4.6
+2011,4,2010/2011,56,US National,1 wk ahead,4.6
+2011,4,2010/2011,56,US National,2 wk ahead,4.5
+2011,4,2010/2011,56,US National,3 wk ahead,4.6
+2011,4,2010/2011,56,US National,4 wk ahead,4.1
+2011,4,2010/2011,56,HHS Region 1,Season onset,4
+2011,4,2010/2011,56,HHS Region 1,Season peak week,7
+2011,4,2010/2011,56,HHS Region 1,Season peak week,8
+2011,4,2010/2011,56,HHS Region 1,Season peak percentage,2.3
+2011,4,2010/2011,56,HHS Region 1,1 wk ahead,1.9
+2011,4,2010/2011,56,HHS Region 1,2 wk ahead,2
+2011,4,2010/2011,56,HHS Region 1,3 wk ahead,2.3
+2011,4,2010/2011,56,HHS Region 1,4 wk ahead,2.3
+2011,4,2010/2011,56,HHS Region 2,Season onset,49
+2011,4,2010/2011,56,HHS Region 2,Season peak week,52
+2011,4,2010/2011,56,HHS Region 2,Season peak percentage,4.5
+2011,4,2010/2011,56,HHS Region 2,1 wk ahead,4.1
+2011,4,2010/2011,56,HHS Region 2,2 wk ahead,4.1
+2011,4,2010/2011,56,HHS Region 2,3 wk ahead,4.3
+2011,4,2010/2011,56,HHS Region 2,4 wk ahead,4.3
+2011,4,2010/2011,56,HHS Region 3,Season onset,3
+2011,4,2010/2011,56,HHS Region 3,Season peak week,5
+2011,4,2010/2011,56,HHS Region 3,Season peak percentage,4.4
+2011,4,2010/2011,56,HHS Region 3,1 wk ahead,4.4
+2011,4,2010/2011,56,HHS Region 3,2 wk ahead,4.1
+2011,4,2010/2011,56,HHS Region 3,3 wk ahead,4
+2011,4,2010/2011,56,HHS Region 3,4 wk ahead,3.6
+2011,4,2010/2011,56,HHS Region 4,Season onset,50
+2011,4,2010/2011,56,HHS Region 4,Season peak week,5
+2011,4,2010/2011,56,HHS Region 4,Season peak percentage,5.5
+2011,4,2010/2011,56,HHS Region 4,1 wk ahead,5.5
+2011,4,2010/2011,56,HHS Region 4,2 wk ahead,5.2
+2011,4,2010/2011,56,HHS Region 4,3 wk ahead,4.8
+2011,4,2010/2011,56,HHS Region 4,4 wk ahead,3.9
+2011,4,2010/2011,56,HHS Region 5,Season onset,3
+2011,4,2010/2011,56,HHS Region 5,Season peak week,5
+2011,4,2010/2011,56,HHS Region 5,Season peak percentage,3.8
+2011,4,2010/2011,56,HHS Region 5,1 wk ahead,3.8
+2011,4,2010/2011,56,HHS Region 5,2 wk ahead,3.3
+2011,4,2010/2011,56,HHS Region 5,3 wk ahead,3.3
+2011,4,2010/2011,56,HHS Region 5,4 wk ahead,3.1
+2011,4,2010/2011,56,HHS Region 6,Season onset,3
+2011,4,2010/2011,56,HHS Region 6,Season peak week,7
+2011,4,2010/2011,56,HHS Region 6,Season peak percentage,7.9
+2011,4,2010/2011,56,HHS Region 6,1 wk ahead,7.6
+2011,4,2010/2011,56,HHS Region 6,2 wk ahead,7.8
+2011,4,2010/2011,56,HHS Region 6,3 wk ahead,7.9
+2011,4,2010/2011,56,HHS Region 6,4 wk ahead,6.3
+2011,4,2010/2011,56,HHS Region 7,Season onset,4
+2011,4,2010/2011,56,HHS Region 7,Season peak week,8
+2011,4,2010/2011,56,HHS Region 7,Season peak percentage,4.7
+2011,4,2010/2011,56,HHS Region 7,1 wk ahead,4.3
+2011,4,2010/2011,56,HHS Region 7,2 wk ahead,3.7
+2011,4,2010/2011,56,HHS Region 7,3 wk ahead,4.5
+2011,4,2010/2011,56,HHS Region 7,4 wk ahead,4.7
+2011,4,2010/2011,56,HHS Region 8,Season onset,5
+2011,4,2010/2011,56,HHS Region 8,Season peak week,7
+2011,4,2010/2011,56,HHS Region 8,Season peak percentage,2.7
+2011,4,2010/2011,56,HHS Region 8,1 wk ahead,2.2
+2011,4,2010/2011,56,HHS Region 8,2 wk ahead,2.5
+2011,4,2010/2011,56,HHS Region 8,3 wk ahead,2.7
+2011,4,2010/2011,56,HHS Region 8,4 wk ahead,2.5
+2011,4,2010/2011,56,HHS Region 9,Season onset,6
+2011,4,2010/2011,56,HHS Region 9,Season peak week,7
+2011,4,2010/2011,56,HHS Region 9,Season peak week,8
+2011,4,2010/2011,56,HHS Region 9,Season peak percentage,4.7
+2011,4,2010/2011,56,HHS Region 9,1 wk ahead,4
+2011,4,2010/2011,56,HHS Region 9,2 wk ahead,4.5
+2011,4,2010/2011,56,HHS Region 9,3 wk ahead,4.7
+2011,4,2010/2011,56,HHS Region 9,4 wk ahead,4.7
+2011,4,2010/2011,56,HHS Region 10,Season onset,5
+2011,4,2010/2011,56,HHS Region 10,Season peak week,7
+2011,4,2010/2011,56,HHS Region 10,Season peak percentage,3.9
+2011,4,2010/2011,56,HHS Region 10,1 wk ahead,2.6
+2011,4,2010/2011,56,HHS Region 10,2 wk ahead,2.5
+2011,4,2010/2011,56,HHS Region 10,3 wk ahead,3.9
+2011,4,2010/2011,56,HHS Region 10,4 wk ahead,3.5
+2011,5,2010/2011,57,US National,Season onset,51
+2011,5,2010/2011,57,US National,Season peak week,5
+2011,5,2010/2011,57,US National,Season peak week,7
+2011,5,2010/2011,57,US National,Season peak percentage,4.6
+2011,5,2010/2011,57,US National,1 wk ahead,4.5
+2011,5,2010/2011,57,US National,2 wk ahead,4.6
+2011,5,2010/2011,57,US National,3 wk ahead,4.1
+2011,5,2010/2011,57,US National,4 wk ahead,3.4
+2011,5,2010/2011,57,HHS Region 1,Season onset,4
+2011,5,2010/2011,57,HHS Region 1,Season peak week,7
+2011,5,2010/2011,57,HHS Region 1,Season peak week,8
+2011,5,2010/2011,57,HHS Region 1,Season peak percentage,2.3
+2011,5,2010/2011,57,HHS Region 1,1 wk ahead,2
+2011,5,2010/2011,57,HHS Region 1,2 wk ahead,2.3
+2011,5,2010/2011,57,HHS Region 1,3 wk ahead,2.3
+2011,5,2010/2011,57,HHS Region 1,4 wk ahead,1.8
+2011,5,2010/2011,57,HHS Region 2,Season onset,49
+2011,5,2010/2011,57,HHS Region 2,Season peak week,52
+2011,5,2010/2011,57,HHS Region 2,Season peak percentage,4.5
+2011,5,2010/2011,57,HHS Region 2,1 wk ahead,4.1
+2011,5,2010/2011,57,HHS Region 2,2 wk ahead,4.3
+2011,5,2010/2011,57,HHS Region 2,3 wk ahead,4.3
+2011,5,2010/2011,57,HHS Region 2,4 wk ahead,3.4
+2011,5,2010/2011,57,HHS Region 3,Season onset,3
+2011,5,2010/2011,57,HHS Region 3,Season peak week,5
+2011,5,2010/2011,57,HHS Region 3,Season peak percentage,4.4
+2011,5,2010/2011,57,HHS Region 3,1 wk ahead,4.1
+2011,5,2010/2011,57,HHS Region 3,2 wk ahead,4
+2011,5,2010/2011,57,HHS Region 3,3 wk ahead,3.6
+2011,5,2010/2011,57,HHS Region 3,4 wk ahead,3
+2011,5,2010/2011,57,HHS Region 4,Season onset,50
+2011,5,2010/2011,57,HHS Region 4,Season peak week,5
+2011,5,2010/2011,57,HHS Region 4,Season peak percentage,5.5
+2011,5,2010/2011,57,HHS Region 4,1 wk ahead,5.2
+2011,5,2010/2011,57,HHS Region 4,2 wk ahead,4.8
+2011,5,2010/2011,57,HHS Region 4,3 wk ahead,3.9
+2011,5,2010/2011,57,HHS Region 4,4 wk ahead,2.8
+2011,5,2010/2011,57,HHS Region 5,Season onset,3
+2011,5,2010/2011,57,HHS Region 5,Season peak week,5
+2011,5,2010/2011,57,HHS Region 5,Season peak percentage,3.8
+2011,5,2010/2011,57,HHS Region 5,1 wk ahead,3.3
+2011,5,2010/2011,57,HHS Region 5,2 wk ahead,3.3
+2011,5,2010/2011,57,HHS Region 5,3 wk ahead,3.1
+2011,5,2010/2011,57,HHS Region 5,4 wk ahead,2.9
+2011,5,2010/2011,57,HHS Region 6,Season onset,3
+2011,5,2010/2011,57,HHS Region 6,Season peak week,7
+2011,5,2010/2011,57,HHS Region 6,Season peak percentage,7.9
+2011,5,2010/2011,57,HHS Region 6,1 wk ahead,7.8
+2011,5,2010/2011,57,HHS Region 6,2 wk ahead,7.9
+2011,5,2010/2011,57,HHS Region 6,3 wk ahead,6.3
+2011,5,2010/2011,57,HHS Region 6,4 wk ahead,4.7
+2011,5,2010/2011,57,HHS Region 7,Season onset,4
+2011,5,2010/2011,57,HHS Region 7,Season peak week,8
+2011,5,2010/2011,57,HHS Region 7,Season peak percentage,4.7
+2011,5,2010/2011,57,HHS Region 7,1 wk ahead,3.7
+2011,5,2010/2011,57,HHS Region 7,2 wk ahead,4.5
+2011,5,2010/2011,57,HHS Region 7,3 wk ahead,4.7
+2011,5,2010/2011,57,HHS Region 7,4 wk ahead,3.7
+2011,5,2010/2011,57,HHS Region 8,Season onset,5
+2011,5,2010/2011,57,HHS Region 8,Season peak week,7
+2011,5,2010/2011,57,HHS Region 8,Season peak percentage,2.7
+2011,5,2010/2011,57,HHS Region 8,1 wk ahead,2.5
+2011,5,2010/2011,57,HHS Region 8,2 wk ahead,2.7
+2011,5,2010/2011,57,HHS Region 8,3 wk ahead,2.5
+2011,5,2010/2011,57,HHS Region 8,4 wk ahead,2.2
+2011,5,2010/2011,57,HHS Region 9,Season onset,6
+2011,5,2010/2011,57,HHS Region 9,Season peak week,7
+2011,5,2010/2011,57,HHS Region 9,Season peak week,8
+2011,5,2010/2011,57,HHS Region 9,Season peak percentage,4.7
+2011,5,2010/2011,57,HHS Region 9,1 wk ahead,4.5
+2011,5,2010/2011,57,HHS Region 9,2 wk ahead,4.7
+2011,5,2010/2011,57,HHS Region 9,3 wk ahead,4.7
+2011,5,2010/2011,57,HHS Region 9,4 wk ahead,4.5
+2011,5,2010/2011,57,HHS Region 10,Season onset,5
+2011,5,2010/2011,57,HHS Region 10,Season peak week,7
+2011,5,2010/2011,57,HHS Region 10,Season peak percentage,3.9
+2011,5,2010/2011,57,HHS Region 10,1 wk ahead,2.5
+2011,5,2010/2011,57,HHS Region 10,2 wk ahead,3.9
+2011,5,2010/2011,57,HHS Region 10,3 wk ahead,3.5
+2011,5,2010/2011,57,HHS Region 10,4 wk ahead,3.3
+2011,6,2010/2011,58,US National,Season onset,51
+2011,6,2010/2011,58,US National,Season peak week,5
+2011,6,2010/2011,58,US National,Season peak week,7
+2011,6,2010/2011,58,US National,Season peak percentage,4.6
+2011,6,2010/2011,58,US National,1 wk ahead,4.6
+2011,6,2010/2011,58,US National,2 wk ahead,4.1
+2011,6,2010/2011,58,US National,3 wk ahead,3.4
+2011,6,2010/2011,58,US National,4 wk ahead,3
+2011,6,2010/2011,58,HHS Region 1,Season onset,4
+2011,6,2010/2011,58,HHS Region 1,Season peak week,7
+2011,6,2010/2011,58,HHS Region 1,Season peak week,8
+2011,6,2010/2011,58,HHS Region 1,Season peak percentage,2.3
+2011,6,2010/2011,58,HHS Region 1,1 wk ahead,2.3
+2011,6,2010/2011,58,HHS Region 1,2 wk ahead,2.3
+2011,6,2010/2011,58,HHS Region 1,3 wk ahead,1.8
+2011,6,2010/2011,58,HHS Region 1,4 wk ahead,1.7
+2011,6,2010/2011,58,HHS Region 2,Season onset,49
+2011,6,2010/2011,58,HHS Region 2,Season peak week,52
+2011,6,2010/2011,58,HHS Region 2,Season peak percentage,4.5
+2011,6,2010/2011,58,HHS Region 2,1 wk ahead,4.3
+2011,6,2010/2011,58,HHS Region 2,2 wk ahead,4.3
+2011,6,2010/2011,58,HHS Region 2,3 wk ahead,3.4
+2011,6,2010/2011,58,HHS Region 2,4 wk ahead,3.2
+2011,6,2010/2011,58,HHS Region 3,Season onset,3
+2011,6,2010/2011,58,HHS Region 3,Season peak week,5
+2011,6,2010/2011,58,HHS Region 3,Season peak percentage,4.4
+2011,6,2010/2011,58,HHS Region 3,1 wk ahead,4
+2011,6,2010/2011,58,HHS Region 3,2 wk ahead,3.6
+2011,6,2010/2011,58,HHS Region 3,3 wk ahead,3
+2011,6,2010/2011,58,HHS Region 3,4 wk ahead,2.6
+2011,6,2010/2011,58,HHS Region 4,Season onset,50
+2011,6,2010/2011,58,HHS Region 4,Season peak week,5
+2011,6,2010/2011,58,HHS Region 4,Season peak percentage,5.5
+2011,6,2010/2011,58,HHS Region 4,1 wk ahead,4.8
+2011,6,2010/2011,58,HHS Region 4,2 wk ahead,3.9
+2011,6,2010/2011,58,HHS Region 4,3 wk ahead,2.8
+2011,6,2010/2011,58,HHS Region 4,4 wk ahead,2.5
+2011,6,2010/2011,58,HHS Region 5,Season onset,3
+2011,6,2010/2011,58,HHS Region 5,Season peak week,5
+2011,6,2010/2011,58,HHS Region 5,Season peak percentage,3.8
+2011,6,2010/2011,58,HHS Region 5,1 wk ahead,3.3
+2011,6,2010/2011,58,HHS Region 5,2 wk ahead,3.1
+2011,6,2010/2011,58,HHS Region 5,3 wk ahead,2.9
+2011,6,2010/2011,58,HHS Region 5,4 wk ahead,2.5
+2011,6,2010/2011,58,HHS Region 6,Season onset,3
+2011,6,2010/2011,58,HHS Region 6,Season peak week,7
+2011,6,2010/2011,58,HHS Region 6,Season peak percentage,7.9
+2011,6,2010/2011,58,HHS Region 6,1 wk ahead,7.9
+2011,6,2010/2011,58,HHS Region 6,2 wk ahead,6.3
+2011,6,2010/2011,58,HHS Region 6,3 wk ahead,4.7
+2011,6,2010/2011,58,HHS Region 6,4 wk ahead,3.6
+2011,6,2010/2011,58,HHS Region 7,Season onset,4
+2011,6,2010/2011,58,HHS Region 7,Season peak week,8
+2011,6,2010/2011,58,HHS Region 7,Season peak percentage,4.7
+2011,6,2010/2011,58,HHS Region 7,1 wk ahead,4.5
+2011,6,2010/2011,58,HHS Region 7,2 wk ahead,4.7
+2011,6,2010/2011,58,HHS Region 7,3 wk ahead,3.7
+2011,6,2010/2011,58,HHS Region 7,4 wk ahead,3.5
+2011,6,2010/2011,58,HHS Region 8,Season onset,5
+2011,6,2010/2011,58,HHS Region 8,Season peak week,7
+2011,6,2010/2011,58,HHS Region 8,Season peak percentage,2.7
+2011,6,2010/2011,58,HHS Region 8,1 wk ahead,2.7
+2011,6,2010/2011,58,HHS Region 8,2 wk ahead,2.5
+2011,6,2010/2011,58,HHS Region 8,3 wk ahead,2.2
+2011,6,2010/2011,58,HHS Region 8,4 wk ahead,2.1
+2011,6,2010/2011,58,HHS Region 9,Season onset,6
+2011,6,2010/2011,58,HHS Region 9,Season peak week,7
+2011,6,2010/2011,58,HHS Region 9,Season peak week,8
+2011,6,2010/2011,58,HHS Region 9,Season peak percentage,4.7
+2011,6,2010/2011,58,HHS Region 9,1 wk ahead,4.7
+2011,6,2010/2011,58,HHS Region 9,2 wk ahead,4.7
+2011,6,2010/2011,58,HHS Region 9,3 wk ahead,4.5
+2011,6,2010/2011,58,HHS Region 9,4 wk ahead,4.2
+2011,6,2010/2011,58,HHS Region 10,Season onset,5
+2011,6,2010/2011,58,HHS Region 10,Season peak week,7
+2011,6,2010/2011,58,HHS Region 10,Season peak percentage,3.9
+2011,6,2010/2011,58,HHS Region 10,1 wk ahead,3.9
+2011,6,2010/2011,58,HHS Region 10,2 wk ahead,3.5
+2011,6,2010/2011,58,HHS Region 10,3 wk ahead,3.3
+2011,6,2010/2011,58,HHS Region 10,4 wk ahead,3.2
+2011,7,2010/2011,59,US National,Season onset,51
+2011,7,2010/2011,59,US National,Season peak week,5
+2011,7,2010/2011,59,US National,Season peak week,7
+2011,7,2010/2011,59,US National,Season peak percentage,4.6
+2011,7,2010/2011,59,US National,1 wk ahead,4.1
+2011,7,2010/2011,59,US National,2 wk ahead,3.4
+2011,7,2010/2011,59,US National,3 wk ahead,3
+2011,7,2010/2011,59,US National,4 wk ahead,2.6
+2011,7,2010/2011,59,HHS Region 1,Season onset,4
+2011,7,2010/2011,59,HHS Region 1,Season peak week,7
+2011,7,2010/2011,59,HHS Region 1,Season peak week,8
+2011,7,2010/2011,59,HHS Region 1,Season peak percentage,2.3
+2011,7,2010/2011,59,HHS Region 1,1 wk ahead,2.3
+2011,7,2010/2011,59,HHS Region 1,2 wk ahead,1.8
+2011,7,2010/2011,59,HHS Region 1,3 wk ahead,1.7
+2011,7,2010/2011,59,HHS Region 1,4 wk ahead,1.4
+2011,7,2010/2011,59,HHS Region 2,Season onset,49
+2011,7,2010/2011,59,HHS Region 2,Season peak week,52
+2011,7,2010/2011,59,HHS Region 2,Season peak percentage,4.5
+2011,7,2010/2011,59,HHS Region 2,1 wk ahead,4.3
+2011,7,2010/2011,59,HHS Region 2,2 wk ahead,3.4
+2011,7,2010/2011,59,HHS Region 2,3 wk ahead,3.2
+2011,7,2010/2011,59,HHS Region 2,4 wk ahead,3.2
+2011,7,2010/2011,59,HHS Region 3,Season onset,3
+2011,7,2010/2011,59,HHS Region 3,Season peak week,5
+2011,7,2010/2011,59,HHS Region 3,Season peak percentage,4.4
+2011,7,2010/2011,59,HHS Region 3,1 wk ahead,3.6
+2011,7,2010/2011,59,HHS Region 3,2 wk ahead,3
+2011,7,2010/2011,59,HHS Region 3,3 wk ahead,2.6
+2011,7,2010/2011,59,HHS Region 3,4 wk ahead,2
+2011,7,2010/2011,59,HHS Region 4,Season onset,50
+2011,7,2010/2011,59,HHS Region 4,Season peak week,5
+2011,7,2010/2011,59,HHS Region 4,Season peak percentage,5.5
+2011,7,2010/2011,59,HHS Region 4,1 wk ahead,3.9
+2011,7,2010/2011,59,HHS Region 4,2 wk ahead,2.8
+2011,7,2010/2011,59,HHS Region 4,3 wk ahead,2.5
+2011,7,2010/2011,59,HHS Region 4,4 wk ahead,2
+2011,7,2010/2011,59,HHS Region 5,Season onset,3
+2011,7,2010/2011,59,HHS Region 5,Season peak week,5
+2011,7,2010/2011,59,HHS Region 5,Season peak percentage,3.8
+2011,7,2010/2011,59,HHS Region 5,1 wk ahead,3.1
+2011,7,2010/2011,59,HHS Region 5,2 wk ahead,2.9
+2011,7,2010/2011,59,HHS Region 5,3 wk ahead,2.5
+2011,7,2010/2011,59,HHS Region 5,4 wk ahead,2.4
+2011,7,2010/2011,59,HHS Region 6,Season onset,3
+2011,7,2010/2011,59,HHS Region 6,Season peak week,7
+2011,7,2010/2011,59,HHS Region 6,Season peak percentage,7.9
+2011,7,2010/2011,59,HHS Region 6,1 wk ahead,6.3
+2011,7,2010/2011,59,HHS Region 6,2 wk ahead,4.7
+2011,7,2010/2011,59,HHS Region 6,3 wk ahead,3.6
+2011,7,2010/2011,59,HHS Region 6,4 wk ahead,3
+2011,7,2010/2011,59,HHS Region 7,Season onset,4
+2011,7,2010/2011,59,HHS Region 7,Season peak week,8
+2011,7,2010/2011,59,HHS Region 7,Season peak percentage,4.7
+2011,7,2010/2011,59,HHS Region 7,1 wk ahead,4.7
+2011,7,2010/2011,59,HHS Region 7,2 wk ahead,3.7
+2011,7,2010/2011,59,HHS Region 7,3 wk ahead,3.5
+2011,7,2010/2011,59,HHS Region 7,4 wk ahead,2.3
+2011,7,2010/2011,59,HHS Region 8,Season onset,5
+2011,7,2010/2011,59,HHS Region 8,Season peak week,7
+2011,7,2010/2011,59,HHS Region 8,Season peak percentage,2.7
+2011,7,2010/2011,59,HHS Region 8,1 wk ahead,2.5
+2011,7,2010/2011,59,HHS Region 8,2 wk ahead,2.2
+2011,7,2010/2011,59,HHS Region 8,3 wk ahead,2.1
+2011,7,2010/2011,59,HHS Region 8,4 wk ahead,1.7
+2011,7,2010/2011,59,HHS Region 9,Season onset,6
+2011,7,2010/2011,59,HHS Region 9,Season peak week,7
+2011,7,2010/2011,59,HHS Region 9,Season peak week,8
+2011,7,2010/2011,59,HHS Region 9,Season peak percentage,4.7
+2011,7,2010/2011,59,HHS Region 9,1 wk ahead,4.7
+2011,7,2010/2011,59,HHS Region 9,2 wk ahead,4.5
+2011,7,2010/2011,59,HHS Region 9,3 wk ahead,4.2
+2011,7,2010/2011,59,HHS Region 9,4 wk ahead,3.9
+2011,7,2010/2011,59,HHS Region 10,Season onset,5
+2011,7,2010/2011,59,HHS Region 10,Season peak week,7
+2011,7,2010/2011,59,HHS Region 10,Season peak percentage,3.9
+2011,7,2010/2011,59,HHS Region 10,1 wk ahead,3.5
+2011,7,2010/2011,59,HHS Region 10,2 wk ahead,3.3
+2011,7,2010/2011,59,HHS Region 10,3 wk ahead,3.2
+2011,7,2010/2011,59,HHS Region 10,4 wk ahead,3.1
+2011,8,2010/2011,60,US National,Season onset,51
+2011,8,2010/2011,60,US National,Season peak week,5
+2011,8,2010/2011,60,US National,Season peak week,7
+2011,8,2010/2011,60,US National,Season peak percentage,4.6
+2011,8,2010/2011,60,US National,1 wk ahead,3.4
+2011,8,2010/2011,60,US National,2 wk ahead,3
+2011,8,2010/2011,60,US National,3 wk ahead,2.6
+2011,8,2010/2011,60,US National,4 wk ahead,2.1
+2011,8,2010/2011,60,HHS Region 1,Season onset,4
+2011,8,2010/2011,60,HHS Region 1,Season peak week,7
+2011,8,2010/2011,60,HHS Region 1,Season peak week,8
+2011,8,2010/2011,60,HHS Region 1,Season peak percentage,2.3
+2011,8,2010/2011,60,HHS Region 1,1 wk ahead,1.8
+2011,8,2010/2011,60,HHS Region 1,2 wk ahead,1.7
+2011,8,2010/2011,60,HHS Region 1,3 wk ahead,1.4
+2011,8,2010/2011,60,HHS Region 1,4 wk ahead,1
+2011,8,2010/2011,60,HHS Region 2,Season onset,49
+2011,8,2010/2011,60,HHS Region 2,Season peak week,52
+2011,8,2010/2011,60,HHS Region 2,Season peak percentage,4.5
+2011,8,2010/2011,60,HHS Region 2,1 wk ahead,3.4
+2011,8,2010/2011,60,HHS Region 2,2 wk ahead,3.2
+2011,8,2010/2011,60,HHS Region 2,3 wk ahead,3.2
+2011,8,2010/2011,60,HHS Region 2,4 wk ahead,2.5
+2011,8,2010/2011,60,HHS Region 3,Season onset,3
+2011,8,2010/2011,60,HHS Region 3,Season peak week,5
+2011,8,2010/2011,60,HHS Region 3,Season peak percentage,4.4
+2011,8,2010/2011,60,HHS Region 3,1 wk ahead,3
+2011,8,2010/2011,60,HHS Region 3,2 wk ahead,2.6
+2011,8,2010/2011,60,HHS Region 3,3 wk ahead,2
+2011,8,2010/2011,60,HHS Region 3,4 wk ahead,1.7
+2011,8,2010/2011,60,HHS Region 4,Season onset,50
+2011,8,2010/2011,60,HHS Region 4,Season peak week,5
+2011,8,2010/2011,60,HHS Region 4,Season peak percentage,5.5
+2011,8,2010/2011,60,HHS Region 4,1 wk ahead,2.8
+2011,8,2010/2011,60,HHS Region 4,2 wk ahead,2.5
+2011,8,2010/2011,60,HHS Region 4,3 wk ahead,2
+2011,8,2010/2011,60,HHS Region 4,4 wk ahead,1.6
+2011,8,2010/2011,60,HHS Region 5,Season onset,3
+2011,8,2010/2011,60,HHS Region 5,Season peak week,5
+2011,8,2010/2011,60,HHS Region 5,Season peak percentage,3.8
+2011,8,2010/2011,60,HHS Region 5,1 wk ahead,2.9
+2011,8,2010/2011,60,HHS Region 5,2 wk ahead,2.5
+2011,8,2010/2011,60,HHS Region 5,3 wk ahead,2.4
+2011,8,2010/2011,60,HHS Region 5,4 wk ahead,1.6
+2011,8,2010/2011,60,HHS Region 6,Season onset,3
+2011,8,2010/2011,60,HHS Region 6,Season peak week,7
+2011,8,2010/2011,60,HHS Region 6,Season peak percentage,7.9
+2011,8,2010/2011,60,HHS Region 6,1 wk ahead,4.7
+2011,8,2010/2011,60,HHS Region 6,2 wk ahead,3.6
+2011,8,2010/2011,60,HHS Region 6,3 wk ahead,3
+2011,8,2010/2011,60,HHS Region 6,4 wk ahead,2.9
+2011,8,2010/2011,60,HHS Region 7,Season onset,4
+2011,8,2010/2011,60,HHS Region 7,Season peak week,8
+2011,8,2010/2011,60,HHS Region 7,Season peak percentage,4.7
+2011,8,2010/2011,60,HHS Region 7,1 wk ahead,3.7
+2011,8,2010/2011,60,HHS Region 7,2 wk ahead,3.5
+2011,8,2010/2011,60,HHS Region 7,3 wk ahead,2.3
+2011,8,2010/2011,60,HHS Region 7,4 wk ahead,1.7
+2011,8,2010/2011,60,HHS Region 8,Season onset,5
+2011,8,2010/2011,60,HHS Region 8,Season peak week,7
+2011,8,2010/2011,60,HHS Region 8,Season peak percentage,2.7
+2011,8,2010/2011,60,HHS Region 8,1 wk ahead,2.2
+2011,8,2010/2011,60,HHS Region 8,2 wk ahead,2.1
+2011,8,2010/2011,60,HHS Region 8,3 wk ahead,1.7
+2011,8,2010/2011,60,HHS Region 8,4 wk ahead,1.4
+2011,8,2010/2011,60,HHS Region 9,Season onset,6
+2011,8,2010/2011,60,HHS Region 9,Season peak week,7
+2011,8,2010/2011,60,HHS Region 9,Season peak week,8
+2011,8,2010/2011,60,HHS Region 9,Season peak percentage,4.7
+2011,8,2010/2011,60,HHS Region 9,1 wk ahead,4.5
+2011,8,2010/2011,60,HHS Region 9,2 wk ahead,4.2
+2011,8,2010/2011,60,HHS Region 9,3 wk ahead,3.9
+2011,8,2010/2011,60,HHS Region 9,4 wk ahead,3
+2011,8,2010/2011,60,HHS Region 10,Season onset,5
+2011,8,2010/2011,60,HHS Region 10,Season peak week,7
+2011,8,2010/2011,60,HHS Region 10,Season peak percentage,3.9
+2011,8,2010/2011,60,HHS Region 10,1 wk ahead,3.3
+2011,8,2010/2011,60,HHS Region 10,2 wk ahead,3.2
+2011,8,2010/2011,60,HHS Region 10,3 wk ahead,3.1
+2011,8,2010/2011,60,HHS Region 10,4 wk ahead,2.8
+2011,9,2010/2011,61,US National,Season onset,51
+2011,9,2010/2011,61,US National,Season peak week,5
+2011,9,2010/2011,61,US National,Season peak week,7
+2011,9,2010/2011,61,US National,Season peak percentage,4.6
+2011,9,2010/2011,61,US National,1 wk ahead,3
+2011,9,2010/2011,61,US National,2 wk ahead,2.6
+2011,9,2010/2011,61,US National,3 wk ahead,2.1
+2011,9,2010/2011,61,US National,4 wk ahead,1.9
+2011,9,2010/2011,61,HHS Region 1,Season onset,4
+2011,9,2010/2011,61,HHS Region 1,Season peak week,7
+2011,9,2010/2011,61,HHS Region 1,Season peak week,8
+2011,9,2010/2011,61,HHS Region 1,Season peak percentage,2.3
+2011,9,2010/2011,61,HHS Region 1,1 wk ahead,1.7
+2011,9,2010/2011,61,HHS Region 1,2 wk ahead,1.4
+2011,9,2010/2011,61,HHS Region 1,3 wk ahead,1
+2011,9,2010/2011,61,HHS Region 1,4 wk ahead,1.1
+2011,9,2010/2011,61,HHS Region 2,Season onset,49
+2011,9,2010/2011,61,HHS Region 2,Season peak week,52
+2011,9,2010/2011,61,HHS Region 2,Season peak percentage,4.5
+2011,9,2010/2011,61,HHS Region 2,1 wk ahead,3.2
+2011,9,2010/2011,61,HHS Region 2,2 wk ahead,3.2
+2011,9,2010/2011,61,HHS Region 2,3 wk ahead,2.5
+2011,9,2010/2011,61,HHS Region 2,4 wk ahead,2.7
+2011,9,2010/2011,61,HHS Region 3,Season onset,3
+2011,9,2010/2011,61,HHS Region 3,Season peak week,5
+2011,9,2010/2011,61,HHS Region 3,Season peak percentage,4.4
+2011,9,2010/2011,61,HHS Region 3,1 wk ahead,2.6
+2011,9,2010/2011,61,HHS Region 3,2 wk ahead,2
+2011,9,2010/2011,61,HHS Region 3,3 wk ahead,1.7
+2011,9,2010/2011,61,HHS Region 3,4 wk ahead,1.5
+2011,9,2010/2011,61,HHS Region 4,Season onset,50
+2011,9,2010/2011,61,HHS Region 4,Season peak week,5
+2011,9,2010/2011,61,HHS Region 4,Season peak percentage,5.5
+2011,9,2010/2011,61,HHS Region 4,1 wk ahead,2.5
+2011,9,2010/2011,61,HHS Region 4,2 wk ahead,2
+2011,9,2010/2011,61,HHS Region 4,3 wk ahead,1.6
+2011,9,2010/2011,61,HHS Region 4,4 wk ahead,1.5
+2011,9,2010/2011,61,HHS Region 5,Season onset,3
+2011,9,2010/2011,61,HHS Region 5,Season peak week,5
+2011,9,2010/2011,61,HHS Region 5,Season peak percentage,3.8
+2011,9,2010/2011,61,HHS Region 5,1 wk ahead,2.5
+2011,9,2010/2011,61,HHS Region 5,2 wk ahead,2.4
+2011,9,2010/2011,61,HHS Region 5,3 wk ahead,1.6
+2011,9,2010/2011,61,HHS Region 5,4 wk ahead,1.5
+2011,9,2010/2011,61,HHS Region 6,Season onset,3
+2011,9,2010/2011,61,HHS Region 6,Season peak week,7
+2011,9,2010/2011,61,HHS Region 6,Season peak percentage,7.9
+2011,9,2010/2011,61,HHS Region 6,1 wk ahead,3.6
+2011,9,2010/2011,61,HHS Region 6,2 wk ahead,3
+2011,9,2010/2011,61,HHS Region 6,3 wk ahead,2.9
+2011,9,2010/2011,61,HHS Region 6,4 wk ahead,2
+2011,9,2010/2011,61,HHS Region 7,Season onset,4
+2011,9,2010/2011,61,HHS Region 7,Season peak week,8
+2011,9,2010/2011,61,HHS Region 7,Season peak percentage,4.7
+2011,9,2010/2011,61,HHS Region 7,1 wk ahead,3.5
+2011,9,2010/2011,61,HHS Region 7,2 wk ahead,2.3
+2011,9,2010/2011,61,HHS Region 7,3 wk ahead,1.7
+2011,9,2010/2011,61,HHS Region 7,4 wk ahead,1.4
+2011,9,2010/2011,61,HHS Region 8,Season onset,5
+2011,9,2010/2011,61,HHS Region 8,Season peak week,7
+2011,9,2010/2011,61,HHS Region 8,Season peak percentage,2.7
+2011,9,2010/2011,61,HHS Region 8,1 wk ahead,2.1
+2011,9,2010/2011,61,HHS Region 8,2 wk ahead,1.7
+2011,9,2010/2011,61,HHS Region 8,3 wk ahead,1.4
+2011,9,2010/2011,61,HHS Region 8,4 wk ahead,1.1
+2011,9,2010/2011,61,HHS Region 9,Season onset,6
+2011,9,2010/2011,61,HHS Region 9,Season peak week,7
+2011,9,2010/2011,61,HHS Region 9,Season peak week,8
+2011,9,2010/2011,61,HHS Region 9,Season peak percentage,4.7
+2011,9,2010/2011,61,HHS Region 9,1 wk ahead,4.2
+2011,9,2010/2011,61,HHS Region 9,2 wk ahead,3.9
+2011,9,2010/2011,61,HHS Region 9,3 wk ahead,3
+2011,9,2010/2011,61,HHS Region 9,4 wk ahead,2.8
+2011,9,2010/2011,61,HHS Region 10,Season onset,5
+2011,9,2010/2011,61,HHS Region 10,Season peak week,7
+2011,9,2010/2011,61,HHS Region 10,Season peak percentage,3.9
+2011,9,2010/2011,61,HHS Region 10,1 wk ahead,3.2
+2011,9,2010/2011,61,HHS Region 10,2 wk ahead,3.1
+2011,9,2010/2011,61,HHS Region 10,3 wk ahead,2.8
+2011,9,2010/2011,61,HHS Region 10,4 wk ahead,1.7
+2011,10,2010/2011,62,US National,Season onset,51
+2011,10,2010/2011,62,US National,Season peak week,5
+2011,10,2010/2011,62,US National,Season peak week,7
+2011,10,2010/2011,62,US National,Season peak percentage,4.6
+2011,10,2010/2011,62,US National,1 wk ahead,2.6
+2011,10,2010/2011,62,US National,2 wk ahead,2.1
+2011,10,2010/2011,62,US National,3 wk ahead,1.9
+2011,10,2010/2011,62,US National,4 wk ahead,1.6
+2011,10,2010/2011,62,HHS Region 1,Season onset,4
+2011,10,2010/2011,62,HHS Region 1,Season peak week,7
+2011,10,2010/2011,62,HHS Region 1,Season peak week,8
+2011,10,2010/2011,62,HHS Region 1,Season peak percentage,2.3
+2011,10,2010/2011,62,HHS Region 1,1 wk ahead,1.4
+2011,10,2010/2011,62,HHS Region 1,2 wk ahead,1
+2011,10,2010/2011,62,HHS Region 1,3 wk ahead,1.1
+2011,10,2010/2011,62,HHS Region 1,4 wk ahead,0.9
+2011,10,2010/2011,62,HHS Region 2,Season onset,49
+2011,10,2010/2011,62,HHS Region 2,Season peak week,52
+2011,10,2010/2011,62,HHS Region 2,Season peak percentage,4.5
+2011,10,2010/2011,62,HHS Region 2,1 wk ahead,3.2
+2011,10,2010/2011,62,HHS Region 2,2 wk ahead,2.5
+2011,10,2010/2011,62,HHS Region 2,3 wk ahead,2.7
+2011,10,2010/2011,62,HHS Region 2,4 wk ahead,2.5
+2011,10,2010/2011,62,HHS Region 3,Season onset,3
+2011,10,2010/2011,62,HHS Region 3,Season peak week,5
+2011,10,2010/2011,62,HHS Region 3,Season peak percentage,4.4
+2011,10,2010/2011,62,HHS Region 3,1 wk ahead,2
+2011,10,2010/2011,62,HHS Region 3,2 wk ahead,1.7
+2011,10,2010/2011,62,HHS Region 3,3 wk ahead,1.5
+2011,10,2010/2011,62,HHS Region 3,4 wk ahead,1.5
+2011,10,2010/2011,62,HHS Region 4,Season onset,50
+2011,10,2010/2011,62,HHS Region 4,Season peak week,5
+2011,10,2010/2011,62,HHS Region 4,Season peak percentage,5.5
+2011,10,2010/2011,62,HHS Region 4,1 wk ahead,2
+2011,10,2010/2011,62,HHS Region 4,2 wk ahead,1.6
+2011,10,2010/2011,62,HHS Region 4,3 wk ahead,1.5
+2011,10,2010/2011,62,HHS Region 4,4 wk ahead,1.3
+2011,10,2010/2011,62,HHS Region 5,Season onset,3
+2011,10,2010/2011,62,HHS Region 5,Season peak week,5
+2011,10,2010/2011,62,HHS Region 5,Season peak percentage,3.8
+2011,10,2010/2011,62,HHS Region 5,1 wk ahead,2.4
+2011,10,2010/2011,62,HHS Region 5,2 wk ahead,1.6
+2011,10,2010/2011,62,HHS Region 5,3 wk ahead,1.5
+2011,10,2010/2011,62,HHS Region 5,4 wk ahead,1.3
+2011,10,2010/2011,62,HHS Region 6,Season onset,3
+2011,10,2010/2011,62,HHS Region 6,Season peak week,7
+2011,10,2010/2011,62,HHS Region 6,Season peak percentage,7.9
+2011,10,2010/2011,62,HHS Region 6,1 wk ahead,3
+2011,10,2010/2011,62,HHS Region 6,2 wk ahead,2.9
+2011,10,2010/2011,62,HHS Region 6,3 wk ahead,2
+2011,10,2010/2011,62,HHS Region 6,4 wk ahead,1.8
+2011,10,2010/2011,62,HHS Region 7,Season onset,4
+2011,10,2010/2011,62,HHS Region 7,Season peak week,8
+2011,10,2010/2011,62,HHS Region 7,Season peak percentage,4.7
+2011,10,2010/2011,62,HHS Region 7,1 wk ahead,2.3
+2011,10,2010/2011,62,HHS Region 7,2 wk ahead,1.7
+2011,10,2010/2011,62,HHS Region 7,3 wk ahead,1.4
+2011,10,2010/2011,62,HHS Region 7,4 wk ahead,1.2
+2011,10,2010/2011,62,HHS Region 8,Season onset,5
+2011,10,2010/2011,62,HHS Region 8,Season peak week,7
+2011,10,2010/2011,62,HHS Region 8,Season peak percentage,2.7
+2011,10,2010/2011,62,HHS Region 8,1 wk ahead,1.7
+2011,10,2010/2011,62,HHS Region 8,2 wk ahead,1.4
+2011,10,2010/2011,62,HHS Region 8,3 wk ahead,1.1
+2011,10,2010/2011,62,HHS Region 8,4 wk ahead,0.8
+2011,10,2010/2011,62,HHS Region 9,Season onset,6
+2011,10,2010/2011,62,HHS Region 9,Season peak week,7
+2011,10,2010/2011,62,HHS Region 9,Season peak week,8
+2011,10,2010/2011,62,HHS Region 9,Season peak percentage,4.7
+2011,10,2010/2011,62,HHS Region 9,1 wk ahead,3.9
+2011,10,2010/2011,62,HHS Region 9,2 wk ahead,3
+2011,10,2010/2011,62,HHS Region 9,3 wk ahead,2.8
+2011,10,2010/2011,62,HHS Region 9,4 wk ahead,2.4
+2011,10,2010/2011,62,HHS Region 10,Season onset,5
+2011,10,2010/2011,62,HHS Region 10,Season peak week,7
+2011,10,2010/2011,62,HHS Region 10,Season peak percentage,3.9
+2011,10,2010/2011,62,HHS Region 10,1 wk ahead,3.1
+2011,10,2010/2011,62,HHS Region 10,2 wk ahead,2.8
+2011,10,2010/2011,62,HHS Region 10,3 wk ahead,1.7
+2011,10,2010/2011,62,HHS Region 10,4 wk ahead,1.2
+2011,11,2010/2011,63,US National,Season onset,51
+2011,11,2010/2011,63,US National,Season peak week,5
+2011,11,2010/2011,63,US National,Season peak week,7
+2011,11,2010/2011,63,US National,Season peak percentage,4.6
+2011,11,2010/2011,63,US National,1 wk ahead,2.1
+2011,11,2010/2011,63,US National,2 wk ahead,1.9
+2011,11,2010/2011,63,US National,3 wk ahead,1.6
+2011,11,2010/2011,63,US National,4 wk ahead,1.4
+2011,11,2010/2011,63,HHS Region 1,Season onset,4
+2011,11,2010/2011,63,HHS Region 1,Season peak week,7
+2011,11,2010/2011,63,HHS Region 1,Season peak week,8
+2011,11,2010/2011,63,HHS Region 1,Season peak percentage,2.3
+2011,11,2010/2011,63,HHS Region 1,1 wk ahead,1
+2011,11,2010/2011,63,HHS Region 1,2 wk ahead,1.1
+2011,11,2010/2011,63,HHS Region 1,3 wk ahead,0.9
+2011,11,2010/2011,63,HHS Region 1,4 wk ahead,0.8
+2011,11,2010/2011,63,HHS Region 2,Season onset,49
+2011,11,2010/2011,63,HHS Region 2,Season peak week,52
+2011,11,2010/2011,63,HHS Region 2,Season peak percentage,4.5
+2011,11,2010/2011,63,HHS Region 2,1 wk ahead,2.5
+2011,11,2010/2011,63,HHS Region 2,2 wk ahead,2.7
+2011,11,2010/2011,63,HHS Region 2,3 wk ahead,2.5
+2011,11,2010/2011,63,HHS Region 2,4 wk ahead,2.2
+2011,11,2010/2011,63,HHS Region 3,Season onset,3
+2011,11,2010/2011,63,HHS Region 3,Season peak week,5
+2011,11,2010/2011,63,HHS Region 3,Season peak percentage,4.4
+2011,11,2010/2011,63,HHS Region 3,1 wk ahead,1.7
+2011,11,2010/2011,63,HHS Region 3,2 wk ahead,1.5
+2011,11,2010/2011,63,HHS Region 3,3 wk ahead,1.5
+2011,11,2010/2011,63,HHS Region 3,4 wk ahead,1.4
+2011,11,2010/2011,63,HHS Region 4,Season onset,50
+2011,11,2010/2011,63,HHS Region 4,Season peak week,5
+2011,11,2010/2011,63,HHS Region 4,Season peak percentage,5.5
+2011,11,2010/2011,63,HHS Region 4,1 wk ahead,1.6
+2011,11,2010/2011,63,HHS Region 4,2 wk ahead,1.5
+2011,11,2010/2011,63,HHS Region 4,3 wk ahead,1.3
+2011,11,2010/2011,63,HHS Region 4,4 wk ahead,1.2
+2011,11,2010/2011,63,HHS Region 5,Season onset,3
+2011,11,2010/2011,63,HHS Region 5,Season peak week,5
+2011,11,2010/2011,63,HHS Region 5,Season peak percentage,3.8
+2011,11,2010/2011,63,HHS Region 5,1 wk ahead,1.6
+2011,11,2010/2011,63,HHS Region 5,2 wk ahead,1.5
+2011,11,2010/2011,63,HHS Region 5,3 wk ahead,1.3
+2011,11,2010/2011,63,HHS Region 5,4 wk ahead,0.9
+2011,11,2010/2011,63,HHS Region 6,Season onset,3
+2011,11,2010/2011,63,HHS Region 6,Season peak week,7
+2011,11,2010/2011,63,HHS Region 6,Season peak percentage,7.9
+2011,11,2010/2011,63,HHS Region 6,1 wk ahead,2.9
+2011,11,2010/2011,63,HHS Region 6,2 wk ahead,2
+2011,11,2010/2011,63,HHS Region 6,3 wk ahead,1.8
+2011,11,2010/2011,63,HHS Region 6,4 wk ahead,1.5
+2011,11,2010/2011,63,HHS Region 7,Season onset,4
+2011,11,2010/2011,63,HHS Region 7,Season peak week,8
+2011,11,2010/2011,63,HHS Region 7,Season peak percentage,4.7
+2011,11,2010/2011,63,HHS Region 7,1 wk ahead,1.7
+2011,11,2010/2011,63,HHS Region 7,2 wk ahead,1.4
+2011,11,2010/2011,63,HHS Region 7,3 wk ahead,1.2
+2011,11,2010/2011,63,HHS Region 7,4 wk ahead,1
+2011,11,2010/2011,63,HHS Region 8,Season onset,5
+2011,11,2010/2011,63,HHS Region 8,Season peak week,7
+2011,11,2010/2011,63,HHS Region 8,Season peak percentage,2.7
+2011,11,2010/2011,63,HHS Region 8,1 wk ahead,1.4
+2011,11,2010/2011,63,HHS Region 8,2 wk ahead,1.1
+2011,11,2010/2011,63,HHS Region 8,3 wk ahead,0.8
+2011,11,2010/2011,63,HHS Region 8,4 wk ahead,0.8
+2011,11,2010/2011,63,HHS Region 9,Season onset,6
+2011,11,2010/2011,63,HHS Region 9,Season peak week,7
+2011,11,2010/2011,63,HHS Region 9,Season peak week,8
+2011,11,2010/2011,63,HHS Region 9,Season peak percentage,4.7
+2011,11,2010/2011,63,HHS Region 9,1 wk ahead,3
+2011,11,2010/2011,63,HHS Region 9,2 wk ahead,2.8
+2011,11,2010/2011,63,HHS Region 9,3 wk ahead,2.4
+2011,11,2010/2011,63,HHS Region 9,4 wk ahead,2.3
+2011,11,2010/2011,63,HHS Region 10,Season onset,5
+2011,11,2010/2011,63,HHS Region 10,Season peak week,7
+2011,11,2010/2011,63,HHS Region 10,Season peak percentage,3.9
+2011,11,2010/2011,63,HHS Region 10,1 wk ahead,2.8
+2011,11,2010/2011,63,HHS Region 10,2 wk ahead,1.7
+2011,11,2010/2011,63,HHS Region 10,3 wk ahead,1.2
+2011,11,2010/2011,63,HHS Region 10,4 wk ahead,1.2
+2011,12,2010/2011,64,US National,Season onset,51
+2011,12,2010/2011,64,US National,Season peak week,5
+2011,12,2010/2011,64,US National,Season peak week,7
+2011,12,2010/2011,64,US National,Season peak percentage,4.6
+2011,12,2010/2011,64,US National,1 wk ahead,1.9
+2011,12,2010/2011,64,US National,2 wk ahead,1.6
+2011,12,2010/2011,64,US National,3 wk ahead,1.4
+2011,12,2010/2011,64,US National,4 wk ahead,1.3
+2011,12,2010/2011,64,HHS Region 1,Season onset,4
+2011,12,2010/2011,64,HHS Region 1,Season peak week,7
+2011,12,2010/2011,64,HHS Region 1,Season peak week,8
+2011,12,2010/2011,64,HHS Region 1,Season peak percentage,2.3
+2011,12,2010/2011,64,HHS Region 1,1 wk ahead,1.1
+2011,12,2010/2011,64,HHS Region 1,2 wk ahead,0.9
+2011,12,2010/2011,64,HHS Region 1,3 wk ahead,0.8
+2011,12,2010/2011,64,HHS Region 1,4 wk ahead,0.8
+2011,12,2010/2011,64,HHS Region 2,Season onset,49
+2011,12,2010/2011,64,HHS Region 2,Season peak week,52
+2011,12,2010/2011,64,HHS Region 2,Season peak percentage,4.5
+2011,12,2010/2011,64,HHS Region 2,1 wk ahead,2.7
+2011,12,2010/2011,64,HHS Region 2,2 wk ahead,2.5
+2011,12,2010/2011,64,HHS Region 2,3 wk ahead,2.2
+2011,12,2010/2011,64,HHS Region 2,4 wk ahead,2.2
+2011,12,2010/2011,64,HHS Region 3,Season onset,3
+2011,12,2010/2011,64,HHS Region 3,Season peak week,5
+2011,12,2010/2011,64,HHS Region 3,Season peak percentage,4.4
+2011,12,2010/2011,64,HHS Region 3,1 wk ahead,1.5
+2011,12,2010/2011,64,HHS Region 3,2 wk ahead,1.5
+2011,12,2010/2011,64,HHS Region 3,3 wk ahead,1.4
+2011,12,2010/2011,64,HHS Region 3,4 wk ahead,1.2
+2011,12,2010/2011,64,HHS Region 4,Season onset,50
+2011,12,2010/2011,64,HHS Region 4,Season peak week,5
+2011,12,2010/2011,64,HHS Region 4,Season peak percentage,5.5
+2011,12,2010/2011,64,HHS Region 4,1 wk ahead,1.5
+2011,12,2010/2011,64,HHS Region 4,2 wk ahead,1.3
+2011,12,2010/2011,64,HHS Region 4,3 wk ahead,1.2
+2011,12,2010/2011,64,HHS Region 4,4 wk ahead,1.1
+2011,12,2010/2011,64,HHS Region 5,Season onset,3
+2011,12,2010/2011,64,HHS Region 5,Season peak week,5
+2011,12,2010/2011,64,HHS Region 5,Season peak percentage,3.8
+2011,12,2010/2011,64,HHS Region 5,1 wk ahead,1.5
+2011,12,2010/2011,64,HHS Region 5,2 wk ahead,1.3
+2011,12,2010/2011,64,HHS Region 5,3 wk ahead,0.9
+2011,12,2010/2011,64,HHS Region 5,4 wk ahead,0.9
+2011,12,2010/2011,64,HHS Region 6,Season onset,3
+2011,12,2010/2011,64,HHS Region 6,Season peak week,7
+2011,12,2010/2011,64,HHS Region 6,Season peak percentage,7.9
+2011,12,2010/2011,64,HHS Region 6,1 wk ahead,2
+2011,12,2010/2011,64,HHS Region 6,2 wk ahead,1.8
+2011,12,2010/2011,64,HHS Region 6,3 wk ahead,1.5
+2011,12,2010/2011,64,HHS Region 6,4 wk ahead,1.5
+2011,12,2010/2011,64,HHS Region 7,Season onset,4
+2011,12,2010/2011,64,HHS Region 7,Season peak week,8
+2011,12,2010/2011,64,HHS Region 7,Season peak percentage,4.7
+2011,12,2010/2011,64,HHS Region 7,1 wk ahead,1.4
+2011,12,2010/2011,64,HHS Region 7,2 wk ahead,1.2
+2011,12,2010/2011,64,HHS Region 7,3 wk ahead,1
+2011,12,2010/2011,64,HHS Region 7,4 wk ahead,0.8
+2011,12,2010/2011,64,HHS Region 8,Season onset,5
+2011,12,2010/2011,64,HHS Region 8,Season peak week,7
+2011,12,2010/2011,64,HHS Region 8,Season peak percentage,2.7
+2011,12,2010/2011,64,HHS Region 8,1 wk ahead,1.1
+2011,12,2010/2011,64,HHS Region 8,2 wk ahead,0.8
+2011,12,2010/2011,64,HHS Region 8,3 wk ahead,0.8
+2011,12,2010/2011,64,HHS Region 8,4 wk ahead,0.6
+2011,12,2010/2011,64,HHS Region 9,Season onset,6
+2011,12,2010/2011,64,HHS Region 9,Season peak week,7
+2011,12,2010/2011,64,HHS Region 9,Season peak week,8
+2011,12,2010/2011,64,HHS Region 9,Season peak percentage,4.7
+2011,12,2010/2011,64,HHS Region 9,1 wk ahead,2.8
+2011,12,2010/2011,64,HHS Region 9,2 wk ahead,2.4
+2011,12,2010/2011,64,HHS Region 9,3 wk ahead,2.3
+2011,12,2010/2011,64,HHS Region 9,4 wk ahead,2.1
+2011,12,2010/2011,64,HHS Region 10,Season onset,5
+2011,12,2010/2011,64,HHS Region 10,Season peak week,7
+2011,12,2010/2011,64,HHS Region 10,Season peak percentage,3.9
+2011,12,2010/2011,64,HHS Region 10,1 wk ahead,1.7
+2011,12,2010/2011,64,HHS Region 10,2 wk ahead,1.2
+2011,12,2010/2011,64,HHS Region 10,3 wk ahead,1.2
+2011,12,2010/2011,64,HHS Region 10,4 wk ahead,1.3
+2011,13,2010/2011,65,US National,Season onset,51
+2011,13,2010/2011,65,US National,Season peak week,5
+2011,13,2010/2011,65,US National,Season peak week,7
+2011,13,2010/2011,65,US National,Season peak percentage,4.6
+2011,13,2010/2011,65,US National,1 wk ahead,1.6
+2011,13,2010/2011,65,US National,2 wk ahead,1.4
+2011,13,2010/2011,65,US National,3 wk ahead,1.3
+2011,13,2010/2011,65,US National,4 wk ahead,1.2
+2011,13,2010/2011,65,HHS Region 1,Season onset,4
+2011,13,2010/2011,65,HHS Region 1,Season peak week,7
+2011,13,2010/2011,65,HHS Region 1,Season peak week,8
+2011,13,2010/2011,65,HHS Region 1,Season peak percentage,2.3
+2011,13,2010/2011,65,HHS Region 1,1 wk ahead,0.9
+2011,13,2010/2011,65,HHS Region 1,2 wk ahead,0.8
+2011,13,2010/2011,65,HHS Region 1,3 wk ahead,0.8
+2011,13,2010/2011,65,HHS Region 1,4 wk ahead,0.7
+2011,13,2010/2011,65,HHS Region 2,Season onset,49
+2011,13,2010/2011,65,HHS Region 2,Season peak week,52
+2011,13,2010/2011,65,HHS Region 2,Season peak percentage,4.5
+2011,13,2010/2011,65,HHS Region 2,1 wk ahead,2.5
+2011,13,2010/2011,65,HHS Region 2,2 wk ahead,2.2
+2011,13,2010/2011,65,HHS Region 2,3 wk ahead,2.2
+2011,13,2010/2011,65,HHS Region 2,4 wk ahead,1.7
+2011,13,2010/2011,65,HHS Region 3,Season onset,3
+2011,13,2010/2011,65,HHS Region 3,Season peak week,5
+2011,13,2010/2011,65,HHS Region 3,Season peak percentage,4.4
+2011,13,2010/2011,65,HHS Region 3,1 wk ahead,1.5
+2011,13,2010/2011,65,HHS Region 3,2 wk ahead,1.4
+2011,13,2010/2011,65,HHS Region 3,3 wk ahead,1.2
+2011,13,2010/2011,65,HHS Region 3,4 wk ahead,0.9
+2011,13,2010/2011,65,HHS Region 4,Season onset,50
+2011,13,2010/2011,65,HHS Region 4,Season peak week,5
+2011,13,2010/2011,65,HHS Region 4,Season peak percentage,5.5
+2011,13,2010/2011,65,HHS Region 4,1 wk ahead,1.3
+2011,13,2010/2011,65,HHS Region 4,2 wk ahead,1.2
+2011,13,2010/2011,65,HHS Region 4,3 wk ahead,1.1
+2011,13,2010/2011,65,HHS Region 4,4 wk ahead,1.1
+2011,13,2010/2011,65,HHS Region 5,Season onset,3
+2011,13,2010/2011,65,HHS Region 5,Season peak week,5
+2011,13,2010/2011,65,HHS Region 5,Season peak percentage,3.8
+2011,13,2010/2011,65,HHS Region 5,1 wk ahead,1.3
+2011,13,2010/2011,65,HHS Region 5,2 wk ahead,0.9
+2011,13,2010/2011,65,HHS Region 5,3 wk ahead,0.9
+2011,13,2010/2011,65,HHS Region 5,4 wk ahead,0.8
+2011,13,2010/2011,65,HHS Region 6,Season onset,3
+2011,13,2010/2011,65,HHS Region 6,Season peak week,7
+2011,13,2010/2011,65,HHS Region 6,Season peak percentage,7.9
+2011,13,2010/2011,65,HHS Region 6,1 wk ahead,1.8
+2011,13,2010/2011,65,HHS Region 6,2 wk ahead,1.5
+2011,13,2010/2011,65,HHS Region 6,3 wk ahead,1.5
+2011,13,2010/2011,65,HHS Region 6,4 wk ahead,1.3
+2011,13,2010/2011,65,HHS Region 7,Season onset,4
+2011,13,2010/2011,65,HHS Region 7,Season peak week,8
+2011,13,2010/2011,65,HHS Region 7,Season peak percentage,4.7
+2011,13,2010/2011,65,HHS Region 7,1 wk ahead,1.2
+2011,13,2010/2011,65,HHS Region 7,2 wk ahead,1
+2011,13,2010/2011,65,HHS Region 7,3 wk ahead,0.8
+2011,13,2010/2011,65,HHS Region 7,4 wk ahead,0.6
+2011,13,2010/2011,65,HHS Region 8,Season onset,5
+2011,13,2010/2011,65,HHS Region 8,Season peak week,7
+2011,13,2010/2011,65,HHS Region 8,Season peak percentage,2.7
+2011,13,2010/2011,65,HHS Region 8,1 wk ahead,0.8
+2011,13,2010/2011,65,HHS Region 8,2 wk ahead,0.8
+2011,13,2010/2011,65,HHS Region 8,3 wk ahead,0.6
+2011,13,2010/2011,65,HHS Region 8,4 wk ahead,0.6
+2011,13,2010/2011,65,HHS Region 9,Season onset,6
+2011,13,2010/2011,65,HHS Region 9,Season peak week,7
+2011,13,2010/2011,65,HHS Region 9,Season peak week,8
+2011,13,2010/2011,65,HHS Region 9,Season peak percentage,4.7
+2011,13,2010/2011,65,HHS Region 9,1 wk ahead,2.4
+2011,13,2010/2011,65,HHS Region 9,2 wk ahead,2.3
+2011,13,2010/2011,65,HHS Region 9,3 wk ahead,2.1
+2011,13,2010/2011,65,HHS Region 9,4 wk ahead,2.1
+2011,13,2010/2011,65,HHS Region 10,Season onset,5
+2011,13,2010/2011,65,HHS Region 10,Season peak week,7
+2011,13,2010/2011,65,HHS Region 10,Season peak percentage,3.9
+2011,13,2010/2011,65,HHS Region 10,1 wk ahead,1.2
+2011,13,2010/2011,65,HHS Region 10,2 wk ahead,1.2
+2011,13,2010/2011,65,HHS Region 10,3 wk ahead,1.3
+2011,13,2010/2011,65,HHS Region 10,4 wk ahead,0.9
+2011,14,2010/2011,66,US National,Season onset,51
+2011,14,2010/2011,66,US National,Season peak week,5
+2011,14,2010/2011,66,US National,Season peak week,7
+2011,14,2010/2011,66,US National,Season peak percentage,4.6
+2011,14,2010/2011,66,US National,1 wk ahead,1.4
+2011,14,2010/2011,66,US National,2 wk ahead,1.3
+2011,14,2010/2011,66,US National,3 wk ahead,1.2
+2011,14,2010/2011,66,US National,4 wk ahead,1.1
+2011,14,2010/2011,66,HHS Region 1,Season onset,4
+2011,14,2010/2011,66,HHS Region 1,Season peak week,7
+2011,14,2010/2011,66,HHS Region 1,Season peak week,8
+2011,14,2010/2011,66,HHS Region 1,Season peak percentage,2.3
+2011,14,2010/2011,66,HHS Region 1,1 wk ahead,0.8
+2011,14,2010/2011,66,HHS Region 1,2 wk ahead,0.8
+2011,14,2010/2011,66,HHS Region 1,3 wk ahead,0.7
+2011,14,2010/2011,66,HHS Region 1,4 wk ahead,0.6
+2011,14,2010/2011,66,HHS Region 2,Season onset,49
+2011,14,2010/2011,66,HHS Region 2,Season peak week,52
+2011,14,2010/2011,66,HHS Region 2,Season peak percentage,4.5
+2011,14,2010/2011,66,HHS Region 2,1 wk ahead,2.2
+2011,14,2010/2011,66,HHS Region 2,2 wk ahead,2.2
+2011,14,2010/2011,66,HHS Region 2,3 wk ahead,1.7
+2011,14,2010/2011,66,HHS Region 2,4 wk ahead,1.6
+2011,14,2010/2011,66,HHS Region 3,Season onset,3
+2011,14,2010/2011,66,HHS Region 3,Season peak week,5
+2011,14,2010/2011,66,HHS Region 3,Season peak percentage,4.4
+2011,14,2010/2011,66,HHS Region 3,1 wk ahead,1.4
+2011,14,2010/2011,66,HHS Region 3,2 wk ahead,1.2
+2011,14,2010/2011,66,HHS Region 3,3 wk ahead,0.9
+2011,14,2010/2011,66,HHS Region 3,4 wk ahead,1
+2011,14,2010/2011,66,HHS Region 4,Season onset,50
+2011,14,2010/2011,66,HHS Region 4,Season peak week,5
+2011,14,2010/2011,66,HHS Region 4,Season peak percentage,5.5
+2011,14,2010/2011,66,HHS Region 4,1 wk ahead,1.2
+2011,14,2010/2011,66,HHS Region 4,2 wk ahead,1.1
+2011,14,2010/2011,66,HHS Region 4,3 wk ahead,1.1
+2011,14,2010/2011,66,HHS Region 4,4 wk ahead,1
+2011,14,2010/2011,66,HHS Region 5,Season onset,3
+2011,14,2010/2011,66,HHS Region 5,Season peak week,5
+2011,14,2010/2011,66,HHS Region 5,Season peak percentage,3.8
+2011,14,2010/2011,66,HHS Region 5,1 wk ahead,0.9
+2011,14,2010/2011,66,HHS Region 5,2 wk ahead,0.9
+2011,14,2010/2011,66,HHS Region 5,3 wk ahead,0.8
+2011,14,2010/2011,66,HHS Region 5,4 wk ahead,0.8
+2011,14,2010/2011,66,HHS Region 6,Season onset,3
+2011,14,2010/2011,66,HHS Region 6,Season peak week,7
+2011,14,2010/2011,66,HHS Region 6,Season peak percentage,7.9
+2011,14,2010/2011,66,HHS Region 6,1 wk ahead,1.5
+2011,14,2010/2011,66,HHS Region 6,2 wk ahead,1.5
+2011,14,2010/2011,66,HHS Region 6,3 wk ahead,1.3
+2011,14,2010/2011,66,HHS Region 6,4 wk ahead,1.4
+2011,14,2010/2011,66,HHS Region 7,Season onset,4
+2011,14,2010/2011,66,HHS Region 7,Season peak week,8
+2011,14,2010/2011,66,HHS Region 7,Season peak percentage,4.7
+2011,14,2010/2011,66,HHS Region 7,1 wk ahead,1
+2011,14,2010/2011,66,HHS Region 7,2 wk ahead,0.8
+2011,14,2010/2011,66,HHS Region 7,3 wk ahead,0.6
+2011,14,2010/2011,66,HHS Region 7,4 wk ahead,0.5
+2011,14,2010/2011,66,HHS Region 8,Season onset,5
+2011,14,2010/2011,66,HHS Region 8,Season peak week,7
+2011,14,2010/2011,66,HHS Region 8,Season peak percentage,2.7
+2011,14,2010/2011,66,HHS Region 8,1 wk ahead,0.8
+2011,14,2010/2011,66,HHS Region 8,2 wk ahead,0.6
+2011,14,2010/2011,66,HHS Region 8,3 wk ahead,0.6
+2011,14,2010/2011,66,HHS Region 8,4 wk ahead,0.5
+2011,14,2010/2011,66,HHS Region 9,Season onset,6
+2011,14,2010/2011,66,HHS Region 9,Season peak week,7
+2011,14,2010/2011,66,HHS Region 9,Season peak week,8
+2011,14,2010/2011,66,HHS Region 9,Season peak percentage,4.7
+2011,14,2010/2011,66,HHS Region 9,1 wk ahead,2.3
+2011,14,2010/2011,66,HHS Region 9,2 wk ahead,2.1
+2011,14,2010/2011,66,HHS Region 9,3 wk ahead,2.1
+2011,14,2010/2011,66,HHS Region 9,4 wk ahead,1.9
+2011,14,2010/2011,66,HHS Region 10,Season onset,5
+2011,14,2010/2011,66,HHS Region 10,Season peak week,7
+2011,14,2010/2011,66,HHS Region 10,Season peak percentage,3.9
+2011,14,2010/2011,66,HHS Region 10,1 wk ahead,1.2
+2011,14,2010/2011,66,HHS Region 10,2 wk ahead,1.3
+2011,14,2010/2011,66,HHS Region 10,3 wk ahead,0.9
+2011,14,2010/2011,66,HHS Region 10,4 wk ahead,0.9
+2011,15,2010/2011,67,US National,Season onset,51
+2011,15,2010/2011,67,US National,Season peak week,5
+2011,15,2010/2011,67,US National,Season peak week,7
+2011,15,2010/2011,67,US National,Season peak percentage,4.6
+2011,15,2010/2011,67,US National,1 wk ahead,1.3
+2011,15,2010/2011,67,US National,2 wk ahead,1.2
+2011,15,2010/2011,67,US National,3 wk ahead,1.1
+2011,15,2010/2011,67,US National,4 wk ahead,1.1
+2011,15,2010/2011,67,HHS Region 1,Season onset,4
+2011,15,2010/2011,67,HHS Region 1,Season peak week,7
+2011,15,2010/2011,67,HHS Region 1,Season peak week,8
+2011,15,2010/2011,67,HHS Region 1,Season peak percentage,2.3
+2011,15,2010/2011,67,HHS Region 1,1 wk ahead,0.8
+2011,15,2010/2011,67,HHS Region 1,2 wk ahead,0.7
+2011,15,2010/2011,67,HHS Region 1,3 wk ahead,0.6
+2011,15,2010/2011,67,HHS Region 1,4 wk ahead,0.5
+2011,15,2010/2011,67,HHS Region 2,Season onset,49
+2011,15,2010/2011,67,HHS Region 2,Season peak week,52
+2011,15,2010/2011,67,HHS Region 2,Season peak percentage,4.5
+2011,15,2010/2011,67,HHS Region 2,1 wk ahead,2.2
+2011,15,2010/2011,67,HHS Region 2,2 wk ahead,1.7
+2011,15,2010/2011,67,HHS Region 2,3 wk ahead,1.6
+2011,15,2010/2011,67,HHS Region 2,4 wk ahead,1.7
+2011,15,2010/2011,67,HHS Region 3,Season onset,3
+2011,15,2010/2011,67,HHS Region 3,Season peak week,5
+2011,15,2010/2011,67,HHS Region 3,Season peak percentage,4.4
+2011,15,2010/2011,67,HHS Region 3,1 wk ahead,1.2
+2011,15,2010/2011,67,HHS Region 3,2 wk ahead,0.9
+2011,15,2010/2011,67,HHS Region 3,3 wk ahead,1
+2011,15,2010/2011,67,HHS Region 3,4 wk ahead,0.9
+2011,15,2010/2011,67,HHS Region 4,Season onset,50
+2011,15,2010/2011,67,HHS Region 4,Season peak week,5
+2011,15,2010/2011,67,HHS Region 4,Season peak percentage,5.5
+2011,15,2010/2011,67,HHS Region 4,1 wk ahead,1.1
+2011,15,2010/2011,67,HHS Region 4,2 wk ahead,1.1
+2011,15,2010/2011,67,HHS Region 4,3 wk ahead,1
+2011,15,2010/2011,67,HHS Region 4,4 wk ahead,0.9
+2011,15,2010/2011,67,HHS Region 5,Season onset,3
+2011,15,2010/2011,67,HHS Region 5,Season peak week,5
+2011,15,2010/2011,67,HHS Region 5,Season peak percentage,3.8
+2011,15,2010/2011,67,HHS Region 5,1 wk ahead,0.9
+2011,15,2010/2011,67,HHS Region 5,2 wk ahead,0.8
+2011,15,2010/2011,67,HHS Region 5,3 wk ahead,0.8
+2011,15,2010/2011,67,HHS Region 5,4 wk ahead,0.8
+2011,15,2010/2011,67,HHS Region 6,Season onset,3
+2011,15,2010/2011,67,HHS Region 6,Season peak week,7
+2011,15,2010/2011,67,HHS Region 6,Season peak percentage,7.9
+2011,15,2010/2011,67,HHS Region 6,1 wk ahead,1.5
+2011,15,2010/2011,67,HHS Region 6,2 wk ahead,1.3
+2011,15,2010/2011,67,HHS Region 6,3 wk ahead,1.4
+2011,15,2010/2011,67,HHS Region 6,4 wk ahead,1.4
+2011,15,2010/2011,67,HHS Region 7,Season onset,4
+2011,15,2010/2011,67,HHS Region 7,Season peak week,8
+2011,15,2010/2011,67,HHS Region 7,Season peak percentage,4.7
+2011,15,2010/2011,67,HHS Region 7,1 wk ahead,0.8
+2011,15,2010/2011,67,HHS Region 7,2 wk ahead,0.6
+2011,15,2010/2011,67,HHS Region 7,3 wk ahead,0.5
+2011,15,2010/2011,67,HHS Region 7,4 wk ahead,0.6
+2011,15,2010/2011,67,HHS Region 8,Season onset,5
+2011,15,2010/2011,67,HHS Region 8,Season peak week,7
+2011,15,2010/2011,67,HHS Region 8,Season peak percentage,2.7
+2011,15,2010/2011,67,HHS Region 8,1 wk ahead,0.6
+2011,15,2010/2011,67,HHS Region 8,2 wk ahead,0.6
+2011,15,2010/2011,67,HHS Region 8,3 wk ahead,0.5
+2011,15,2010/2011,67,HHS Region 8,4 wk ahead,0.5
+2011,15,2010/2011,67,HHS Region 9,Season onset,6
+2011,15,2010/2011,67,HHS Region 9,Season peak week,7
+2011,15,2010/2011,67,HHS Region 9,Season peak week,8
+2011,15,2010/2011,67,HHS Region 9,Season peak percentage,4.7
+2011,15,2010/2011,67,HHS Region 9,1 wk ahead,2.1
+2011,15,2010/2011,67,HHS Region 9,2 wk ahead,2.1
+2011,15,2010/2011,67,HHS Region 9,3 wk ahead,1.9
+2011,15,2010/2011,67,HHS Region 9,4 wk ahead,1.9
+2011,15,2010/2011,67,HHS Region 10,Season onset,5
+2011,15,2010/2011,67,HHS Region 10,Season peak week,7
+2011,15,2010/2011,67,HHS Region 10,Season peak percentage,3.9
+2011,15,2010/2011,67,HHS Region 10,1 wk ahead,1.3
+2011,15,2010/2011,67,HHS Region 10,2 wk ahead,0.9
+2011,15,2010/2011,67,HHS Region 10,3 wk ahead,0.9
+2011,15,2010/2011,67,HHS Region 10,4 wk ahead,0.8
+2011,16,2010/2011,68,US National,Season onset,51
+2011,16,2010/2011,68,US National,Season peak week,5
+2011,16,2010/2011,68,US National,Season peak week,7
+2011,16,2010/2011,68,US National,Season peak percentage,4.6
+2011,16,2010/2011,68,US National,1 wk ahead,1.2
+2011,16,2010/2011,68,US National,2 wk ahead,1.1
+2011,16,2010/2011,68,US National,3 wk ahead,1.1
+2011,16,2010/2011,68,US National,4 wk ahead,1.1
+2011,16,2010/2011,68,HHS Region 1,Season onset,4
+2011,16,2010/2011,68,HHS Region 1,Season peak week,7
+2011,16,2010/2011,68,HHS Region 1,Season peak week,8
+2011,16,2010/2011,68,HHS Region 1,Season peak percentage,2.3
+2011,16,2010/2011,68,HHS Region 1,1 wk ahead,0.7
+2011,16,2010/2011,68,HHS Region 1,2 wk ahead,0.6
+2011,16,2010/2011,68,HHS Region 1,3 wk ahead,0.5
+2011,16,2010/2011,68,HHS Region 1,4 wk ahead,0.5
+2011,16,2010/2011,68,HHS Region 2,Season onset,49
+2011,16,2010/2011,68,HHS Region 2,Season peak week,52
+2011,16,2010/2011,68,HHS Region 2,Season peak percentage,4.5
+2011,16,2010/2011,68,HHS Region 2,1 wk ahead,1.7
+2011,16,2010/2011,68,HHS Region 2,2 wk ahead,1.6
+2011,16,2010/2011,68,HHS Region 2,3 wk ahead,1.7
+2011,16,2010/2011,68,HHS Region 2,4 wk ahead,1.4
+2011,16,2010/2011,68,HHS Region 3,Season onset,3
+2011,16,2010/2011,68,HHS Region 3,Season peak week,5
+2011,16,2010/2011,68,HHS Region 3,Season peak percentage,4.4
+2011,16,2010/2011,68,HHS Region 3,1 wk ahead,0.9
+2011,16,2010/2011,68,HHS Region 3,2 wk ahead,1
+2011,16,2010/2011,68,HHS Region 3,3 wk ahead,0.9
+2011,16,2010/2011,68,HHS Region 3,4 wk ahead,1
+2011,16,2010/2011,68,HHS Region 4,Season onset,50
+2011,16,2010/2011,68,HHS Region 4,Season peak week,5
+2011,16,2010/2011,68,HHS Region 4,Season peak percentage,5.5
+2011,16,2010/2011,68,HHS Region 4,1 wk ahead,1.1
+2011,16,2010/2011,68,HHS Region 4,2 wk ahead,1
+2011,16,2010/2011,68,HHS Region 4,3 wk ahead,0.9
+2011,16,2010/2011,68,HHS Region 4,4 wk ahead,0.9
+2011,16,2010/2011,68,HHS Region 5,Season onset,3
+2011,16,2010/2011,68,HHS Region 5,Season peak week,5
+2011,16,2010/2011,68,HHS Region 5,Season peak percentage,3.8
+2011,16,2010/2011,68,HHS Region 5,1 wk ahead,0.8
+2011,16,2010/2011,68,HHS Region 5,2 wk ahead,0.8
+2011,16,2010/2011,68,HHS Region 5,3 wk ahead,0.8
+2011,16,2010/2011,68,HHS Region 5,4 wk ahead,0.8
+2011,16,2010/2011,68,HHS Region 6,Season onset,3
+2011,16,2010/2011,68,HHS Region 6,Season peak week,7
+2011,16,2010/2011,68,HHS Region 6,Season peak percentage,7.9
+2011,16,2010/2011,68,HHS Region 6,1 wk ahead,1.3
+2011,16,2010/2011,68,HHS Region 6,2 wk ahead,1.4
+2011,16,2010/2011,68,HHS Region 6,3 wk ahead,1.4
+2011,16,2010/2011,68,HHS Region 6,4 wk ahead,1.2
+2011,16,2010/2011,68,HHS Region 7,Season onset,4
+2011,16,2010/2011,68,HHS Region 7,Season peak week,8
+2011,16,2010/2011,68,HHS Region 7,Season peak percentage,4.7
+2011,16,2010/2011,68,HHS Region 7,1 wk ahead,0.6
+2011,16,2010/2011,68,HHS Region 7,2 wk ahead,0.5
+2011,16,2010/2011,68,HHS Region 7,3 wk ahead,0.6
+2011,16,2010/2011,68,HHS Region 7,4 wk ahead,0.5
+2011,16,2010/2011,68,HHS Region 8,Season onset,5
+2011,16,2010/2011,68,HHS Region 8,Season peak week,7
+2011,16,2010/2011,68,HHS Region 8,Season peak percentage,2.7
+2011,16,2010/2011,68,HHS Region 8,1 wk ahead,0.6
+2011,16,2010/2011,68,HHS Region 8,2 wk ahead,0.5
+2011,16,2010/2011,68,HHS Region 8,3 wk ahead,0.5
+2011,16,2010/2011,68,HHS Region 8,4 wk ahead,0.5
+2011,16,2010/2011,68,HHS Region 9,Season onset,6
+2011,16,2010/2011,68,HHS Region 9,Season peak week,7
+2011,16,2010/2011,68,HHS Region 9,Season peak week,8
+2011,16,2010/2011,68,HHS Region 9,Season peak percentage,4.7
+2011,16,2010/2011,68,HHS Region 9,1 wk ahead,2.1
+2011,16,2010/2011,68,HHS Region 9,2 wk ahead,1.9
+2011,16,2010/2011,68,HHS Region 9,3 wk ahead,1.9
+2011,16,2010/2011,68,HHS Region 9,4 wk ahead,1.8
+2011,16,2010/2011,68,HHS Region 10,Season onset,5
+2011,16,2010/2011,68,HHS Region 10,Season peak week,7
+2011,16,2010/2011,68,HHS Region 10,Season peak percentage,3.9
+2011,16,2010/2011,68,HHS Region 10,1 wk ahead,0.9
+2011,16,2010/2011,68,HHS Region 10,2 wk ahead,0.9
+2011,16,2010/2011,68,HHS Region 10,3 wk ahead,0.8
+2011,16,2010/2011,68,HHS Region 10,4 wk ahead,0.8
+2011,17,2010/2011,69,US National,Season onset,51
+2011,17,2010/2011,69,US National,Season peak week,5
+2011,17,2010/2011,69,US National,Season peak week,7
+2011,17,2010/2011,69,US National,Season peak percentage,4.6
+2011,17,2010/2011,69,US National,1 wk ahead,1.1
+2011,17,2010/2011,69,US National,2 wk ahead,1.1
+2011,17,2010/2011,69,US National,3 wk ahead,1.1
+2011,17,2010/2011,69,US National,4 wk ahead,1.1
+2011,17,2010/2011,69,HHS Region 1,Season onset,4
+2011,17,2010/2011,69,HHS Region 1,Season peak week,7
+2011,17,2010/2011,69,HHS Region 1,Season peak week,8
+2011,17,2010/2011,69,HHS Region 1,Season peak percentage,2.3
+2011,17,2010/2011,69,HHS Region 1,1 wk ahead,0.6
+2011,17,2010/2011,69,HHS Region 1,2 wk ahead,0.5
+2011,17,2010/2011,69,HHS Region 1,3 wk ahead,0.5
+2011,17,2010/2011,69,HHS Region 1,4 wk ahead,0.6
+2011,17,2010/2011,69,HHS Region 2,Season onset,49
+2011,17,2010/2011,69,HHS Region 2,Season peak week,52
+2011,17,2010/2011,69,HHS Region 2,Season peak percentage,4.5
+2011,17,2010/2011,69,HHS Region 2,1 wk ahead,1.6
+2011,17,2010/2011,69,HHS Region 2,2 wk ahead,1.7
+2011,17,2010/2011,69,HHS Region 2,3 wk ahead,1.4
+2011,17,2010/2011,69,HHS Region 2,4 wk ahead,1.9
+2011,17,2010/2011,69,HHS Region 3,Season onset,3
+2011,17,2010/2011,69,HHS Region 3,Season peak week,5
+2011,17,2010/2011,69,HHS Region 3,Season peak percentage,4.4
+2011,17,2010/2011,69,HHS Region 3,1 wk ahead,1
+2011,17,2010/2011,69,HHS Region 3,2 wk ahead,0.9
+2011,17,2010/2011,69,HHS Region 3,3 wk ahead,1
+2011,17,2010/2011,69,HHS Region 3,4 wk ahead,0.9
+2011,17,2010/2011,69,HHS Region 4,Season onset,50
+2011,17,2010/2011,69,HHS Region 4,Season peak week,5
+2011,17,2010/2011,69,HHS Region 4,Season peak percentage,5.5
+2011,17,2010/2011,69,HHS Region 4,1 wk ahead,1
+2011,17,2010/2011,69,HHS Region 4,2 wk ahead,0.9
+2011,17,2010/2011,69,HHS Region 4,3 wk ahead,0.9
+2011,17,2010/2011,69,HHS Region 4,4 wk ahead,0.9
+2011,17,2010/2011,69,HHS Region 5,Season onset,3
+2011,17,2010/2011,69,HHS Region 5,Season peak week,5
+2011,17,2010/2011,69,HHS Region 5,Season peak percentage,3.8
+2011,17,2010/2011,69,HHS Region 5,1 wk ahead,0.8
+2011,17,2010/2011,69,HHS Region 5,2 wk ahead,0.8
+2011,17,2010/2011,69,HHS Region 5,3 wk ahead,0.8
+2011,17,2010/2011,69,HHS Region 5,4 wk ahead,0.6
+2011,17,2010/2011,69,HHS Region 6,Season onset,3
+2011,17,2010/2011,69,HHS Region 6,Season peak week,7
+2011,17,2010/2011,69,HHS Region 6,Season peak percentage,7.9
+2011,17,2010/2011,69,HHS Region 6,1 wk ahead,1.4
+2011,17,2010/2011,69,HHS Region 6,2 wk ahead,1.4
+2011,17,2010/2011,69,HHS Region 6,3 wk ahead,1.2
+2011,17,2010/2011,69,HHS Region 6,4 wk ahead,1.1
+2011,17,2010/2011,69,HHS Region 7,Season onset,4
+2011,17,2010/2011,69,HHS Region 7,Season peak week,8
+2011,17,2010/2011,69,HHS Region 7,Season peak percentage,4.7
+2011,17,2010/2011,69,HHS Region 7,1 wk ahead,0.5
+2011,17,2010/2011,69,HHS Region 7,2 wk ahead,0.6
+2011,17,2010/2011,69,HHS Region 7,3 wk ahead,0.5
+2011,17,2010/2011,69,HHS Region 7,4 wk ahead,0.5
+2011,17,2010/2011,69,HHS Region 8,Season onset,5
+2011,17,2010/2011,69,HHS Region 8,Season peak week,7
+2011,17,2010/2011,69,HHS Region 8,Season peak percentage,2.7
+2011,17,2010/2011,69,HHS Region 8,1 wk ahead,0.5
+2011,17,2010/2011,69,HHS Region 8,2 wk ahead,0.5
+2011,17,2010/2011,69,HHS Region 8,3 wk ahead,0.5
+2011,17,2010/2011,69,HHS Region 8,4 wk ahead,0.4
+2011,17,2010/2011,69,HHS Region 9,Season onset,6
+2011,17,2010/2011,69,HHS Region 9,Season peak week,7
+2011,17,2010/2011,69,HHS Region 9,Season peak week,8
+2011,17,2010/2011,69,HHS Region 9,Season peak percentage,4.7
+2011,17,2010/2011,69,HHS Region 9,1 wk ahead,1.9
+2011,17,2010/2011,69,HHS Region 9,2 wk ahead,1.9
+2011,17,2010/2011,69,HHS Region 9,3 wk ahead,1.8
+2011,17,2010/2011,69,HHS Region 9,4 wk ahead,1.8
+2011,17,2010/2011,69,HHS Region 10,Season onset,5
+2011,17,2010/2011,69,HHS Region 10,Season peak week,7
+2011,17,2010/2011,69,HHS Region 10,Season peak percentage,3.9
+2011,17,2010/2011,69,HHS Region 10,1 wk ahead,0.9
+2011,17,2010/2011,69,HHS Region 10,2 wk ahead,0.8
+2011,17,2010/2011,69,HHS Region 10,3 wk ahead,0.8
+2011,17,2010/2011,69,HHS Region 10,4 wk ahead,0.5
+2011,18,2010/2011,70,US National,Season onset,51
+2011,18,2010/2011,70,US National,Season peak week,5
+2011,18,2010/2011,70,US National,Season peak week,7
+2011,18,2010/2011,70,US National,Season peak percentage,4.6
+2011,18,2010/2011,70,US National,1 wk ahead,1.1
+2011,18,2010/2011,70,US National,2 wk ahead,1.1
+2011,18,2010/2011,70,US National,3 wk ahead,1.1
+2011,18,2010/2011,70,US National,4 wk ahead,1.2
+2011,18,2010/2011,70,HHS Region 1,Season onset,4
+2011,18,2010/2011,70,HHS Region 1,Season peak week,7
+2011,18,2010/2011,70,HHS Region 1,Season peak week,8
+2011,18,2010/2011,70,HHS Region 1,Season peak percentage,2.3
+2011,18,2010/2011,70,HHS Region 1,1 wk ahead,0.5
+2011,18,2010/2011,70,HHS Region 1,2 wk ahead,0.5
+2011,18,2010/2011,70,HHS Region 1,3 wk ahead,0.6
+2011,18,2010/2011,70,HHS Region 1,4 wk ahead,0.6
+2011,18,2010/2011,70,HHS Region 2,Season onset,49
+2011,18,2010/2011,70,HHS Region 2,Season peak week,52
+2011,18,2010/2011,70,HHS Region 2,Season peak percentage,4.5
+2011,18,2010/2011,70,HHS Region 2,1 wk ahead,1.7
+2011,18,2010/2011,70,HHS Region 2,2 wk ahead,1.4
+2011,18,2010/2011,70,HHS Region 2,3 wk ahead,1.9
+2011,18,2010/2011,70,HHS Region 2,4 wk ahead,1.8
+2011,18,2010/2011,70,HHS Region 3,Season onset,3
+2011,18,2010/2011,70,HHS Region 3,Season peak week,5
+2011,18,2010/2011,70,HHS Region 3,Season peak percentage,4.4
+2011,18,2010/2011,70,HHS Region 3,1 wk ahead,0.9
+2011,18,2010/2011,70,HHS Region 3,2 wk ahead,1
+2011,18,2010/2011,70,HHS Region 3,3 wk ahead,0.9
+2011,18,2010/2011,70,HHS Region 3,4 wk ahead,0.9
+2011,18,2010/2011,70,HHS Region 4,Season onset,50
+2011,18,2010/2011,70,HHS Region 4,Season peak week,5
+2011,18,2010/2011,70,HHS Region 4,Season peak percentage,5.5
+2011,18,2010/2011,70,HHS Region 4,1 wk ahead,0.9
+2011,18,2010/2011,70,HHS Region 4,2 wk ahead,0.9
+2011,18,2010/2011,70,HHS Region 4,3 wk ahead,0.9
+2011,18,2010/2011,70,HHS Region 4,4 wk ahead,1
+2011,18,2010/2011,70,HHS Region 5,Season onset,3
+2011,18,2010/2011,70,HHS Region 5,Season peak week,5
+2011,18,2010/2011,70,HHS Region 5,Season peak percentage,3.8
+2011,18,2010/2011,70,HHS Region 5,1 wk ahead,0.8
+2011,18,2010/2011,70,HHS Region 5,2 wk ahead,0.8
+2011,18,2010/2011,70,HHS Region 5,3 wk ahead,0.6
+2011,18,2010/2011,70,HHS Region 5,4 wk ahead,0.8
+2011,18,2010/2011,70,HHS Region 6,Season onset,3
+2011,18,2010/2011,70,HHS Region 6,Season peak week,7
+2011,18,2010/2011,70,HHS Region 6,Season peak percentage,7.9
+2011,18,2010/2011,70,HHS Region 6,1 wk ahead,1.4
+2011,18,2010/2011,70,HHS Region 6,2 wk ahead,1.2
+2011,18,2010/2011,70,HHS Region 6,3 wk ahead,1.1
+2011,18,2010/2011,70,HHS Region 6,4 wk ahead,1.2
+2011,18,2010/2011,70,HHS Region 7,Season onset,4
+2011,18,2010/2011,70,HHS Region 7,Season peak week,8
+2011,18,2010/2011,70,HHS Region 7,Season peak percentage,4.7
+2011,18,2010/2011,70,HHS Region 7,1 wk ahead,0.6
+2011,18,2010/2011,70,HHS Region 7,2 wk ahead,0.5
+2011,18,2010/2011,70,HHS Region 7,3 wk ahead,0.5
+2011,18,2010/2011,70,HHS Region 7,4 wk ahead,0.2
+2011,18,2010/2011,70,HHS Region 8,Season onset,5
+2011,18,2010/2011,70,HHS Region 8,Season peak week,7
+2011,18,2010/2011,70,HHS Region 8,Season peak percentage,2.7
+2011,18,2010/2011,70,HHS Region 8,1 wk ahead,0.5
+2011,18,2010/2011,70,HHS Region 8,2 wk ahead,0.5
+2011,18,2010/2011,70,HHS Region 8,3 wk ahead,0.4
+2011,18,2010/2011,70,HHS Region 8,4 wk ahead,0.4
+2011,18,2010/2011,70,HHS Region 9,Season onset,6
+2011,18,2010/2011,70,HHS Region 9,Season peak week,7
+2011,18,2010/2011,70,HHS Region 9,Season peak week,8
+2011,18,2010/2011,70,HHS Region 9,Season peak percentage,4.7
+2011,18,2010/2011,70,HHS Region 9,1 wk ahead,1.9
+2011,18,2010/2011,70,HHS Region 9,2 wk ahead,1.8
+2011,18,2010/2011,70,HHS Region 9,3 wk ahead,1.8
+2011,18,2010/2011,70,HHS Region 9,4 wk ahead,2.2
+2011,18,2010/2011,70,HHS Region 10,Season onset,5
+2011,18,2010/2011,70,HHS Region 10,Season peak week,7
+2011,18,2010/2011,70,HHS Region 10,Season peak percentage,3.9
+2011,18,2010/2011,70,HHS Region 10,1 wk ahead,0.8
+2011,18,2010/2011,70,HHS Region 10,2 wk ahead,0.8
+2011,18,2010/2011,70,HHS Region 10,3 wk ahead,0.5
+2011,18,2010/2011,70,HHS Region 10,4 wk ahead,0.7
+2011,19,2010/2011,71,US National,Season onset,51
+2011,19,2010/2011,71,US National,Season peak week,5
+2011,19,2010/2011,71,US National,Season peak week,7
+2011,19,2010/2011,71,US National,Season peak percentage,4.6
+2011,19,2010/2011,71,US National,1 wk ahead,1.1
+2011,19,2010/2011,71,US National,2 wk ahead,1.1
+2011,19,2010/2011,71,US National,3 wk ahead,1.2
+2011,19,2010/2011,71,US National,4 wk ahead,1
+2011,19,2010/2011,71,HHS Region 1,Season onset,4
+2011,19,2010/2011,71,HHS Region 1,Season peak week,7
+2011,19,2010/2011,71,HHS Region 1,Season peak week,8
+2011,19,2010/2011,71,HHS Region 1,Season peak percentage,2.3
+2011,19,2010/2011,71,HHS Region 1,1 wk ahead,0.5
+2011,19,2010/2011,71,HHS Region 1,2 wk ahead,0.6
+2011,19,2010/2011,71,HHS Region 1,3 wk ahead,0.6
+2011,19,2010/2011,71,HHS Region 1,4 wk ahead,0.5
+2011,19,2010/2011,71,HHS Region 2,Season onset,49
+2011,19,2010/2011,71,HHS Region 2,Season peak week,52
+2011,19,2010/2011,71,HHS Region 2,Season peak percentage,4.5
+2011,19,2010/2011,71,HHS Region 2,1 wk ahead,1.4
+2011,19,2010/2011,71,HHS Region 2,2 wk ahead,1.9
+2011,19,2010/2011,71,HHS Region 2,3 wk ahead,1.8
+2011,19,2010/2011,71,HHS Region 2,4 wk ahead,1.3
+2011,19,2010/2011,71,HHS Region 3,Season onset,3
+2011,19,2010/2011,71,HHS Region 3,Season peak week,5
+2011,19,2010/2011,71,HHS Region 3,Season peak percentage,4.4
+2011,19,2010/2011,71,HHS Region 3,1 wk ahead,1
+2011,19,2010/2011,71,HHS Region 3,2 wk ahead,0.9
+2011,19,2010/2011,71,HHS Region 3,3 wk ahead,0.9
+2011,19,2010/2011,71,HHS Region 3,4 wk ahead,1.1
+2011,19,2010/2011,71,HHS Region 4,Season onset,50
+2011,19,2010/2011,71,HHS Region 4,Season peak week,5
+2011,19,2010/2011,71,HHS Region 4,Season peak percentage,5.5
+2011,19,2010/2011,71,HHS Region 4,1 wk ahead,0.9
+2011,19,2010/2011,71,HHS Region 4,2 wk ahead,0.9
+2011,19,2010/2011,71,HHS Region 4,3 wk ahead,1
+2011,19,2010/2011,71,HHS Region 4,4 wk ahead,0.9
+2011,19,2010/2011,71,HHS Region 5,Season onset,3
+2011,19,2010/2011,71,HHS Region 5,Season peak week,5
+2011,19,2010/2011,71,HHS Region 5,Season peak percentage,3.8
+2011,19,2010/2011,71,HHS Region 5,1 wk ahead,0.8
+2011,19,2010/2011,71,HHS Region 5,2 wk ahead,0.6
+2011,19,2010/2011,71,HHS Region 5,3 wk ahead,0.8
+2011,19,2010/2011,71,HHS Region 5,4 wk ahead,0.6
+2011,19,2010/2011,71,HHS Region 6,Season onset,3
+2011,19,2010/2011,71,HHS Region 6,Season peak week,7
+2011,19,2010/2011,71,HHS Region 6,Season peak percentage,7.9
+2011,19,2010/2011,71,HHS Region 6,1 wk ahead,1.2
+2011,19,2010/2011,71,HHS Region 6,2 wk ahead,1.1
+2011,19,2010/2011,71,HHS Region 6,3 wk ahead,1.2
+2011,19,2010/2011,71,HHS Region 6,4 wk ahead,0.9
+2011,19,2010/2011,71,HHS Region 7,Season onset,4
+2011,19,2010/2011,71,HHS Region 7,Season peak week,8
+2011,19,2010/2011,71,HHS Region 7,Season peak percentage,4.7
+2011,19,2010/2011,71,HHS Region 7,1 wk ahead,0.5
+2011,19,2010/2011,71,HHS Region 7,2 wk ahead,0.5
+2011,19,2010/2011,71,HHS Region 7,3 wk ahead,0.2
+2011,19,2010/2011,71,HHS Region 7,4 wk ahead,0.2
+2011,19,2010/2011,71,HHS Region 8,Season onset,5
+2011,19,2010/2011,71,HHS Region 8,Season peak week,7
+2011,19,2010/2011,71,HHS Region 8,Season peak percentage,2.7
+2011,19,2010/2011,71,HHS Region 8,1 wk ahead,0.5
+2011,19,2010/2011,71,HHS Region 8,2 wk ahead,0.4
+2011,19,2010/2011,71,HHS Region 8,3 wk ahead,0.4
+2011,19,2010/2011,71,HHS Region 8,4 wk ahead,0.3
+2011,19,2010/2011,71,HHS Region 9,Season onset,6
+2011,19,2010/2011,71,HHS Region 9,Season peak week,7
+2011,19,2010/2011,71,HHS Region 9,Season peak week,8
+2011,19,2010/2011,71,HHS Region 9,Season peak percentage,4.7
+2011,19,2010/2011,71,HHS Region 9,1 wk ahead,1.8
+2011,19,2010/2011,71,HHS Region 9,2 wk ahead,1.8
+2011,19,2010/2011,71,HHS Region 9,3 wk ahead,2.2
+2011,19,2010/2011,71,HHS Region 9,4 wk ahead,1.9
+2011,19,2010/2011,71,HHS Region 10,Season onset,5
+2011,19,2010/2011,71,HHS Region 10,Season peak week,7
+2011,19,2010/2011,71,HHS Region 10,Season peak percentage,3.9
+2011,19,2010/2011,71,HHS Region 10,1 wk ahead,0.8
+2011,19,2010/2011,71,HHS Region 10,2 wk ahead,0.5
+2011,19,2010/2011,71,HHS Region 10,3 wk ahead,0.7
+2011,19,2010/2011,71,HHS Region 10,4 wk ahead,0.6
+2011,20,2010/2011,72,US National,Season onset,51
+2011,20,2010/2011,72,US National,Season peak week,5
+2011,20,2010/2011,72,US National,Season peak week,7
+2011,20,2010/2011,72,US National,Season peak percentage,4.6
+2011,20,2010/2011,72,US National,1 wk ahead,1.1
+2011,20,2010/2011,72,US National,2 wk ahead,1.2
+2011,20,2010/2011,72,US National,3 wk ahead,1
+2011,20,2010/2011,72,US National,4 wk ahead,0.9
+2011,20,2010/2011,72,HHS Region 1,Season onset,4
+2011,20,2010/2011,72,HHS Region 1,Season peak week,7
+2011,20,2010/2011,72,HHS Region 1,Season peak week,8
+2011,20,2010/2011,72,HHS Region 1,Season peak percentage,2.3
+2011,20,2010/2011,72,HHS Region 1,1 wk ahead,0.6
+2011,20,2010/2011,72,HHS Region 1,2 wk ahead,0.6
+2011,20,2010/2011,72,HHS Region 1,3 wk ahead,0.5
+2011,20,2010/2011,72,HHS Region 1,4 wk ahead,0.5
+2011,20,2010/2011,72,HHS Region 2,Season onset,49
+2011,20,2010/2011,72,HHS Region 2,Season peak week,52
+2011,20,2010/2011,72,HHS Region 2,Season peak percentage,4.5
+2011,20,2010/2011,72,HHS Region 2,1 wk ahead,1.9
+2011,20,2010/2011,72,HHS Region 2,2 wk ahead,1.8
+2011,20,2010/2011,72,HHS Region 2,3 wk ahead,1.3
+2011,20,2010/2011,72,HHS Region 2,4 wk ahead,1.3
+2011,20,2010/2011,72,HHS Region 3,Season onset,3
+2011,20,2010/2011,72,HHS Region 3,Season peak week,5
+2011,20,2010/2011,72,HHS Region 3,Season peak percentage,4.4
+2011,20,2010/2011,72,HHS Region 3,1 wk ahead,0.9
+2011,20,2010/2011,72,HHS Region 3,2 wk ahead,0.9
+2011,20,2010/2011,72,HHS Region 3,3 wk ahead,1.1
+2011,20,2010/2011,72,HHS Region 3,4 wk ahead,1
+2011,20,2010/2011,72,HHS Region 4,Season onset,50
+2011,20,2010/2011,72,HHS Region 4,Season peak week,5
+2011,20,2010/2011,72,HHS Region 4,Season peak percentage,5.5
+2011,20,2010/2011,72,HHS Region 4,1 wk ahead,0.9
+2011,20,2010/2011,72,HHS Region 4,2 wk ahead,1
+2011,20,2010/2011,72,HHS Region 4,3 wk ahead,0.9
+2011,20,2010/2011,72,HHS Region 4,4 wk ahead,0.7
+2011,20,2010/2011,72,HHS Region 5,Season onset,3
+2011,20,2010/2011,72,HHS Region 5,Season peak week,5
+2011,20,2010/2011,72,HHS Region 5,Season peak percentage,3.8
+2011,20,2010/2011,72,HHS Region 5,1 wk ahead,0.6
+2011,20,2010/2011,72,HHS Region 5,2 wk ahead,0.8
+2011,20,2010/2011,72,HHS Region 5,3 wk ahead,0.6
+2011,20,2010/2011,72,HHS Region 5,4 wk ahead,0.5
+2011,20,2010/2011,72,HHS Region 6,Season onset,3
+2011,20,2010/2011,72,HHS Region 6,Season peak week,7
+2011,20,2010/2011,72,HHS Region 6,Season peak percentage,7.9
+2011,20,2010/2011,72,HHS Region 6,1 wk ahead,1.1
+2011,20,2010/2011,72,HHS Region 6,2 wk ahead,1.2
+2011,20,2010/2011,72,HHS Region 6,3 wk ahead,0.9
+2011,20,2010/2011,72,HHS Region 6,4 wk ahead,1.1
+2011,20,2010/2011,72,HHS Region 7,Season onset,4
+2011,20,2010/2011,72,HHS Region 7,Season peak week,8
+2011,20,2010/2011,72,HHS Region 7,Season peak percentage,4.7
+2011,20,2010/2011,72,HHS Region 7,1 wk ahead,0.5
+2011,20,2010/2011,72,HHS Region 7,2 wk ahead,0.2
+2011,20,2010/2011,72,HHS Region 7,3 wk ahead,0.2
+2011,20,2010/2011,72,HHS Region 7,4 wk ahead,0.1
+2011,20,2010/2011,72,HHS Region 8,Season onset,5
+2011,20,2010/2011,72,HHS Region 8,Season peak week,7
+2011,20,2010/2011,72,HHS Region 8,Season peak percentage,2.7
+2011,20,2010/2011,72,HHS Region 8,1 wk ahead,0.4
+2011,20,2010/2011,72,HHS Region 8,2 wk ahead,0.4
+2011,20,2010/2011,72,HHS Region 8,3 wk ahead,0.3
+2011,20,2010/2011,72,HHS Region 8,4 wk ahead,0.3
+2011,20,2010/2011,72,HHS Region 9,Season onset,6
+2011,20,2010/2011,72,HHS Region 9,Season peak week,7
+2011,20,2010/2011,72,HHS Region 9,Season peak week,8
+2011,20,2010/2011,72,HHS Region 9,Season peak percentage,4.7
+2011,20,2010/2011,72,HHS Region 9,1 wk ahead,1.8
+2011,20,2010/2011,72,HHS Region 9,2 wk ahead,2.2
+2011,20,2010/2011,72,HHS Region 9,3 wk ahead,1.9
+2011,20,2010/2011,72,HHS Region 9,4 wk ahead,1.6
+2011,20,2010/2011,72,HHS Region 10,Season onset,5
+2011,20,2010/2011,72,HHS Region 10,Season peak week,7
+2011,20,2010/2011,72,HHS Region 10,Season peak percentage,3.9
+2011,20,2010/2011,72,HHS Region 10,1 wk ahead,0.5
+2011,20,2010/2011,72,HHS Region 10,2 wk ahead,0.7
+2011,20,2010/2011,72,HHS Region 10,3 wk ahead,0.6
+2011,20,2010/2011,72,HHS Region 10,4 wk ahead,0.7
+2011,40,2011/2012,40,US National,Season onset,none
+2011,40,2011/2012,40,US National,Season peak week,11
+2011,40,2011/2012,40,US National,Season peak percentage,2.4
+2011,40,2011/2012,40,US National,1 wk ahead,1.2
+2011,40,2011/2012,40,US National,2 wk ahead,1.3
+2011,40,2011/2012,40,US National,3 wk ahead,1.3
+2011,40,2011/2012,40,US National,4 wk ahead,1.4
+2011,40,2011/2012,40,HHS Region 1,Season onset,none
+2011,40,2011/2012,40,HHS Region 1,Season peak week,52
+2011,40,2011/2012,40,HHS Region 1,Season peak percentage,1
+2011,40,2011/2012,40,HHS Region 1,1 wk ahead,0.7
+2011,40,2011/2012,40,HHS Region 1,2 wk ahead,0.6
+2011,40,2011/2012,40,HHS Region 1,3 wk ahead,0.7
+2011,40,2011/2012,40,HHS Region 1,4 wk ahead,0.7
+2011,40,2011/2012,40,HHS Region 2,Season onset,none
+2011,40,2011/2012,40,HHS Region 2,Season peak week,49
+2011,40,2011/2012,40,HHS Region 2,Season peak percentage,1.4
+2011,40,2011/2012,40,HHS Region 2,1 wk ahead,1
+2011,40,2011/2012,40,HHS Region 2,2 wk ahead,0.9
+2011,40,2011/2012,40,HHS Region 2,3 wk ahead,0.9
+2011,40,2011/2012,40,HHS Region 2,4 wk ahead,1.2
+2011,40,2011/2012,40,HHS Region 3,Season onset,none
+2011,40,2011/2012,40,HHS Region 3,Season peak week,52
+2011,40,2011/2012,40,HHS Region 3,Season peak percentage,2.1
+2011,40,2011/2012,40,HHS Region 3,1 wk ahead,1.2
+2011,40,2011/2012,40,HHS Region 3,2 wk ahead,1.1
+2011,40,2011/2012,40,HHS Region 3,3 wk ahead,1.3
+2011,40,2011/2012,40,HHS Region 3,4 wk ahead,1.3
+2011,40,2011/2012,40,HHS Region 4,Season onset,none
+2011,40,2011/2012,40,HHS Region 4,Season peak week,52
+2011,40,2011/2012,40,HHS Region 4,Season peak week,10
+2011,40,2011/2012,40,HHS Region 4,Season peak percentage,2.3
+2011,40,2011/2012,40,HHS Region 4,1 wk ahead,1.2
+2011,40,2011/2012,40,HHS Region 4,2 wk ahead,1.2
+2011,40,2011/2012,40,HHS Region 4,3 wk ahead,1.3
+2011,40,2011/2012,40,HHS Region 4,4 wk ahead,1.5
+2011,40,2011/2012,40,HHS Region 5,Season onset,7
+2011,40,2011/2012,40,HHS Region 5,Season peak week,11
+2011,40,2011/2012,40,HHS Region 5,Season peak percentage,2.4
+2011,40,2011/2012,40,HHS Region 5,1 wk ahead,0.9
+2011,40,2011/2012,40,HHS Region 5,2 wk ahead,1.1
+2011,40,2011/2012,40,HHS Region 5,3 wk ahead,1
+2011,40,2011/2012,40,HHS Region 5,4 wk ahead,1.1
+2011,40,2011/2012,40,HHS Region 6,Season onset,none
+2011,40,2011/2012,40,HHS Region 6,Season peak week,11
+2011,40,2011/2012,40,HHS Region 6,Season peak percentage,4.1
+2011,40,2011/2012,40,HHS Region 6,1 wk ahead,1.7
+2011,40,2011/2012,40,HHS Region 6,2 wk ahead,1.9
+2011,40,2011/2012,40,HHS Region 6,3 wk ahead,1.9
+2011,40,2011/2012,40,HHS Region 6,4 wk ahead,1.9
+2011,40,2011/2012,40,HHS Region 7,Season onset,5
+2011,40,2011/2012,40,HHS Region 7,Season peak week,9
+2011,40,2011/2012,40,HHS Region 7,Season peak percentage,3.4
+2011,40,2011/2012,40,HHS Region 7,1 wk ahead,0.9
+2011,40,2011/2012,40,HHS Region 7,2 wk ahead,0.8
+2011,40,2011/2012,40,HHS Region 7,3 wk ahead,1
+2011,40,2011/2012,40,HHS Region 7,4 wk ahead,1.1
+2011,40,2011/2012,40,HHS Region 8,Season onset,none
+2011,40,2011/2012,40,HHS Region 8,Season peak week,11
+2011,40,2011/2012,40,HHS Region 8,Season peak percentage,2.2
+2011,40,2011/2012,40,HHS Region 8,1 wk ahead,0.8
+2011,40,2011/2012,40,HHS Region 8,2 wk ahead,0.8
+2011,40,2011/2012,40,HHS Region 8,3 wk ahead,0.9
+2011,40,2011/2012,40,HHS Region 8,4 wk ahead,0.9
+2011,40,2011/2012,40,HHS Region 9,Season onset,none
+2011,40,2011/2012,40,HHS Region 9,Season peak week,52
+2011,40,2011/2012,40,HHS Region 9,Season peak week,8
+2011,40,2011/2012,40,HHS Region 9,Season peak percentage,3.7
+2011,40,2011/2012,40,HHS Region 9,1 wk ahead,1.7
+2011,40,2011/2012,40,HHS Region 9,2 wk ahead,2
+2011,40,2011/2012,40,HHS Region 9,3 wk ahead,2
+2011,40,2011/2012,40,HHS Region 9,4 wk ahead,2.2
+2011,40,2011/2012,40,HHS Region 10,Season onset,none
+2011,40,2011/2012,40,HHS Region 10,Season peak week,12
+2011,40,2011/2012,40,HHS Region 10,Season peak percentage,2.2
+2011,40,2011/2012,40,HHS Region 10,1 wk ahead,0.7
+2011,40,2011/2012,40,HHS Region 10,2 wk ahead,0.6
+2011,40,2011/2012,40,HHS Region 10,3 wk ahead,0.7
+2011,40,2011/2012,40,HHS Region 10,4 wk ahead,0.8
+2011,41,2011/2012,41,US National,Season onset,none
+2011,41,2011/2012,41,US National,Season peak week,11
+2011,41,2011/2012,41,US National,Season peak percentage,2.4
+2011,41,2011/2012,41,US National,1 wk ahead,1.3
+2011,41,2011/2012,41,US National,2 wk ahead,1.3
+2011,41,2011/2012,41,US National,3 wk ahead,1.4
+2011,41,2011/2012,41,US National,4 wk ahead,1.4
+2011,41,2011/2012,41,HHS Region 1,Season onset,none
+2011,41,2011/2012,41,HHS Region 1,Season peak week,52
+2011,41,2011/2012,41,HHS Region 1,Season peak percentage,1
+2011,41,2011/2012,41,HHS Region 1,1 wk ahead,0.6
+2011,41,2011/2012,41,HHS Region 1,2 wk ahead,0.7
+2011,41,2011/2012,41,HHS Region 1,3 wk ahead,0.7
+2011,41,2011/2012,41,HHS Region 1,4 wk ahead,0.7
+2011,41,2011/2012,41,HHS Region 2,Season onset,none
+2011,41,2011/2012,41,HHS Region 2,Season peak week,49
+2011,41,2011/2012,41,HHS Region 2,Season peak percentage,1.4
+2011,41,2011/2012,41,HHS Region 2,1 wk ahead,0.9
+2011,41,2011/2012,41,HHS Region 2,2 wk ahead,0.9
+2011,41,2011/2012,41,HHS Region 2,3 wk ahead,1.2
+2011,41,2011/2012,41,HHS Region 2,4 wk ahead,1.1
+2011,41,2011/2012,41,HHS Region 3,Season onset,none
+2011,41,2011/2012,41,HHS Region 3,Season peak week,52
+2011,41,2011/2012,41,HHS Region 3,Season peak percentage,2.1
+2011,41,2011/2012,41,HHS Region 3,1 wk ahead,1.1
+2011,41,2011/2012,41,HHS Region 3,2 wk ahead,1.3
+2011,41,2011/2012,41,HHS Region 3,3 wk ahead,1.3
+2011,41,2011/2012,41,HHS Region 3,4 wk ahead,1.4
+2011,41,2011/2012,41,HHS Region 4,Season onset,none
+2011,41,2011/2012,41,HHS Region 4,Season peak week,52
+2011,41,2011/2012,41,HHS Region 4,Season peak week,10
+2011,41,2011/2012,41,HHS Region 4,Season peak percentage,2.3
+2011,41,2011/2012,41,HHS Region 4,1 wk ahead,1.2
+2011,41,2011/2012,41,HHS Region 4,2 wk ahead,1.3
+2011,41,2011/2012,41,HHS Region 4,3 wk ahead,1.5
+2011,41,2011/2012,41,HHS Region 4,4 wk ahead,1.5
+2011,41,2011/2012,41,HHS Region 5,Season onset,7
+2011,41,2011/2012,41,HHS Region 5,Season peak week,11
+2011,41,2011/2012,41,HHS Region 5,Season peak percentage,2.4
+2011,41,2011/2012,41,HHS Region 5,1 wk ahead,1.1
+2011,41,2011/2012,41,HHS Region 5,2 wk ahead,1
+2011,41,2011/2012,41,HHS Region 5,3 wk ahead,1.1
+2011,41,2011/2012,41,HHS Region 5,4 wk ahead,1.1
+2011,41,2011/2012,41,HHS Region 6,Season onset,none
+2011,41,2011/2012,41,HHS Region 6,Season peak week,11
+2011,41,2011/2012,41,HHS Region 6,Season peak percentage,4.1
+2011,41,2011/2012,41,HHS Region 6,1 wk ahead,1.9
+2011,41,2011/2012,41,HHS Region 6,2 wk ahead,1.9
+2011,41,2011/2012,41,HHS Region 6,3 wk ahead,1.9
+2011,41,2011/2012,41,HHS Region 6,4 wk ahead,2
+2011,41,2011/2012,41,HHS Region 7,Season onset,5
+2011,41,2011/2012,41,HHS Region 7,Season peak week,9
+2011,41,2011/2012,41,HHS Region 7,Season peak percentage,3.4
+2011,41,2011/2012,41,HHS Region 7,1 wk ahead,0.8
+2011,41,2011/2012,41,HHS Region 7,2 wk ahead,1
+2011,41,2011/2012,41,HHS Region 7,3 wk ahead,1.1
+2011,41,2011/2012,41,HHS Region 7,4 wk ahead,0.9
+2011,41,2011/2012,41,HHS Region 8,Season onset,none
+2011,41,2011/2012,41,HHS Region 8,Season peak week,11
+2011,41,2011/2012,41,HHS Region 8,Season peak percentage,2.2
+2011,41,2011/2012,41,HHS Region 8,1 wk ahead,0.8
+2011,41,2011/2012,41,HHS Region 8,2 wk ahead,0.9
+2011,41,2011/2012,41,HHS Region 8,3 wk ahead,0.9
+2011,41,2011/2012,41,HHS Region 8,4 wk ahead,1
+2011,41,2011/2012,41,HHS Region 9,Season onset,none
+2011,41,2011/2012,41,HHS Region 9,Season peak week,52
+2011,41,2011/2012,41,HHS Region 9,Season peak week,8
+2011,41,2011/2012,41,HHS Region 9,Season peak percentage,3.7
+2011,41,2011/2012,41,HHS Region 9,1 wk ahead,2
+2011,41,2011/2012,41,HHS Region 9,2 wk ahead,2
+2011,41,2011/2012,41,HHS Region 9,3 wk ahead,2.2
+2011,41,2011/2012,41,HHS Region 9,4 wk ahead,1.9
+2011,41,2011/2012,41,HHS Region 10,Season onset,none
+2011,41,2011/2012,41,HHS Region 10,Season peak week,12
+2011,41,2011/2012,41,HHS Region 10,Season peak percentage,2.2
+2011,41,2011/2012,41,HHS Region 10,1 wk ahead,0.6
+2011,41,2011/2012,41,HHS Region 10,2 wk ahead,0.7
+2011,41,2011/2012,41,HHS Region 10,3 wk ahead,0.8
+2011,41,2011/2012,41,HHS Region 10,4 wk ahead,0.7
+2011,42,2011/2012,42,US National,Season onset,none
+2011,42,2011/2012,42,US National,Season peak week,11
+2011,42,2011/2012,42,US National,Season peak percentage,2.4
+2011,42,2011/2012,42,US National,1 wk ahead,1.3
+2011,42,2011/2012,42,US National,2 wk ahead,1.4
+2011,42,2011/2012,42,US National,3 wk ahead,1.4
+2011,42,2011/2012,42,US National,4 wk ahead,1.5
+2011,42,2011/2012,42,HHS Region 1,Season onset,none
+2011,42,2011/2012,42,HHS Region 1,Season peak week,52
+2011,42,2011/2012,42,HHS Region 1,Season peak percentage,1
+2011,42,2011/2012,42,HHS Region 1,1 wk ahead,0.7
+2011,42,2011/2012,42,HHS Region 1,2 wk ahead,0.7
+2011,42,2011/2012,42,HHS Region 1,3 wk ahead,0.7
+2011,42,2011/2012,42,HHS Region 1,4 wk ahead,0.6
+2011,42,2011/2012,42,HHS Region 2,Season onset,none
+2011,42,2011/2012,42,HHS Region 2,Season peak week,49
+2011,42,2011/2012,42,HHS Region 2,Season peak percentage,1.4
+2011,42,2011/2012,42,HHS Region 2,1 wk ahead,0.9
+2011,42,2011/2012,42,HHS Region 2,2 wk ahead,1.2
+2011,42,2011/2012,42,HHS Region 2,3 wk ahead,1.1
+2011,42,2011/2012,42,HHS Region 2,4 wk ahead,1.2
+2011,42,2011/2012,42,HHS Region 3,Season onset,none
+2011,42,2011/2012,42,HHS Region 3,Season peak week,52
+2011,42,2011/2012,42,HHS Region 3,Season peak percentage,2.1
+2011,42,2011/2012,42,HHS Region 3,1 wk ahead,1.3
+2011,42,2011/2012,42,HHS Region 3,2 wk ahead,1.3
+2011,42,2011/2012,42,HHS Region 3,3 wk ahead,1.4
+2011,42,2011/2012,42,HHS Region 3,4 wk ahead,1.4
+2011,42,2011/2012,42,HHS Region 4,Season onset,none
+2011,42,2011/2012,42,HHS Region 4,Season peak week,52
+2011,42,2011/2012,42,HHS Region 4,Season peak week,10
+2011,42,2011/2012,42,HHS Region 4,Season peak percentage,2.3
+2011,42,2011/2012,42,HHS Region 4,1 wk ahead,1.3
+2011,42,2011/2012,42,HHS Region 4,2 wk ahead,1.5
+2011,42,2011/2012,42,HHS Region 4,3 wk ahead,1.5
+2011,42,2011/2012,42,HHS Region 4,4 wk ahead,1.4
+2011,42,2011/2012,42,HHS Region 5,Season onset,7
+2011,42,2011/2012,42,HHS Region 5,Season peak week,11
+2011,42,2011/2012,42,HHS Region 5,Season peak percentage,2.4
+2011,42,2011/2012,42,HHS Region 5,1 wk ahead,1
+2011,42,2011/2012,42,HHS Region 5,2 wk ahead,1.1
+2011,42,2011/2012,42,HHS Region 5,3 wk ahead,1.1
+2011,42,2011/2012,42,HHS Region 5,4 wk ahead,1
+2011,42,2011/2012,42,HHS Region 6,Season onset,none
+2011,42,2011/2012,42,HHS Region 6,Season peak week,11
+2011,42,2011/2012,42,HHS Region 6,Season peak percentage,4.1
+2011,42,2011/2012,42,HHS Region 6,1 wk ahead,1.9
+2011,42,2011/2012,42,HHS Region 6,2 wk ahead,1.9
+2011,42,2011/2012,42,HHS Region 6,3 wk ahead,2
+2011,42,2011/2012,42,HHS Region 6,4 wk ahead,2.2
+2011,42,2011/2012,42,HHS Region 7,Season onset,5
+2011,42,2011/2012,42,HHS Region 7,Season peak week,9
+2011,42,2011/2012,42,HHS Region 7,Season peak percentage,3.4
+2011,42,2011/2012,42,HHS Region 7,1 wk ahead,1
+2011,42,2011/2012,42,HHS Region 7,2 wk ahead,1.1
+2011,42,2011/2012,42,HHS Region 7,3 wk ahead,0.9
+2011,42,2011/2012,42,HHS Region 7,4 wk ahead,0.8
+2011,42,2011/2012,42,HHS Region 8,Season onset,none
+2011,42,2011/2012,42,HHS Region 8,Season peak week,11
+2011,42,2011/2012,42,HHS Region 8,Season peak percentage,2.2
+2011,42,2011/2012,42,HHS Region 8,1 wk ahead,0.9
+2011,42,2011/2012,42,HHS Region 8,2 wk ahead,0.9
+2011,42,2011/2012,42,HHS Region 8,3 wk ahead,1
+2011,42,2011/2012,42,HHS Region 8,4 wk ahead,1
+2011,42,2011/2012,42,HHS Region 9,Season onset,none
+2011,42,2011/2012,42,HHS Region 9,Season peak week,52
+2011,42,2011/2012,42,HHS Region 9,Season peak week,8
+2011,42,2011/2012,42,HHS Region 9,Season peak percentage,3.7
+2011,42,2011/2012,42,HHS Region 9,1 wk ahead,2
+2011,42,2011/2012,42,HHS Region 9,2 wk ahead,2.2
+2011,42,2011/2012,42,HHS Region 9,3 wk ahead,1.9
+2011,42,2011/2012,42,HHS Region 9,4 wk ahead,2.3
+2011,42,2011/2012,42,HHS Region 10,Season onset,none
+2011,42,2011/2012,42,HHS Region 10,Season peak week,12
+2011,42,2011/2012,42,HHS Region 10,Season peak percentage,2.2
+2011,42,2011/2012,42,HHS Region 10,1 wk ahead,0.7
+2011,42,2011/2012,42,HHS Region 10,2 wk ahead,0.8
+2011,42,2011/2012,42,HHS Region 10,3 wk ahead,0.7
+2011,42,2011/2012,42,HHS Region 10,4 wk ahead,0.9
+2011,43,2011/2012,43,US National,Season onset,none
+2011,43,2011/2012,43,US National,Season peak week,11
+2011,43,2011/2012,43,US National,Season peak percentage,2.4
+2011,43,2011/2012,43,US National,1 wk ahead,1.4
+2011,43,2011/2012,43,US National,2 wk ahead,1.4
+2011,43,2011/2012,43,US National,3 wk ahead,1.5
+2011,43,2011/2012,43,US National,4 wk ahead,1.6
+2011,43,2011/2012,43,HHS Region 1,Season onset,none
+2011,43,2011/2012,43,HHS Region 1,Season peak week,52
+2011,43,2011/2012,43,HHS Region 1,Season peak percentage,1
+2011,43,2011/2012,43,HHS Region 1,1 wk ahead,0.7
+2011,43,2011/2012,43,HHS Region 1,2 wk ahead,0.7
+2011,43,2011/2012,43,HHS Region 1,3 wk ahead,0.6
+2011,43,2011/2012,43,HHS Region 1,4 wk ahead,0.7
+2011,43,2011/2012,43,HHS Region 2,Season onset,none
+2011,43,2011/2012,43,HHS Region 2,Season peak week,49
+2011,43,2011/2012,43,HHS Region 2,Season peak percentage,1.4
+2011,43,2011/2012,43,HHS Region 2,1 wk ahead,1.2
+2011,43,2011/2012,43,HHS Region 2,2 wk ahead,1.1
+2011,43,2011/2012,43,HHS Region 2,3 wk ahead,1.2
+2011,43,2011/2012,43,HHS Region 2,4 wk ahead,1.3
+2011,43,2011/2012,43,HHS Region 3,Season onset,none
+2011,43,2011/2012,43,HHS Region 3,Season peak week,52
+2011,43,2011/2012,43,HHS Region 3,Season peak percentage,2.1
+2011,43,2011/2012,43,HHS Region 3,1 wk ahead,1.3
+2011,43,2011/2012,43,HHS Region 3,2 wk ahead,1.4
+2011,43,2011/2012,43,HHS Region 3,3 wk ahead,1.4
+2011,43,2011/2012,43,HHS Region 3,4 wk ahead,1.6
+2011,43,2011/2012,43,HHS Region 4,Season onset,none
+2011,43,2011/2012,43,HHS Region 4,Season peak week,52
+2011,43,2011/2012,43,HHS Region 4,Season peak week,10
+2011,43,2011/2012,43,HHS Region 4,Season peak percentage,2.3
+2011,43,2011/2012,43,HHS Region 4,1 wk ahead,1.5
+2011,43,2011/2012,43,HHS Region 4,2 wk ahead,1.5
+2011,43,2011/2012,43,HHS Region 4,3 wk ahead,1.4
+2011,43,2011/2012,43,HHS Region 4,4 wk ahead,1.7
+2011,43,2011/2012,43,HHS Region 5,Season onset,7
+2011,43,2011/2012,43,HHS Region 5,Season peak week,11
+2011,43,2011/2012,43,HHS Region 5,Season peak percentage,2.4
+2011,43,2011/2012,43,HHS Region 5,1 wk ahead,1.1
+2011,43,2011/2012,43,HHS Region 5,2 wk ahead,1.1
+2011,43,2011/2012,43,HHS Region 5,3 wk ahead,1
+2011,43,2011/2012,43,HHS Region 5,4 wk ahead,1.2
+2011,43,2011/2012,43,HHS Region 6,Season onset,none
+2011,43,2011/2012,43,HHS Region 6,Season peak week,11
+2011,43,2011/2012,43,HHS Region 6,Season peak percentage,4.1
+2011,43,2011/2012,43,HHS Region 6,1 wk ahead,1.9
+2011,43,2011/2012,43,HHS Region 6,2 wk ahead,2
+2011,43,2011/2012,43,HHS Region 6,3 wk ahead,2.2
+2011,43,2011/2012,43,HHS Region 6,4 wk ahead,2.1
+2011,43,2011/2012,43,HHS Region 7,Season onset,5
+2011,43,2011/2012,43,HHS Region 7,Season peak week,9
+2011,43,2011/2012,43,HHS Region 7,Season peak percentage,3.4
+2011,43,2011/2012,43,HHS Region 7,1 wk ahead,1.1
+2011,43,2011/2012,43,HHS Region 7,2 wk ahead,0.9
+2011,43,2011/2012,43,HHS Region 7,3 wk ahead,0.8
+2011,43,2011/2012,43,HHS Region 7,4 wk ahead,0.9
+2011,43,2011/2012,43,HHS Region 8,Season onset,none
+2011,43,2011/2012,43,HHS Region 8,Season peak week,11
+2011,43,2011/2012,43,HHS Region 8,Season peak percentage,2.2
+2011,43,2011/2012,43,HHS Region 8,1 wk ahead,0.9
+2011,43,2011/2012,43,HHS Region 8,2 wk ahead,1
+2011,43,2011/2012,43,HHS Region 8,3 wk ahead,1
+2011,43,2011/2012,43,HHS Region 8,4 wk ahead,1.1
+2011,43,2011/2012,43,HHS Region 9,Season onset,none
+2011,43,2011/2012,43,HHS Region 9,Season peak week,52
+2011,43,2011/2012,43,HHS Region 9,Season peak week,8
+2011,43,2011/2012,43,HHS Region 9,Season peak percentage,3.7
+2011,43,2011/2012,43,HHS Region 9,1 wk ahead,2.2
+2011,43,2011/2012,43,HHS Region 9,2 wk ahead,1.9
+2011,43,2011/2012,43,HHS Region 9,3 wk ahead,2.3
+2011,43,2011/2012,43,HHS Region 9,4 wk ahead,2.2
+2011,43,2011/2012,43,HHS Region 10,Season onset,none
+2011,43,2011/2012,43,HHS Region 10,Season peak week,12
+2011,43,2011/2012,43,HHS Region 10,Season peak percentage,2.2
+2011,43,2011/2012,43,HHS Region 10,1 wk ahead,0.8
+2011,43,2011/2012,43,HHS Region 10,2 wk ahead,0.7
+2011,43,2011/2012,43,HHS Region 10,3 wk ahead,0.9
+2011,43,2011/2012,43,HHS Region 10,4 wk ahead,1.1
+2011,44,2011/2012,44,US National,Season onset,none
+2011,44,2011/2012,44,US National,Season peak week,11
+2011,44,2011/2012,44,US National,Season peak percentage,2.4
+2011,44,2011/2012,44,US National,1 wk ahead,1.4
+2011,44,2011/2012,44,US National,2 wk ahead,1.5
+2011,44,2011/2012,44,US National,3 wk ahead,1.6
+2011,44,2011/2012,44,US National,4 wk ahead,1.3
+2011,44,2011/2012,44,HHS Region 1,Season onset,none
+2011,44,2011/2012,44,HHS Region 1,Season peak week,52
+2011,44,2011/2012,44,HHS Region 1,Season peak percentage,1
+2011,44,2011/2012,44,HHS Region 1,1 wk ahead,0.7
+2011,44,2011/2012,44,HHS Region 1,2 wk ahead,0.6
+2011,44,2011/2012,44,HHS Region 1,3 wk ahead,0.7
+2011,44,2011/2012,44,HHS Region 1,4 wk ahead,0.6
+2011,44,2011/2012,44,HHS Region 2,Season onset,none
+2011,44,2011/2012,44,HHS Region 2,Season peak week,49
+2011,44,2011/2012,44,HHS Region 2,Season peak percentage,1.4
+2011,44,2011/2012,44,HHS Region 2,1 wk ahead,1.1
+2011,44,2011/2012,44,HHS Region 2,2 wk ahead,1.2
+2011,44,2011/2012,44,HHS Region 2,3 wk ahead,1.3
+2011,44,2011/2012,44,HHS Region 2,4 wk ahead,1.3
+2011,44,2011/2012,44,HHS Region 3,Season onset,none
+2011,44,2011/2012,44,HHS Region 3,Season peak week,52
+2011,44,2011/2012,44,HHS Region 3,Season peak percentage,2.1
+2011,44,2011/2012,44,HHS Region 3,1 wk ahead,1.4
+2011,44,2011/2012,44,HHS Region 3,2 wk ahead,1.4
+2011,44,2011/2012,44,HHS Region 3,3 wk ahead,1.6
+2011,44,2011/2012,44,HHS Region 3,4 wk ahead,1.5
+2011,44,2011/2012,44,HHS Region 4,Season onset,none
+2011,44,2011/2012,44,HHS Region 4,Season peak week,52
+2011,44,2011/2012,44,HHS Region 4,Season peak week,10
+2011,44,2011/2012,44,HHS Region 4,Season peak percentage,2.3
+2011,44,2011/2012,44,HHS Region 4,1 wk ahead,1.5
+2011,44,2011/2012,44,HHS Region 4,2 wk ahead,1.4
+2011,44,2011/2012,44,HHS Region 4,3 wk ahead,1.7
+2011,44,2011/2012,44,HHS Region 4,4 wk ahead,1.3
+2011,44,2011/2012,44,HHS Region 5,Season onset,7
+2011,44,2011/2012,44,HHS Region 5,Season peak week,11
+2011,44,2011/2012,44,HHS Region 5,Season peak percentage,2.4
+2011,44,2011/2012,44,HHS Region 5,1 wk ahead,1.1
+2011,44,2011/2012,44,HHS Region 5,2 wk ahead,1
+2011,44,2011/2012,44,HHS Region 5,3 wk ahead,1.2
+2011,44,2011/2012,44,HHS Region 5,4 wk ahead,1.1
+2011,44,2011/2012,44,HHS Region 6,Season onset,none
+2011,44,2011/2012,44,HHS Region 6,Season peak week,11
+2011,44,2011/2012,44,HHS Region 6,Season peak percentage,4.1
+2011,44,2011/2012,44,HHS Region 6,1 wk ahead,2
+2011,44,2011/2012,44,HHS Region 6,2 wk ahead,2.2
+2011,44,2011/2012,44,HHS Region 6,3 wk ahead,2.1
+2011,44,2011/2012,44,HHS Region 6,4 wk ahead,2.2
+2011,44,2011/2012,44,HHS Region 7,Season onset,5
+2011,44,2011/2012,44,HHS Region 7,Season peak week,9
+2011,44,2011/2012,44,HHS Region 7,Season peak percentage,3.4
+2011,44,2011/2012,44,HHS Region 7,1 wk ahead,0.9
+2011,44,2011/2012,44,HHS Region 7,2 wk ahead,0.8
+2011,44,2011/2012,44,HHS Region 7,3 wk ahead,0.9
+2011,44,2011/2012,44,HHS Region 7,4 wk ahead,1
+2011,44,2011/2012,44,HHS Region 8,Season onset,none
+2011,44,2011/2012,44,HHS Region 8,Season peak week,11
+2011,44,2011/2012,44,HHS Region 8,Season peak percentage,2.2
+2011,44,2011/2012,44,HHS Region 8,1 wk ahead,1
+2011,44,2011/2012,44,HHS Region 8,2 wk ahead,1
+2011,44,2011/2012,44,HHS Region 8,3 wk ahead,1.1
+2011,44,2011/2012,44,HHS Region 8,4 wk ahead,0.9
+2011,44,2011/2012,44,HHS Region 9,Season onset,none
+2011,44,2011/2012,44,HHS Region 9,Season peak week,52
+2011,44,2011/2012,44,HHS Region 9,Season peak week,8
+2011,44,2011/2012,44,HHS Region 9,Season peak percentage,3.7
+2011,44,2011/2012,44,HHS Region 9,1 wk ahead,1.9
+2011,44,2011/2012,44,HHS Region 9,2 wk ahead,2.3
+2011,44,2011/2012,44,HHS Region 9,3 wk ahead,2.2
+2011,44,2011/2012,44,HHS Region 9,4 wk ahead,1.5
+2011,44,2011/2012,44,HHS Region 10,Season onset,none
+2011,44,2011/2012,44,HHS Region 10,Season peak week,12
+2011,44,2011/2012,44,HHS Region 10,Season peak percentage,2.2
+2011,44,2011/2012,44,HHS Region 10,1 wk ahead,0.7
+2011,44,2011/2012,44,HHS Region 10,2 wk ahead,0.9
+2011,44,2011/2012,44,HHS Region 10,3 wk ahead,1.1
+2011,44,2011/2012,44,HHS Region 10,4 wk ahead,0.8
+2011,45,2011/2012,45,US National,Season onset,none
+2011,45,2011/2012,45,US National,Season peak week,11
+2011,45,2011/2012,45,US National,Season peak percentage,2.4
+2011,45,2011/2012,45,US National,1 wk ahead,1.5
+2011,45,2011/2012,45,US National,2 wk ahead,1.6
+2011,45,2011/2012,45,US National,3 wk ahead,1.3
+2011,45,2011/2012,45,US National,4 wk ahead,1.5
+2011,45,2011/2012,45,HHS Region 1,Season onset,none
+2011,45,2011/2012,45,HHS Region 1,Season peak week,52
+2011,45,2011/2012,45,HHS Region 1,Season peak percentage,1
+2011,45,2011/2012,45,HHS Region 1,1 wk ahead,0.6
+2011,45,2011/2012,45,HHS Region 1,2 wk ahead,0.7
+2011,45,2011/2012,45,HHS Region 1,3 wk ahead,0.6
+2011,45,2011/2012,45,HHS Region 1,4 wk ahead,0.6
+2011,45,2011/2012,45,HHS Region 2,Season onset,none
+2011,45,2011/2012,45,HHS Region 2,Season peak week,49
+2011,45,2011/2012,45,HHS Region 2,Season peak percentage,1.4
+2011,45,2011/2012,45,HHS Region 2,1 wk ahead,1.2
+2011,45,2011/2012,45,HHS Region 2,2 wk ahead,1.3
+2011,45,2011/2012,45,HHS Region 2,3 wk ahead,1.3
+2011,45,2011/2012,45,HHS Region 2,4 wk ahead,1.4
+2011,45,2011/2012,45,HHS Region 3,Season onset,none
+2011,45,2011/2012,45,HHS Region 3,Season peak week,52
+2011,45,2011/2012,45,HHS Region 3,Season peak percentage,2.1
+2011,45,2011/2012,45,HHS Region 3,1 wk ahead,1.4
+2011,45,2011/2012,45,HHS Region 3,2 wk ahead,1.6
+2011,45,2011/2012,45,HHS Region 3,3 wk ahead,1.5
+2011,45,2011/2012,45,HHS Region 3,4 wk ahead,1.3
+2011,45,2011/2012,45,HHS Region 4,Season onset,none
+2011,45,2011/2012,45,HHS Region 4,Season peak week,52
+2011,45,2011/2012,45,HHS Region 4,Season peak week,10
+2011,45,2011/2012,45,HHS Region 4,Season peak percentage,2.3
+2011,45,2011/2012,45,HHS Region 4,1 wk ahead,1.4
+2011,45,2011/2012,45,HHS Region 4,2 wk ahead,1.7
+2011,45,2011/2012,45,HHS Region 4,3 wk ahead,1.3
+2011,45,2011/2012,45,HHS Region 4,4 wk ahead,1.7
+2011,45,2011/2012,45,HHS Region 5,Season onset,7
+2011,45,2011/2012,45,HHS Region 5,Season peak week,11
+2011,45,2011/2012,45,HHS Region 5,Season peak percentage,2.4
+2011,45,2011/2012,45,HHS Region 5,1 wk ahead,1
+2011,45,2011/2012,45,HHS Region 5,2 wk ahead,1.2
+2011,45,2011/2012,45,HHS Region 5,3 wk ahead,1.1
+2011,45,2011/2012,45,HHS Region 5,4 wk ahead,1
+2011,45,2011/2012,45,HHS Region 6,Season onset,none
+2011,45,2011/2012,45,HHS Region 6,Season peak week,11
+2011,45,2011/2012,45,HHS Region 6,Season peak percentage,4.1
+2011,45,2011/2012,45,HHS Region 6,1 wk ahead,2.2
+2011,45,2011/2012,45,HHS Region 6,2 wk ahead,2.1
+2011,45,2011/2012,45,HHS Region 6,3 wk ahead,2.2
+2011,45,2011/2012,45,HHS Region 6,4 wk ahead,2
+2011,45,2011/2012,45,HHS Region 7,Season onset,5
+2011,45,2011/2012,45,HHS Region 7,Season peak week,9
+2011,45,2011/2012,45,HHS Region 7,Season peak percentage,3.4
+2011,45,2011/2012,45,HHS Region 7,1 wk ahead,0.8
+2011,45,2011/2012,45,HHS Region 7,2 wk ahead,0.9
+2011,45,2011/2012,45,HHS Region 7,3 wk ahead,1
+2011,45,2011/2012,45,HHS Region 7,4 wk ahead,0.8
+2011,45,2011/2012,45,HHS Region 8,Season onset,none
+2011,45,2011/2012,45,HHS Region 8,Season peak week,11
+2011,45,2011/2012,45,HHS Region 8,Season peak percentage,2.2
+2011,45,2011/2012,45,HHS Region 8,1 wk ahead,1
+2011,45,2011/2012,45,HHS Region 8,2 wk ahead,1.1
+2011,45,2011/2012,45,HHS Region 8,3 wk ahead,0.9
+2011,45,2011/2012,45,HHS Region 8,4 wk ahead,0.9
+2011,45,2011/2012,45,HHS Region 9,Season onset,none
+2011,45,2011/2012,45,HHS Region 9,Season peak week,52
+2011,45,2011/2012,45,HHS Region 9,Season peak week,8
+2011,45,2011/2012,45,HHS Region 9,Season peak percentage,3.7
+2011,45,2011/2012,45,HHS Region 9,1 wk ahead,2.3
+2011,45,2011/2012,45,HHS Region 9,2 wk ahead,2.2
+2011,45,2011/2012,45,HHS Region 9,3 wk ahead,1.5
+2011,45,2011/2012,45,HHS Region 9,4 wk ahead,2.3
+2011,45,2011/2012,45,HHS Region 10,Season onset,none
+2011,45,2011/2012,45,HHS Region 10,Season peak week,12
+2011,45,2011/2012,45,HHS Region 10,Season peak percentage,2.2
+2011,45,2011/2012,45,HHS Region 10,1 wk ahead,0.9
+2011,45,2011/2012,45,HHS Region 10,2 wk ahead,1.1
+2011,45,2011/2012,45,HHS Region 10,3 wk ahead,0.8
+2011,45,2011/2012,45,HHS Region 10,4 wk ahead,0.6
+2011,46,2011/2012,46,US National,Season onset,none
+2011,46,2011/2012,46,US National,Season peak week,11
+2011,46,2011/2012,46,US National,Season peak percentage,2.4
+2011,46,2011/2012,46,US National,1 wk ahead,1.6
+2011,46,2011/2012,46,US National,2 wk ahead,1.3
+2011,46,2011/2012,46,US National,3 wk ahead,1.5
+2011,46,2011/2012,46,US National,4 wk ahead,1.6
+2011,46,2011/2012,46,HHS Region 1,Season onset,none
+2011,46,2011/2012,46,HHS Region 1,Season peak week,52
+2011,46,2011/2012,46,HHS Region 1,Season peak percentage,1
+2011,46,2011/2012,46,HHS Region 1,1 wk ahead,0.7
+2011,46,2011/2012,46,HHS Region 1,2 wk ahead,0.6
+2011,46,2011/2012,46,HHS Region 1,3 wk ahead,0.6
+2011,46,2011/2012,46,HHS Region 1,4 wk ahead,0.8
+2011,46,2011/2012,46,HHS Region 2,Season onset,none
+2011,46,2011/2012,46,HHS Region 2,Season peak week,49
+2011,46,2011/2012,46,HHS Region 2,Season peak percentage,1.4
+2011,46,2011/2012,46,HHS Region 2,1 wk ahead,1.3
+2011,46,2011/2012,46,HHS Region 2,2 wk ahead,1.3
+2011,46,2011/2012,46,HHS Region 2,3 wk ahead,1.4
+2011,46,2011/2012,46,HHS Region 2,4 wk ahead,1.3
+2011,46,2011/2012,46,HHS Region 3,Season onset,none
+2011,46,2011/2012,46,HHS Region 3,Season peak week,52
+2011,46,2011/2012,46,HHS Region 3,Season peak percentage,2.1
+2011,46,2011/2012,46,HHS Region 3,1 wk ahead,1.6
+2011,46,2011/2012,46,HHS Region 3,2 wk ahead,1.5
+2011,46,2011/2012,46,HHS Region 3,3 wk ahead,1.3
+2011,46,2011/2012,46,HHS Region 3,4 wk ahead,1.5
+2011,46,2011/2012,46,HHS Region 4,Season onset,none
+2011,46,2011/2012,46,HHS Region 4,Season peak week,52
+2011,46,2011/2012,46,HHS Region 4,Season peak week,10
+2011,46,2011/2012,46,HHS Region 4,Season peak percentage,2.3
+2011,46,2011/2012,46,HHS Region 4,1 wk ahead,1.7
+2011,46,2011/2012,46,HHS Region 4,2 wk ahead,1.3
+2011,46,2011/2012,46,HHS Region 4,3 wk ahead,1.7
+2011,46,2011/2012,46,HHS Region 4,4 wk ahead,1.7
+2011,46,2011/2012,46,HHS Region 5,Season onset,7
+2011,46,2011/2012,46,HHS Region 5,Season peak week,11
+2011,46,2011/2012,46,HHS Region 5,Season peak percentage,2.4
+2011,46,2011/2012,46,HHS Region 5,1 wk ahead,1.2
+2011,46,2011/2012,46,HHS Region 5,2 wk ahead,1.1
+2011,46,2011/2012,46,HHS Region 5,3 wk ahead,1
+2011,46,2011/2012,46,HHS Region 5,4 wk ahead,1.1
+2011,46,2011/2012,46,HHS Region 6,Season onset,none
+2011,46,2011/2012,46,HHS Region 6,Season peak week,11
+2011,46,2011/2012,46,HHS Region 6,Season peak percentage,4.1
+2011,46,2011/2012,46,HHS Region 6,1 wk ahead,2.1
+2011,46,2011/2012,46,HHS Region 6,2 wk ahead,2.2
+2011,46,2011/2012,46,HHS Region 6,3 wk ahead,2
+2011,46,2011/2012,46,HHS Region 6,4 wk ahead,2.1
+2011,46,2011/2012,46,HHS Region 7,Season onset,5
+2011,46,2011/2012,46,HHS Region 7,Season peak week,9
+2011,46,2011/2012,46,HHS Region 7,Season peak percentage,3.4
+2011,46,2011/2012,46,HHS Region 7,1 wk ahead,0.9
+2011,46,2011/2012,46,HHS Region 7,2 wk ahead,1
+2011,46,2011/2012,46,HHS Region 7,3 wk ahead,0.8
+2011,46,2011/2012,46,HHS Region 7,4 wk ahead,1.4
+2011,46,2011/2012,46,HHS Region 8,Season onset,none
+2011,46,2011/2012,46,HHS Region 8,Season peak week,11
+2011,46,2011/2012,46,HHS Region 8,Season peak percentage,2.2
+2011,46,2011/2012,46,HHS Region 8,1 wk ahead,1.1
+2011,46,2011/2012,46,HHS Region 8,2 wk ahead,0.9
+2011,46,2011/2012,46,HHS Region 8,3 wk ahead,0.9
+2011,46,2011/2012,46,HHS Region 8,4 wk ahead,1
+2011,46,2011/2012,46,HHS Region 9,Season onset,none
+2011,46,2011/2012,46,HHS Region 9,Season peak week,52
+2011,46,2011/2012,46,HHS Region 9,Season peak week,8
+2011,46,2011/2012,46,HHS Region 9,Season peak percentage,3.7
+2011,46,2011/2012,46,HHS Region 9,1 wk ahead,2.2
+2011,46,2011/2012,46,HHS Region 9,2 wk ahead,1.5
+2011,46,2011/2012,46,HHS Region 9,3 wk ahead,2.3
+2011,46,2011/2012,46,HHS Region 9,4 wk ahead,2.6
+2011,46,2011/2012,46,HHS Region 10,Season onset,none
+2011,46,2011/2012,46,HHS Region 10,Season peak week,12
+2011,46,2011/2012,46,HHS Region 10,Season peak percentage,2.2
+2011,46,2011/2012,46,HHS Region 10,1 wk ahead,1.1
+2011,46,2011/2012,46,HHS Region 10,2 wk ahead,0.8
+2011,46,2011/2012,46,HHS Region 10,3 wk ahead,0.6
+2011,46,2011/2012,46,HHS Region 10,4 wk ahead,1
+2011,47,2011/2012,47,US National,Season onset,none
+2011,47,2011/2012,47,US National,Season peak week,11
+2011,47,2011/2012,47,US National,Season peak percentage,2.4
+2011,47,2011/2012,47,US National,1 wk ahead,1.3
+2011,47,2011/2012,47,US National,2 wk ahead,1.5
+2011,47,2011/2012,47,US National,3 wk ahead,1.6
+2011,47,2011/2012,47,US National,4 wk ahead,1.8
+2011,47,2011/2012,47,HHS Region 1,Season onset,none
+2011,47,2011/2012,47,HHS Region 1,Season peak week,52
+2011,47,2011/2012,47,HHS Region 1,Season peak percentage,1
+2011,47,2011/2012,47,HHS Region 1,1 wk ahead,0.6
+2011,47,2011/2012,47,HHS Region 1,2 wk ahead,0.6
+2011,47,2011/2012,47,HHS Region 1,3 wk ahead,0.8
+2011,47,2011/2012,47,HHS Region 1,4 wk ahead,0.9
+2011,47,2011/2012,47,HHS Region 2,Season onset,none
+2011,47,2011/2012,47,HHS Region 2,Season peak week,49
+2011,47,2011/2012,47,HHS Region 2,Season peak percentage,1.4
+2011,47,2011/2012,47,HHS Region 2,1 wk ahead,1.3
+2011,47,2011/2012,47,HHS Region 2,2 wk ahead,1.4
+2011,47,2011/2012,47,HHS Region 2,3 wk ahead,1.3
+2011,47,2011/2012,47,HHS Region 2,4 wk ahead,1.2
+2011,47,2011/2012,47,HHS Region 3,Season onset,none
+2011,47,2011/2012,47,HHS Region 3,Season peak week,52
+2011,47,2011/2012,47,HHS Region 3,Season peak percentage,2.1
+2011,47,2011/2012,47,HHS Region 3,1 wk ahead,1.5
+2011,47,2011/2012,47,HHS Region 3,2 wk ahead,1.3
+2011,47,2011/2012,47,HHS Region 3,3 wk ahead,1.5
+2011,47,2011/2012,47,HHS Region 3,4 wk ahead,1.8
+2011,47,2011/2012,47,HHS Region 4,Season onset,none
+2011,47,2011/2012,47,HHS Region 4,Season peak week,52
+2011,47,2011/2012,47,HHS Region 4,Season peak week,10
+2011,47,2011/2012,47,HHS Region 4,Season peak percentage,2.3
+2011,47,2011/2012,47,HHS Region 4,1 wk ahead,1.3
+2011,47,2011/2012,47,HHS Region 4,2 wk ahead,1.7
+2011,47,2011/2012,47,HHS Region 4,3 wk ahead,1.7
+2011,47,2011/2012,47,HHS Region 4,4 wk ahead,2
+2011,47,2011/2012,47,HHS Region 5,Season onset,7
+2011,47,2011/2012,47,HHS Region 5,Season peak week,11
+2011,47,2011/2012,47,HHS Region 5,Season peak percentage,2.4
+2011,47,2011/2012,47,HHS Region 5,1 wk ahead,1.1
+2011,47,2011/2012,47,HHS Region 5,2 wk ahead,1
+2011,47,2011/2012,47,HHS Region 5,3 wk ahead,1.1
+2011,47,2011/2012,47,HHS Region 5,4 wk ahead,1.2
+2011,47,2011/2012,47,HHS Region 6,Season onset,none
+2011,47,2011/2012,47,HHS Region 6,Season peak week,11
+2011,47,2011/2012,47,HHS Region 6,Season peak percentage,4.1
+2011,47,2011/2012,47,HHS Region 6,1 wk ahead,2.2
+2011,47,2011/2012,47,HHS Region 6,2 wk ahead,2
+2011,47,2011/2012,47,HHS Region 6,3 wk ahead,2.1
+2011,47,2011/2012,47,HHS Region 6,4 wk ahead,2.2
+2011,47,2011/2012,47,HHS Region 7,Season onset,5
+2011,47,2011/2012,47,HHS Region 7,Season peak week,9
+2011,47,2011/2012,47,HHS Region 7,Season peak percentage,3.4
+2011,47,2011/2012,47,HHS Region 7,1 wk ahead,1
+2011,47,2011/2012,47,HHS Region 7,2 wk ahead,0.8
+2011,47,2011/2012,47,HHS Region 7,3 wk ahead,1.4
+2011,47,2011/2012,47,HHS Region 7,4 wk ahead,1.4
+2011,47,2011/2012,47,HHS Region 8,Season onset,none
+2011,47,2011/2012,47,HHS Region 8,Season peak week,11
+2011,47,2011/2012,47,HHS Region 8,Season peak percentage,2.2
+2011,47,2011/2012,47,HHS Region 8,1 wk ahead,0.9
+2011,47,2011/2012,47,HHS Region 8,2 wk ahead,0.9
+2011,47,2011/2012,47,HHS Region 8,3 wk ahead,1
+2011,47,2011/2012,47,HHS Region 8,4 wk ahead,1
+2011,47,2011/2012,47,HHS Region 9,Season onset,none
+2011,47,2011/2012,47,HHS Region 9,Season peak week,52
+2011,47,2011/2012,47,HHS Region 9,Season peak week,8
+2011,47,2011/2012,47,HHS Region 9,Season peak percentage,3.7
+2011,47,2011/2012,47,HHS Region 9,1 wk ahead,1.5
+2011,47,2011/2012,47,HHS Region 9,2 wk ahead,2.3
+2011,47,2011/2012,47,HHS Region 9,3 wk ahead,2.6
+2011,47,2011/2012,47,HHS Region 9,4 wk ahead,3.1
+2011,47,2011/2012,47,HHS Region 10,Season onset,none
+2011,47,2011/2012,47,HHS Region 10,Season peak week,12
+2011,47,2011/2012,47,HHS Region 10,Season peak percentage,2.2
+2011,47,2011/2012,47,HHS Region 10,1 wk ahead,0.8
+2011,47,2011/2012,47,HHS Region 10,2 wk ahead,0.6
+2011,47,2011/2012,47,HHS Region 10,3 wk ahead,1
+2011,47,2011/2012,47,HHS Region 10,4 wk ahead,1.2
+2011,48,2011/2012,48,US National,Season onset,none
+2011,48,2011/2012,48,US National,Season peak week,11
+2011,48,2011/2012,48,US National,Season peak percentage,2.4
+2011,48,2011/2012,48,US National,1 wk ahead,1.5
+2011,48,2011/2012,48,US National,2 wk ahead,1.6
+2011,48,2011/2012,48,US National,3 wk ahead,1.8
+2011,48,2011/2012,48,US National,4 wk ahead,2.1
+2011,48,2011/2012,48,HHS Region 1,Season onset,none
+2011,48,2011/2012,48,HHS Region 1,Season peak week,52
+2011,48,2011/2012,48,HHS Region 1,Season peak percentage,1
+2011,48,2011/2012,48,HHS Region 1,1 wk ahead,0.6
+2011,48,2011/2012,48,HHS Region 1,2 wk ahead,0.8
+2011,48,2011/2012,48,HHS Region 1,3 wk ahead,0.9
+2011,48,2011/2012,48,HHS Region 1,4 wk ahead,1
+2011,48,2011/2012,48,HHS Region 2,Season onset,none
+2011,48,2011/2012,48,HHS Region 2,Season peak week,49
+2011,48,2011/2012,48,HHS Region 2,Season peak percentage,1.4
+2011,48,2011/2012,48,HHS Region 2,1 wk ahead,1.4
+2011,48,2011/2012,48,HHS Region 2,2 wk ahead,1.3
+2011,48,2011/2012,48,HHS Region 2,3 wk ahead,1.2
+2011,48,2011/2012,48,HHS Region 2,4 wk ahead,1.2
+2011,48,2011/2012,48,HHS Region 3,Season onset,none
+2011,48,2011/2012,48,HHS Region 3,Season peak week,52
+2011,48,2011/2012,48,HHS Region 3,Season peak percentage,2.1
+2011,48,2011/2012,48,HHS Region 3,1 wk ahead,1.3
+2011,48,2011/2012,48,HHS Region 3,2 wk ahead,1.5
+2011,48,2011/2012,48,HHS Region 3,3 wk ahead,1.8
+2011,48,2011/2012,48,HHS Region 3,4 wk ahead,2.1
+2011,48,2011/2012,48,HHS Region 4,Season onset,none
+2011,48,2011/2012,48,HHS Region 4,Season peak week,52
+2011,48,2011/2012,48,HHS Region 4,Season peak week,10
+2011,48,2011/2012,48,HHS Region 4,Season peak percentage,2.3
+2011,48,2011/2012,48,HHS Region 4,1 wk ahead,1.7
+2011,48,2011/2012,48,HHS Region 4,2 wk ahead,1.7
+2011,48,2011/2012,48,HHS Region 4,3 wk ahead,2
+2011,48,2011/2012,48,HHS Region 4,4 wk ahead,2.3
+2011,48,2011/2012,48,HHS Region 5,Season onset,7
+2011,48,2011/2012,48,HHS Region 5,Season peak week,11
+2011,48,2011/2012,48,HHS Region 5,Season peak percentage,2.4
+2011,48,2011/2012,48,HHS Region 5,1 wk ahead,1
+2011,48,2011/2012,48,HHS Region 5,2 wk ahead,1.1
+2011,48,2011/2012,48,HHS Region 5,3 wk ahead,1.2
+2011,48,2011/2012,48,HHS Region 5,4 wk ahead,1.5
+2011,48,2011/2012,48,HHS Region 6,Season onset,none
+2011,48,2011/2012,48,HHS Region 6,Season peak week,11
+2011,48,2011/2012,48,HHS Region 6,Season peak percentage,4.1
+2011,48,2011/2012,48,HHS Region 6,1 wk ahead,2
+2011,48,2011/2012,48,HHS Region 6,2 wk ahead,2.1
+2011,48,2011/2012,48,HHS Region 6,3 wk ahead,2.2
+2011,48,2011/2012,48,HHS Region 6,4 wk ahead,2.3
+2011,48,2011/2012,48,HHS Region 7,Season onset,5
+2011,48,2011/2012,48,HHS Region 7,Season peak week,9
+2011,48,2011/2012,48,HHS Region 7,Season peak percentage,3.4
+2011,48,2011/2012,48,HHS Region 7,1 wk ahead,0.8
+2011,48,2011/2012,48,HHS Region 7,2 wk ahead,1.4
+2011,48,2011/2012,48,HHS Region 7,3 wk ahead,1.4
+2011,48,2011/2012,48,HHS Region 7,4 wk ahead,1.9
+2011,48,2011/2012,48,HHS Region 8,Season onset,none
+2011,48,2011/2012,48,HHS Region 8,Season peak week,11
+2011,48,2011/2012,48,HHS Region 8,Season peak percentage,2.2
+2011,48,2011/2012,48,HHS Region 8,1 wk ahead,0.9
+2011,48,2011/2012,48,HHS Region 8,2 wk ahead,1
+2011,48,2011/2012,48,HHS Region 8,3 wk ahead,1
+2011,48,2011/2012,48,HHS Region 8,4 wk ahead,1.1
+2011,48,2011/2012,48,HHS Region 9,Season onset,none
+2011,48,2011/2012,48,HHS Region 9,Season peak week,52
+2011,48,2011/2012,48,HHS Region 9,Season peak week,8
+2011,48,2011/2012,48,HHS Region 9,Season peak percentage,3.7
+2011,48,2011/2012,48,HHS Region 9,1 wk ahead,2.3
+2011,48,2011/2012,48,HHS Region 9,2 wk ahead,2.6
+2011,48,2011/2012,48,HHS Region 9,3 wk ahead,3.1
+2011,48,2011/2012,48,HHS Region 9,4 wk ahead,3.7
+2011,48,2011/2012,48,HHS Region 10,Season onset,none
+2011,48,2011/2012,48,HHS Region 10,Season peak week,12
+2011,48,2011/2012,48,HHS Region 10,Season peak percentage,2.2
+2011,48,2011/2012,48,HHS Region 10,1 wk ahead,0.6
+2011,48,2011/2012,48,HHS Region 10,2 wk ahead,1
+2011,48,2011/2012,48,HHS Region 10,3 wk ahead,1.2
+2011,48,2011/2012,48,HHS Region 10,4 wk ahead,1.3
+2011,49,2011/2012,49,US National,Season onset,none
+2011,49,2011/2012,49,US National,Season peak week,11
+2011,49,2011/2012,49,US National,Season peak percentage,2.4
+2011,49,2011/2012,49,US National,1 wk ahead,1.6
+2011,49,2011/2012,49,US National,2 wk ahead,1.8
+2011,49,2011/2012,49,US National,3 wk ahead,2.1
+2011,49,2011/2012,49,US National,4 wk ahead,1.7
+2011,49,2011/2012,49,HHS Region 1,Season onset,none
+2011,49,2011/2012,49,HHS Region 1,Season peak week,52
+2011,49,2011/2012,49,HHS Region 1,Season peak percentage,1
+2011,49,2011/2012,49,HHS Region 1,1 wk ahead,0.8
+2011,49,2011/2012,49,HHS Region 1,2 wk ahead,0.9
+2011,49,2011/2012,49,HHS Region 1,3 wk ahead,1
+2011,49,2011/2012,49,HHS Region 1,4 wk ahead,0.9
+2011,49,2011/2012,49,HHS Region 2,Season onset,none
+2011,49,2011/2012,49,HHS Region 2,Season peak week,49
+2011,49,2011/2012,49,HHS Region 2,Season peak percentage,1.4
+2011,49,2011/2012,49,HHS Region 2,1 wk ahead,1.3
+2011,49,2011/2012,49,HHS Region 2,2 wk ahead,1.2
+2011,49,2011/2012,49,HHS Region 2,3 wk ahead,1.2
+2011,49,2011/2012,49,HHS Region 2,4 wk ahead,1.3
+2011,49,2011/2012,49,HHS Region 3,Season onset,none
+2011,49,2011/2012,49,HHS Region 3,Season peak week,52
+2011,49,2011/2012,49,HHS Region 3,Season peak percentage,2.1
+2011,49,2011/2012,49,HHS Region 3,1 wk ahead,1.5
+2011,49,2011/2012,49,HHS Region 3,2 wk ahead,1.8
+2011,49,2011/2012,49,HHS Region 3,3 wk ahead,2.1
+2011,49,2011/2012,49,HHS Region 3,4 wk ahead,1.7
+2011,49,2011/2012,49,HHS Region 4,Season onset,none
+2011,49,2011/2012,49,HHS Region 4,Season peak week,52
+2011,49,2011/2012,49,HHS Region 4,Season peak week,10
+2011,49,2011/2012,49,HHS Region 4,Season peak percentage,2.3
+2011,49,2011/2012,49,HHS Region 4,1 wk ahead,1.7
+2011,49,2011/2012,49,HHS Region 4,2 wk ahead,2
+2011,49,2011/2012,49,HHS Region 4,3 wk ahead,2.3
+2011,49,2011/2012,49,HHS Region 4,4 wk ahead,1.6
+2011,49,2011/2012,49,HHS Region 5,Season onset,7
+2011,49,2011/2012,49,HHS Region 5,Season peak week,11
+2011,49,2011/2012,49,HHS Region 5,Season peak percentage,2.4
+2011,49,2011/2012,49,HHS Region 5,1 wk ahead,1.1
+2011,49,2011/2012,49,HHS Region 5,2 wk ahead,1.2
+2011,49,2011/2012,49,HHS Region 5,3 wk ahead,1.5
+2011,49,2011/2012,49,HHS Region 5,4 wk ahead,1.2
+2011,49,2011/2012,49,HHS Region 6,Season onset,none
+2011,49,2011/2012,49,HHS Region 6,Season peak week,11
+2011,49,2011/2012,49,HHS Region 6,Season peak percentage,4.1
+2011,49,2011/2012,49,HHS Region 6,1 wk ahead,2.1
+2011,49,2011/2012,49,HHS Region 6,2 wk ahead,2.2
+2011,49,2011/2012,49,HHS Region 6,3 wk ahead,2.3
+2011,49,2011/2012,49,HHS Region 6,4 wk ahead,2.1
+2011,49,2011/2012,49,HHS Region 7,Season onset,5
+2011,49,2011/2012,49,HHS Region 7,Season peak week,9
+2011,49,2011/2012,49,HHS Region 7,Season peak percentage,3.4
+2011,49,2011/2012,49,HHS Region 7,1 wk ahead,1.4
+2011,49,2011/2012,49,HHS Region 7,2 wk ahead,1.4
+2011,49,2011/2012,49,HHS Region 7,3 wk ahead,1.9
+2011,49,2011/2012,49,HHS Region 7,4 wk ahead,1.5
+2011,49,2011/2012,49,HHS Region 8,Season onset,none
+2011,49,2011/2012,49,HHS Region 8,Season peak week,11
+2011,49,2011/2012,49,HHS Region 8,Season peak percentage,2.2
+2011,49,2011/2012,49,HHS Region 8,1 wk ahead,1
+2011,49,2011/2012,49,HHS Region 8,2 wk ahead,1
+2011,49,2011/2012,49,HHS Region 8,3 wk ahead,1.1
+2011,49,2011/2012,49,HHS Region 8,4 wk ahead,1.1
+2011,49,2011/2012,49,HHS Region 9,Season onset,none
+2011,49,2011/2012,49,HHS Region 9,Season peak week,52
+2011,49,2011/2012,49,HHS Region 9,Season peak week,8
+2011,49,2011/2012,49,HHS Region 9,Season peak percentage,3.7
+2011,49,2011/2012,49,HHS Region 9,1 wk ahead,2.6
+2011,49,2011/2012,49,HHS Region 9,2 wk ahead,3.1
+2011,49,2011/2012,49,HHS Region 9,3 wk ahead,3.7
+2011,49,2011/2012,49,HHS Region 9,4 wk ahead,3
+2011,49,2011/2012,49,HHS Region 10,Season onset,none
+2011,49,2011/2012,49,HHS Region 10,Season peak week,12
+2011,49,2011/2012,49,HHS Region 10,Season peak percentage,2.2
+2011,49,2011/2012,49,HHS Region 10,1 wk ahead,1
+2011,49,2011/2012,49,HHS Region 10,2 wk ahead,1.2
+2011,49,2011/2012,49,HHS Region 10,3 wk ahead,1.3
+2011,49,2011/2012,49,HHS Region 10,4 wk ahead,1.1
+2011,50,2011/2012,50,US National,Season onset,none
+2011,50,2011/2012,50,US National,Season peak week,11
+2011,50,2011/2012,50,US National,Season peak percentage,2.4
+2011,50,2011/2012,50,US National,1 wk ahead,1.8
+2011,50,2011/2012,50,US National,2 wk ahead,2.1
+2011,50,2011/2012,50,US National,3 wk ahead,1.7
+2011,50,2011/2012,50,US National,4 wk ahead,1.6
+2011,50,2011/2012,50,HHS Region 1,Season onset,none
+2011,50,2011/2012,50,HHS Region 1,Season peak week,52
+2011,50,2011/2012,50,HHS Region 1,Season peak percentage,1
+2011,50,2011/2012,50,HHS Region 1,1 wk ahead,0.9
+2011,50,2011/2012,50,HHS Region 1,2 wk ahead,1
+2011,50,2011/2012,50,HHS Region 1,3 wk ahead,0.9
+2011,50,2011/2012,50,HHS Region 1,4 wk ahead,0.8
+2011,50,2011/2012,50,HHS Region 2,Season onset,none
+2011,50,2011/2012,50,HHS Region 2,Season peak week,49
+2011,50,2011/2012,50,HHS Region 2,Season peak percentage,1.4
+2011,50,2011/2012,50,HHS Region 2,1 wk ahead,1.2
+2011,50,2011/2012,50,HHS Region 2,2 wk ahead,1.2
+2011,50,2011/2012,50,HHS Region 2,3 wk ahead,1.3
+2011,50,2011/2012,50,HHS Region 2,4 wk ahead,1
+2011,50,2011/2012,50,HHS Region 3,Season onset,none
+2011,50,2011/2012,50,HHS Region 3,Season peak week,52
+2011,50,2011/2012,50,HHS Region 3,Season peak percentage,2.1
+2011,50,2011/2012,50,HHS Region 3,1 wk ahead,1.8
+2011,50,2011/2012,50,HHS Region 3,2 wk ahead,2.1
+2011,50,2011/2012,50,HHS Region 3,3 wk ahead,1.7
+2011,50,2011/2012,50,HHS Region 3,4 wk ahead,1.5
+2011,50,2011/2012,50,HHS Region 4,Season onset,none
+2011,50,2011/2012,50,HHS Region 4,Season peak week,52
+2011,50,2011/2012,50,HHS Region 4,Season peak week,10
+2011,50,2011/2012,50,HHS Region 4,Season peak percentage,2.3
+2011,50,2011/2012,50,HHS Region 4,1 wk ahead,2
+2011,50,2011/2012,50,HHS Region 4,2 wk ahead,2.3
+2011,50,2011/2012,50,HHS Region 4,3 wk ahead,1.6
+2011,50,2011/2012,50,HHS Region 4,4 wk ahead,1.5
+2011,50,2011/2012,50,HHS Region 5,Season onset,7
+2011,50,2011/2012,50,HHS Region 5,Season peak week,11
+2011,50,2011/2012,50,HHS Region 5,Season peak percentage,2.4
+2011,50,2011/2012,50,HHS Region 5,1 wk ahead,1.2
+2011,50,2011/2012,50,HHS Region 5,2 wk ahead,1.5
+2011,50,2011/2012,50,HHS Region 5,3 wk ahead,1.2
+2011,50,2011/2012,50,HHS Region 5,4 wk ahead,1.2
+2011,50,2011/2012,50,HHS Region 6,Season onset,none
+2011,50,2011/2012,50,HHS Region 6,Season peak week,11
+2011,50,2011/2012,50,HHS Region 6,Season peak percentage,4.1
+2011,50,2011/2012,50,HHS Region 6,1 wk ahead,2.2
+2011,50,2011/2012,50,HHS Region 6,2 wk ahead,2.3
+2011,50,2011/2012,50,HHS Region 6,3 wk ahead,2.1
+2011,50,2011/2012,50,HHS Region 6,4 wk ahead,2.1
+2011,50,2011/2012,50,HHS Region 7,Season onset,5
+2011,50,2011/2012,50,HHS Region 7,Season peak week,9
+2011,50,2011/2012,50,HHS Region 7,Season peak percentage,3.4
+2011,50,2011/2012,50,HHS Region 7,1 wk ahead,1.4
+2011,50,2011/2012,50,HHS Region 7,2 wk ahead,1.9
+2011,50,2011/2012,50,HHS Region 7,3 wk ahead,1.5
+2011,50,2011/2012,50,HHS Region 7,4 wk ahead,1.5
+2011,50,2011/2012,50,HHS Region 8,Season onset,none
+2011,50,2011/2012,50,HHS Region 8,Season peak week,11
+2011,50,2011/2012,50,HHS Region 8,Season peak percentage,2.2
+2011,50,2011/2012,50,HHS Region 8,1 wk ahead,1
+2011,50,2011/2012,50,HHS Region 8,2 wk ahead,1.1
+2011,50,2011/2012,50,HHS Region 8,3 wk ahead,1.1
+2011,50,2011/2012,50,HHS Region 8,4 wk ahead,1.1
+2011,50,2011/2012,50,HHS Region 9,Season onset,none
+2011,50,2011/2012,50,HHS Region 9,Season peak week,52
+2011,50,2011/2012,50,HHS Region 9,Season peak week,8
+2011,50,2011/2012,50,HHS Region 9,Season peak percentage,3.7
+2011,50,2011/2012,50,HHS Region 9,1 wk ahead,3.1
+2011,50,2011/2012,50,HHS Region 9,2 wk ahead,3.7
+2011,50,2011/2012,50,HHS Region 9,3 wk ahead,3
+2011,50,2011/2012,50,HHS Region 9,4 wk ahead,2.5
+2011,50,2011/2012,50,HHS Region 10,Season onset,none
+2011,50,2011/2012,50,HHS Region 10,Season peak week,12
+2011,50,2011/2012,50,HHS Region 10,Season peak percentage,2.2
+2011,50,2011/2012,50,HHS Region 10,1 wk ahead,1.2
+2011,50,2011/2012,50,HHS Region 10,2 wk ahead,1.3
+2011,50,2011/2012,50,HHS Region 10,3 wk ahead,1.1
+2011,50,2011/2012,50,HHS Region 10,4 wk ahead,0.7
+2011,51,2011/2012,51,US National,Season onset,none
+2011,51,2011/2012,51,US National,Season peak week,11
+2011,51,2011/2012,51,US National,Season peak percentage,2.4
+2011,51,2011/2012,51,US National,1 wk ahead,2.1
+2011,51,2011/2012,51,US National,2 wk ahead,1.7
+2011,51,2011/2012,51,US National,3 wk ahead,1.6
+2011,51,2011/2012,51,US National,4 wk ahead,1.6
+2011,51,2011/2012,51,HHS Region 1,Season onset,none
+2011,51,2011/2012,51,HHS Region 1,Season peak week,52
+2011,51,2011/2012,51,HHS Region 1,Season peak percentage,1
+2011,51,2011/2012,51,HHS Region 1,1 wk ahead,1
+2011,51,2011/2012,51,HHS Region 1,2 wk ahead,0.9
+2011,51,2011/2012,51,HHS Region 1,3 wk ahead,0.8
+2011,51,2011/2012,51,HHS Region 1,4 wk ahead,0.8
+2011,51,2011/2012,51,HHS Region 2,Season onset,none
+2011,51,2011/2012,51,HHS Region 2,Season peak week,49
+2011,51,2011/2012,51,HHS Region 2,Season peak percentage,1.4
+2011,51,2011/2012,51,HHS Region 2,1 wk ahead,1.2
+2011,51,2011/2012,51,HHS Region 2,2 wk ahead,1.3
+2011,51,2011/2012,51,HHS Region 2,3 wk ahead,1
+2011,51,2011/2012,51,HHS Region 2,4 wk ahead,1.1
+2011,51,2011/2012,51,HHS Region 3,Season onset,none
+2011,51,2011/2012,51,HHS Region 3,Season peak week,52
+2011,51,2011/2012,51,HHS Region 3,Season peak percentage,2.1
+2011,51,2011/2012,51,HHS Region 3,1 wk ahead,2.1
+2011,51,2011/2012,51,HHS Region 3,2 wk ahead,1.7
+2011,51,2011/2012,51,HHS Region 3,3 wk ahead,1.5
+2011,51,2011/2012,51,HHS Region 3,4 wk ahead,1.6
+2011,51,2011/2012,51,HHS Region 4,Season onset,none
+2011,51,2011/2012,51,HHS Region 4,Season peak week,52
+2011,51,2011/2012,51,HHS Region 4,Season peak week,10
+2011,51,2011/2012,51,HHS Region 4,Season peak percentage,2.3
+2011,51,2011/2012,51,HHS Region 4,1 wk ahead,2.3
+2011,51,2011/2012,51,HHS Region 4,2 wk ahead,1.6
+2011,51,2011/2012,51,HHS Region 4,3 wk ahead,1.5
+2011,51,2011/2012,51,HHS Region 4,4 wk ahead,1.7
+2011,51,2011/2012,51,HHS Region 5,Season onset,7
+2011,51,2011/2012,51,HHS Region 5,Season peak week,11
+2011,51,2011/2012,51,HHS Region 5,Season peak percentage,2.4
+2011,51,2011/2012,51,HHS Region 5,1 wk ahead,1.5
+2011,51,2011/2012,51,HHS Region 5,2 wk ahead,1.2
+2011,51,2011/2012,51,HHS Region 5,3 wk ahead,1.2
+2011,51,2011/2012,51,HHS Region 5,4 wk ahead,1.2
+2011,51,2011/2012,51,HHS Region 6,Season onset,none
+2011,51,2011/2012,51,HHS Region 6,Season peak week,11
+2011,51,2011/2012,51,HHS Region 6,Season peak percentage,4.1
+2011,51,2011/2012,51,HHS Region 6,1 wk ahead,2.3
+2011,51,2011/2012,51,HHS Region 6,2 wk ahead,2.1
+2011,51,2011/2012,51,HHS Region 6,3 wk ahead,2.1
+2011,51,2011/2012,51,HHS Region 6,4 wk ahead,2.2
+2011,51,2011/2012,51,HHS Region 7,Season onset,5
+2011,51,2011/2012,51,HHS Region 7,Season peak week,9
+2011,51,2011/2012,51,HHS Region 7,Season peak percentage,3.4
+2011,51,2011/2012,51,HHS Region 7,1 wk ahead,1.9
+2011,51,2011/2012,51,HHS Region 7,2 wk ahead,1.5
+2011,51,2011/2012,51,HHS Region 7,3 wk ahead,1.5
+2011,51,2011/2012,51,HHS Region 7,4 wk ahead,1.6
+2011,51,2011/2012,51,HHS Region 8,Season onset,none
+2011,51,2011/2012,51,HHS Region 8,Season peak week,11
+2011,51,2011/2012,51,HHS Region 8,Season peak percentage,2.2
+2011,51,2011/2012,51,HHS Region 8,1 wk ahead,1.1
+2011,51,2011/2012,51,HHS Region 8,2 wk ahead,1.1
+2011,51,2011/2012,51,HHS Region 8,3 wk ahead,1.1
+2011,51,2011/2012,51,HHS Region 8,4 wk ahead,1.1
+2011,51,2011/2012,51,HHS Region 9,Season onset,none
+2011,51,2011/2012,51,HHS Region 9,Season peak week,52
+2011,51,2011/2012,51,HHS Region 9,Season peak week,8
+2011,51,2011/2012,51,HHS Region 9,Season peak percentage,3.7
+2011,51,2011/2012,51,HHS Region 9,1 wk ahead,3.7
+2011,51,2011/2012,51,HHS Region 9,2 wk ahead,3
+2011,51,2011/2012,51,HHS Region 9,3 wk ahead,2.5
+2011,51,2011/2012,51,HHS Region 9,4 wk ahead,2.4
+2011,51,2011/2012,51,HHS Region 10,Season onset,none
+2011,51,2011/2012,51,HHS Region 10,Season peak week,12
+2011,51,2011/2012,51,HHS Region 10,Season peak percentage,2.2
+2011,51,2011/2012,51,HHS Region 10,1 wk ahead,1.3
+2011,51,2011/2012,51,HHS Region 10,2 wk ahead,1.1
+2011,51,2011/2012,51,HHS Region 10,3 wk ahead,0.7
+2011,51,2011/2012,51,HHS Region 10,4 wk ahead,1.1
+2011,52,2011/2012,52,US National,Season onset,none
+2011,52,2011/2012,52,US National,Season peak week,11
+2011,52,2011/2012,52,US National,Season peak percentage,2.4
+2011,52,2011/2012,52,US National,1 wk ahead,1.7
+2011,52,2011/2012,52,US National,2 wk ahead,1.6
+2011,52,2011/2012,52,US National,3 wk ahead,1.6
+2011,52,2011/2012,52,US National,4 wk ahead,1.8
+2011,52,2011/2012,52,HHS Region 1,Season onset,none
+2011,52,2011/2012,52,HHS Region 1,Season peak week,52
+2011,52,2011/2012,52,HHS Region 1,Season peak percentage,1
+2011,52,2011/2012,52,HHS Region 1,1 wk ahead,0.9
+2011,52,2011/2012,52,HHS Region 1,2 wk ahead,0.8
+2011,52,2011/2012,52,HHS Region 1,3 wk ahead,0.8
+2011,52,2011/2012,52,HHS Region 1,4 wk ahead,0.8
+2011,52,2011/2012,52,HHS Region 2,Season onset,none
+2011,52,2011/2012,52,HHS Region 2,Season peak week,49
+2011,52,2011/2012,52,HHS Region 2,Season peak percentage,1.4
+2011,52,2011/2012,52,HHS Region 2,1 wk ahead,1.3
+2011,52,2011/2012,52,HHS Region 2,2 wk ahead,1
+2011,52,2011/2012,52,HHS Region 2,3 wk ahead,1.1
+2011,52,2011/2012,52,HHS Region 2,4 wk ahead,1
+2011,52,2011/2012,52,HHS Region 3,Season onset,none
+2011,52,2011/2012,52,HHS Region 3,Season peak week,52
+2011,52,2011/2012,52,HHS Region 3,Season peak percentage,2.1
+2011,52,2011/2012,52,HHS Region 3,1 wk ahead,1.7
+2011,52,2011/2012,52,HHS Region 3,2 wk ahead,1.5
+2011,52,2011/2012,52,HHS Region 3,3 wk ahead,1.6
+2011,52,2011/2012,52,HHS Region 3,4 wk ahead,1.5
+2011,52,2011/2012,52,HHS Region 4,Season onset,none
+2011,52,2011/2012,52,HHS Region 4,Season peak week,52
+2011,52,2011/2012,52,HHS Region 4,Season peak week,10
+2011,52,2011/2012,52,HHS Region 4,Season peak percentage,2.3
+2011,52,2011/2012,52,HHS Region 4,1 wk ahead,1.6
+2011,52,2011/2012,52,HHS Region 4,2 wk ahead,1.5
+2011,52,2011/2012,52,HHS Region 4,3 wk ahead,1.7
+2011,52,2011/2012,52,HHS Region 4,4 wk ahead,1.7
+2011,52,2011/2012,52,HHS Region 5,Season onset,7
+2011,52,2011/2012,52,HHS Region 5,Season peak week,11
+2011,52,2011/2012,52,HHS Region 5,Season peak percentage,2.4
+2011,52,2011/2012,52,HHS Region 5,1 wk ahead,1.2
+2011,52,2011/2012,52,HHS Region 5,2 wk ahead,1.2
+2011,52,2011/2012,52,HHS Region 5,3 wk ahead,1.2
+2011,52,2011/2012,52,HHS Region 5,4 wk ahead,1.3
+2011,52,2011/2012,52,HHS Region 6,Season onset,none
+2011,52,2011/2012,52,HHS Region 6,Season peak week,11
+2011,52,2011/2012,52,HHS Region 6,Season peak percentage,4.1
+2011,52,2011/2012,52,HHS Region 6,1 wk ahead,2.1
+2011,52,2011/2012,52,HHS Region 6,2 wk ahead,2.1
+2011,52,2011/2012,52,HHS Region 6,3 wk ahead,2.2
+2011,52,2011/2012,52,HHS Region 6,4 wk ahead,2.4
+2011,52,2011/2012,52,HHS Region 7,Season onset,5
+2011,52,2011/2012,52,HHS Region 7,Season peak week,9
+2011,52,2011/2012,52,HHS Region 7,Season peak percentage,3.4
+2011,52,2011/2012,52,HHS Region 7,1 wk ahead,1.5
+2011,52,2011/2012,52,HHS Region 7,2 wk ahead,1.5
+2011,52,2011/2012,52,HHS Region 7,3 wk ahead,1.6
+2011,52,2011/2012,52,HHS Region 7,4 wk ahead,1.8
+2011,52,2011/2012,52,HHS Region 8,Season onset,none
+2011,52,2011/2012,52,HHS Region 8,Season peak week,11
+2011,52,2011/2012,52,HHS Region 8,Season peak percentage,2.2
+2011,52,2011/2012,52,HHS Region 8,1 wk ahead,1.1
+2011,52,2011/2012,52,HHS Region 8,2 wk ahead,1.1
+2011,52,2011/2012,52,HHS Region 8,3 wk ahead,1.1
+2011,52,2011/2012,52,HHS Region 8,4 wk ahead,1.3
+2011,52,2011/2012,52,HHS Region 9,Season onset,none
+2011,52,2011/2012,52,HHS Region 9,Season peak week,52
+2011,52,2011/2012,52,HHS Region 9,Season peak week,8
+2011,52,2011/2012,52,HHS Region 9,Season peak percentage,3.7
+2011,52,2011/2012,52,HHS Region 9,1 wk ahead,3
+2011,52,2011/2012,52,HHS Region 9,2 wk ahead,2.5
+2011,52,2011/2012,52,HHS Region 9,3 wk ahead,2.4
+2011,52,2011/2012,52,HHS Region 9,4 wk ahead,3
+2011,52,2011/2012,52,HHS Region 10,Season onset,none
+2011,52,2011/2012,52,HHS Region 10,Season peak week,12
+2011,52,2011/2012,52,HHS Region 10,Season peak percentage,2.2
+2011,52,2011/2012,52,HHS Region 10,1 wk ahead,1.1
+2011,52,2011/2012,52,HHS Region 10,2 wk ahead,0.7
+2011,52,2011/2012,52,HHS Region 10,3 wk ahead,1.1
+2011,52,2011/2012,52,HHS Region 10,4 wk ahead,1.1
+2012,1,2011/2012,53,US National,Season onset,none
+2012,1,2011/2012,53,US National,Season peak week,11
+2012,1,2011/2012,53,US National,Season peak percentage,2.4
+2012,1,2011/2012,53,US National,1 wk ahead,1.6
+2012,1,2011/2012,53,US National,2 wk ahead,1.6
+2012,1,2011/2012,53,US National,3 wk ahead,1.8
+2012,1,2011/2012,53,US National,4 wk ahead,1.9
+2012,1,2011/2012,53,HHS Region 1,Season onset,none
+2012,1,2011/2012,53,HHS Region 1,Season peak week,52
+2012,1,2011/2012,53,HHS Region 1,Season peak percentage,1
+2012,1,2011/2012,53,HHS Region 1,1 wk ahead,0.8
+2012,1,2011/2012,53,HHS Region 1,2 wk ahead,0.8
+2012,1,2011/2012,53,HHS Region 1,3 wk ahead,0.8
+2012,1,2011/2012,53,HHS Region 1,4 wk ahead,0.8
+2012,1,2011/2012,53,HHS Region 2,Season onset,none
+2012,1,2011/2012,53,HHS Region 2,Season peak week,49
+2012,1,2011/2012,53,HHS Region 2,Season peak percentage,1.4
+2012,1,2011/2012,53,HHS Region 2,1 wk ahead,1
+2012,1,2011/2012,53,HHS Region 2,2 wk ahead,1.1
+2012,1,2011/2012,53,HHS Region 2,3 wk ahead,1
+2012,1,2011/2012,53,HHS Region 2,4 wk ahead,1.1
+2012,1,2011/2012,53,HHS Region 3,Season onset,none
+2012,1,2011/2012,53,HHS Region 3,Season peak week,52
+2012,1,2011/2012,53,HHS Region 3,Season peak percentage,2.1
+2012,1,2011/2012,53,HHS Region 3,1 wk ahead,1.5
+2012,1,2011/2012,53,HHS Region 3,2 wk ahead,1.6
+2012,1,2011/2012,53,HHS Region 3,3 wk ahead,1.5
+2012,1,2011/2012,53,HHS Region 3,4 wk ahead,1.5
+2012,1,2011/2012,53,HHS Region 4,Season onset,none
+2012,1,2011/2012,53,HHS Region 4,Season peak week,52
+2012,1,2011/2012,53,HHS Region 4,Season peak week,10
+2012,1,2011/2012,53,HHS Region 4,Season peak percentage,2.3
+2012,1,2011/2012,53,HHS Region 4,1 wk ahead,1.5
+2012,1,2011/2012,53,HHS Region 4,2 wk ahead,1.7
+2012,1,2011/2012,53,HHS Region 4,3 wk ahead,1.7
+2012,1,2011/2012,53,HHS Region 4,4 wk ahead,1.8
+2012,1,2011/2012,53,HHS Region 5,Season onset,7
+2012,1,2011/2012,53,HHS Region 5,Season peak week,11
+2012,1,2011/2012,53,HHS Region 5,Season peak percentage,2.4
+2012,1,2011/2012,53,HHS Region 5,1 wk ahead,1.2
+2012,1,2011/2012,53,HHS Region 5,2 wk ahead,1.2
+2012,1,2011/2012,53,HHS Region 5,3 wk ahead,1.3
+2012,1,2011/2012,53,HHS Region 5,4 wk ahead,1.5
+2012,1,2011/2012,53,HHS Region 6,Season onset,none
+2012,1,2011/2012,53,HHS Region 6,Season peak week,11
+2012,1,2011/2012,53,HHS Region 6,Season peak percentage,4.1
+2012,1,2011/2012,53,HHS Region 6,1 wk ahead,2.1
+2012,1,2011/2012,53,HHS Region 6,2 wk ahead,2.2
+2012,1,2011/2012,53,HHS Region 6,3 wk ahead,2.4
+2012,1,2011/2012,53,HHS Region 6,4 wk ahead,2.5
+2012,1,2011/2012,53,HHS Region 7,Season onset,5
+2012,1,2011/2012,53,HHS Region 7,Season peak week,9
+2012,1,2011/2012,53,HHS Region 7,Season peak percentage,3.4
+2012,1,2011/2012,53,HHS Region 7,1 wk ahead,1.5
+2012,1,2011/2012,53,HHS Region 7,2 wk ahead,1.6
+2012,1,2011/2012,53,HHS Region 7,3 wk ahead,1.8
+2012,1,2011/2012,53,HHS Region 7,4 wk ahead,2.6
+2012,1,2011/2012,53,HHS Region 8,Season onset,none
+2012,1,2011/2012,53,HHS Region 8,Season peak week,11
+2012,1,2011/2012,53,HHS Region 8,Season peak percentage,2.2
+2012,1,2011/2012,53,HHS Region 8,1 wk ahead,1.1
+2012,1,2011/2012,53,HHS Region 8,2 wk ahead,1.1
+2012,1,2011/2012,53,HHS Region 8,3 wk ahead,1.3
+2012,1,2011/2012,53,HHS Region 8,4 wk ahead,1.5
+2012,1,2011/2012,53,HHS Region 9,Season onset,none
+2012,1,2011/2012,53,HHS Region 9,Season peak week,52
+2012,1,2011/2012,53,HHS Region 9,Season peak week,8
+2012,1,2011/2012,53,HHS Region 9,Season peak percentage,3.7
+2012,1,2011/2012,53,HHS Region 9,1 wk ahead,2.5
+2012,1,2011/2012,53,HHS Region 9,2 wk ahead,2.4
+2012,1,2011/2012,53,HHS Region 9,3 wk ahead,3
+2012,1,2011/2012,53,HHS Region 9,4 wk ahead,3.3
+2012,1,2011/2012,53,HHS Region 10,Season onset,none
+2012,1,2011/2012,53,HHS Region 10,Season peak week,12
+2012,1,2011/2012,53,HHS Region 10,Season peak percentage,2.2
+2012,1,2011/2012,53,HHS Region 10,1 wk ahead,0.7
+2012,1,2011/2012,53,HHS Region 10,2 wk ahead,1.1
+2012,1,2011/2012,53,HHS Region 10,3 wk ahead,1.1
+2012,1,2011/2012,53,HHS Region 10,4 wk ahead,1.2
+2012,2,2011/2012,54,US National,Season onset,none
+2012,2,2011/2012,54,US National,Season peak week,11
+2012,2,2011/2012,54,US National,Season peak percentage,2.4
+2012,2,2011/2012,54,US National,1 wk ahead,1.6
+2012,2,2011/2012,54,US National,2 wk ahead,1.8
+2012,2,2011/2012,54,US National,3 wk ahead,1.9
+2012,2,2011/2012,54,US National,4 wk ahead,1.9
+2012,2,2011/2012,54,HHS Region 1,Season onset,none
+2012,2,2011/2012,54,HHS Region 1,Season peak week,52
+2012,2,2011/2012,54,HHS Region 1,Season peak percentage,1
+2012,2,2011/2012,54,HHS Region 1,1 wk ahead,0.8
+2012,2,2011/2012,54,HHS Region 1,2 wk ahead,0.8
+2012,2,2011/2012,54,HHS Region 1,3 wk ahead,0.8
+2012,2,2011/2012,54,HHS Region 1,4 wk ahead,0.8
+2012,2,2011/2012,54,HHS Region 2,Season onset,none
+2012,2,2011/2012,54,HHS Region 2,Season peak week,49
+2012,2,2011/2012,54,HHS Region 2,Season peak percentage,1.4
+2012,2,2011/2012,54,HHS Region 2,1 wk ahead,1.1
+2012,2,2011/2012,54,HHS Region 2,2 wk ahead,1
+2012,2,2011/2012,54,HHS Region 2,3 wk ahead,1.1
+2012,2,2011/2012,54,HHS Region 2,4 wk ahead,1
+2012,2,2011/2012,54,HHS Region 3,Season onset,none
+2012,2,2011/2012,54,HHS Region 3,Season peak week,52
+2012,2,2011/2012,54,HHS Region 3,Season peak percentage,2.1
+2012,2,2011/2012,54,HHS Region 3,1 wk ahead,1.6
+2012,2,2011/2012,54,HHS Region 3,2 wk ahead,1.5
+2012,2,2011/2012,54,HHS Region 3,3 wk ahead,1.5
+2012,2,2011/2012,54,HHS Region 3,4 wk ahead,1.6
+2012,2,2011/2012,54,HHS Region 4,Season onset,none
+2012,2,2011/2012,54,HHS Region 4,Season peak week,52
+2012,2,2011/2012,54,HHS Region 4,Season peak week,10
+2012,2,2011/2012,54,HHS Region 4,Season peak percentage,2.3
+2012,2,2011/2012,54,HHS Region 4,1 wk ahead,1.7
+2012,2,2011/2012,54,HHS Region 4,2 wk ahead,1.7
+2012,2,2011/2012,54,HHS Region 4,3 wk ahead,1.8
+2012,2,2011/2012,54,HHS Region 4,4 wk ahead,1.9
+2012,2,2011/2012,54,HHS Region 5,Season onset,7
+2012,2,2011/2012,54,HHS Region 5,Season peak week,11
+2012,2,2011/2012,54,HHS Region 5,Season peak percentage,2.4
+2012,2,2011/2012,54,HHS Region 5,1 wk ahead,1.2
+2012,2,2011/2012,54,HHS Region 5,2 wk ahead,1.3
+2012,2,2011/2012,54,HHS Region 5,3 wk ahead,1.5
+2012,2,2011/2012,54,HHS Region 5,4 wk ahead,1.4
+2012,2,2011/2012,54,HHS Region 6,Season onset,none
+2012,2,2011/2012,54,HHS Region 6,Season peak week,11
+2012,2,2011/2012,54,HHS Region 6,Season peak percentage,4.1
+2012,2,2011/2012,54,HHS Region 6,1 wk ahead,2.2
+2012,2,2011/2012,54,HHS Region 6,2 wk ahead,2.4
+2012,2,2011/2012,54,HHS Region 6,3 wk ahead,2.5
+2012,2,2011/2012,54,HHS Region 6,4 wk ahead,2.7
+2012,2,2011/2012,54,HHS Region 7,Season onset,5
+2012,2,2011/2012,54,HHS Region 7,Season peak week,9
+2012,2,2011/2012,54,HHS Region 7,Season peak percentage,3.4
+2012,2,2011/2012,54,HHS Region 7,1 wk ahead,1.6
+2012,2,2011/2012,54,HHS Region 7,2 wk ahead,1.8
+2012,2,2011/2012,54,HHS Region 7,3 wk ahead,2.6
+2012,2,2011/2012,54,HHS Region 7,4 wk ahead,2.8
+2012,2,2011/2012,54,HHS Region 8,Season onset,none
+2012,2,2011/2012,54,HHS Region 8,Season peak week,11
+2012,2,2011/2012,54,HHS Region 8,Season peak percentage,2.2
+2012,2,2011/2012,54,HHS Region 8,1 wk ahead,1.1
+2012,2,2011/2012,54,HHS Region 8,2 wk ahead,1.3
+2012,2,2011/2012,54,HHS Region 8,3 wk ahead,1.5
+2012,2,2011/2012,54,HHS Region 8,4 wk ahead,1.6
+2012,2,2011/2012,54,HHS Region 9,Season onset,none
+2012,2,2011/2012,54,HHS Region 9,Season peak week,52
+2012,2,2011/2012,54,HHS Region 9,Season peak week,8
+2012,2,2011/2012,54,HHS Region 9,Season peak percentage,3.7
+2012,2,2011/2012,54,HHS Region 9,1 wk ahead,2.4
+2012,2,2011/2012,54,HHS Region 9,2 wk ahead,3
+2012,2,2011/2012,54,HHS Region 9,3 wk ahead,3.3
+2012,2,2011/2012,54,HHS Region 9,4 wk ahead,2.9
+2012,2,2011/2012,54,HHS Region 10,Season onset,none
+2012,2,2011/2012,54,HHS Region 10,Season peak week,12
+2012,2,2011/2012,54,HHS Region 10,Season peak percentage,2.2
+2012,2,2011/2012,54,HHS Region 10,1 wk ahead,1.1
+2012,2,2011/2012,54,HHS Region 10,2 wk ahead,1.1
+2012,2,2011/2012,54,HHS Region 10,3 wk ahead,1.2
+2012,2,2011/2012,54,HHS Region 10,4 wk ahead,1.2
+2012,3,2011/2012,55,US National,Season onset,none
+2012,3,2011/2012,55,US National,Season peak week,11
+2012,3,2011/2012,55,US National,Season peak percentage,2.4
+2012,3,2011/2012,55,US National,1 wk ahead,1.8
+2012,3,2011/2012,55,US National,2 wk ahead,1.9
+2012,3,2011/2012,55,US National,3 wk ahead,1.9
+2012,3,2011/2012,55,US National,4 wk ahead,2.1
+2012,3,2011/2012,55,HHS Region 1,Season onset,none
+2012,3,2011/2012,55,HHS Region 1,Season peak week,52
+2012,3,2011/2012,55,HHS Region 1,Season peak percentage,1
+2012,3,2011/2012,55,HHS Region 1,1 wk ahead,0.8
+2012,3,2011/2012,55,HHS Region 1,2 wk ahead,0.8
+2012,3,2011/2012,55,HHS Region 1,3 wk ahead,0.8
+2012,3,2011/2012,55,HHS Region 1,4 wk ahead,0.9
+2012,3,2011/2012,55,HHS Region 2,Season onset,none
+2012,3,2011/2012,55,HHS Region 2,Season peak week,49
+2012,3,2011/2012,55,HHS Region 2,Season peak percentage,1.4
+2012,3,2011/2012,55,HHS Region 2,1 wk ahead,1
+2012,3,2011/2012,55,HHS Region 2,2 wk ahead,1.1
+2012,3,2011/2012,55,HHS Region 2,3 wk ahead,1
+2012,3,2011/2012,55,HHS Region 2,4 wk ahead,1.1
+2012,3,2011/2012,55,HHS Region 3,Season onset,none
+2012,3,2011/2012,55,HHS Region 3,Season peak week,52
+2012,3,2011/2012,55,HHS Region 3,Season peak percentage,2.1
+2012,3,2011/2012,55,HHS Region 3,1 wk ahead,1.5
+2012,3,2011/2012,55,HHS Region 3,2 wk ahead,1.5
+2012,3,2011/2012,55,HHS Region 3,3 wk ahead,1.6
+2012,3,2011/2012,55,HHS Region 3,4 wk ahead,1.7
+2012,3,2011/2012,55,HHS Region 4,Season onset,none
+2012,3,2011/2012,55,HHS Region 4,Season peak week,52
+2012,3,2011/2012,55,HHS Region 4,Season peak week,10
+2012,3,2011/2012,55,HHS Region 4,Season peak percentage,2.3
+2012,3,2011/2012,55,HHS Region 4,1 wk ahead,1.7
+2012,3,2011/2012,55,HHS Region 4,2 wk ahead,1.8
+2012,3,2011/2012,55,HHS Region 4,3 wk ahead,1.9
+2012,3,2011/2012,55,HHS Region 4,4 wk ahead,2
+2012,3,2011/2012,55,HHS Region 5,Season onset,7
+2012,3,2011/2012,55,HHS Region 5,Season peak week,11
+2012,3,2011/2012,55,HHS Region 5,Season peak percentage,2.4
+2012,3,2011/2012,55,HHS Region 5,1 wk ahead,1.3
+2012,3,2011/2012,55,HHS Region 5,2 wk ahead,1.5
+2012,3,2011/2012,55,HHS Region 5,3 wk ahead,1.4
+2012,3,2011/2012,55,HHS Region 5,4 wk ahead,1.6
+2012,3,2011/2012,55,HHS Region 6,Season onset,none
+2012,3,2011/2012,55,HHS Region 6,Season peak week,11
+2012,3,2011/2012,55,HHS Region 6,Season peak percentage,4.1
+2012,3,2011/2012,55,HHS Region 6,1 wk ahead,2.4
+2012,3,2011/2012,55,HHS Region 6,2 wk ahead,2.5
+2012,3,2011/2012,55,HHS Region 6,3 wk ahead,2.7
+2012,3,2011/2012,55,HHS Region 6,4 wk ahead,3
+2012,3,2011/2012,55,HHS Region 7,Season onset,5
+2012,3,2011/2012,55,HHS Region 7,Season peak week,9
+2012,3,2011/2012,55,HHS Region 7,Season peak percentage,3.4
+2012,3,2011/2012,55,HHS Region 7,1 wk ahead,1.8
+2012,3,2011/2012,55,HHS Region 7,2 wk ahead,2.6
+2012,3,2011/2012,55,HHS Region 7,3 wk ahead,2.8
+2012,3,2011/2012,55,HHS Region 7,4 wk ahead,3.1
+2012,3,2011/2012,55,HHS Region 8,Season onset,none
+2012,3,2011/2012,55,HHS Region 8,Season peak week,11
+2012,3,2011/2012,55,HHS Region 8,Season peak percentage,2.2
+2012,3,2011/2012,55,HHS Region 8,1 wk ahead,1.3
+2012,3,2011/2012,55,HHS Region 8,2 wk ahead,1.5
+2012,3,2011/2012,55,HHS Region 8,3 wk ahead,1.6
+2012,3,2011/2012,55,HHS Region 8,4 wk ahead,1.6
+2012,3,2011/2012,55,HHS Region 9,Season onset,none
+2012,3,2011/2012,55,HHS Region 9,Season peak week,52
+2012,3,2011/2012,55,HHS Region 9,Season peak week,8
+2012,3,2011/2012,55,HHS Region 9,Season peak percentage,3.7
+2012,3,2011/2012,55,HHS Region 9,1 wk ahead,3
+2012,3,2011/2012,55,HHS Region 9,2 wk ahead,3.3
+2012,3,2011/2012,55,HHS Region 9,3 wk ahead,2.9
+2012,3,2011/2012,55,HHS Region 9,4 wk ahead,3.2
+2012,3,2011/2012,55,HHS Region 10,Season onset,none
+2012,3,2011/2012,55,HHS Region 10,Season peak week,12
+2012,3,2011/2012,55,HHS Region 10,Season peak percentage,2.2
+2012,3,2011/2012,55,HHS Region 10,1 wk ahead,1.1
+2012,3,2011/2012,55,HHS Region 10,2 wk ahead,1.2
+2012,3,2011/2012,55,HHS Region 10,3 wk ahead,1.2
+2012,3,2011/2012,55,HHS Region 10,4 wk ahead,1.5
+2012,4,2011/2012,56,US National,Season onset,none
+2012,4,2011/2012,56,US National,Season peak week,11
+2012,4,2011/2012,56,US National,Season peak percentage,2.4
+2012,4,2011/2012,56,US National,1 wk ahead,1.9
+2012,4,2011/2012,56,US National,2 wk ahead,1.9
+2012,4,2011/2012,56,US National,3 wk ahead,2.1
+2012,4,2011/2012,56,US National,4 wk ahead,2.2
+2012,4,2011/2012,56,HHS Region 1,Season onset,none
+2012,4,2011/2012,56,HHS Region 1,Season peak week,52
+2012,4,2011/2012,56,HHS Region 1,Season peak percentage,1
+2012,4,2011/2012,56,HHS Region 1,1 wk ahead,0.8
+2012,4,2011/2012,56,HHS Region 1,2 wk ahead,0.8
+2012,4,2011/2012,56,HHS Region 1,3 wk ahead,0.9
+2012,4,2011/2012,56,HHS Region 1,4 wk ahead,0.9
+2012,4,2011/2012,56,HHS Region 2,Season onset,none
+2012,4,2011/2012,56,HHS Region 2,Season peak week,49
+2012,4,2011/2012,56,HHS Region 2,Season peak percentage,1.4
+2012,4,2011/2012,56,HHS Region 2,1 wk ahead,1.1
+2012,4,2011/2012,56,HHS Region 2,2 wk ahead,1
+2012,4,2011/2012,56,HHS Region 2,3 wk ahead,1.1
+2012,4,2011/2012,56,HHS Region 2,4 wk ahead,1.3
+2012,4,2011/2012,56,HHS Region 3,Season onset,none
+2012,4,2011/2012,56,HHS Region 3,Season peak week,52
+2012,4,2011/2012,56,HHS Region 3,Season peak percentage,2.1
+2012,4,2011/2012,56,HHS Region 3,1 wk ahead,1.5
+2012,4,2011/2012,56,HHS Region 3,2 wk ahead,1.6
+2012,4,2011/2012,56,HHS Region 3,3 wk ahead,1.7
+2012,4,2011/2012,56,HHS Region 3,4 wk ahead,1.5
+2012,4,2011/2012,56,HHS Region 4,Season onset,none
+2012,4,2011/2012,56,HHS Region 4,Season peak week,52
+2012,4,2011/2012,56,HHS Region 4,Season peak week,10
+2012,4,2011/2012,56,HHS Region 4,Season peak percentage,2.3
+2012,4,2011/2012,56,HHS Region 4,1 wk ahead,1.8
+2012,4,2011/2012,56,HHS Region 4,2 wk ahead,1.9
+2012,4,2011/2012,56,HHS Region 4,3 wk ahead,2
+2012,4,2011/2012,56,HHS Region 4,4 wk ahead,2
+2012,4,2011/2012,56,HHS Region 5,Season onset,7
+2012,4,2011/2012,56,HHS Region 5,Season peak week,11
+2012,4,2011/2012,56,HHS Region 5,Season peak percentage,2.4
+2012,4,2011/2012,56,HHS Region 5,1 wk ahead,1.5
+2012,4,2011/2012,56,HHS Region 5,2 wk ahead,1.4
+2012,4,2011/2012,56,HHS Region 5,3 wk ahead,1.6
+2012,4,2011/2012,56,HHS Region 5,4 wk ahead,1.8
+2012,4,2011/2012,56,HHS Region 6,Season onset,none
+2012,4,2011/2012,56,HHS Region 6,Season peak week,11
+2012,4,2011/2012,56,HHS Region 6,Season peak percentage,4.1
+2012,4,2011/2012,56,HHS Region 6,1 wk ahead,2.5
+2012,4,2011/2012,56,HHS Region 6,2 wk ahead,2.7
+2012,4,2011/2012,56,HHS Region 6,3 wk ahead,3
+2012,4,2011/2012,56,HHS Region 6,4 wk ahead,3.3
+2012,4,2011/2012,56,HHS Region 7,Season onset,5
+2012,4,2011/2012,56,HHS Region 7,Season peak week,9
+2012,4,2011/2012,56,HHS Region 7,Season peak percentage,3.4
+2012,4,2011/2012,56,HHS Region 7,1 wk ahead,2.6
+2012,4,2011/2012,56,HHS Region 7,2 wk ahead,2.8
+2012,4,2011/2012,56,HHS Region 7,3 wk ahead,3.1
+2012,4,2011/2012,56,HHS Region 7,4 wk ahead,3
+2012,4,2011/2012,56,HHS Region 8,Season onset,none
+2012,4,2011/2012,56,HHS Region 8,Season peak week,11
+2012,4,2011/2012,56,HHS Region 8,Season peak percentage,2.2
+2012,4,2011/2012,56,HHS Region 8,1 wk ahead,1.5
+2012,4,2011/2012,56,HHS Region 8,2 wk ahead,1.6
+2012,4,2011/2012,56,HHS Region 8,3 wk ahead,1.6
+2012,4,2011/2012,56,HHS Region 8,4 wk ahead,1.9
+2012,4,2011/2012,56,HHS Region 9,Season onset,none
+2012,4,2011/2012,56,HHS Region 9,Season peak week,52
+2012,4,2011/2012,56,HHS Region 9,Season peak week,8
+2012,4,2011/2012,56,HHS Region 9,Season peak percentage,3.7
+2012,4,2011/2012,56,HHS Region 9,1 wk ahead,3.3
+2012,4,2011/2012,56,HHS Region 9,2 wk ahead,2.9
+2012,4,2011/2012,56,HHS Region 9,3 wk ahead,3.2
+2012,4,2011/2012,56,HHS Region 9,4 wk ahead,3.7
+2012,4,2011/2012,56,HHS Region 10,Season onset,none
+2012,4,2011/2012,56,HHS Region 10,Season peak week,12
+2012,4,2011/2012,56,HHS Region 10,Season peak percentage,2.2
+2012,4,2011/2012,56,HHS Region 10,1 wk ahead,1.2
+2012,4,2011/2012,56,HHS Region 10,2 wk ahead,1.2
+2012,4,2011/2012,56,HHS Region 10,3 wk ahead,1.5
+2012,4,2011/2012,56,HHS Region 10,4 wk ahead,1.4
+2012,5,2011/2012,57,US National,Season onset,none
+2012,5,2011/2012,57,US National,Season peak week,11
+2012,5,2011/2012,57,US National,Season peak percentage,2.4
+2012,5,2011/2012,57,US National,1 wk ahead,1.9
+2012,5,2011/2012,57,US National,2 wk ahead,2.1
+2012,5,2011/2012,57,US National,3 wk ahead,2.2
+2012,5,2011/2012,57,US National,4 wk ahead,2.2
+2012,5,2011/2012,57,HHS Region 1,Season onset,none
+2012,5,2011/2012,57,HHS Region 1,Season peak week,52
+2012,5,2011/2012,57,HHS Region 1,Season peak percentage,1
+2012,5,2011/2012,57,HHS Region 1,1 wk ahead,0.8
+2012,5,2011/2012,57,HHS Region 1,2 wk ahead,0.9
+2012,5,2011/2012,57,HHS Region 1,3 wk ahead,0.9
+2012,5,2011/2012,57,HHS Region 1,4 wk ahead,0.8
+2012,5,2011/2012,57,HHS Region 2,Season onset,none
+2012,5,2011/2012,57,HHS Region 2,Season peak week,49
+2012,5,2011/2012,57,HHS Region 2,Season peak percentage,1.4
+2012,5,2011/2012,57,HHS Region 2,1 wk ahead,1
+2012,5,2011/2012,57,HHS Region 2,2 wk ahead,1.1
+2012,5,2011/2012,57,HHS Region 2,3 wk ahead,1.3
+2012,5,2011/2012,57,HHS Region 2,4 wk ahead,1.2
+2012,5,2011/2012,57,HHS Region 3,Season onset,none
+2012,5,2011/2012,57,HHS Region 3,Season peak week,52
+2012,5,2011/2012,57,HHS Region 3,Season peak percentage,2.1
+2012,5,2011/2012,57,HHS Region 3,1 wk ahead,1.6
+2012,5,2011/2012,57,HHS Region 3,2 wk ahead,1.7
+2012,5,2011/2012,57,HHS Region 3,3 wk ahead,1.5
+2012,5,2011/2012,57,HHS Region 3,4 wk ahead,1.7
+2012,5,2011/2012,57,HHS Region 4,Season onset,none
+2012,5,2011/2012,57,HHS Region 4,Season peak week,52
+2012,5,2011/2012,57,HHS Region 4,Season peak week,10
+2012,5,2011/2012,57,HHS Region 4,Season peak percentage,2.3
+2012,5,2011/2012,57,HHS Region 4,1 wk ahead,1.9
+2012,5,2011/2012,57,HHS Region 4,2 wk ahead,2
+2012,5,2011/2012,57,HHS Region 4,3 wk ahead,2
+2012,5,2011/2012,57,HHS Region 4,4 wk ahead,2.1
+2012,5,2011/2012,57,HHS Region 5,Season onset,7
+2012,5,2011/2012,57,HHS Region 5,Season peak week,11
+2012,5,2011/2012,57,HHS Region 5,Season peak percentage,2.4
+2012,5,2011/2012,57,HHS Region 5,1 wk ahead,1.4
+2012,5,2011/2012,57,HHS Region 5,2 wk ahead,1.6
+2012,5,2011/2012,57,HHS Region 5,3 wk ahead,1.8
+2012,5,2011/2012,57,HHS Region 5,4 wk ahead,1.8
+2012,5,2011/2012,57,HHS Region 6,Season onset,none
+2012,5,2011/2012,57,HHS Region 6,Season peak week,11
+2012,5,2011/2012,57,HHS Region 6,Season peak percentage,4.1
+2012,5,2011/2012,57,HHS Region 6,1 wk ahead,2.7
+2012,5,2011/2012,57,HHS Region 6,2 wk ahead,3
+2012,5,2011/2012,57,HHS Region 6,3 wk ahead,3.3
+2012,5,2011/2012,57,HHS Region 6,4 wk ahead,3.5
+2012,5,2011/2012,57,HHS Region 7,Season onset,5
+2012,5,2011/2012,57,HHS Region 7,Season peak week,9
+2012,5,2011/2012,57,HHS Region 7,Season peak percentage,3.4
+2012,5,2011/2012,57,HHS Region 7,1 wk ahead,2.8
+2012,5,2011/2012,57,HHS Region 7,2 wk ahead,3.1
+2012,5,2011/2012,57,HHS Region 7,3 wk ahead,3
+2012,5,2011/2012,57,HHS Region 7,4 wk ahead,3.4
+2012,5,2011/2012,57,HHS Region 8,Season onset,none
+2012,5,2011/2012,57,HHS Region 8,Season peak week,11
+2012,5,2011/2012,57,HHS Region 8,Season peak percentage,2.2
+2012,5,2011/2012,57,HHS Region 8,1 wk ahead,1.6
+2012,5,2011/2012,57,HHS Region 8,2 wk ahead,1.6
+2012,5,2011/2012,57,HHS Region 8,3 wk ahead,1.9
+2012,5,2011/2012,57,HHS Region 8,4 wk ahead,1.7
+2012,5,2011/2012,57,HHS Region 9,Season onset,none
+2012,5,2011/2012,57,HHS Region 9,Season peak week,52
+2012,5,2011/2012,57,HHS Region 9,Season peak week,8
+2012,5,2011/2012,57,HHS Region 9,Season peak percentage,3.7
+2012,5,2011/2012,57,HHS Region 9,1 wk ahead,2.9
+2012,5,2011/2012,57,HHS Region 9,2 wk ahead,3.2
+2012,5,2011/2012,57,HHS Region 9,3 wk ahead,3.7
+2012,5,2011/2012,57,HHS Region 9,4 wk ahead,3.1
+2012,5,2011/2012,57,HHS Region 10,Season onset,none
+2012,5,2011/2012,57,HHS Region 10,Season peak week,12
+2012,5,2011/2012,57,HHS Region 10,Season peak percentage,2.2
+2012,5,2011/2012,57,HHS Region 10,1 wk ahead,1.2
+2012,5,2011/2012,57,HHS Region 10,2 wk ahead,1.5
+2012,5,2011/2012,57,HHS Region 10,3 wk ahead,1.4
+2012,5,2011/2012,57,HHS Region 10,4 wk ahead,1.5
+2012,6,2011/2012,58,US National,Season onset,none
+2012,6,2011/2012,58,US National,Season peak week,11
+2012,6,2011/2012,58,US National,Season peak percentage,2.4
+2012,6,2011/2012,58,US National,1 wk ahead,2.1
+2012,6,2011/2012,58,US National,2 wk ahead,2.2
+2012,6,2011/2012,58,US National,3 wk ahead,2.2
+2012,6,2011/2012,58,US National,4 wk ahead,2.2
+2012,6,2011/2012,58,HHS Region 1,Season onset,none
+2012,6,2011/2012,58,HHS Region 1,Season peak week,52
+2012,6,2011/2012,58,HHS Region 1,Season peak percentage,1
+2012,6,2011/2012,58,HHS Region 1,1 wk ahead,0.9
+2012,6,2011/2012,58,HHS Region 1,2 wk ahead,0.9
+2012,6,2011/2012,58,HHS Region 1,3 wk ahead,0.8
+2012,6,2011/2012,58,HHS Region 1,4 wk ahead,0.8
+2012,6,2011/2012,58,HHS Region 2,Season onset,none
+2012,6,2011/2012,58,HHS Region 2,Season peak week,49
+2012,6,2011/2012,58,HHS Region 2,Season peak percentage,1.4
+2012,6,2011/2012,58,HHS Region 2,1 wk ahead,1.1
+2012,6,2011/2012,58,HHS Region 2,2 wk ahead,1.3
+2012,6,2011/2012,58,HHS Region 2,3 wk ahead,1.2
+2012,6,2011/2012,58,HHS Region 2,4 wk ahead,1.3
+2012,6,2011/2012,58,HHS Region 3,Season onset,none
+2012,6,2011/2012,58,HHS Region 3,Season peak week,52
+2012,6,2011/2012,58,HHS Region 3,Season peak percentage,2.1
+2012,6,2011/2012,58,HHS Region 3,1 wk ahead,1.7
+2012,6,2011/2012,58,HHS Region 3,2 wk ahead,1.5
+2012,6,2011/2012,58,HHS Region 3,3 wk ahead,1.7
+2012,6,2011/2012,58,HHS Region 3,4 wk ahead,1.6
+2012,6,2011/2012,58,HHS Region 4,Season onset,none
+2012,6,2011/2012,58,HHS Region 4,Season peak week,52
+2012,6,2011/2012,58,HHS Region 4,Season peak week,10
+2012,6,2011/2012,58,HHS Region 4,Season peak percentage,2.3
+2012,6,2011/2012,58,HHS Region 4,1 wk ahead,2
+2012,6,2011/2012,58,HHS Region 4,2 wk ahead,2
+2012,6,2011/2012,58,HHS Region 4,3 wk ahead,2.1
+2012,6,2011/2012,58,HHS Region 4,4 wk ahead,2.3
+2012,6,2011/2012,58,HHS Region 5,Season onset,7
+2012,6,2011/2012,58,HHS Region 5,Season peak week,11
+2012,6,2011/2012,58,HHS Region 5,Season peak percentage,2.4
+2012,6,2011/2012,58,HHS Region 5,1 wk ahead,1.6
+2012,6,2011/2012,58,HHS Region 5,2 wk ahead,1.8
+2012,6,2011/2012,58,HHS Region 5,3 wk ahead,1.8
+2012,6,2011/2012,58,HHS Region 5,4 wk ahead,2
+2012,6,2011/2012,58,HHS Region 6,Season onset,none
+2012,6,2011/2012,58,HHS Region 6,Season peak week,11
+2012,6,2011/2012,58,HHS Region 6,Season peak percentage,4.1
+2012,6,2011/2012,58,HHS Region 6,1 wk ahead,3
+2012,6,2011/2012,58,HHS Region 6,2 wk ahead,3.3
+2012,6,2011/2012,58,HHS Region 6,3 wk ahead,3.5
+2012,6,2011/2012,58,HHS Region 6,4 wk ahead,3.4
+2012,6,2011/2012,58,HHS Region 7,Season onset,5
+2012,6,2011/2012,58,HHS Region 7,Season peak week,9
+2012,6,2011/2012,58,HHS Region 7,Season peak percentage,3.4
+2012,6,2011/2012,58,HHS Region 7,1 wk ahead,3.1
+2012,6,2011/2012,58,HHS Region 7,2 wk ahead,3
+2012,6,2011/2012,58,HHS Region 7,3 wk ahead,3.4
+2012,6,2011/2012,58,HHS Region 7,4 wk ahead,3.1
+2012,6,2011/2012,58,HHS Region 8,Season onset,none
+2012,6,2011/2012,58,HHS Region 8,Season peak week,11
+2012,6,2011/2012,58,HHS Region 8,Season peak percentage,2.2
+2012,6,2011/2012,58,HHS Region 8,1 wk ahead,1.6
+2012,6,2011/2012,58,HHS Region 8,2 wk ahead,1.9
+2012,6,2011/2012,58,HHS Region 8,3 wk ahead,1.7
+2012,6,2011/2012,58,HHS Region 8,4 wk ahead,1.8
+2012,6,2011/2012,58,HHS Region 9,Season onset,none
+2012,6,2011/2012,58,HHS Region 9,Season peak week,52
+2012,6,2011/2012,58,HHS Region 9,Season peak week,8
+2012,6,2011/2012,58,HHS Region 9,Season peak percentage,3.7
+2012,6,2011/2012,58,HHS Region 9,1 wk ahead,3.2
+2012,6,2011/2012,58,HHS Region 9,2 wk ahead,3.7
+2012,6,2011/2012,58,HHS Region 9,3 wk ahead,3.1
+2012,6,2011/2012,58,HHS Region 9,4 wk ahead,2.5
+2012,6,2011/2012,58,HHS Region 10,Season onset,none
+2012,6,2011/2012,58,HHS Region 10,Season peak week,12
+2012,6,2011/2012,58,HHS Region 10,Season peak percentage,2.2
+2012,6,2011/2012,58,HHS Region 10,1 wk ahead,1.5
+2012,6,2011/2012,58,HHS Region 10,2 wk ahead,1.4
+2012,6,2011/2012,58,HHS Region 10,3 wk ahead,1.5
+2012,6,2011/2012,58,HHS Region 10,4 wk ahead,1.6
+2012,7,2011/2012,59,US National,Season onset,none
+2012,7,2011/2012,59,US National,Season peak week,11
+2012,7,2011/2012,59,US National,Season peak percentage,2.4
+2012,7,2011/2012,59,US National,1 wk ahead,2.2
+2012,7,2011/2012,59,US National,2 wk ahead,2.2
+2012,7,2011/2012,59,US National,3 wk ahead,2.2
+2012,7,2011/2012,59,US National,4 wk ahead,2.4
+2012,7,2011/2012,59,HHS Region 1,Season onset,none
+2012,7,2011/2012,59,HHS Region 1,Season peak week,52
+2012,7,2011/2012,59,HHS Region 1,Season peak percentage,1
+2012,7,2011/2012,59,HHS Region 1,1 wk ahead,0.9
+2012,7,2011/2012,59,HHS Region 1,2 wk ahead,0.8
+2012,7,2011/2012,59,HHS Region 1,3 wk ahead,0.8
+2012,7,2011/2012,59,HHS Region 1,4 wk ahead,0.9
+2012,7,2011/2012,59,HHS Region 2,Season onset,none
+2012,7,2011/2012,59,HHS Region 2,Season peak week,49
+2012,7,2011/2012,59,HHS Region 2,Season peak percentage,1.4
+2012,7,2011/2012,59,HHS Region 2,1 wk ahead,1.3
+2012,7,2011/2012,59,HHS Region 2,2 wk ahead,1.2
+2012,7,2011/2012,59,HHS Region 2,3 wk ahead,1.3
+2012,7,2011/2012,59,HHS Region 2,4 wk ahead,1.3
+2012,7,2011/2012,59,HHS Region 3,Season onset,none
+2012,7,2011/2012,59,HHS Region 3,Season peak week,52
+2012,7,2011/2012,59,HHS Region 3,Season peak percentage,2.1
+2012,7,2011/2012,59,HHS Region 3,1 wk ahead,1.5
+2012,7,2011/2012,59,HHS Region 3,2 wk ahead,1.7
+2012,7,2011/2012,59,HHS Region 3,3 wk ahead,1.6
+2012,7,2011/2012,59,HHS Region 3,4 wk ahead,1.9
+2012,7,2011/2012,59,HHS Region 4,Season onset,none
+2012,7,2011/2012,59,HHS Region 4,Season peak week,52
+2012,7,2011/2012,59,HHS Region 4,Season peak week,10
+2012,7,2011/2012,59,HHS Region 4,Season peak percentage,2.3
+2012,7,2011/2012,59,HHS Region 4,1 wk ahead,2
+2012,7,2011/2012,59,HHS Region 4,2 wk ahead,2.1
+2012,7,2011/2012,59,HHS Region 4,3 wk ahead,2.3
+2012,7,2011/2012,59,HHS Region 4,4 wk ahead,2.2
+2012,7,2011/2012,59,HHS Region 5,Season onset,7
+2012,7,2011/2012,59,HHS Region 5,Season peak week,11
+2012,7,2011/2012,59,HHS Region 5,Season peak percentage,2.4
+2012,7,2011/2012,59,HHS Region 5,1 wk ahead,1.8
+2012,7,2011/2012,59,HHS Region 5,2 wk ahead,1.8
+2012,7,2011/2012,59,HHS Region 5,3 wk ahead,2
+2012,7,2011/2012,59,HHS Region 5,4 wk ahead,2.4
+2012,7,2011/2012,59,HHS Region 6,Season onset,none
+2012,7,2011/2012,59,HHS Region 6,Season peak week,11
+2012,7,2011/2012,59,HHS Region 6,Season peak percentage,4.1
+2012,7,2011/2012,59,HHS Region 6,1 wk ahead,3.3
+2012,7,2011/2012,59,HHS Region 6,2 wk ahead,3.5
+2012,7,2011/2012,59,HHS Region 6,3 wk ahead,3.4
+2012,7,2011/2012,59,HHS Region 6,4 wk ahead,4.1
+2012,7,2011/2012,59,HHS Region 7,Season onset,5
+2012,7,2011/2012,59,HHS Region 7,Season peak week,9
+2012,7,2011/2012,59,HHS Region 7,Season peak percentage,3.4
+2012,7,2011/2012,59,HHS Region 7,1 wk ahead,3
+2012,7,2011/2012,59,HHS Region 7,2 wk ahead,3.4
+2012,7,2011/2012,59,HHS Region 7,3 wk ahead,3.1
+2012,7,2011/2012,59,HHS Region 7,4 wk ahead,2.6
+2012,7,2011/2012,59,HHS Region 8,Season onset,none
+2012,7,2011/2012,59,HHS Region 8,Season peak week,11
+2012,7,2011/2012,59,HHS Region 8,Season peak percentage,2.2
+2012,7,2011/2012,59,HHS Region 8,1 wk ahead,1.9
+2012,7,2011/2012,59,HHS Region 8,2 wk ahead,1.7
+2012,7,2011/2012,59,HHS Region 8,3 wk ahead,1.8
+2012,7,2011/2012,59,HHS Region 8,4 wk ahead,2.2
+2012,7,2011/2012,59,HHS Region 9,Season onset,none
+2012,7,2011/2012,59,HHS Region 9,Season peak week,52
+2012,7,2011/2012,59,HHS Region 9,Season peak week,8
+2012,7,2011/2012,59,HHS Region 9,Season peak percentage,3.7
+2012,7,2011/2012,59,HHS Region 9,1 wk ahead,3.7
+2012,7,2011/2012,59,HHS Region 9,2 wk ahead,3.1
+2012,7,2011/2012,59,HHS Region 9,3 wk ahead,2.5
+2012,7,2011/2012,59,HHS Region 9,4 wk ahead,2.8
+2012,7,2011/2012,59,HHS Region 10,Season onset,none
+2012,7,2011/2012,59,HHS Region 10,Season peak week,12
+2012,7,2011/2012,59,HHS Region 10,Season peak percentage,2.2
+2012,7,2011/2012,59,HHS Region 10,1 wk ahead,1.4
+2012,7,2011/2012,59,HHS Region 10,2 wk ahead,1.5
+2012,7,2011/2012,59,HHS Region 10,3 wk ahead,1.6
+2012,7,2011/2012,59,HHS Region 10,4 wk ahead,1.9
+2012,8,2011/2012,60,US National,Season onset,none
+2012,8,2011/2012,60,US National,Season peak week,11
+2012,8,2011/2012,60,US National,Season peak percentage,2.4
+2012,8,2011/2012,60,US National,1 wk ahead,2.2
+2012,8,2011/2012,60,US National,2 wk ahead,2.2
+2012,8,2011/2012,60,US National,3 wk ahead,2.4
+2012,8,2011/2012,60,US National,4 wk ahead,2
+2012,8,2011/2012,60,HHS Region 1,Season onset,none
+2012,8,2011/2012,60,HHS Region 1,Season peak week,52
+2012,8,2011/2012,60,HHS Region 1,Season peak percentage,1
+2012,8,2011/2012,60,HHS Region 1,1 wk ahead,0.8
+2012,8,2011/2012,60,HHS Region 1,2 wk ahead,0.8
+2012,8,2011/2012,60,HHS Region 1,3 wk ahead,0.9
+2012,8,2011/2012,60,HHS Region 1,4 wk ahead,0.8
+2012,8,2011/2012,60,HHS Region 2,Season onset,none
+2012,8,2011/2012,60,HHS Region 2,Season peak week,49
+2012,8,2011/2012,60,HHS Region 2,Season peak percentage,1.4
+2012,8,2011/2012,60,HHS Region 2,1 wk ahead,1.2
+2012,8,2011/2012,60,HHS Region 2,2 wk ahead,1.3
+2012,8,2011/2012,60,HHS Region 2,3 wk ahead,1.3
+2012,8,2011/2012,60,HHS Region 2,4 wk ahead,1.2
+2012,8,2011/2012,60,HHS Region 3,Season onset,none
+2012,8,2011/2012,60,HHS Region 3,Season peak week,52
+2012,8,2011/2012,60,HHS Region 3,Season peak percentage,2.1
+2012,8,2011/2012,60,HHS Region 3,1 wk ahead,1.7
+2012,8,2011/2012,60,HHS Region 3,2 wk ahead,1.6
+2012,8,2011/2012,60,HHS Region 3,3 wk ahead,1.9
+2012,8,2011/2012,60,HHS Region 3,4 wk ahead,1.4
+2012,8,2011/2012,60,HHS Region 4,Season onset,none
+2012,8,2011/2012,60,HHS Region 4,Season peak week,52
+2012,8,2011/2012,60,HHS Region 4,Season peak week,10
+2012,8,2011/2012,60,HHS Region 4,Season peak percentage,2.3
+2012,8,2011/2012,60,HHS Region 4,1 wk ahead,2.1
+2012,8,2011/2012,60,HHS Region 4,2 wk ahead,2.3
+2012,8,2011/2012,60,HHS Region 4,3 wk ahead,2.2
+2012,8,2011/2012,60,HHS Region 4,4 wk ahead,1.9
+2012,8,2011/2012,60,HHS Region 5,Season onset,7
+2012,8,2011/2012,60,HHS Region 5,Season peak week,11
+2012,8,2011/2012,60,HHS Region 5,Season peak percentage,2.4
+2012,8,2011/2012,60,HHS Region 5,1 wk ahead,1.8
+2012,8,2011/2012,60,HHS Region 5,2 wk ahead,2
+2012,8,2011/2012,60,HHS Region 5,3 wk ahead,2.4
+2012,8,2011/2012,60,HHS Region 5,4 wk ahead,1.9
+2012,8,2011/2012,60,HHS Region 6,Season onset,none
+2012,8,2011/2012,60,HHS Region 6,Season peak week,11
+2012,8,2011/2012,60,HHS Region 6,Season peak percentage,4.1
+2012,8,2011/2012,60,HHS Region 6,1 wk ahead,3.5
+2012,8,2011/2012,60,HHS Region 6,2 wk ahead,3.4
+2012,8,2011/2012,60,HHS Region 6,3 wk ahead,4.1
+2012,8,2011/2012,60,HHS Region 6,4 wk ahead,2.9
+2012,8,2011/2012,60,HHS Region 7,Season onset,5
+2012,8,2011/2012,60,HHS Region 7,Season peak week,9
+2012,8,2011/2012,60,HHS Region 7,Season peak percentage,3.4
+2012,8,2011/2012,60,HHS Region 7,1 wk ahead,3.4
+2012,8,2011/2012,60,HHS Region 7,2 wk ahead,3.1
+2012,8,2011/2012,60,HHS Region 7,3 wk ahead,2.6
+2012,8,2011/2012,60,HHS Region 7,4 wk ahead,1.7
+2012,8,2011/2012,60,HHS Region 8,Season onset,none
+2012,8,2011/2012,60,HHS Region 8,Season peak week,11
+2012,8,2011/2012,60,HHS Region 8,Season peak percentage,2.2
+2012,8,2011/2012,60,HHS Region 8,1 wk ahead,1.7
+2012,8,2011/2012,60,HHS Region 8,2 wk ahead,1.8
+2012,8,2011/2012,60,HHS Region 8,3 wk ahead,2.2
+2012,8,2011/2012,60,HHS Region 8,4 wk ahead,1.6
+2012,8,2011/2012,60,HHS Region 9,Season onset,none
+2012,8,2011/2012,60,HHS Region 9,Season peak week,52
+2012,8,2011/2012,60,HHS Region 9,Season peak week,8
+2012,8,2011/2012,60,HHS Region 9,Season peak percentage,3.7
+2012,8,2011/2012,60,HHS Region 9,1 wk ahead,3.1
+2012,8,2011/2012,60,HHS Region 9,2 wk ahead,2.5
+2012,8,2011/2012,60,HHS Region 9,3 wk ahead,2.8
+2012,8,2011/2012,60,HHS Region 9,4 wk ahead,2.6
+2012,8,2011/2012,60,HHS Region 10,Season onset,none
+2012,8,2011/2012,60,HHS Region 10,Season peak week,12
+2012,8,2011/2012,60,HHS Region 10,Season peak percentage,2.2
+2012,8,2011/2012,60,HHS Region 10,1 wk ahead,1.5
+2012,8,2011/2012,60,HHS Region 10,2 wk ahead,1.6
+2012,8,2011/2012,60,HHS Region 10,3 wk ahead,1.9
+2012,8,2011/2012,60,HHS Region 10,4 wk ahead,2.2
+2012,9,2011/2012,61,US National,Season onset,none
+2012,9,2011/2012,61,US National,Season peak week,11
+2012,9,2011/2012,61,US National,Season peak percentage,2.4
+2012,9,2011/2012,61,US National,1 wk ahead,2.2
+2012,9,2011/2012,61,US National,2 wk ahead,2.4
+2012,9,2011/2012,61,US National,3 wk ahead,2
+2012,9,2011/2012,61,US National,4 wk ahead,1.8
+2012,9,2011/2012,61,HHS Region 1,Season onset,none
+2012,9,2011/2012,61,HHS Region 1,Season peak week,52
+2012,9,2011/2012,61,HHS Region 1,Season peak percentage,1
+2012,9,2011/2012,61,HHS Region 1,1 wk ahead,0.8
+2012,9,2011/2012,61,HHS Region 1,2 wk ahead,0.9
+2012,9,2011/2012,61,HHS Region 1,3 wk ahead,0.8
+2012,9,2011/2012,61,HHS Region 1,4 wk ahead,0.6
+2012,9,2011/2012,61,HHS Region 2,Season onset,none
+2012,9,2011/2012,61,HHS Region 2,Season peak week,49
+2012,9,2011/2012,61,HHS Region 2,Season peak percentage,1.4
+2012,9,2011/2012,61,HHS Region 2,1 wk ahead,1.3
+2012,9,2011/2012,61,HHS Region 2,2 wk ahead,1.3
+2012,9,2011/2012,61,HHS Region 2,3 wk ahead,1.2
+2012,9,2011/2012,61,HHS Region 2,4 wk ahead,1.1
+2012,9,2011/2012,61,HHS Region 3,Season onset,none
+2012,9,2011/2012,61,HHS Region 3,Season peak week,52
+2012,9,2011/2012,61,HHS Region 3,Season peak percentage,2.1
+2012,9,2011/2012,61,HHS Region 3,1 wk ahead,1.6
+2012,9,2011/2012,61,HHS Region 3,2 wk ahead,1.9
+2012,9,2011/2012,61,HHS Region 3,3 wk ahead,1.4
+2012,9,2011/2012,61,HHS Region 3,4 wk ahead,1.4
+2012,9,2011/2012,61,HHS Region 4,Season onset,none
+2012,9,2011/2012,61,HHS Region 4,Season peak week,52
+2012,9,2011/2012,61,HHS Region 4,Season peak week,10
+2012,9,2011/2012,61,HHS Region 4,Season peak percentage,2.3
+2012,9,2011/2012,61,HHS Region 4,1 wk ahead,2.3
+2012,9,2011/2012,61,HHS Region 4,2 wk ahead,2.2
+2012,9,2011/2012,61,HHS Region 4,3 wk ahead,1.9
+2012,9,2011/2012,61,HHS Region 4,4 wk ahead,1.7
+2012,9,2011/2012,61,HHS Region 5,Season onset,7
+2012,9,2011/2012,61,HHS Region 5,Season peak week,11
+2012,9,2011/2012,61,HHS Region 5,Season peak percentage,2.4
+2012,9,2011/2012,61,HHS Region 5,1 wk ahead,2
+2012,9,2011/2012,61,HHS Region 5,2 wk ahead,2.4
+2012,9,2011/2012,61,HHS Region 5,3 wk ahead,1.9
+2012,9,2011/2012,61,HHS Region 5,4 wk ahead,1.3
+2012,9,2011/2012,61,HHS Region 6,Season onset,none
+2012,9,2011/2012,61,HHS Region 6,Season peak week,11
+2012,9,2011/2012,61,HHS Region 6,Season peak percentage,4.1
+2012,9,2011/2012,61,HHS Region 6,1 wk ahead,3.4
+2012,9,2011/2012,61,HHS Region 6,2 wk ahead,4.1
+2012,9,2011/2012,61,HHS Region 6,3 wk ahead,2.9
+2012,9,2011/2012,61,HHS Region 6,4 wk ahead,2.6
+2012,9,2011/2012,61,HHS Region 7,Season onset,5
+2012,9,2011/2012,61,HHS Region 7,Season peak week,9
+2012,9,2011/2012,61,HHS Region 7,Season peak percentage,3.4
+2012,9,2011/2012,61,HHS Region 7,1 wk ahead,3.1
+2012,9,2011/2012,61,HHS Region 7,2 wk ahead,2.6
+2012,9,2011/2012,61,HHS Region 7,3 wk ahead,1.7
+2012,9,2011/2012,61,HHS Region 7,4 wk ahead,1.2
+2012,9,2011/2012,61,HHS Region 8,Season onset,none
+2012,9,2011/2012,61,HHS Region 8,Season peak week,11
+2012,9,2011/2012,61,HHS Region 8,Season peak percentage,2.2
+2012,9,2011/2012,61,HHS Region 8,1 wk ahead,1.8
+2012,9,2011/2012,61,HHS Region 8,2 wk ahead,2.2
+2012,9,2011/2012,61,HHS Region 8,3 wk ahead,1.6
+2012,9,2011/2012,61,HHS Region 8,4 wk ahead,1.5
+2012,9,2011/2012,61,HHS Region 9,Season onset,none
+2012,9,2011/2012,61,HHS Region 9,Season peak week,52
+2012,9,2011/2012,61,HHS Region 9,Season peak week,8
+2012,9,2011/2012,61,HHS Region 9,Season peak percentage,3.7
+2012,9,2011/2012,61,HHS Region 9,1 wk ahead,2.5
+2012,9,2011/2012,61,HHS Region 9,2 wk ahead,2.8
+2012,9,2011/2012,61,HHS Region 9,3 wk ahead,2.6
+2012,9,2011/2012,61,HHS Region 9,4 wk ahead,3.4
+2012,9,2011/2012,61,HHS Region 10,Season onset,none
+2012,9,2011/2012,61,HHS Region 10,Season peak week,12
+2012,9,2011/2012,61,HHS Region 10,Season peak percentage,2.2
+2012,9,2011/2012,61,HHS Region 10,1 wk ahead,1.6
+2012,9,2011/2012,61,HHS Region 10,2 wk ahead,1.9
+2012,9,2011/2012,61,HHS Region 10,3 wk ahead,2.2
+2012,9,2011/2012,61,HHS Region 10,4 wk ahead,1.8
+2012,10,2011/2012,62,US National,Season onset,none
+2012,10,2011/2012,62,US National,Season peak week,11
+2012,10,2011/2012,62,US National,Season peak percentage,2.4
+2012,10,2011/2012,62,US National,1 wk ahead,2.4
+2012,10,2011/2012,62,US National,2 wk ahead,2
+2012,10,2011/2012,62,US National,3 wk ahead,1.8
+2012,10,2011/2012,62,US National,4 wk ahead,1.7
+2012,10,2011/2012,62,HHS Region 1,Season onset,none
+2012,10,2011/2012,62,HHS Region 1,Season peak week,52
+2012,10,2011/2012,62,HHS Region 1,Season peak percentage,1
+2012,10,2011/2012,62,HHS Region 1,1 wk ahead,0.9
+2012,10,2011/2012,62,HHS Region 1,2 wk ahead,0.8
+2012,10,2011/2012,62,HHS Region 1,3 wk ahead,0.6
+2012,10,2011/2012,62,HHS Region 1,4 wk ahead,0.8
+2012,10,2011/2012,62,HHS Region 2,Season onset,none
+2012,10,2011/2012,62,HHS Region 2,Season peak week,49
+2012,10,2011/2012,62,HHS Region 2,Season peak percentage,1.4
+2012,10,2011/2012,62,HHS Region 2,1 wk ahead,1.3
+2012,10,2011/2012,62,HHS Region 2,2 wk ahead,1.2
+2012,10,2011/2012,62,HHS Region 2,3 wk ahead,1.1
+2012,10,2011/2012,62,HHS Region 2,4 wk ahead,1.3
+2012,10,2011/2012,62,HHS Region 3,Season onset,none
+2012,10,2011/2012,62,HHS Region 3,Season peak week,52
+2012,10,2011/2012,62,HHS Region 3,Season peak percentage,2.1
+2012,10,2011/2012,62,HHS Region 3,1 wk ahead,1.9
+2012,10,2011/2012,62,HHS Region 3,2 wk ahead,1.4
+2012,10,2011/2012,62,HHS Region 3,3 wk ahead,1.4
+2012,10,2011/2012,62,HHS Region 3,4 wk ahead,1.3
+2012,10,2011/2012,62,HHS Region 4,Season onset,none
+2012,10,2011/2012,62,HHS Region 4,Season peak week,52
+2012,10,2011/2012,62,HHS Region 4,Season peak week,10
+2012,10,2011/2012,62,HHS Region 4,Season peak percentage,2.3
+2012,10,2011/2012,62,HHS Region 4,1 wk ahead,2.2
+2012,10,2011/2012,62,HHS Region 4,2 wk ahead,1.9
+2012,10,2011/2012,62,HHS Region 4,3 wk ahead,1.7
+2012,10,2011/2012,62,HHS Region 4,4 wk ahead,1.6
+2012,10,2011/2012,62,HHS Region 5,Season onset,7
+2012,10,2011/2012,62,HHS Region 5,Season peak week,11
+2012,10,2011/2012,62,HHS Region 5,Season peak percentage,2.4
+2012,10,2011/2012,62,HHS Region 5,1 wk ahead,2.4
+2012,10,2011/2012,62,HHS Region 5,2 wk ahead,1.9
+2012,10,2011/2012,62,HHS Region 5,3 wk ahead,1.3
+2012,10,2011/2012,62,HHS Region 5,4 wk ahead,1.4
+2012,10,2011/2012,62,HHS Region 6,Season onset,none
+2012,10,2011/2012,62,HHS Region 6,Season peak week,11
+2012,10,2011/2012,62,HHS Region 6,Season peak percentage,4.1
+2012,10,2011/2012,62,HHS Region 6,1 wk ahead,4.1
+2012,10,2011/2012,62,HHS Region 6,2 wk ahead,2.9
+2012,10,2011/2012,62,HHS Region 6,3 wk ahead,2.6
+2012,10,2011/2012,62,HHS Region 6,4 wk ahead,2.4
+2012,10,2011/2012,62,HHS Region 7,Season onset,5
+2012,10,2011/2012,62,HHS Region 7,Season peak week,9
+2012,10,2011/2012,62,HHS Region 7,Season peak percentage,3.4
+2012,10,2011/2012,62,HHS Region 7,1 wk ahead,2.6
+2012,10,2011/2012,62,HHS Region 7,2 wk ahead,1.7
+2012,10,2011/2012,62,HHS Region 7,3 wk ahead,1.2
+2012,10,2011/2012,62,HHS Region 7,4 wk ahead,0.9
+2012,10,2011/2012,62,HHS Region 8,Season onset,none
+2012,10,2011/2012,62,HHS Region 8,Season peak week,11
+2012,10,2011/2012,62,HHS Region 8,Season peak percentage,2.2
+2012,10,2011/2012,62,HHS Region 8,1 wk ahead,2.2
+2012,10,2011/2012,62,HHS Region 8,2 wk ahead,1.6
+2012,10,2011/2012,62,HHS Region 8,3 wk ahead,1.5
+2012,10,2011/2012,62,HHS Region 8,4 wk ahead,1.2
+2012,10,2011/2012,62,HHS Region 9,Season onset,none
+2012,10,2011/2012,62,HHS Region 9,Season peak week,52
+2012,10,2011/2012,62,HHS Region 9,Season peak week,8
+2012,10,2011/2012,62,HHS Region 9,Season peak percentage,3.7
+2012,10,2011/2012,62,HHS Region 9,1 wk ahead,2.8
+2012,10,2011/2012,62,HHS Region 9,2 wk ahead,2.6
+2012,10,2011/2012,62,HHS Region 9,3 wk ahead,3.4
+2012,10,2011/2012,62,HHS Region 9,4 wk ahead,2.7
+2012,10,2011/2012,62,HHS Region 10,Season onset,none
+2012,10,2011/2012,62,HHS Region 10,Season peak week,12
+2012,10,2011/2012,62,HHS Region 10,Season peak percentage,2.2
+2012,10,2011/2012,62,HHS Region 10,1 wk ahead,1.9
+2012,10,2011/2012,62,HHS Region 10,2 wk ahead,2.2
+2012,10,2011/2012,62,HHS Region 10,3 wk ahead,1.8
+2012,10,2011/2012,62,HHS Region 10,4 wk ahead,1.6
+2012,11,2011/2012,63,US National,Season onset,none
+2012,11,2011/2012,63,US National,Season peak week,11
+2012,11,2011/2012,63,US National,Season peak percentage,2.4
+2012,11,2011/2012,63,US National,1 wk ahead,2
+2012,11,2011/2012,63,US National,2 wk ahead,1.8
+2012,11,2011/2012,63,US National,3 wk ahead,1.7
+2012,11,2011/2012,63,US National,4 wk ahead,1.5
+2012,11,2011/2012,63,HHS Region 1,Season onset,none
+2012,11,2011/2012,63,HHS Region 1,Season peak week,52
+2012,11,2011/2012,63,HHS Region 1,Season peak percentage,1
+2012,11,2011/2012,63,HHS Region 1,1 wk ahead,0.8
+2012,11,2011/2012,63,HHS Region 1,2 wk ahead,0.6
+2012,11,2011/2012,63,HHS Region 1,3 wk ahead,0.8
+2012,11,2011/2012,63,HHS Region 1,4 wk ahead,0.9
+2012,11,2011/2012,63,HHS Region 2,Season onset,none
+2012,11,2011/2012,63,HHS Region 2,Season peak week,49
+2012,11,2011/2012,63,HHS Region 2,Season peak percentage,1.4
+2012,11,2011/2012,63,HHS Region 2,1 wk ahead,1.2
+2012,11,2011/2012,63,HHS Region 2,2 wk ahead,1.1
+2012,11,2011/2012,63,HHS Region 2,3 wk ahead,1.3
+2012,11,2011/2012,63,HHS Region 2,4 wk ahead,1.1
+2012,11,2011/2012,63,HHS Region 3,Season onset,none
+2012,11,2011/2012,63,HHS Region 3,Season peak week,52
+2012,11,2011/2012,63,HHS Region 3,Season peak percentage,2.1
+2012,11,2011/2012,63,HHS Region 3,1 wk ahead,1.4
+2012,11,2011/2012,63,HHS Region 3,2 wk ahead,1.4
+2012,11,2011/2012,63,HHS Region 3,3 wk ahead,1.3
+2012,11,2011/2012,63,HHS Region 3,4 wk ahead,1.2
+2012,11,2011/2012,63,HHS Region 4,Season onset,none
+2012,11,2011/2012,63,HHS Region 4,Season peak week,52
+2012,11,2011/2012,63,HHS Region 4,Season peak week,10
+2012,11,2011/2012,63,HHS Region 4,Season peak percentage,2.3
+2012,11,2011/2012,63,HHS Region 4,1 wk ahead,1.9
+2012,11,2011/2012,63,HHS Region 4,2 wk ahead,1.7
+2012,11,2011/2012,63,HHS Region 4,3 wk ahead,1.6
+2012,11,2011/2012,63,HHS Region 4,4 wk ahead,1.4
+2012,11,2011/2012,63,HHS Region 5,Season onset,7
+2012,11,2011/2012,63,HHS Region 5,Season peak week,11
+2012,11,2011/2012,63,HHS Region 5,Season peak percentage,2.4
+2012,11,2011/2012,63,HHS Region 5,1 wk ahead,1.9
+2012,11,2011/2012,63,HHS Region 5,2 wk ahead,1.3
+2012,11,2011/2012,63,HHS Region 5,3 wk ahead,1.4
+2012,11,2011/2012,63,HHS Region 5,4 wk ahead,1.2
+2012,11,2011/2012,63,HHS Region 6,Season onset,none
+2012,11,2011/2012,63,HHS Region 6,Season peak week,11
+2012,11,2011/2012,63,HHS Region 6,Season peak percentage,4.1
+2012,11,2011/2012,63,HHS Region 6,1 wk ahead,2.9
+2012,11,2011/2012,63,HHS Region 6,2 wk ahead,2.6
+2012,11,2011/2012,63,HHS Region 6,3 wk ahead,2.4
+2012,11,2011/2012,63,HHS Region 6,4 wk ahead,1.9
+2012,11,2011/2012,63,HHS Region 7,Season onset,5
+2012,11,2011/2012,63,HHS Region 7,Season peak week,9
+2012,11,2011/2012,63,HHS Region 7,Season peak percentage,3.4
+2012,11,2011/2012,63,HHS Region 7,1 wk ahead,1.7
+2012,11,2011/2012,63,HHS Region 7,2 wk ahead,1.2
+2012,11,2011/2012,63,HHS Region 7,3 wk ahead,0.9
+2012,11,2011/2012,63,HHS Region 7,4 wk ahead,0.8
+2012,11,2011/2012,63,HHS Region 8,Season onset,none
+2012,11,2011/2012,63,HHS Region 8,Season peak week,11
+2012,11,2011/2012,63,HHS Region 8,Season peak percentage,2.2
+2012,11,2011/2012,63,HHS Region 8,1 wk ahead,1.6
+2012,11,2011/2012,63,HHS Region 8,2 wk ahead,1.5
+2012,11,2011/2012,63,HHS Region 8,3 wk ahead,1.2
+2012,11,2011/2012,63,HHS Region 8,4 wk ahead,1.1
+2012,11,2011/2012,63,HHS Region 9,Season onset,none
+2012,11,2011/2012,63,HHS Region 9,Season peak week,52
+2012,11,2011/2012,63,HHS Region 9,Season peak week,8
+2012,11,2011/2012,63,HHS Region 9,Season peak percentage,3.7
+2012,11,2011/2012,63,HHS Region 9,1 wk ahead,2.6
+2012,11,2011/2012,63,HHS Region 9,2 wk ahead,3.4
+2012,11,2011/2012,63,HHS Region 9,3 wk ahead,2.7
+2012,11,2011/2012,63,HHS Region 9,4 wk ahead,2.6
+2012,11,2011/2012,63,HHS Region 10,Season onset,none
+2012,11,2011/2012,63,HHS Region 10,Season peak week,12
+2012,11,2011/2012,63,HHS Region 10,Season peak percentage,2.2
+2012,11,2011/2012,63,HHS Region 10,1 wk ahead,2.2
+2012,11,2011/2012,63,HHS Region 10,2 wk ahead,1.8
+2012,11,2011/2012,63,HHS Region 10,3 wk ahead,1.6
+2012,11,2011/2012,63,HHS Region 10,4 wk ahead,1.9
+2012,12,2011/2012,64,US National,Season onset,none
+2012,12,2011/2012,64,US National,Season peak week,11
+2012,12,2011/2012,64,US National,Season peak percentage,2.4
+2012,12,2011/2012,64,US National,1 wk ahead,1.8
+2012,12,2011/2012,64,US National,2 wk ahead,1.7
+2012,12,2011/2012,64,US National,3 wk ahead,1.5
+2012,12,2011/2012,64,US National,4 wk ahead,1.4
+2012,12,2011/2012,64,HHS Region 1,Season onset,none
+2012,12,2011/2012,64,HHS Region 1,Season peak week,52
+2012,12,2011/2012,64,HHS Region 1,Season peak percentage,1
+2012,12,2011/2012,64,HHS Region 1,1 wk ahead,0.6
+2012,12,2011/2012,64,HHS Region 1,2 wk ahead,0.8
+2012,12,2011/2012,64,HHS Region 1,3 wk ahead,0.9
+2012,12,2011/2012,64,HHS Region 1,4 wk ahead,0.8
+2012,12,2011/2012,64,HHS Region 2,Season onset,none
+2012,12,2011/2012,64,HHS Region 2,Season peak week,49
+2012,12,2011/2012,64,HHS Region 2,Season peak percentage,1.4
+2012,12,2011/2012,64,HHS Region 2,1 wk ahead,1.1
+2012,12,2011/2012,64,HHS Region 2,2 wk ahead,1.3
+2012,12,2011/2012,64,HHS Region 2,3 wk ahead,1.1
+2012,12,2011/2012,64,HHS Region 2,4 wk ahead,1.1
+2012,12,2011/2012,64,HHS Region 3,Season onset,none
+2012,12,2011/2012,64,HHS Region 3,Season peak week,52
+2012,12,2011/2012,64,HHS Region 3,Season peak percentage,2.1
+2012,12,2011/2012,64,HHS Region 3,1 wk ahead,1.4
+2012,12,2011/2012,64,HHS Region 3,2 wk ahead,1.3
+2012,12,2011/2012,64,HHS Region 3,3 wk ahead,1.2
+2012,12,2011/2012,64,HHS Region 3,4 wk ahead,1.1
+2012,12,2011/2012,64,HHS Region 4,Season onset,none
+2012,12,2011/2012,64,HHS Region 4,Season peak week,52
+2012,12,2011/2012,64,HHS Region 4,Season peak week,10
+2012,12,2011/2012,64,HHS Region 4,Season peak percentage,2.3
+2012,12,2011/2012,64,HHS Region 4,1 wk ahead,1.7
+2012,12,2011/2012,64,HHS Region 4,2 wk ahead,1.6
+2012,12,2011/2012,64,HHS Region 4,3 wk ahead,1.4
+2012,12,2011/2012,64,HHS Region 4,4 wk ahead,1.4
+2012,12,2011/2012,64,HHS Region 5,Season onset,7
+2012,12,2011/2012,64,HHS Region 5,Season peak week,11
+2012,12,2011/2012,64,HHS Region 5,Season peak percentage,2.4
+2012,12,2011/2012,64,HHS Region 5,1 wk ahead,1.3
+2012,12,2011/2012,64,HHS Region 5,2 wk ahead,1.4
+2012,12,2011/2012,64,HHS Region 5,3 wk ahead,1.2
+2012,12,2011/2012,64,HHS Region 5,4 wk ahead,1
+2012,12,2011/2012,64,HHS Region 6,Season onset,none
+2012,12,2011/2012,64,HHS Region 6,Season peak week,11
+2012,12,2011/2012,64,HHS Region 6,Season peak percentage,4.1
+2012,12,2011/2012,64,HHS Region 6,1 wk ahead,2.6
+2012,12,2011/2012,64,HHS Region 6,2 wk ahead,2.4
+2012,12,2011/2012,64,HHS Region 6,3 wk ahead,1.9
+2012,12,2011/2012,64,HHS Region 6,4 wk ahead,2
+2012,12,2011/2012,64,HHS Region 7,Season onset,5
+2012,12,2011/2012,64,HHS Region 7,Season peak week,9
+2012,12,2011/2012,64,HHS Region 7,Season peak percentage,3.4
+2012,12,2011/2012,64,HHS Region 7,1 wk ahead,1.2
+2012,12,2011/2012,64,HHS Region 7,2 wk ahead,0.9
+2012,12,2011/2012,64,HHS Region 7,3 wk ahead,0.8
+2012,12,2011/2012,64,HHS Region 7,4 wk ahead,0.8
+2012,12,2011/2012,64,HHS Region 8,Season onset,none
+2012,12,2011/2012,64,HHS Region 8,Season peak week,11
+2012,12,2011/2012,64,HHS Region 8,Season peak percentage,2.2
+2012,12,2011/2012,64,HHS Region 8,1 wk ahead,1.5
+2012,12,2011/2012,64,HHS Region 8,2 wk ahead,1.2
+2012,12,2011/2012,64,HHS Region 8,3 wk ahead,1.1
+2012,12,2011/2012,64,HHS Region 8,4 wk ahead,0.9
+2012,12,2011/2012,64,HHS Region 9,Season onset,none
+2012,12,2011/2012,64,HHS Region 9,Season peak week,52
+2012,12,2011/2012,64,HHS Region 9,Season peak week,8
+2012,12,2011/2012,64,HHS Region 9,Season peak percentage,3.7
+2012,12,2011/2012,64,HHS Region 9,1 wk ahead,3.4
+2012,12,2011/2012,64,HHS Region 9,2 wk ahead,2.7
+2012,12,2011/2012,64,HHS Region 9,3 wk ahead,2.6
+2012,12,2011/2012,64,HHS Region 9,4 wk ahead,2
+2012,12,2011/2012,64,HHS Region 10,Season onset,none
+2012,12,2011/2012,64,HHS Region 10,Season peak week,12
+2012,12,2011/2012,64,HHS Region 10,Season peak percentage,2.2
+2012,12,2011/2012,64,HHS Region 10,1 wk ahead,1.8
+2012,12,2011/2012,64,HHS Region 10,2 wk ahead,1.6
+2012,12,2011/2012,64,HHS Region 10,3 wk ahead,1.9
+2012,12,2011/2012,64,HHS Region 10,4 wk ahead,1.6
+2012,13,2011/2012,65,US National,Season onset,none
+2012,13,2011/2012,65,US National,Season peak week,11
+2012,13,2011/2012,65,US National,Season peak percentage,2.4
+2012,13,2011/2012,65,US National,1 wk ahead,1.7
+2012,13,2011/2012,65,US National,2 wk ahead,1.5
+2012,13,2011/2012,65,US National,3 wk ahead,1.4
+2012,13,2011/2012,65,US National,4 wk ahead,1.3
+2012,13,2011/2012,65,HHS Region 1,Season onset,none
+2012,13,2011/2012,65,HHS Region 1,Season peak week,52
+2012,13,2011/2012,65,HHS Region 1,Season peak percentage,1
+2012,13,2011/2012,65,HHS Region 1,1 wk ahead,0.8
+2012,13,2011/2012,65,HHS Region 1,2 wk ahead,0.9
+2012,13,2011/2012,65,HHS Region 1,3 wk ahead,0.8
+2012,13,2011/2012,65,HHS Region 1,4 wk ahead,0.6
+2012,13,2011/2012,65,HHS Region 2,Season onset,none
+2012,13,2011/2012,65,HHS Region 2,Season peak week,49
+2012,13,2011/2012,65,HHS Region 2,Season peak percentage,1.4
+2012,13,2011/2012,65,HHS Region 2,1 wk ahead,1.3
+2012,13,2011/2012,65,HHS Region 2,2 wk ahead,1.1
+2012,13,2011/2012,65,HHS Region 2,3 wk ahead,1.1
+2012,13,2011/2012,65,HHS Region 2,4 wk ahead,0.9
+2012,13,2011/2012,65,HHS Region 3,Season onset,none
+2012,13,2011/2012,65,HHS Region 3,Season peak week,52
+2012,13,2011/2012,65,HHS Region 3,Season peak percentage,2.1
+2012,13,2011/2012,65,HHS Region 3,1 wk ahead,1.3
+2012,13,2011/2012,65,HHS Region 3,2 wk ahead,1.2
+2012,13,2011/2012,65,HHS Region 3,3 wk ahead,1.1
+2012,13,2011/2012,65,HHS Region 3,4 wk ahead,1.1
+2012,13,2011/2012,65,HHS Region 4,Season onset,none
+2012,13,2011/2012,65,HHS Region 4,Season peak week,52
+2012,13,2011/2012,65,HHS Region 4,Season peak week,10
+2012,13,2011/2012,65,HHS Region 4,Season peak percentage,2.3
+2012,13,2011/2012,65,HHS Region 4,1 wk ahead,1.6
+2012,13,2011/2012,65,HHS Region 4,2 wk ahead,1.4
+2012,13,2011/2012,65,HHS Region 4,3 wk ahead,1.4
+2012,13,2011/2012,65,HHS Region 4,4 wk ahead,1.3
+2012,13,2011/2012,65,HHS Region 5,Season onset,7
+2012,13,2011/2012,65,HHS Region 5,Season peak week,11
+2012,13,2011/2012,65,HHS Region 5,Season peak percentage,2.4
+2012,13,2011/2012,65,HHS Region 5,1 wk ahead,1.4
+2012,13,2011/2012,65,HHS Region 5,2 wk ahead,1.2
+2012,13,2011/2012,65,HHS Region 5,3 wk ahead,1
+2012,13,2011/2012,65,HHS Region 5,4 wk ahead,0.9
+2012,13,2011/2012,65,HHS Region 6,Season onset,none
+2012,13,2011/2012,65,HHS Region 6,Season peak week,11
+2012,13,2011/2012,65,HHS Region 6,Season peak percentage,4.1
+2012,13,2011/2012,65,HHS Region 6,1 wk ahead,2.4
+2012,13,2011/2012,65,HHS Region 6,2 wk ahead,1.9
+2012,13,2011/2012,65,HHS Region 6,3 wk ahead,2
+2012,13,2011/2012,65,HHS Region 6,4 wk ahead,1.9
+2012,13,2011/2012,65,HHS Region 7,Season onset,5
+2012,13,2011/2012,65,HHS Region 7,Season peak week,9
+2012,13,2011/2012,65,HHS Region 7,Season peak percentage,3.4
+2012,13,2011/2012,65,HHS Region 7,1 wk ahead,0.9
+2012,13,2011/2012,65,HHS Region 7,2 wk ahead,0.8
+2012,13,2011/2012,65,HHS Region 7,3 wk ahead,0.8
+2012,13,2011/2012,65,HHS Region 7,4 wk ahead,0.7
+2012,13,2011/2012,65,HHS Region 8,Season onset,none
+2012,13,2011/2012,65,HHS Region 8,Season peak week,11
+2012,13,2011/2012,65,HHS Region 8,Season peak percentage,2.2
+2012,13,2011/2012,65,HHS Region 8,1 wk ahead,1.2
+2012,13,2011/2012,65,HHS Region 8,2 wk ahead,1.1
+2012,13,2011/2012,65,HHS Region 8,3 wk ahead,0.9
+2012,13,2011/2012,65,HHS Region 8,4 wk ahead,0.9
+2012,13,2011/2012,65,HHS Region 9,Season onset,none
+2012,13,2011/2012,65,HHS Region 9,Season peak week,52
+2012,13,2011/2012,65,HHS Region 9,Season peak week,8
+2012,13,2011/2012,65,HHS Region 9,Season peak percentage,3.7
+2012,13,2011/2012,65,HHS Region 9,1 wk ahead,2.7
+2012,13,2011/2012,65,HHS Region 9,2 wk ahead,2.6
+2012,13,2011/2012,65,HHS Region 9,3 wk ahead,2
+2012,13,2011/2012,65,HHS Region 9,4 wk ahead,1.9
+2012,13,2011/2012,65,HHS Region 10,Season onset,none
+2012,13,2011/2012,65,HHS Region 10,Season peak week,12
+2012,13,2011/2012,65,HHS Region 10,Season peak percentage,2.2
+2012,13,2011/2012,65,HHS Region 10,1 wk ahead,1.6
+2012,13,2011/2012,65,HHS Region 10,2 wk ahead,1.9
+2012,13,2011/2012,65,HHS Region 10,3 wk ahead,1.6
+2012,13,2011/2012,65,HHS Region 10,4 wk ahead,1.4
+2012,14,2011/2012,66,US National,Season onset,none
+2012,14,2011/2012,66,US National,Season peak week,11
+2012,14,2011/2012,66,US National,Season peak percentage,2.4
+2012,14,2011/2012,66,US National,1 wk ahead,1.5
+2012,14,2011/2012,66,US National,2 wk ahead,1.4
+2012,14,2011/2012,66,US National,3 wk ahead,1.3
+2012,14,2011/2012,66,US National,4 wk ahead,1.4
+2012,14,2011/2012,66,HHS Region 1,Season onset,none
+2012,14,2011/2012,66,HHS Region 1,Season peak week,52
+2012,14,2011/2012,66,HHS Region 1,Season peak percentage,1
+2012,14,2011/2012,66,HHS Region 1,1 wk ahead,0.9
+2012,14,2011/2012,66,HHS Region 1,2 wk ahead,0.8
+2012,14,2011/2012,66,HHS Region 1,3 wk ahead,0.6
+2012,14,2011/2012,66,HHS Region 1,4 wk ahead,0.5
+2012,14,2011/2012,66,HHS Region 2,Season onset,none
+2012,14,2011/2012,66,HHS Region 2,Season peak week,49
+2012,14,2011/2012,66,HHS Region 2,Season peak percentage,1.4
+2012,14,2011/2012,66,HHS Region 2,1 wk ahead,1.1
+2012,14,2011/2012,66,HHS Region 2,2 wk ahead,1.1
+2012,14,2011/2012,66,HHS Region 2,3 wk ahead,0.9
+2012,14,2011/2012,66,HHS Region 2,4 wk ahead,1
+2012,14,2011/2012,66,HHS Region 3,Season onset,none
+2012,14,2011/2012,66,HHS Region 3,Season peak week,52
+2012,14,2011/2012,66,HHS Region 3,Season peak percentage,2.1
+2012,14,2011/2012,66,HHS Region 3,1 wk ahead,1.2
+2012,14,2011/2012,66,HHS Region 3,2 wk ahead,1.1
+2012,14,2011/2012,66,HHS Region 3,3 wk ahead,1.1
+2012,14,2011/2012,66,HHS Region 3,4 wk ahead,1.3
+2012,14,2011/2012,66,HHS Region 4,Season onset,none
+2012,14,2011/2012,66,HHS Region 4,Season peak week,52
+2012,14,2011/2012,66,HHS Region 4,Season peak week,10
+2012,14,2011/2012,66,HHS Region 4,Season peak percentage,2.3
+2012,14,2011/2012,66,HHS Region 4,1 wk ahead,1.4
+2012,14,2011/2012,66,HHS Region 4,2 wk ahead,1.4
+2012,14,2011/2012,66,HHS Region 4,3 wk ahead,1.3
+2012,14,2011/2012,66,HHS Region 4,4 wk ahead,1.5
+2012,14,2011/2012,66,HHS Region 5,Season onset,7
+2012,14,2011/2012,66,HHS Region 5,Season peak week,11
+2012,14,2011/2012,66,HHS Region 5,Season peak percentage,2.4
+2012,14,2011/2012,66,HHS Region 5,1 wk ahead,1.2
+2012,14,2011/2012,66,HHS Region 5,2 wk ahead,1
+2012,14,2011/2012,66,HHS Region 5,3 wk ahead,0.9
+2012,14,2011/2012,66,HHS Region 5,4 wk ahead,1
+2012,14,2011/2012,66,HHS Region 6,Season onset,none
+2012,14,2011/2012,66,HHS Region 6,Season peak week,11
+2012,14,2011/2012,66,HHS Region 6,Season peak percentage,4.1
+2012,14,2011/2012,66,HHS Region 6,1 wk ahead,1.9
+2012,14,2011/2012,66,HHS Region 6,2 wk ahead,2
+2012,14,2011/2012,66,HHS Region 6,3 wk ahead,1.9
+2012,14,2011/2012,66,HHS Region 6,4 wk ahead,1.9
+2012,14,2011/2012,66,HHS Region 7,Season onset,5
+2012,14,2011/2012,66,HHS Region 7,Season peak week,9
+2012,14,2011/2012,66,HHS Region 7,Season peak percentage,3.4
+2012,14,2011/2012,66,HHS Region 7,1 wk ahead,0.8
+2012,14,2011/2012,66,HHS Region 7,2 wk ahead,0.8
+2012,14,2011/2012,66,HHS Region 7,3 wk ahead,0.7
+2012,14,2011/2012,66,HHS Region 7,4 wk ahead,0.8
+2012,14,2011/2012,66,HHS Region 8,Season onset,none
+2012,14,2011/2012,66,HHS Region 8,Season peak week,11
+2012,14,2011/2012,66,HHS Region 8,Season peak percentage,2.2
+2012,14,2011/2012,66,HHS Region 8,1 wk ahead,1.1
+2012,14,2011/2012,66,HHS Region 8,2 wk ahead,0.9
+2012,14,2011/2012,66,HHS Region 8,3 wk ahead,0.9
+2012,14,2011/2012,66,HHS Region 8,4 wk ahead,0.9
+2012,14,2011/2012,66,HHS Region 9,Season onset,none
+2012,14,2011/2012,66,HHS Region 9,Season peak week,52
+2012,14,2011/2012,66,HHS Region 9,Season peak week,8
+2012,14,2011/2012,66,HHS Region 9,Season peak percentage,3.7
+2012,14,2011/2012,66,HHS Region 9,1 wk ahead,2.6
+2012,14,2011/2012,66,HHS Region 9,2 wk ahead,2
+2012,14,2011/2012,66,HHS Region 9,3 wk ahead,1.9
+2012,14,2011/2012,66,HHS Region 9,4 wk ahead,2.1
+2012,14,2011/2012,66,HHS Region 10,Season onset,none
+2012,14,2011/2012,66,HHS Region 10,Season peak week,12
+2012,14,2011/2012,66,HHS Region 10,Season peak percentage,2.2
+2012,14,2011/2012,66,HHS Region 10,1 wk ahead,1.9
+2012,14,2011/2012,66,HHS Region 10,2 wk ahead,1.6
+2012,14,2011/2012,66,HHS Region 10,3 wk ahead,1.4
+2012,14,2011/2012,66,HHS Region 10,4 wk ahead,1.4
+2012,15,2011/2012,67,US National,Season onset,none
+2012,15,2011/2012,67,US National,Season peak week,11
+2012,15,2011/2012,67,US National,Season peak percentage,2.4
+2012,15,2011/2012,67,US National,1 wk ahead,1.4
+2012,15,2011/2012,67,US National,2 wk ahead,1.3
+2012,15,2011/2012,67,US National,3 wk ahead,1.4
+2012,15,2011/2012,67,US National,4 wk ahead,1.3
+2012,15,2011/2012,67,HHS Region 1,Season onset,none
+2012,15,2011/2012,67,HHS Region 1,Season peak week,52
+2012,15,2011/2012,67,HHS Region 1,Season peak percentage,1
+2012,15,2011/2012,67,HHS Region 1,1 wk ahead,0.8
+2012,15,2011/2012,67,HHS Region 1,2 wk ahead,0.6
+2012,15,2011/2012,67,HHS Region 1,3 wk ahead,0.5
+2012,15,2011/2012,67,HHS Region 1,4 wk ahead,0.6
+2012,15,2011/2012,67,HHS Region 2,Season onset,none
+2012,15,2011/2012,67,HHS Region 2,Season peak week,49
+2012,15,2011/2012,67,HHS Region 2,Season peak percentage,1.4
+2012,15,2011/2012,67,HHS Region 2,1 wk ahead,1.1
+2012,15,2011/2012,67,HHS Region 2,2 wk ahead,0.9
+2012,15,2011/2012,67,HHS Region 2,3 wk ahead,1
+2012,15,2011/2012,67,HHS Region 2,4 wk ahead,0.9
+2012,15,2011/2012,67,HHS Region 3,Season onset,none
+2012,15,2011/2012,67,HHS Region 3,Season peak week,52
+2012,15,2011/2012,67,HHS Region 3,Season peak percentage,2.1
+2012,15,2011/2012,67,HHS Region 3,1 wk ahead,1.1
+2012,15,2011/2012,67,HHS Region 3,2 wk ahead,1.1
+2012,15,2011/2012,67,HHS Region 3,3 wk ahead,1.3
+2012,15,2011/2012,67,HHS Region 3,4 wk ahead,1.5
+2012,15,2011/2012,67,HHS Region 4,Season onset,none
+2012,15,2011/2012,67,HHS Region 4,Season peak week,52
+2012,15,2011/2012,67,HHS Region 4,Season peak week,10
+2012,15,2011/2012,67,HHS Region 4,Season peak percentage,2.3
+2012,15,2011/2012,67,HHS Region 4,1 wk ahead,1.4
+2012,15,2011/2012,67,HHS Region 4,2 wk ahead,1.3
+2012,15,2011/2012,67,HHS Region 4,3 wk ahead,1.5
+2012,15,2011/2012,67,HHS Region 4,4 wk ahead,1.4
+2012,15,2011/2012,67,HHS Region 5,Season onset,7
+2012,15,2011/2012,67,HHS Region 5,Season peak week,11
+2012,15,2011/2012,67,HHS Region 5,Season peak percentage,2.4
+2012,15,2011/2012,67,HHS Region 5,1 wk ahead,1
+2012,15,2011/2012,67,HHS Region 5,2 wk ahead,0.9
+2012,15,2011/2012,67,HHS Region 5,3 wk ahead,1
+2012,15,2011/2012,67,HHS Region 5,4 wk ahead,1
+2012,15,2011/2012,67,HHS Region 6,Season onset,none
+2012,15,2011/2012,67,HHS Region 6,Season peak week,11
+2012,15,2011/2012,67,HHS Region 6,Season peak percentage,4.1
+2012,15,2011/2012,67,HHS Region 6,1 wk ahead,2
+2012,15,2011/2012,67,HHS Region 6,2 wk ahead,1.9
+2012,15,2011/2012,67,HHS Region 6,3 wk ahead,1.9
+2012,15,2011/2012,67,HHS Region 6,4 wk ahead,1.9
+2012,15,2011/2012,67,HHS Region 7,Season onset,5
+2012,15,2011/2012,67,HHS Region 7,Season peak week,9
+2012,15,2011/2012,67,HHS Region 7,Season peak percentage,3.4
+2012,15,2011/2012,67,HHS Region 7,1 wk ahead,0.8
+2012,15,2011/2012,67,HHS Region 7,2 wk ahead,0.7
+2012,15,2011/2012,67,HHS Region 7,3 wk ahead,0.8
+2012,15,2011/2012,67,HHS Region 7,4 wk ahead,0.7
+2012,15,2011/2012,67,HHS Region 8,Season onset,none
+2012,15,2011/2012,67,HHS Region 8,Season peak week,11
+2012,15,2011/2012,67,HHS Region 8,Season peak percentage,2.2
+2012,15,2011/2012,67,HHS Region 8,1 wk ahead,0.9
+2012,15,2011/2012,67,HHS Region 8,2 wk ahead,0.9
+2012,15,2011/2012,67,HHS Region 8,3 wk ahead,0.9
+2012,15,2011/2012,67,HHS Region 8,4 wk ahead,0.8
+2012,15,2011/2012,67,HHS Region 9,Season onset,none
+2012,15,2011/2012,67,HHS Region 9,Season peak week,52
+2012,15,2011/2012,67,HHS Region 9,Season peak week,8
+2012,15,2011/2012,67,HHS Region 9,Season peak percentage,3.7
+2012,15,2011/2012,67,HHS Region 9,1 wk ahead,2
+2012,15,2011/2012,67,HHS Region 9,2 wk ahead,1.9
+2012,15,2011/2012,67,HHS Region 9,3 wk ahead,2.1
+2012,15,2011/2012,67,HHS Region 9,4 wk ahead,2
+2012,15,2011/2012,67,HHS Region 10,Season onset,none
+2012,15,2011/2012,67,HHS Region 10,Season peak week,12
+2012,15,2011/2012,67,HHS Region 10,Season peak percentage,2.2
+2012,15,2011/2012,67,HHS Region 10,1 wk ahead,1.6
+2012,15,2011/2012,67,HHS Region 10,2 wk ahead,1.4
+2012,15,2011/2012,67,HHS Region 10,3 wk ahead,1.4
+2012,15,2011/2012,67,HHS Region 10,4 wk ahead,1.1
+2012,16,2011/2012,68,US National,Season onset,none
+2012,16,2011/2012,68,US National,Season peak week,11
+2012,16,2011/2012,68,US National,Season peak percentage,2.4
+2012,16,2011/2012,68,US National,1 wk ahead,1.3
+2012,16,2011/2012,68,US National,2 wk ahead,1.4
+2012,16,2011/2012,68,US National,3 wk ahead,1.3
+2012,16,2011/2012,68,US National,4 wk ahead,1.2
+2012,16,2011/2012,68,HHS Region 1,Season onset,none
+2012,16,2011/2012,68,HHS Region 1,Season peak week,52
+2012,16,2011/2012,68,HHS Region 1,Season peak percentage,1
+2012,16,2011/2012,68,HHS Region 1,1 wk ahead,0.6
+2012,16,2011/2012,68,HHS Region 1,2 wk ahead,0.5
+2012,16,2011/2012,68,HHS Region 1,3 wk ahead,0.6
+2012,16,2011/2012,68,HHS Region 1,4 wk ahead,0.5
+2012,16,2011/2012,68,HHS Region 2,Season onset,none
+2012,16,2011/2012,68,HHS Region 2,Season peak week,49
+2012,16,2011/2012,68,HHS Region 2,Season peak percentage,1.4
+2012,16,2011/2012,68,HHS Region 2,1 wk ahead,0.9
+2012,16,2011/2012,68,HHS Region 2,2 wk ahead,1
+2012,16,2011/2012,68,HHS Region 2,3 wk ahead,0.9
+2012,16,2011/2012,68,HHS Region 2,4 wk ahead,0.9
+2012,16,2011/2012,68,HHS Region 3,Season onset,none
+2012,16,2011/2012,68,HHS Region 3,Season peak week,52
+2012,16,2011/2012,68,HHS Region 3,Season peak percentage,2.1
+2012,16,2011/2012,68,HHS Region 3,1 wk ahead,1.1
+2012,16,2011/2012,68,HHS Region 3,2 wk ahead,1.3
+2012,16,2011/2012,68,HHS Region 3,3 wk ahead,1.5
+2012,16,2011/2012,68,HHS Region 3,4 wk ahead,1
+2012,16,2011/2012,68,HHS Region 4,Season onset,none
+2012,16,2011/2012,68,HHS Region 4,Season peak week,52
+2012,16,2011/2012,68,HHS Region 4,Season peak week,10
+2012,16,2011/2012,68,HHS Region 4,Season peak percentage,2.3
+2012,16,2011/2012,68,HHS Region 4,1 wk ahead,1.3
+2012,16,2011/2012,68,HHS Region 4,2 wk ahead,1.5
+2012,16,2011/2012,68,HHS Region 4,3 wk ahead,1.4
+2012,16,2011/2012,68,HHS Region 4,4 wk ahead,1.4
+2012,16,2011/2012,68,HHS Region 5,Season onset,7
+2012,16,2011/2012,68,HHS Region 5,Season peak week,11
+2012,16,2011/2012,68,HHS Region 5,Season peak percentage,2.4
+2012,16,2011/2012,68,HHS Region 5,1 wk ahead,0.9
+2012,16,2011/2012,68,HHS Region 5,2 wk ahead,1
+2012,16,2011/2012,68,HHS Region 5,3 wk ahead,1
+2012,16,2011/2012,68,HHS Region 5,4 wk ahead,0.8
+2012,16,2011/2012,68,HHS Region 6,Season onset,none
+2012,16,2011/2012,68,HHS Region 6,Season peak week,11
+2012,16,2011/2012,68,HHS Region 6,Season peak percentage,4.1
+2012,16,2011/2012,68,HHS Region 6,1 wk ahead,1.9
+2012,16,2011/2012,68,HHS Region 6,2 wk ahead,1.9
+2012,16,2011/2012,68,HHS Region 6,3 wk ahead,1.9
+2012,16,2011/2012,68,HHS Region 6,4 wk ahead,1.9
+2012,16,2011/2012,68,HHS Region 7,Season onset,5
+2012,16,2011/2012,68,HHS Region 7,Season peak week,9
+2012,16,2011/2012,68,HHS Region 7,Season peak percentage,3.4
+2012,16,2011/2012,68,HHS Region 7,1 wk ahead,0.7
+2012,16,2011/2012,68,HHS Region 7,2 wk ahead,0.8
+2012,16,2011/2012,68,HHS Region 7,3 wk ahead,0.7
+2012,16,2011/2012,68,HHS Region 7,4 wk ahead,0.5
+2012,16,2011/2012,68,HHS Region 8,Season onset,none
+2012,16,2011/2012,68,HHS Region 8,Season peak week,11
+2012,16,2011/2012,68,HHS Region 8,Season peak percentage,2.2
+2012,16,2011/2012,68,HHS Region 8,1 wk ahead,0.9
+2012,16,2011/2012,68,HHS Region 8,2 wk ahead,0.9
+2012,16,2011/2012,68,HHS Region 8,3 wk ahead,0.8
+2012,16,2011/2012,68,HHS Region 8,4 wk ahead,0.8
+2012,16,2011/2012,68,HHS Region 9,Season onset,none
+2012,16,2011/2012,68,HHS Region 9,Season peak week,52
+2012,16,2011/2012,68,HHS Region 9,Season peak week,8
+2012,16,2011/2012,68,HHS Region 9,Season peak percentage,3.7
+2012,16,2011/2012,68,HHS Region 9,1 wk ahead,1.9
+2012,16,2011/2012,68,HHS Region 9,2 wk ahead,2.1
+2012,16,2011/2012,68,HHS Region 9,3 wk ahead,2
+2012,16,2011/2012,68,HHS Region 9,4 wk ahead,1.9
+2012,16,2011/2012,68,HHS Region 10,Season onset,none
+2012,16,2011/2012,68,HHS Region 10,Season peak week,12
+2012,16,2011/2012,68,HHS Region 10,Season peak percentage,2.2
+2012,16,2011/2012,68,HHS Region 10,1 wk ahead,1.4
+2012,16,2011/2012,68,HHS Region 10,2 wk ahead,1.4
+2012,16,2011/2012,68,HHS Region 10,3 wk ahead,1.1
+2012,16,2011/2012,68,HHS Region 10,4 wk ahead,0.9
+2012,17,2011/2012,69,US National,Season onset,none
+2012,17,2011/2012,69,US National,Season peak week,11
+2012,17,2011/2012,69,US National,Season peak percentage,2.4
+2012,17,2011/2012,69,US National,1 wk ahead,1.4
+2012,17,2011/2012,69,US National,2 wk ahead,1.3
+2012,17,2011/2012,69,US National,3 wk ahead,1.2
+2012,17,2011/2012,69,US National,4 wk ahead,1.2
+2012,17,2011/2012,69,HHS Region 1,Season onset,none
+2012,17,2011/2012,69,HHS Region 1,Season peak week,52
+2012,17,2011/2012,69,HHS Region 1,Season peak percentage,1
+2012,17,2011/2012,69,HHS Region 1,1 wk ahead,0.5
+2012,17,2011/2012,69,HHS Region 1,2 wk ahead,0.6
+2012,17,2011/2012,69,HHS Region 1,3 wk ahead,0.5
+2012,17,2011/2012,69,HHS Region 1,4 wk ahead,0.6
+2012,17,2011/2012,69,HHS Region 2,Season onset,none
+2012,17,2011/2012,69,HHS Region 2,Season peak week,49
+2012,17,2011/2012,69,HHS Region 2,Season peak percentage,1.4
+2012,17,2011/2012,69,HHS Region 2,1 wk ahead,1
+2012,17,2011/2012,69,HHS Region 2,2 wk ahead,0.9
+2012,17,2011/2012,69,HHS Region 2,3 wk ahead,0.9
+2012,17,2011/2012,69,HHS Region 2,4 wk ahead,0.7
+2012,17,2011/2012,69,HHS Region 3,Season onset,none
+2012,17,2011/2012,69,HHS Region 3,Season peak week,52
+2012,17,2011/2012,69,HHS Region 3,Season peak percentage,2.1
+2012,17,2011/2012,69,HHS Region 3,1 wk ahead,1.3
+2012,17,2011/2012,69,HHS Region 3,2 wk ahead,1.5
+2012,17,2011/2012,69,HHS Region 3,3 wk ahead,1
+2012,17,2011/2012,69,HHS Region 3,4 wk ahead,1.1
+2012,17,2011/2012,69,HHS Region 4,Season onset,none
+2012,17,2011/2012,69,HHS Region 4,Season peak week,52
+2012,17,2011/2012,69,HHS Region 4,Season peak week,10
+2012,17,2011/2012,69,HHS Region 4,Season peak percentage,2.3
+2012,17,2011/2012,69,HHS Region 4,1 wk ahead,1.5
+2012,17,2011/2012,69,HHS Region 4,2 wk ahead,1.4
+2012,17,2011/2012,69,HHS Region 4,3 wk ahead,1.4
+2012,17,2011/2012,69,HHS Region 4,4 wk ahead,1.5
+2012,17,2011/2012,69,HHS Region 5,Season onset,7
+2012,17,2011/2012,69,HHS Region 5,Season peak week,11
+2012,17,2011/2012,69,HHS Region 5,Season peak percentage,2.4
+2012,17,2011/2012,69,HHS Region 5,1 wk ahead,1
+2012,17,2011/2012,69,HHS Region 5,2 wk ahead,1
+2012,17,2011/2012,69,HHS Region 5,3 wk ahead,0.8
+2012,17,2011/2012,69,HHS Region 5,4 wk ahead,0.7
+2012,17,2011/2012,69,HHS Region 6,Season onset,none
+2012,17,2011/2012,69,HHS Region 6,Season peak week,11
+2012,17,2011/2012,69,HHS Region 6,Season peak percentage,4.1
+2012,17,2011/2012,69,HHS Region 6,1 wk ahead,1.9
+2012,17,2011/2012,69,HHS Region 6,2 wk ahead,1.9
+2012,17,2011/2012,69,HHS Region 6,3 wk ahead,1.9
+2012,17,2011/2012,69,HHS Region 6,4 wk ahead,1.9
+2012,17,2011/2012,69,HHS Region 7,Season onset,5
+2012,17,2011/2012,69,HHS Region 7,Season peak week,9
+2012,17,2011/2012,69,HHS Region 7,Season peak percentage,3.4
+2012,17,2011/2012,69,HHS Region 7,1 wk ahead,0.8
+2012,17,2011/2012,69,HHS Region 7,2 wk ahead,0.7
+2012,17,2011/2012,69,HHS Region 7,3 wk ahead,0.5
+2012,17,2011/2012,69,HHS Region 7,4 wk ahead,0.4
+2012,17,2011/2012,69,HHS Region 8,Season onset,none
+2012,17,2011/2012,69,HHS Region 8,Season peak week,11
+2012,17,2011/2012,69,HHS Region 8,Season peak percentage,2.2
+2012,17,2011/2012,69,HHS Region 8,1 wk ahead,0.9
+2012,17,2011/2012,69,HHS Region 8,2 wk ahead,0.8
+2012,17,2011/2012,69,HHS Region 8,3 wk ahead,0.8
+2012,17,2011/2012,69,HHS Region 8,4 wk ahead,0.6
+2012,17,2011/2012,69,HHS Region 9,Season onset,none
+2012,17,2011/2012,69,HHS Region 9,Season peak week,52
+2012,17,2011/2012,69,HHS Region 9,Season peak week,8
+2012,17,2011/2012,69,HHS Region 9,Season peak percentage,3.7
+2012,17,2011/2012,69,HHS Region 9,1 wk ahead,2.1
+2012,17,2011/2012,69,HHS Region 9,2 wk ahead,2
+2012,17,2011/2012,69,HHS Region 9,3 wk ahead,1.9
+2012,17,2011/2012,69,HHS Region 9,4 wk ahead,2
+2012,17,2011/2012,69,HHS Region 10,Season onset,none
+2012,17,2011/2012,69,HHS Region 10,Season peak week,12
+2012,17,2011/2012,69,HHS Region 10,Season peak percentage,2.2
+2012,17,2011/2012,69,HHS Region 10,1 wk ahead,1.4
+2012,17,2011/2012,69,HHS Region 10,2 wk ahead,1.1
+2012,17,2011/2012,69,HHS Region 10,3 wk ahead,0.9
+2012,17,2011/2012,69,HHS Region 10,4 wk ahead,0.7
+2012,18,2011/2012,70,US National,Season onset,none
+2012,18,2011/2012,70,US National,Season peak week,11
+2012,18,2011/2012,70,US National,Season peak percentage,2.4
+2012,18,2011/2012,70,US National,1 wk ahead,1.3
+2012,18,2011/2012,70,US National,2 wk ahead,1.2
+2012,18,2011/2012,70,US National,3 wk ahead,1.2
+2012,18,2011/2012,70,US National,4 wk ahead,1.3
+2012,18,2011/2012,70,HHS Region 1,Season onset,none
+2012,18,2011/2012,70,HHS Region 1,Season peak week,52
+2012,18,2011/2012,70,HHS Region 1,Season peak percentage,1
+2012,18,2011/2012,70,HHS Region 1,1 wk ahead,0.6
+2012,18,2011/2012,70,HHS Region 1,2 wk ahead,0.5
+2012,18,2011/2012,70,HHS Region 1,3 wk ahead,0.6
+2012,18,2011/2012,70,HHS Region 1,4 wk ahead,0.6
+2012,18,2011/2012,70,HHS Region 2,Season onset,none
+2012,18,2011/2012,70,HHS Region 2,Season peak week,49
+2012,18,2011/2012,70,HHS Region 2,Season peak percentage,1.4
+2012,18,2011/2012,70,HHS Region 2,1 wk ahead,0.9
+2012,18,2011/2012,70,HHS Region 2,2 wk ahead,0.9
+2012,18,2011/2012,70,HHS Region 2,3 wk ahead,0.7
+2012,18,2011/2012,70,HHS Region 2,4 wk ahead,0.7
+2012,18,2011/2012,70,HHS Region 3,Season onset,none
+2012,18,2011/2012,70,HHS Region 3,Season peak week,52
+2012,18,2011/2012,70,HHS Region 3,Season peak percentage,2.1
+2012,18,2011/2012,70,HHS Region 3,1 wk ahead,1.5
+2012,18,2011/2012,70,HHS Region 3,2 wk ahead,1
+2012,18,2011/2012,70,HHS Region 3,3 wk ahead,1.1
+2012,18,2011/2012,70,HHS Region 3,4 wk ahead,0.7
+2012,18,2011/2012,70,HHS Region 4,Season onset,none
+2012,18,2011/2012,70,HHS Region 4,Season peak week,52
+2012,18,2011/2012,70,HHS Region 4,Season peak week,10
+2012,18,2011/2012,70,HHS Region 4,Season peak percentage,2.3
+2012,18,2011/2012,70,HHS Region 4,1 wk ahead,1.4
+2012,18,2011/2012,70,HHS Region 4,2 wk ahead,1.4
+2012,18,2011/2012,70,HHS Region 4,3 wk ahead,1.5
+2012,18,2011/2012,70,HHS Region 4,4 wk ahead,1.7
+2012,18,2011/2012,70,HHS Region 5,Season onset,7
+2012,18,2011/2012,70,HHS Region 5,Season peak week,11
+2012,18,2011/2012,70,HHS Region 5,Season peak percentage,2.4
+2012,18,2011/2012,70,HHS Region 5,1 wk ahead,1
+2012,18,2011/2012,70,HHS Region 5,2 wk ahead,0.8
+2012,18,2011/2012,70,HHS Region 5,3 wk ahead,0.7
+2012,18,2011/2012,70,HHS Region 5,4 wk ahead,0.8
+2012,18,2011/2012,70,HHS Region 6,Season onset,none
+2012,18,2011/2012,70,HHS Region 6,Season peak week,11
+2012,18,2011/2012,70,HHS Region 6,Season peak percentage,4.1
+2012,18,2011/2012,70,HHS Region 6,1 wk ahead,1.9
+2012,18,2011/2012,70,HHS Region 6,2 wk ahead,1.9
+2012,18,2011/2012,70,HHS Region 6,3 wk ahead,1.9
+2012,18,2011/2012,70,HHS Region 6,4 wk ahead,2.2
+2012,18,2011/2012,70,HHS Region 7,Season onset,5
+2012,18,2011/2012,70,HHS Region 7,Season peak week,9
+2012,18,2011/2012,70,HHS Region 7,Season peak percentage,3.4
+2012,18,2011/2012,70,HHS Region 7,1 wk ahead,0.7
+2012,18,2011/2012,70,HHS Region 7,2 wk ahead,0.5
+2012,18,2011/2012,70,HHS Region 7,3 wk ahead,0.4
+2012,18,2011/2012,70,HHS Region 7,4 wk ahead,0.3
+2012,18,2011/2012,70,HHS Region 8,Season onset,none
+2012,18,2011/2012,70,HHS Region 8,Season peak week,11
+2012,18,2011/2012,70,HHS Region 8,Season peak percentage,2.2
+2012,18,2011/2012,70,HHS Region 8,1 wk ahead,0.8
+2012,18,2011/2012,70,HHS Region 8,2 wk ahead,0.8
+2012,18,2011/2012,70,HHS Region 8,3 wk ahead,0.6
+2012,18,2011/2012,70,HHS Region 8,4 wk ahead,0.8
+2012,18,2011/2012,70,HHS Region 9,Season onset,none
+2012,18,2011/2012,70,HHS Region 9,Season peak week,52
+2012,18,2011/2012,70,HHS Region 9,Season peak week,8
+2012,18,2011/2012,70,HHS Region 9,Season peak percentage,3.7
+2012,18,2011/2012,70,HHS Region 9,1 wk ahead,2
+2012,18,2011/2012,70,HHS Region 9,2 wk ahead,1.9
+2012,18,2011/2012,70,HHS Region 9,3 wk ahead,2
+2012,18,2011/2012,70,HHS Region 9,4 wk ahead,2
+2012,18,2011/2012,70,HHS Region 10,Season onset,none
+2012,18,2011/2012,70,HHS Region 10,Season peak week,12
+2012,18,2011/2012,70,HHS Region 10,Season peak percentage,2.2
+2012,18,2011/2012,70,HHS Region 10,1 wk ahead,1.1
+2012,18,2011/2012,70,HHS Region 10,2 wk ahead,0.9
+2012,18,2011/2012,70,HHS Region 10,3 wk ahead,0.7
+2012,18,2011/2012,70,HHS Region 10,4 wk ahead,0.7
+2012,19,2011/2012,71,US National,Season onset,none
+2012,19,2011/2012,71,US National,Season peak week,11
+2012,19,2011/2012,71,US National,Season peak percentage,2.4
+2012,19,2011/2012,71,US National,1 wk ahead,1.2
+2012,19,2011/2012,71,US National,2 wk ahead,1.2
+2012,19,2011/2012,71,US National,3 wk ahead,1.3
+2012,19,2011/2012,71,US National,4 wk ahead,1.1
+2012,19,2011/2012,71,HHS Region 1,Season onset,none
+2012,19,2011/2012,71,HHS Region 1,Season peak week,52
+2012,19,2011/2012,71,HHS Region 1,Season peak percentage,1
+2012,19,2011/2012,71,HHS Region 1,1 wk ahead,0.5
+2012,19,2011/2012,71,HHS Region 1,2 wk ahead,0.6
+2012,19,2011/2012,71,HHS Region 1,3 wk ahead,0.6
+2012,19,2011/2012,71,HHS Region 1,4 wk ahead,0.4
+2012,19,2011/2012,71,HHS Region 2,Season onset,none
+2012,19,2011/2012,71,HHS Region 2,Season peak week,49
+2012,19,2011/2012,71,HHS Region 2,Season peak percentage,1.4
+2012,19,2011/2012,71,HHS Region 2,1 wk ahead,0.9
+2012,19,2011/2012,71,HHS Region 2,2 wk ahead,0.7
+2012,19,2011/2012,71,HHS Region 2,3 wk ahead,0.7
+2012,19,2011/2012,71,HHS Region 2,4 wk ahead,0.6
+2012,19,2011/2012,71,HHS Region 3,Season onset,none
+2012,19,2011/2012,71,HHS Region 3,Season peak week,52
+2012,19,2011/2012,71,HHS Region 3,Season peak percentage,2.1
+2012,19,2011/2012,71,HHS Region 3,1 wk ahead,1
+2012,19,2011/2012,71,HHS Region 3,2 wk ahead,1.1
+2012,19,2011/2012,71,HHS Region 3,3 wk ahead,0.7
+2012,19,2011/2012,71,HHS Region 3,4 wk ahead,1.3
+2012,19,2011/2012,71,HHS Region 4,Season onset,none
+2012,19,2011/2012,71,HHS Region 4,Season peak week,52
+2012,19,2011/2012,71,HHS Region 4,Season peak week,10
+2012,19,2011/2012,71,HHS Region 4,Season peak percentage,2.3
+2012,19,2011/2012,71,HHS Region 4,1 wk ahead,1.4
+2012,19,2011/2012,71,HHS Region 4,2 wk ahead,1.5
+2012,19,2011/2012,71,HHS Region 4,3 wk ahead,1.7
+2012,19,2011/2012,71,HHS Region 4,4 wk ahead,1.5
+2012,19,2011/2012,71,HHS Region 5,Season onset,7
+2012,19,2011/2012,71,HHS Region 5,Season peak week,11
+2012,19,2011/2012,71,HHS Region 5,Season peak percentage,2.4
+2012,19,2011/2012,71,HHS Region 5,1 wk ahead,0.8
+2012,19,2011/2012,71,HHS Region 5,2 wk ahead,0.7
+2012,19,2011/2012,71,HHS Region 5,3 wk ahead,0.8
+2012,19,2011/2012,71,HHS Region 5,4 wk ahead,0.6
+2012,19,2011/2012,71,HHS Region 6,Season onset,none
+2012,19,2011/2012,71,HHS Region 6,Season peak week,11
+2012,19,2011/2012,71,HHS Region 6,Season peak percentage,4.1
+2012,19,2011/2012,71,HHS Region 6,1 wk ahead,1.9
+2012,19,2011/2012,71,HHS Region 6,2 wk ahead,1.9
+2012,19,2011/2012,71,HHS Region 6,3 wk ahead,2.2
+2012,19,2011/2012,71,HHS Region 6,4 wk ahead,1.5
+2012,19,2011/2012,71,HHS Region 7,Season onset,5
+2012,19,2011/2012,71,HHS Region 7,Season peak week,9
+2012,19,2011/2012,71,HHS Region 7,Season peak percentage,3.4
+2012,19,2011/2012,71,HHS Region 7,1 wk ahead,0.5
+2012,19,2011/2012,71,HHS Region 7,2 wk ahead,0.4
+2012,19,2011/2012,71,HHS Region 7,3 wk ahead,0.3
+2012,19,2011/2012,71,HHS Region 7,4 wk ahead,0.1
+2012,19,2011/2012,71,HHS Region 8,Season onset,none
+2012,19,2011/2012,71,HHS Region 8,Season peak week,11
+2012,19,2011/2012,71,HHS Region 8,Season peak percentage,2.2
+2012,19,2011/2012,71,HHS Region 8,1 wk ahead,0.8
+2012,19,2011/2012,71,HHS Region 8,2 wk ahead,0.6
+2012,19,2011/2012,71,HHS Region 8,3 wk ahead,0.8
+2012,19,2011/2012,71,HHS Region 8,4 wk ahead,0.7
+2012,19,2011/2012,71,HHS Region 9,Season onset,none
+2012,19,2011/2012,71,HHS Region 9,Season peak week,52
+2012,19,2011/2012,71,HHS Region 9,Season peak week,8
+2012,19,2011/2012,71,HHS Region 9,Season peak percentage,3.7
+2012,19,2011/2012,71,HHS Region 9,1 wk ahead,1.9
+2012,19,2011/2012,71,HHS Region 9,2 wk ahead,2
+2012,19,2011/2012,71,HHS Region 9,3 wk ahead,2
+2012,19,2011/2012,71,HHS Region 9,4 wk ahead,1.7
+2012,19,2011/2012,71,HHS Region 10,Season onset,none
+2012,19,2011/2012,71,HHS Region 10,Season peak week,12
+2012,19,2011/2012,71,HHS Region 10,Season peak percentage,2.2
+2012,19,2011/2012,71,HHS Region 10,1 wk ahead,0.9
+2012,19,2011/2012,71,HHS Region 10,2 wk ahead,0.7
+2012,19,2011/2012,71,HHS Region 10,3 wk ahead,0.7
+2012,19,2011/2012,71,HHS Region 10,4 wk ahead,0.6
+2012,20,2011/2012,72,US National,Season onset,none
+2012,20,2011/2012,72,US National,Season peak week,11
+2012,20,2011/2012,72,US National,Season peak percentage,2.4
+2012,20,2011/2012,72,US National,1 wk ahead,1.2
+2012,20,2011/2012,72,US National,2 wk ahead,1.3
+2012,20,2011/2012,72,US National,3 wk ahead,1.1
+2012,20,2011/2012,72,US National,4 wk ahead,1.1
+2012,20,2011/2012,72,HHS Region 1,Season onset,none
+2012,20,2011/2012,72,HHS Region 1,Season peak week,52
+2012,20,2011/2012,72,HHS Region 1,Season peak percentage,1
+2012,20,2011/2012,72,HHS Region 1,1 wk ahead,0.6
+2012,20,2011/2012,72,HHS Region 1,2 wk ahead,0.6
+2012,20,2011/2012,72,HHS Region 1,3 wk ahead,0.4
+2012,20,2011/2012,72,HHS Region 1,4 wk ahead,0.6
+2012,20,2011/2012,72,HHS Region 2,Season onset,none
+2012,20,2011/2012,72,HHS Region 2,Season peak week,49
+2012,20,2011/2012,72,HHS Region 2,Season peak percentage,1.4
+2012,20,2011/2012,72,HHS Region 2,1 wk ahead,0.7
+2012,20,2011/2012,72,HHS Region 2,2 wk ahead,0.7
+2012,20,2011/2012,72,HHS Region 2,3 wk ahead,0.6
+2012,20,2011/2012,72,HHS Region 2,4 wk ahead,0.5
+2012,20,2011/2012,72,HHS Region 3,Season onset,none
+2012,20,2011/2012,72,HHS Region 3,Season peak week,52
+2012,20,2011/2012,72,HHS Region 3,Season peak percentage,2.1
+2012,20,2011/2012,72,HHS Region 3,1 wk ahead,1.1
+2012,20,2011/2012,72,HHS Region 3,2 wk ahead,0.7
+2012,20,2011/2012,72,HHS Region 3,3 wk ahead,1.3
+2012,20,2011/2012,72,HHS Region 3,4 wk ahead,1.9
+2012,20,2011/2012,72,HHS Region 4,Season onset,none
+2012,20,2011/2012,72,HHS Region 4,Season peak week,52
+2012,20,2011/2012,72,HHS Region 4,Season peak week,10
+2012,20,2011/2012,72,HHS Region 4,Season peak percentage,2.3
+2012,20,2011/2012,72,HHS Region 4,1 wk ahead,1.5
+2012,20,2011/2012,72,HHS Region 4,2 wk ahead,1.7
+2012,20,2011/2012,72,HHS Region 4,3 wk ahead,1.5
+2012,20,2011/2012,72,HHS Region 4,4 wk ahead,1.5
+2012,20,2011/2012,72,HHS Region 5,Season onset,7
+2012,20,2011/2012,72,HHS Region 5,Season peak week,11
+2012,20,2011/2012,72,HHS Region 5,Season peak percentage,2.4
+2012,20,2011/2012,72,HHS Region 5,1 wk ahead,0.7
+2012,20,2011/2012,72,HHS Region 5,2 wk ahead,0.8
+2012,20,2011/2012,72,HHS Region 5,3 wk ahead,0.6
+2012,20,2011/2012,72,HHS Region 5,4 wk ahead,0.5
+2012,20,2011/2012,72,HHS Region 6,Season onset,none
+2012,20,2011/2012,72,HHS Region 6,Season peak week,11
+2012,20,2011/2012,72,HHS Region 6,Season peak percentage,4.1
+2012,20,2011/2012,72,HHS Region 6,1 wk ahead,1.9
+2012,20,2011/2012,72,HHS Region 6,2 wk ahead,2.2
+2012,20,2011/2012,72,HHS Region 6,3 wk ahead,1.5
+2012,20,2011/2012,72,HHS Region 6,4 wk ahead,1.3
+2012,20,2011/2012,72,HHS Region 7,Season onset,5
+2012,20,2011/2012,72,HHS Region 7,Season peak week,9
+2012,20,2011/2012,72,HHS Region 7,Season peak percentage,3.4
+2012,20,2011/2012,72,HHS Region 7,1 wk ahead,0.4
+2012,20,2011/2012,72,HHS Region 7,2 wk ahead,0.3
+2012,20,2011/2012,72,HHS Region 7,3 wk ahead,0.1
+2012,20,2011/2012,72,HHS Region 7,4 wk ahead,0.1
+2012,20,2011/2012,72,HHS Region 8,Season onset,none
+2012,20,2011/2012,72,HHS Region 8,Season peak week,11
+2012,20,2011/2012,72,HHS Region 8,Season peak percentage,2.2
+2012,20,2011/2012,72,HHS Region 8,1 wk ahead,0.6
+2012,20,2011/2012,72,HHS Region 8,2 wk ahead,0.8
+2012,20,2011/2012,72,HHS Region 8,3 wk ahead,0.7
+2012,20,2011/2012,72,HHS Region 8,4 wk ahead,0.6
+2012,20,2011/2012,72,HHS Region 9,Season onset,none
+2012,20,2011/2012,72,HHS Region 9,Season peak week,52
+2012,20,2011/2012,72,HHS Region 9,Season peak week,8
+2012,20,2011/2012,72,HHS Region 9,Season peak percentage,3.7
+2012,20,2011/2012,72,HHS Region 9,1 wk ahead,2
+2012,20,2011/2012,72,HHS Region 9,2 wk ahead,2
+2012,20,2011/2012,72,HHS Region 9,3 wk ahead,1.7
+2012,20,2011/2012,72,HHS Region 9,4 wk ahead,1.6
+2012,20,2011/2012,72,HHS Region 10,Season onset,none
+2012,20,2011/2012,72,HHS Region 10,Season peak week,12
+2012,20,2011/2012,72,HHS Region 10,Season peak percentage,2.2
+2012,20,2011/2012,72,HHS Region 10,1 wk ahead,0.7
+2012,20,2011/2012,72,HHS Region 10,2 wk ahead,0.7
+2012,20,2011/2012,72,HHS Region 10,3 wk ahead,0.6
+2012,20,2011/2012,72,HHS Region 10,4 wk ahead,0.5
+2012,40,2012/2013,40,US National,Season onset,47
+2012,40,2012/2013,40,US National,Season peak week,52
+2012,40,2012/2013,40,US National,Season peak percentage,6.1
+2012,40,2012/2013,40,US National,1 wk ahead,1.3
+2012,40,2012/2013,40,US National,2 wk ahead,1.3
+2012,40,2012/2013,40,US National,3 wk ahead,1.4
+2012,40,2012/2013,40,US National,4 wk ahead,1.5
+2012,40,2012/2013,40,HHS Region 1,Season onset,49
+2012,40,2012/2013,40,HHS Region 1,Season peak week,52
+2012,40,2012/2013,40,HHS Region 1,Season peak percentage,3.9
+2012,40,2012/2013,40,HHS Region 1,1 wk ahead,0.6
+2012,40,2012/2013,40,HHS Region 1,2 wk ahead,0.8
+2012,40,2012/2013,40,HHS Region 1,3 wk ahead,0.6
+2012,40,2012/2013,40,HHS Region 1,4 wk ahead,0.6
+2012,40,2012/2013,40,HHS Region 2,Season onset,48
+2012,40,2012/2013,40,HHS Region 2,Season peak week,52
+2012,40,2012/2013,40,HHS Region 2,Season peak percentage,5.5
+2012,40,2012/2013,40,HHS Region 2,1 wk ahead,1.2
+2012,40,2012/2013,40,HHS Region 2,2 wk ahead,1.3
+2012,40,2012/2013,40,HHS Region 2,3 wk ahead,1.3
+2012,40,2012/2013,40,HHS Region 2,4 wk ahead,1.2
+2012,40,2012/2013,40,HHS Region 3,Season onset,49
+2012,40,2012/2013,40,HHS Region 3,Season peak week,52
+2012,40,2012/2013,40,HHS Region 3,Season peak percentage,7.1
+2012,40,2012/2013,40,HHS Region 3,1 wk ahead,1.1
+2012,40,2012/2013,40,HHS Region 3,2 wk ahead,1.1
+2012,40,2012/2013,40,HHS Region 3,3 wk ahead,1.1
+2012,40,2012/2013,40,HHS Region 3,4 wk ahead,1.3
+2012,40,2012/2013,40,HHS Region 4,Season onset,47
+2012,40,2012/2013,40,HHS Region 4,Season peak week,52
+2012,40,2012/2013,40,HHS Region 4,Season peak percentage,6.3
+2012,40,2012/2013,40,HHS Region 4,1 wk ahead,1.2
+2012,40,2012/2013,40,HHS Region 4,2 wk ahead,1.2
+2012,40,2012/2013,40,HHS Region 4,3 wk ahead,1.3
+2012,40,2012/2013,40,HHS Region 4,4 wk ahead,1.4
+2012,40,2012/2013,40,HHS Region 5,Season onset,47
+2012,40,2012/2013,40,HHS Region 5,Season peak week,52
+2012,40,2012/2013,40,HHS Region 5,Season peak percentage,5.7
+2012,40,2012/2013,40,HHS Region 5,1 wk ahead,1
+2012,40,2012/2013,40,HHS Region 5,2 wk ahead,1
+2012,40,2012/2013,40,HHS Region 5,3 wk ahead,1
+2012,40,2012/2013,40,HHS Region 5,4 wk ahead,1.1
+2012,40,2012/2013,40,HHS Region 6,Season onset,47
+2012,40,2012/2013,40,HHS Region 6,Season peak week,52
+2012,40,2012/2013,40,HHS Region 6,Season peak percentage,9.3
+2012,40,2012/2013,40,HHS Region 6,1 wk ahead,2.2
+2012,40,2012/2013,40,HHS Region 6,2 wk ahead,1.8
+2012,40,2012/2013,40,HHS Region 6,3 wk ahead,2.4
+2012,40,2012/2013,40,HHS Region 6,4 wk ahead,2.5
+2012,40,2012/2013,40,HHS Region 7,Season onset,47
+2012,40,2012/2013,40,HHS Region 7,Season peak week,52
+2012,40,2012/2013,40,HHS Region 7,Season peak percentage,6.7
+2012,40,2012/2013,40,HHS Region 7,1 wk ahead,1.1
+2012,40,2012/2013,40,HHS Region 7,2 wk ahead,1.4
+2012,40,2012/2013,40,HHS Region 7,3 wk ahead,1.3
+2012,40,2012/2013,40,HHS Region 7,4 wk ahead,1.5
+2012,40,2012/2013,40,HHS Region 8,Season onset,50
+2012,40,2012/2013,40,HHS Region 8,Season peak week,52
+2012,40,2012/2013,40,HHS Region 8,Season peak week,3
+2012,40,2012/2013,40,HHS Region 8,Season peak percentage,4.1
+2012,40,2012/2013,40,HHS Region 8,1 wk ahead,0.8
+2012,40,2012/2013,40,HHS Region 8,2 wk ahead,0.8
+2012,40,2012/2013,40,HHS Region 8,3 wk ahead,0.7
+2012,40,2012/2013,40,HHS Region 8,4 wk ahead,0.9
+2012,40,2012/2013,40,HHS Region 9,Season onset,2
+2012,40,2012/2013,40,HHS Region 9,Season peak week,4
+2012,40,2012/2013,40,HHS Region 9,Season peak percentage,5.6
+2012,40,2012/2013,40,HHS Region 9,1 wk ahead,1.9
+2012,40,2012/2013,40,HHS Region 9,2 wk ahead,2
+2012,40,2012/2013,40,HHS Region 9,3 wk ahead,2
+2012,40,2012/2013,40,HHS Region 9,4 wk ahead,2.1
+2012,40,2012/2013,40,HHS Region 10,Season onset,50
+2012,40,2012/2013,40,HHS Region 10,Season peak week,4
+2012,40,2012/2013,40,HHS Region 10,Season peak percentage,3.7
+2012,40,2012/2013,40,HHS Region 10,1 wk ahead,0.7
+2012,40,2012/2013,40,HHS Region 10,2 wk ahead,0.7
+2012,40,2012/2013,40,HHS Region 10,3 wk ahead,0.7
+2012,40,2012/2013,40,HHS Region 10,4 wk ahead,0.9
+2012,41,2012/2013,41,US National,Season onset,47
+2012,41,2012/2013,41,US National,Season peak week,52
+2012,41,2012/2013,41,US National,Season peak percentage,6.1
+2012,41,2012/2013,41,US National,1 wk ahead,1.3
+2012,41,2012/2013,41,US National,2 wk ahead,1.4
+2012,41,2012/2013,41,US National,3 wk ahead,1.5
+2012,41,2012/2013,41,US National,4 wk ahead,1.7
+2012,41,2012/2013,41,HHS Region 1,Season onset,49
+2012,41,2012/2013,41,HHS Region 1,Season peak week,52
+2012,41,2012/2013,41,HHS Region 1,Season peak percentage,3.9
+2012,41,2012/2013,41,HHS Region 1,1 wk ahead,0.8
+2012,41,2012/2013,41,HHS Region 1,2 wk ahead,0.6
+2012,41,2012/2013,41,HHS Region 1,3 wk ahead,0.6
+2012,41,2012/2013,41,HHS Region 1,4 wk ahead,0.6
+2012,41,2012/2013,41,HHS Region 2,Season onset,48
+2012,41,2012/2013,41,HHS Region 2,Season peak week,52
+2012,41,2012/2013,41,HHS Region 2,Season peak percentage,5.5
+2012,41,2012/2013,41,HHS Region 2,1 wk ahead,1.3
+2012,41,2012/2013,41,HHS Region 2,2 wk ahead,1.3
+2012,41,2012/2013,41,HHS Region 2,3 wk ahead,1.2
+2012,41,2012/2013,41,HHS Region 2,4 wk ahead,1.4
+2012,41,2012/2013,41,HHS Region 3,Season onset,49
+2012,41,2012/2013,41,HHS Region 3,Season peak week,52
+2012,41,2012/2013,41,HHS Region 3,Season peak percentage,7.1
+2012,41,2012/2013,41,HHS Region 3,1 wk ahead,1.1
+2012,41,2012/2013,41,HHS Region 3,2 wk ahead,1.1
+2012,41,2012/2013,41,HHS Region 3,3 wk ahead,1.3
+2012,41,2012/2013,41,HHS Region 3,4 wk ahead,1.3
+2012,41,2012/2013,41,HHS Region 4,Season onset,47
+2012,41,2012/2013,41,HHS Region 4,Season peak week,52
+2012,41,2012/2013,41,HHS Region 4,Season peak percentage,6.3
+2012,41,2012/2013,41,HHS Region 4,1 wk ahead,1.2
+2012,41,2012/2013,41,HHS Region 4,2 wk ahead,1.3
+2012,41,2012/2013,41,HHS Region 4,3 wk ahead,1.4
+2012,41,2012/2013,41,HHS Region 4,4 wk ahead,1.7
+2012,41,2012/2013,41,HHS Region 5,Season onset,47
+2012,41,2012/2013,41,HHS Region 5,Season peak week,52
+2012,41,2012/2013,41,HHS Region 5,Season peak percentage,5.7
+2012,41,2012/2013,41,HHS Region 5,1 wk ahead,1
+2012,41,2012/2013,41,HHS Region 5,2 wk ahead,1
+2012,41,2012/2013,41,HHS Region 5,3 wk ahead,1.1
+2012,41,2012/2013,41,HHS Region 5,4 wk ahead,1.1
+2012,41,2012/2013,41,HHS Region 6,Season onset,47
+2012,41,2012/2013,41,HHS Region 6,Season peak week,52
+2012,41,2012/2013,41,HHS Region 6,Season peak percentage,9.3
+2012,41,2012/2013,41,HHS Region 6,1 wk ahead,1.8
+2012,41,2012/2013,41,HHS Region 6,2 wk ahead,2.4
+2012,41,2012/2013,41,HHS Region 6,3 wk ahead,2.5
+2012,41,2012/2013,41,HHS Region 6,4 wk ahead,2.9
+2012,41,2012/2013,41,HHS Region 7,Season onset,47
+2012,41,2012/2013,41,HHS Region 7,Season peak week,52
+2012,41,2012/2013,41,HHS Region 7,Season peak percentage,6.7
+2012,41,2012/2013,41,HHS Region 7,1 wk ahead,1.4
+2012,41,2012/2013,41,HHS Region 7,2 wk ahead,1.3
+2012,41,2012/2013,41,HHS Region 7,3 wk ahead,1.5
+2012,41,2012/2013,41,HHS Region 7,4 wk ahead,1.6
+2012,41,2012/2013,41,HHS Region 8,Season onset,50
+2012,41,2012/2013,41,HHS Region 8,Season peak week,52
+2012,41,2012/2013,41,HHS Region 8,Season peak week,3
+2012,41,2012/2013,41,HHS Region 8,Season peak percentage,4.1
+2012,41,2012/2013,41,HHS Region 8,1 wk ahead,0.8
+2012,41,2012/2013,41,HHS Region 8,2 wk ahead,0.7
+2012,41,2012/2013,41,HHS Region 8,3 wk ahead,0.9
+2012,41,2012/2013,41,HHS Region 8,4 wk ahead,0.9
+2012,41,2012/2013,41,HHS Region 9,Season onset,2
+2012,41,2012/2013,41,HHS Region 9,Season peak week,4
+2012,41,2012/2013,41,HHS Region 9,Season peak percentage,5.6
+2012,41,2012/2013,41,HHS Region 9,1 wk ahead,2
+2012,41,2012/2013,41,HHS Region 9,2 wk ahead,2
+2012,41,2012/2013,41,HHS Region 9,3 wk ahead,2.1
+2012,41,2012/2013,41,HHS Region 9,4 wk ahead,2.2
+2012,41,2012/2013,41,HHS Region 10,Season onset,50
+2012,41,2012/2013,41,HHS Region 10,Season peak week,4
+2012,41,2012/2013,41,HHS Region 10,Season peak percentage,3.7
+2012,41,2012/2013,41,HHS Region 10,1 wk ahead,0.7
+2012,41,2012/2013,41,HHS Region 10,2 wk ahead,0.7
+2012,41,2012/2013,41,HHS Region 10,3 wk ahead,0.9
+2012,41,2012/2013,41,HHS Region 10,4 wk ahead,0.9
+2012,42,2012/2013,42,US National,Season onset,47
+2012,42,2012/2013,42,US National,Season peak week,52
+2012,42,2012/2013,42,US National,Season peak percentage,6.1
+2012,42,2012/2013,42,US National,1 wk ahead,1.4
+2012,42,2012/2013,42,US National,2 wk ahead,1.5
+2012,42,2012/2013,42,US National,3 wk ahead,1.7
+2012,42,2012/2013,42,US National,4 wk ahead,1.8
+2012,42,2012/2013,42,HHS Region 1,Season onset,49
+2012,42,2012/2013,42,HHS Region 1,Season peak week,52
+2012,42,2012/2013,42,HHS Region 1,Season peak percentage,3.9
+2012,42,2012/2013,42,HHS Region 1,1 wk ahead,0.6
+2012,42,2012/2013,42,HHS Region 1,2 wk ahead,0.6
+2012,42,2012/2013,42,HHS Region 1,3 wk ahead,0.6
+2012,42,2012/2013,42,HHS Region 1,4 wk ahead,0.7
+2012,42,2012/2013,42,HHS Region 2,Season onset,48
+2012,42,2012/2013,42,HHS Region 2,Season peak week,52
+2012,42,2012/2013,42,HHS Region 2,Season peak percentage,5.5
+2012,42,2012/2013,42,HHS Region 2,1 wk ahead,1.3
+2012,42,2012/2013,42,HHS Region 2,2 wk ahead,1.2
+2012,42,2012/2013,42,HHS Region 2,3 wk ahead,1.4
+2012,42,2012/2013,42,HHS Region 2,4 wk ahead,1.3
+2012,42,2012/2013,42,HHS Region 3,Season onset,49
+2012,42,2012/2013,42,HHS Region 3,Season peak week,52
+2012,42,2012/2013,42,HHS Region 3,Season peak percentage,7.1
+2012,42,2012/2013,42,HHS Region 3,1 wk ahead,1.1
+2012,42,2012/2013,42,HHS Region 3,2 wk ahead,1.3
+2012,42,2012/2013,42,HHS Region 3,3 wk ahead,1.3
+2012,42,2012/2013,42,HHS Region 3,4 wk ahead,1.3
+2012,42,2012/2013,42,HHS Region 4,Season onset,47
+2012,42,2012/2013,42,HHS Region 4,Season peak week,52
+2012,42,2012/2013,42,HHS Region 4,Season peak percentage,6.3
+2012,42,2012/2013,42,HHS Region 4,1 wk ahead,1.3
+2012,42,2012/2013,42,HHS Region 4,2 wk ahead,1.4
+2012,42,2012/2013,42,HHS Region 4,3 wk ahead,1.7
+2012,42,2012/2013,42,HHS Region 4,4 wk ahead,2.1
+2012,42,2012/2013,42,HHS Region 5,Season onset,47
+2012,42,2012/2013,42,HHS Region 5,Season peak week,52
+2012,42,2012/2013,42,HHS Region 5,Season peak percentage,5.7
+2012,42,2012/2013,42,HHS Region 5,1 wk ahead,1
+2012,42,2012/2013,42,HHS Region 5,2 wk ahead,1.1
+2012,42,2012/2013,42,HHS Region 5,3 wk ahead,1.1
+2012,42,2012/2013,42,HHS Region 5,4 wk ahead,1.2
+2012,42,2012/2013,42,HHS Region 6,Season onset,47
+2012,42,2012/2013,42,HHS Region 6,Season peak week,52
+2012,42,2012/2013,42,HHS Region 6,Season peak percentage,9.3
+2012,42,2012/2013,42,HHS Region 6,1 wk ahead,2.4
+2012,42,2012/2013,42,HHS Region 6,2 wk ahead,2.5
+2012,42,2012/2013,42,HHS Region 6,3 wk ahead,2.9
+2012,42,2012/2013,42,HHS Region 6,4 wk ahead,2.9
+2012,42,2012/2013,42,HHS Region 7,Season onset,47
+2012,42,2012/2013,42,HHS Region 7,Season peak week,52
+2012,42,2012/2013,42,HHS Region 7,Season peak percentage,6.7
+2012,42,2012/2013,42,HHS Region 7,1 wk ahead,1.3
+2012,42,2012/2013,42,HHS Region 7,2 wk ahead,1.5
+2012,42,2012/2013,42,HHS Region 7,3 wk ahead,1.6
+2012,42,2012/2013,42,HHS Region 7,4 wk ahead,2
+2012,42,2012/2013,42,HHS Region 8,Season onset,50
+2012,42,2012/2013,42,HHS Region 8,Season peak week,52
+2012,42,2012/2013,42,HHS Region 8,Season peak week,3
+2012,42,2012/2013,42,HHS Region 8,Season peak percentage,4.1
+2012,42,2012/2013,42,HHS Region 8,1 wk ahead,0.7
+2012,42,2012/2013,42,HHS Region 8,2 wk ahead,0.9
+2012,42,2012/2013,42,HHS Region 8,3 wk ahead,0.9
+2012,42,2012/2013,42,HHS Region 8,4 wk ahead,1
+2012,42,2012/2013,42,HHS Region 9,Season onset,2
+2012,42,2012/2013,42,HHS Region 9,Season peak week,4
+2012,42,2012/2013,42,HHS Region 9,Season peak percentage,5.6
+2012,42,2012/2013,42,HHS Region 9,1 wk ahead,2
+2012,42,2012/2013,42,HHS Region 9,2 wk ahead,2.1
+2012,42,2012/2013,42,HHS Region 9,3 wk ahead,2.2
+2012,42,2012/2013,42,HHS Region 9,4 wk ahead,2.2
+2012,42,2012/2013,42,HHS Region 10,Season onset,50
+2012,42,2012/2013,42,HHS Region 10,Season peak week,4
+2012,42,2012/2013,42,HHS Region 10,Season peak percentage,3.7
+2012,42,2012/2013,42,HHS Region 10,1 wk ahead,0.7
+2012,42,2012/2013,42,HHS Region 10,2 wk ahead,0.9
+2012,42,2012/2013,42,HHS Region 10,3 wk ahead,0.9
+2012,42,2012/2013,42,HHS Region 10,4 wk ahead,1.1
+2012,43,2012/2013,43,US National,Season onset,47
+2012,43,2012/2013,43,US National,Season peak week,52
+2012,43,2012/2013,43,US National,Season peak percentage,6.1
+2012,43,2012/2013,43,US National,1 wk ahead,1.5
+2012,43,2012/2013,43,US National,2 wk ahead,1.7
+2012,43,2012/2013,43,US National,3 wk ahead,1.8
+2012,43,2012/2013,43,US National,4 wk ahead,2.3
+2012,43,2012/2013,43,HHS Region 1,Season onset,49
+2012,43,2012/2013,43,HHS Region 1,Season peak week,52
+2012,43,2012/2013,43,HHS Region 1,Season peak percentage,3.9
+2012,43,2012/2013,43,HHS Region 1,1 wk ahead,0.6
+2012,43,2012/2013,43,HHS Region 1,2 wk ahead,0.6
+2012,43,2012/2013,43,HHS Region 1,3 wk ahead,0.7
+2012,43,2012/2013,43,HHS Region 1,4 wk ahead,0.8
+2012,43,2012/2013,43,HHS Region 2,Season onset,48
+2012,43,2012/2013,43,HHS Region 2,Season peak week,52
+2012,43,2012/2013,43,HHS Region 2,Season peak percentage,5.5
+2012,43,2012/2013,43,HHS Region 2,1 wk ahead,1.2
+2012,43,2012/2013,43,HHS Region 2,2 wk ahead,1.4
+2012,43,2012/2013,43,HHS Region 2,3 wk ahead,1.3
+2012,43,2012/2013,43,HHS Region 2,4 wk ahead,1.7
+2012,43,2012/2013,43,HHS Region 3,Season onset,49
+2012,43,2012/2013,43,HHS Region 3,Season peak week,52
+2012,43,2012/2013,43,HHS Region 3,Season peak percentage,7.1
+2012,43,2012/2013,43,HHS Region 3,1 wk ahead,1.3
+2012,43,2012/2013,43,HHS Region 3,2 wk ahead,1.3
+2012,43,2012/2013,43,HHS Region 3,3 wk ahead,1.3
+2012,43,2012/2013,43,HHS Region 3,4 wk ahead,1.7
+2012,43,2012/2013,43,HHS Region 4,Season onset,47
+2012,43,2012/2013,43,HHS Region 4,Season peak week,52
+2012,43,2012/2013,43,HHS Region 4,Season peak percentage,6.3
+2012,43,2012/2013,43,HHS Region 4,1 wk ahead,1.4
+2012,43,2012/2013,43,HHS Region 4,2 wk ahead,1.7
+2012,43,2012/2013,43,HHS Region 4,3 wk ahead,2.1
+2012,43,2012/2013,43,HHS Region 4,4 wk ahead,2.8
+2012,43,2012/2013,43,HHS Region 5,Season onset,47
+2012,43,2012/2013,43,HHS Region 5,Season peak week,52
+2012,43,2012/2013,43,HHS Region 5,Season peak percentage,5.7
+2012,43,2012/2013,43,HHS Region 5,1 wk ahead,1.1
+2012,43,2012/2013,43,HHS Region 5,2 wk ahead,1.1
+2012,43,2012/2013,43,HHS Region 5,3 wk ahead,1.2
+2012,43,2012/2013,43,HHS Region 5,4 wk ahead,1.6
+2012,43,2012/2013,43,HHS Region 6,Season onset,47
+2012,43,2012/2013,43,HHS Region 6,Season peak week,52
+2012,43,2012/2013,43,HHS Region 6,Season peak percentage,9.3
+2012,43,2012/2013,43,HHS Region 6,1 wk ahead,2.5
+2012,43,2012/2013,43,HHS Region 6,2 wk ahead,2.9
+2012,43,2012/2013,43,HHS Region 6,3 wk ahead,2.9
+2012,43,2012/2013,43,HHS Region 6,4 wk ahead,4.4
+2012,43,2012/2013,43,HHS Region 7,Season onset,47
+2012,43,2012/2013,43,HHS Region 7,Season peak week,52
+2012,43,2012/2013,43,HHS Region 7,Season peak percentage,6.7
+2012,43,2012/2013,43,HHS Region 7,1 wk ahead,1.5
+2012,43,2012/2013,43,HHS Region 7,2 wk ahead,1.6
+2012,43,2012/2013,43,HHS Region 7,3 wk ahead,2
+2012,43,2012/2013,43,HHS Region 7,4 wk ahead,2.3
+2012,43,2012/2013,43,HHS Region 8,Season onset,50
+2012,43,2012/2013,43,HHS Region 8,Season peak week,52
+2012,43,2012/2013,43,HHS Region 8,Season peak week,3
+2012,43,2012/2013,43,HHS Region 8,Season peak percentage,4.1
+2012,43,2012/2013,43,HHS Region 8,1 wk ahead,0.9
+2012,43,2012/2013,43,HHS Region 8,2 wk ahead,0.9
+2012,43,2012/2013,43,HHS Region 8,3 wk ahead,1
+2012,43,2012/2013,43,HHS Region 8,4 wk ahead,1.4
+2012,43,2012/2013,43,HHS Region 9,Season onset,2
+2012,43,2012/2013,43,HHS Region 9,Season peak week,4
+2012,43,2012/2013,43,HHS Region 9,Season peak percentage,5.6
+2012,43,2012/2013,43,HHS Region 9,1 wk ahead,2.1
+2012,43,2012/2013,43,HHS Region 9,2 wk ahead,2.2
+2012,43,2012/2013,43,HHS Region 9,3 wk ahead,2.2
+2012,43,2012/2013,43,HHS Region 9,4 wk ahead,2.4
+2012,43,2012/2013,43,HHS Region 10,Season onset,50
+2012,43,2012/2013,43,HHS Region 10,Season peak week,4
+2012,43,2012/2013,43,HHS Region 10,Season peak percentage,3.7
+2012,43,2012/2013,43,HHS Region 10,1 wk ahead,0.9
+2012,43,2012/2013,43,HHS Region 10,2 wk ahead,0.9
+2012,43,2012/2013,43,HHS Region 10,3 wk ahead,1.1
+2012,43,2012/2013,43,HHS Region 10,4 wk ahead,1.2
+2012,44,2012/2013,44,US National,Season onset,47
+2012,44,2012/2013,44,US National,Season peak week,52
+2012,44,2012/2013,44,US National,Season peak percentage,6.1
+2012,44,2012/2013,44,US National,1 wk ahead,1.7
+2012,44,2012/2013,44,US National,2 wk ahead,1.8
+2012,44,2012/2013,44,US National,3 wk ahead,2.3
+2012,44,2012/2013,44,US National,4 wk ahead,2.2
+2012,44,2012/2013,44,HHS Region 1,Season onset,49
+2012,44,2012/2013,44,HHS Region 1,Season peak week,52
+2012,44,2012/2013,44,HHS Region 1,Season peak percentage,3.9
+2012,44,2012/2013,44,HHS Region 1,1 wk ahead,0.6
+2012,44,2012/2013,44,HHS Region 1,2 wk ahead,0.7
+2012,44,2012/2013,44,HHS Region 1,3 wk ahead,0.8
+2012,44,2012/2013,44,HHS Region 1,4 wk ahead,0.9
+2012,44,2012/2013,44,HHS Region 2,Season onset,48
+2012,44,2012/2013,44,HHS Region 2,Season peak week,52
+2012,44,2012/2013,44,HHS Region 2,Season peak percentage,5.5
+2012,44,2012/2013,44,HHS Region 2,1 wk ahead,1.4
+2012,44,2012/2013,44,HHS Region 2,2 wk ahead,1.3
+2012,44,2012/2013,44,HHS Region 2,3 wk ahead,1.7
+2012,44,2012/2013,44,HHS Region 2,4 wk ahead,2
+2012,44,2012/2013,44,HHS Region 3,Season onset,49
+2012,44,2012/2013,44,HHS Region 3,Season peak week,52
+2012,44,2012/2013,44,HHS Region 3,Season peak percentage,7.1
+2012,44,2012/2013,44,HHS Region 3,1 wk ahead,1.3
+2012,44,2012/2013,44,HHS Region 3,2 wk ahead,1.3
+2012,44,2012/2013,44,HHS Region 3,3 wk ahead,1.7
+2012,44,2012/2013,44,HHS Region 3,4 wk ahead,1.6
+2012,44,2012/2013,44,HHS Region 4,Season onset,47
+2012,44,2012/2013,44,HHS Region 4,Season peak week,52
+2012,44,2012/2013,44,HHS Region 4,Season peak percentage,6.3
+2012,44,2012/2013,44,HHS Region 4,1 wk ahead,1.7
+2012,44,2012/2013,44,HHS Region 4,2 wk ahead,2.1
+2012,44,2012/2013,44,HHS Region 4,3 wk ahead,2.8
+2012,44,2012/2013,44,HHS Region 4,4 wk ahead,2.7
+2012,44,2012/2013,44,HHS Region 5,Season onset,47
+2012,44,2012/2013,44,HHS Region 5,Season peak week,52
+2012,44,2012/2013,44,HHS Region 5,Season peak percentage,5.7
+2012,44,2012/2013,44,HHS Region 5,1 wk ahead,1.1
+2012,44,2012/2013,44,HHS Region 5,2 wk ahead,1.2
+2012,44,2012/2013,44,HHS Region 5,3 wk ahead,1.6
+2012,44,2012/2013,44,HHS Region 5,4 wk ahead,1.5
+2012,44,2012/2013,44,HHS Region 6,Season onset,47
+2012,44,2012/2013,44,HHS Region 6,Season peak week,52
+2012,44,2012/2013,44,HHS Region 6,Season peak percentage,9.3
+2012,44,2012/2013,44,HHS Region 6,1 wk ahead,2.9
+2012,44,2012/2013,44,HHS Region 6,2 wk ahead,2.9
+2012,44,2012/2013,44,HHS Region 6,3 wk ahead,4.4
+2012,44,2012/2013,44,HHS Region 6,4 wk ahead,3.7
+2012,44,2012/2013,44,HHS Region 7,Season onset,47
+2012,44,2012/2013,44,HHS Region 7,Season peak week,52
+2012,44,2012/2013,44,HHS Region 7,Season peak percentage,6.7
+2012,44,2012/2013,44,HHS Region 7,1 wk ahead,1.6
+2012,44,2012/2013,44,HHS Region 7,2 wk ahead,2
+2012,44,2012/2013,44,HHS Region 7,3 wk ahead,2.3
+2012,44,2012/2013,44,HHS Region 7,4 wk ahead,2.2
+2012,44,2012/2013,44,HHS Region 8,Season onset,50
+2012,44,2012/2013,44,HHS Region 8,Season peak week,52
+2012,44,2012/2013,44,HHS Region 8,Season peak week,3
+2012,44,2012/2013,44,HHS Region 8,Season peak percentage,4.1
+2012,44,2012/2013,44,HHS Region 8,1 wk ahead,0.9
+2012,44,2012/2013,44,HHS Region 8,2 wk ahead,1
+2012,44,2012/2013,44,HHS Region 8,3 wk ahead,1.4
+2012,44,2012/2013,44,HHS Region 8,4 wk ahead,1.3
+2012,44,2012/2013,44,HHS Region 9,Season onset,2
+2012,44,2012/2013,44,HHS Region 9,Season peak week,4
+2012,44,2012/2013,44,HHS Region 9,Season peak percentage,5.6
+2012,44,2012/2013,44,HHS Region 9,1 wk ahead,2.2
+2012,44,2012/2013,44,HHS Region 9,2 wk ahead,2.2
+2012,44,2012/2013,44,HHS Region 9,3 wk ahead,2.4
+2012,44,2012/2013,44,HHS Region 9,4 wk ahead,2.2
+2012,44,2012/2013,44,HHS Region 10,Season onset,50
+2012,44,2012/2013,44,HHS Region 10,Season peak week,4
+2012,44,2012/2013,44,HHS Region 10,Season peak percentage,3.7
+2012,44,2012/2013,44,HHS Region 10,1 wk ahead,0.9
+2012,44,2012/2013,44,HHS Region 10,2 wk ahead,1.1
+2012,44,2012/2013,44,HHS Region 10,3 wk ahead,1.2
+2012,44,2012/2013,44,HHS Region 10,4 wk ahead,1
+2012,45,2012/2013,45,US National,Season onset,47
+2012,45,2012/2013,45,US National,Season peak week,52
+2012,45,2012/2013,45,US National,Season peak percentage,6.1
+2012,45,2012/2013,45,US National,1 wk ahead,1.8
+2012,45,2012/2013,45,US National,2 wk ahead,2.3
+2012,45,2012/2013,45,US National,3 wk ahead,2.2
+2012,45,2012/2013,45,US National,4 wk ahead,2.8
+2012,45,2012/2013,45,HHS Region 1,Season onset,49
+2012,45,2012/2013,45,HHS Region 1,Season peak week,52
+2012,45,2012/2013,45,HHS Region 1,Season peak percentage,3.9
+2012,45,2012/2013,45,HHS Region 1,1 wk ahead,0.7
+2012,45,2012/2013,45,HHS Region 1,2 wk ahead,0.8
+2012,45,2012/2013,45,HHS Region 1,3 wk ahead,0.9
+2012,45,2012/2013,45,HHS Region 1,4 wk ahead,1.2
+2012,45,2012/2013,45,HHS Region 2,Season onset,48
+2012,45,2012/2013,45,HHS Region 2,Season peak week,52
+2012,45,2012/2013,45,HHS Region 2,Season peak percentage,5.5
+2012,45,2012/2013,45,HHS Region 2,1 wk ahead,1.3
+2012,45,2012/2013,45,HHS Region 2,2 wk ahead,1.7
+2012,45,2012/2013,45,HHS Region 2,3 wk ahead,2
+2012,45,2012/2013,45,HHS Region 2,4 wk ahead,2.4
+2012,45,2012/2013,45,HHS Region 3,Season onset,49
+2012,45,2012/2013,45,HHS Region 3,Season peak week,52
+2012,45,2012/2013,45,HHS Region 3,Season peak percentage,7.1
+2012,45,2012/2013,45,HHS Region 3,1 wk ahead,1.3
+2012,45,2012/2013,45,HHS Region 3,2 wk ahead,1.7
+2012,45,2012/2013,45,HHS Region 3,3 wk ahead,1.6
+2012,45,2012/2013,45,HHS Region 3,4 wk ahead,2.5
+2012,45,2012/2013,45,HHS Region 4,Season onset,47
+2012,45,2012/2013,45,HHS Region 4,Season peak week,52
+2012,45,2012/2013,45,HHS Region 4,Season peak percentage,6.3
+2012,45,2012/2013,45,HHS Region 4,1 wk ahead,2.1
+2012,45,2012/2013,45,HHS Region 4,2 wk ahead,2.8
+2012,45,2012/2013,45,HHS Region 4,3 wk ahead,2.7
+2012,45,2012/2013,45,HHS Region 4,4 wk ahead,4.2
+2012,45,2012/2013,45,HHS Region 5,Season onset,47
+2012,45,2012/2013,45,HHS Region 5,Season peak week,52
+2012,45,2012/2013,45,HHS Region 5,Season peak percentage,5.7
+2012,45,2012/2013,45,HHS Region 5,1 wk ahead,1.2
+2012,45,2012/2013,45,HHS Region 5,2 wk ahead,1.6
+2012,45,2012/2013,45,HHS Region 5,3 wk ahead,1.5
+2012,45,2012/2013,45,HHS Region 5,4 wk ahead,2.1
+2012,45,2012/2013,45,HHS Region 6,Season onset,47
+2012,45,2012/2013,45,HHS Region 6,Season peak week,52
+2012,45,2012/2013,45,HHS Region 6,Season peak percentage,9.3
+2012,45,2012/2013,45,HHS Region 6,1 wk ahead,2.9
+2012,45,2012/2013,45,HHS Region 6,2 wk ahead,4.4
+2012,45,2012/2013,45,HHS Region 6,3 wk ahead,3.7
+2012,45,2012/2013,45,HHS Region 6,4 wk ahead,4.6
+2012,45,2012/2013,45,HHS Region 7,Season onset,47
+2012,45,2012/2013,45,HHS Region 7,Season peak week,52
+2012,45,2012/2013,45,HHS Region 7,Season peak percentage,6.7
+2012,45,2012/2013,45,HHS Region 7,1 wk ahead,2
+2012,45,2012/2013,45,HHS Region 7,2 wk ahead,2.3
+2012,45,2012/2013,45,HHS Region 7,3 wk ahead,2.2
+2012,45,2012/2013,45,HHS Region 7,4 wk ahead,2.3
+2012,45,2012/2013,45,HHS Region 8,Season onset,50
+2012,45,2012/2013,45,HHS Region 8,Season peak week,52
+2012,45,2012/2013,45,HHS Region 8,Season peak week,3
+2012,45,2012/2013,45,HHS Region 8,Season peak percentage,4.1
+2012,45,2012/2013,45,HHS Region 8,1 wk ahead,1
+2012,45,2012/2013,45,HHS Region 8,2 wk ahead,1.4
+2012,45,2012/2013,45,HHS Region 8,3 wk ahead,1.3
+2012,45,2012/2013,45,HHS Region 8,4 wk ahead,1.7
+2012,45,2012/2013,45,HHS Region 9,Season onset,2
+2012,45,2012/2013,45,HHS Region 9,Season peak week,4
+2012,45,2012/2013,45,HHS Region 9,Season peak percentage,5.6
+2012,45,2012/2013,45,HHS Region 9,1 wk ahead,2.2
+2012,45,2012/2013,45,HHS Region 9,2 wk ahead,2.4
+2012,45,2012/2013,45,HHS Region 9,3 wk ahead,2.2
+2012,45,2012/2013,45,HHS Region 9,4 wk ahead,2.2
+2012,45,2012/2013,45,HHS Region 10,Season onset,50
+2012,45,2012/2013,45,HHS Region 10,Season peak week,4
+2012,45,2012/2013,45,HHS Region 10,Season peak percentage,3.7
+2012,45,2012/2013,45,HHS Region 10,1 wk ahead,1.1
+2012,45,2012/2013,45,HHS Region 10,2 wk ahead,1.2
+2012,45,2012/2013,45,HHS Region 10,3 wk ahead,1
+2012,45,2012/2013,45,HHS Region 10,4 wk ahead,1.1
+2012,46,2012/2013,46,US National,Season onset,47
+2012,46,2012/2013,46,US National,Season peak week,52
+2012,46,2012/2013,46,US National,Season peak percentage,6.1
+2012,46,2012/2013,46,US National,1 wk ahead,2.3
+2012,46,2012/2013,46,US National,2 wk ahead,2.2
+2012,46,2012/2013,46,US National,3 wk ahead,2.8
+2012,46,2012/2013,46,US National,4 wk ahead,3.4
+2012,46,2012/2013,46,HHS Region 1,Season onset,49
+2012,46,2012/2013,46,HHS Region 1,Season peak week,52
+2012,46,2012/2013,46,HHS Region 1,Season peak percentage,3.9
+2012,46,2012/2013,46,HHS Region 1,1 wk ahead,0.8
+2012,46,2012/2013,46,HHS Region 1,2 wk ahead,0.9
+2012,46,2012/2013,46,HHS Region 1,3 wk ahead,1.2
+2012,46,2012/2013,46,HHS Region 1,4 wk ahead,1.7
+2012,46,2012/2013,46,HHS Region 2,Season onset,48
+2012,46,2012/2013,46,HHS Region 2,Season peak week,52
+2012,46,2012/2013,46,HHS Region 2,Season peak percentage,5.5
+2012,46,2012/2013,46,HHS Region 2,1 wk ahead,1.7
+2012,46,2012/2013,46,HHS Region 2,2 wk ahead,2
+2012,46,2012/2013,46,HHS Region 2,3 wk ahead,2.4
+2012,46,2012/2013,46,HHS Region 2,4 wk ahead,2.8
+2012,46,2012/2013,46,HHS Region 3,Season onset,49
+2012,46,2012/2013,46,HHS Region 3,Season peak week,52
+2012,46,2012/2013,46,HHS Region 3,Season peak percentage,7.1
+2012,46,2012/2013,46,HHS Region 3,1 wk ahead,1.7
+2012,46,2012/2013,46,HHS Region 3,2 wk ahead,1.6
+2012,46,2012/2013,46,HHS Region 3,3 wk ahead,2.5
+2012,46,2012/2013,46,HHS Region 3,4 wk ahead,3.4
+2012,46,2012/2013,46,HHS Region 4,Season onset,47
+2012,46,2012/2013,46,HHS Region 4,Season peak week,52
+2012,46,2012/2013,46,HHS Region 4,Season peak percentage,6.3
+2012,46,2012/2013,46,HHS Region 4,1 wk ahead,2.8
+2012,46,2012/2013,46,HHS Region 4,2 wk ahead,2.7
+2012,46,2012/2013,46,HHS Region 4,3 wk ahead,4.2
+2012,46,2012/2013,46,HHS Region 4,4 wk ahead,4.7
+2012,46,2012/2013,46,HHS Region 5,Season onset,47
+2012,46,2012/2013,46,HHS Region 5,Season peak week,52
+2012,46,2012/2013,46,HHS Region 5,Season peak percentage,5.7
+2012,46,2012/2013,46,HHS Region 5,1 wk ahead,1.6
+2012,46,2012/2013,46,HHS Region 5,2 wk ahead,1.5
+2012,46,2012/2013,46,HHS Region 5,3 wk ahead,2.1
+2012,46,2012/2013,46,HHS Region 5,4 wk ahead,3
+2012,46,2012/2013,46,HHS Region 6,Season onset,47
+2012,46,2012/2013,46,HHS Region 6,Season peak week,52
+2012,46,2012/2013,46,HHS Region 6,Season peak percentage,9.3
+2012,46,2012/2013,46,HHS Region 6,1 wk ahead,4.4
+2012,46,2012/2013,46,HHS Region 6,2 wk ahead,3.7
+2012,46,2012/2013,46,HHS Region 6,3 wk ahead,4.6
+2012,46,2012/2013,46,HHS Region 6,4 wk ahead,5.6
+2012,46,2012/2013,46,HHS Region 7,Season onset,47
+2012,46,2012/2013,46,HHS Region 7,Season peak week,52
+2012,46,2012/2013,46,HHS Region 7,Season peak percentage,6.7
+2012,46,2012/2013,46,HHS Region 7,1 wk ahead,2.3
+2012,46,2012/2013,46,HHS Region 7,2 wk ahead,2.2
+2012,46,2012/2013,46,HHS Region 7,3 wk ahead,2.3
+2012,46,2012/2013,46,HHS Region 7,4 wk ahead,2.8
+2012,46,2012/2013,46,HHS Region 8,Season onset,50
+2012,46,2012/2013,46,HHS Region 8,Season peak week,52
+2012,46,2012/2013,46,HHS Region 8,Season peak week,3
+2012,46,2012/2013,46,HHS Region 8,Season peak percentage,4.1
+2012,46,2012/2013,46,HHS Region 8,1 wk ahead,1.4
+2012,46,2012/2013,46,HHS Region 8,2 wk ahead,1.3
+2012,46,2012/2013,46,HHS Region 8,3 wk ahead,1.7
+2012,46,2012/2013,46,HHS Region 8,4 wk ahead,2.4
+2012,46,2012/2013,46,HHS Region 9,Season onset,2
+2012,46,2012/2013,46,HHS Region 9,Season peak week,4
+2012,46,2012/2013,46,HHS Region 9,Season peak percentage,5.6
+2012,46,2012/2013,46,HHS Region 9,1 wk ahead,2.4
+2012,46,2012/2013,46,HHS Region 9,2 wk ahead,2.2
+2012,46,2012/2013,46,HHS Region 9,3 wk ahead,2.2
+2012,46,2012/2013,46,HHS Region 9,4 wk ahead,2.5
+2012,46,2012/2013,46,HHS Region 10,Season onset,50
+2012,46,2012/2013,46,HHS Region 10,Season peak week,4
+2012,46,2012/2013,46,HHS Region 10,Season peak percentage,3.7
+2012,46,2012/2013,46,HHS Region 10,1 wk ahead,1.2
+2012,46,2012/2013,46,HHS Region 10,2 wk ahead,1
+2012,46,2012/2013,46,HHS Region 10,3 wk ahead,1.1
+2012,46,2012/2013,46,HHS Region 10,4 wk ahead,1.6
+2012,47,2012/2013,47,US National,Season onset,47
+2012,47,2012/2013,47,US National,Season peak week,52
+2012,47,2012/2013,47,US National,Season peak percentage,6.1
+2012,47,2012/2013,47,US National,1 wk ahead,2.2
+2012,47,2012/2013,47,US National,2 wk ahead,2.8
+2012,47,2012/2013,47,US National,3 wk ahead,3.4
+2012,47,2012/2013,47,US National,4 wk ahead,4.3
+2012,47,2012/2013,47,HHS Region 1,Season onset,49
+2012,47,2012/2013,47,HHS Region 1,Season peak week,52
+2012,47,2012/2013,47,HHS Region 1,Season peak percentage,3.9
+2012,47,2012/2013,47,HHS Region 1,1 wk ahead,0.9
+2012,47,2012/2013,47,HHS Region 1,2 wk ahead,1.2
+2012,47,2012/2013,47,HHS Region 1,3 wk ahead,1.7
+2012,47,2012/2013,47,HHS Region 1,4 wk ahead,2.6
+2012,47,2012/2013,47,HHS Region 2,Season onset,48
+2012,47,2012/2013,47,HHS Region 2,Season peak week,52
+2012,47,2012/2013,47,HHS Region 2,Season peak percentage,5.5
+2012,47,2012/2013,47,HHS Region 2,1 wk ahead,2
+2012,47,2012/2013,47,HHS Region 2,2 wk ahead,2.4
+2012,47,2012/2013,47,HHS Region 2,3 wk ahead,2.8
+2012,47,2012/2013,47,HHS Region 2,4 wk ahead,3.8
+2012,47,2012/2013,47,HHS Region 3,Season onset,49
+2012,47,2012/2013,47,HHS Region 3,Season peak week,52
+2012,47,2012/2013,47,HHS Region 3,Season peak percentage,7.1
+2012,47,2012/2013,47,HHS Region 3,1 wk ahead,1.6
+2012,47,2012/2013,47,HHS Region 3,2 wk ahead,2.5
+2012,47,2012/2013,47,HHS Region 3,3 wk ahead,3.4
+2012,47,2012/2013,47,HHS Region 3,4 wk ahead,4.5
+2012,47,2012/2013,47,HHS Region 4,Season onset,47
+2012,47,2012/2013,47,HHS Region 4,Season peak week,52
+2012,47,2012/2013,47,HHS Region 4,Season peak percentage,6.3
+2012,47,2012/2013,47,HHS Region 4,1 wk ahead,2.7
+2012,47,2012/2013,47,HHS Region 4,2 wk ahead,4.2
+2012,47,2012/2013,47,HHS Region 4,3 wk ahead,4.7
+2012,47,2012/2013,47,HHS Region 4,4 wk ahead,5
+2012,47,2012/2013,47,HHS Region 5,Season onset,47
+2012,47,2012/2013,47,HHS Region 5,Season peak week,52
+2012,47,2012/2013,47,HHS Region 5,Season peak percentage,5.7
+2012,47,2012/2013,47,HHS Region 5,1 wk ahead,1.5
+2012,47,2012/2013,47,HHS Region 5,2 wk ahead,2.1
+2012,47,2012/2013,47,HHS Region 5,3 wk ahead,3
+2012,47,2012/2013,47,HHS Region 5,4 wk ahead,4.2
+2012,47,2012/2013,47,HHS Region 6,Season onset,47
+2012,47,2012/2013,47,HHS Region 6,Season peak week,52
+2012,47,2012/2013,47,HHS Region 6,Season peak percentage,9.3
+2012,47,2012/2013,47,HHS Region 6,1 wk ahead,3.7
+2012,47,2012/2013,47,HHS Region 6,2 wk ahead,4.6
+2012,47,2012/2013,47,HHS Region 6,3 wk ahead,5.6
+2012,47,2012/2013,47,HHS Region 6,4 wk ahead,7.2
+2012,47,2012/2013,47,HHS Region 7,Season onset,47
+2012,47,2012/2013,47,HHS Region 7,Season peak week,52
+2012,47,2012/2013,47,HHS Region 7,Season peak percentage,6.7
+2012,47,2012/2013,47,HHS Region 7,1 wk ahead,2.2
+2012,47,2012/2013,47,HHS Region 7,2 wk ahead,2.3
+2012,47,2012/2013,47,HHS Region 7,3 wk ahead,2.8
+2012,47,2012/2013,47,HHS Region 7,4 wk ahead,4.1
+2012,47,2012/2013,47,HHS Region 8,Season onset,50
+2012,47,2012/2013,47,HHS Region 8,Season peak week,52
+2012,47,2012/2013,47,HHS Region 8,Season peak week,3
+2012,47,2012/2013,47,HHS Region 8,Season peak percentage,4.1
+2012,47,2012/2013,47,HHS Region 8,1 wk ahead,1.3
+2012,47,2012/2013,47,HHS Region 8,2 wk ahead,1.7
+2012,47,2012/2013,47,HHS Region 8,3 wk ahead,2.4
+2012,47,2012/2013,47,HHS Region 8,4 wk ahead,3.2
+2012,47,2012/2013,47,HHS Region 9,Season onset,2
+2012,47,2012/2013,47,HHS Region 9,Season peak week,4
+2012,47,2012/2013,47,HHS Region 9,Season peak percentage,5.6
+2012,47,2012/2013,47,HHS Region 9,1 wk ahead,2.2
+2012,47,2012/2013,47,HHS Region 9,2 wk ahead,2.2
+2012,47,2012/2013,47,HHS Region 9,3 wk ahead,2.5
+2012,47,2012/2013,47,HHS Region 9,4 wk ahead,3.1
+2012,47,2012/2013,47,HHS Region 10,Season onset,50
+2012,47,2012/2013,47,HHS Region 10,Season peak week,4
+2012,47,2012/2013,47,HHS Region 10,Season peak percentage,3.7
+2012,47,2012/2013,47,HHS Region 10,1 wk ahead,1
+2012,47,2012/2013,47,HHS Region 10,2 wk ahead,1.1
+2012,47,2012/2013,47,HHS Region 10,3 wk ahead,1.6
+2012,47,2012/2013,47,HHS Region 10,4 wk ahead,1.5
+2012,48,2012/2013,48,US National,Season onset,47
+2012,48,2012/2013,48,US National,Season peak week,52
+2012,48,2012/2013,48,US National,Season peak percentage,6.1
+2012,48,2012/2013,48,US National,1 wk ahead,2.8
+2012,48,2012/2013,48,US National,2 wk ahead,3.4
+2012,48,2012/2013,48,US National,3 wk ahead,4.3
+2012,48,2012/2013,48,US National,4 wk ahead,6.1
+2012,48,2012/2013,48,HHS Region 1,Season onset,49
+2012,48,2012/2013,48,HHS Region 1,Season peak week,52
+2012,48,2012/2013,48,HHS Region 1,Season peak percentage,3.9
+2012,48,2012/2013,48,HHS Region 1,1 wk ahead,1.2
+2012,48,2012/2013,48,HHS Region 1,2 wk ahead,1.7
+2012,48,2012/2013,48,HHS Region 1,3 wk ahead,2.6
+2012,48,2012/2013,48,HHS Region 1,4 wk ahead,3.9
+2012,48,2012/2013,48,HHS Region 2,Season onset,48
+2012,48,2012/2013,48,HHS Region 2,Season peak week,52
+2012,48,2012/2013,48,HHS Region 2,Season peak percentage,5.5
+2012,48,2012/2013,48,HHS Region 2,1 wk ahead,2.4
+2012,48,2012/2013,48,HHS Region 2,2 wk ahead,2.8
+2012,48,2012/2013,48,HHS Region 2,3 wk ahead,3.8
+2012,48,2012/2013,48,HHS Region 2,4 wk ahead,5.5
+2012,48,2012/2013,48,HHS Region 3,Season onset,49
+2012,48,2012/2013,48,HHS Region 3,Season peak week,52
+2012,48,2012/2013,48,HHS Region 3,Season peak percentage,7.1
+2012,48,2012/2013,48,HHS Region 3,1 wk ahead,2.5
+2012,48,2012/2013,48,HHS Region 3,2 wk ahead,3.4
+2012,48,2012/2013,48,HHS Region 3,3 wk ahead,4.5
+2012,48,2012/2013,48,HHS Region 3,4 wk ahead,7.1
+2012,48,2012/2013,48,HHS Region 4,Season onset,47
+2012,48,2012/2013,48,HHS Region 4,Season peak week,52
+2012,48,2012/2013,48,HHS Region 4,Season peak percentage,6.3
+2012,48,2012/2013,48,HHS Region 4,1 wk ahead,4.2
+2012,48,2012/2013,48,HHS Region 4,2 wk ahead,4.7
+2012,48,2012/2013,48,HHS Region 4,3 wk ahead,5
+2012,48,2012/2013,48,HHS Region 4,4 wk ahead,6.3
+2012,48,2012/2013,48,HHS Region 5,Season onset,47
+2012,48,2012/2013,48,HHS Region 5,Season peak week,52
+2012,48,2012/2013,48,HHS Region 5,Season peak percentage,5.7
+2012,48,2012/2013,48,HHS Region 5,1 wk ahead,2.1
+2012,48,2012/2013,48,HHS Region 5,2 wk ahead,3
+2012,48,2012/2013,48,HHS Region 5,3 wk ahead,4.2
+2012,48,2012/2013,48,HHS Region 5,4 wk ahead,5.7
+2012,48,2012/2013,48,HHS Region 6,Season onset,47
+2012,48,2012/2013,48,HHS Region 6,Season peak week,52
+2012,48,2012/2013,48,HHS Region 6,Season peak percentage,9.3
+2012,48,2012/2013,48,HHS Region 6,1 wk ahead,4.6
+2012,48,2012/2013,48,HHS Region 6,2 wk ahead,5.6
+2012,48,2012/2013,48,HHS Region 6,3 wk ahead,7.2
+2012,48,2012/2013,48,HHS Region 6,4 wk ahead,9.3
+2012,48,2012/2013,48,HHS Region 7,Season onset,47
+2012,48,2012/2013,48,HHS Region 7,Season peak week,52
+2012,48,2012/2013,48,HHS Region 7,Season peak percentage,6.7
+2012,48,2012/2013,48,HHS Region 7,1 wk ahead,2.3
+2012,48,2012/2013,48,HHS Region 7,2 wk ahead,2.8
+2012,48,2012/2013,48,HHS Region 7,3 wk ahead,4.1
+2012,48,2012/2013,48,HHS Region 7,4 wk ahead,6.7
+2012,48,2012/2013,48,HHS Region 8,Season onset,50
+2012,48,2012/2013,48,HHS Region 8,Season peak week,52
+2012,48,2012/2013,48,HHS Region 8,Season peak week,3
+2012,48,2012/2013,48,HHS Region 8,Season peak percentage,4.1
+2012,48,2012/2013,48,HHS Region 8,1 wk ahead,1.7
+2012,48,2012/2013,48,HHS Region 8,2 wk ahead,2.4
+2012,48,2012/2013,48,HHS Region 8,3 wk ahead,3.2
+2012,48,2012/2013,48,HHS Region 8,4 wk ahead,4.1
+2012,48,2012/2013,48,HHS Region 9,Season onset,2
+2012,48,2012/2013,48,HHS Region 9,Season peak week,4
+2012,48,2012/2013,48,HHS Region 9,Season peak percentage,5.6
+2012,48,2012/2013,48,HHS Region 9,1 wk ahead,2.2
+2012,48,2012/2013,48,HHS Region 9,2 wk ahead,2.5
+2012,48,2012/2013,48,HHS Region 9,3 wk ahead,3.1
+2012,48,2012/2013,48,HHS Region 9,4 wk ahead,4.8
+2012,48,2012/2013,48,HHS Region 10,Season onset,50
+2012,48,2012/2013,48,HHS Region 10,Season peak week,4
+2012,48,2012/2013,48,HHS Region 10,Season peak percentage,3.7
+2012,48,2012/2013,48,HHS Region 10,1 wk ahead,1.1
+2012,48,2012/2013,48,HHS Region 10,2 wk ahead,1.6
+2012,48,2012/2013,48,HHS Region 10,3 wk ahead,1.5
+2012,48,2012/2013,48,HHS Region 10,4 wk ahead,3.4
+2012,49,2012/2013,49,US National,Season onset,47
+2012,49,2012/2013,49,US National,Season peak week,52
+2012,49,2012/2013,49,US National,Season peak percentage,6.1
+2012,49,2012/2013,49,US National,1 wk ahead,3.4
+2012,49,2012/2013,49,US National,2 wk ahead,4.3
+2012,49,2012/2013,49,US National,3 wk ahead,6.1
+2012,49,2012/2013,49,US National,4 wk ahead,4.6
+2012,49,2012/2013,49,HHS Region 1,Season onset,49
+2012,49,2012/2013,49,HHS Region 1,Season peak week,52
+2012,49,2012/2013,49,HHS Region 1,Season peak percentage,3.9
+2012,49,2012/2013,49,HHS Region 1,1 wk ahead,1.7
+2012,49,2012/2013,49,HHS Region 1,2 wk ahead,2.6
+2012,49,2012/2013,49,HHS Region 1,3 wk ahead,3.9
+2012,49,2012/2013,49,HHS Region 1,4 wk ahead,3.2
+2012,49,2012/2013,49,HHS Region 2,Season onset,48
+2012,49,2012/2013,49,HHS Region 2,Season peak week,52
+2012,49,2012/2013,49,HHS Region 2,Season peak percentage,5.5
+2012,49,2012/2013,49,HHS Region 2,1 wk ahead,2.8
+2012,49,2012/2013,49,HHS Region 2,2 wk ahead,3.8
+2012,49,2012/2013,49,HHS Region 2,3 wk ahead,5.5
+2012,49,2012/2013,49,HHS Region 2,4 wk ahead,4.5
+2012,49,2012/2013,49,HHS Region 3,Season onset,49
+2012,49,2012/2013,49,HHS Region 3,Season peak week,52
+2012,49,2012/2013,49,HHS Region 3,Season peak percentage,7.1
+2012,49,2012/2013,49,HHS Region 3,1 wk ahead,3.4
+2012,49,2012/2013,49,HHS Region 3,2 wk ahead,4.5
+2012,49,2012/2013,49,HHS Region 3,3 wk ahead,7.1
+2012,49,2012/2013,49,HHS Region 3,4 wk ahead,4.8
+2012,49,2012/2013,49,HHS Region 4,Season onset,47
+2012,49,2012/2013,49,HHS Region 4,Season peak week,52
+2012,49,2012/2013,49,HHS Region 4,Season peak percentage,6.3
+2012,49,2012/2013,49,HHS Region 4,1 wk ahead,4.7
+2012,49,2012/2013,49,HHS Region 4,2 wk ahead,5
+2012,49,2012/2013,49,HHS Region 4,3 wk ahead,6.3
+2012,49,2012/2013,49,HHS Region 4,4 wk ahead,4.5
+2012,49,2012/2013,49,HHS Region 5,Season onset,47
+2012,49,2012/2013,49,HHS Region 5,Season peak week,52
+2012,49,2012/2013,49,HHS Region 5,Season peak percentage,5.7
+2012,49,2012/2013,49,HHS Region 5,1 wk ahead,3
+2012,49,2012/2013,49,HHS Region 5,2 wk ahead,4.2
+2012,49,2012/2013,49,HHS Region 5,3 wk ahead,5.7
+2012,49,2012/2013,49,HHS Region 5,4 wk ahead,4.5
+2012,49,2012/2013,49,HHS Region 6,Season onset,47
+2012,49,2012/2013,49,HHS Region 6,Season peak week,52
+2012,49,2012/2013,49,HHS Region 6,Season peak percentage,9.3
+2012,49,2012/2013,49,HHS Region 6,1 wk ahead,5.6
+2012,49,2012/2013,49,HHS Region 6,2 wk ahead,7.2
+2012,49,2012/2013,49,HHS Region 6,3 wk ahead,9.3
+2012,49,2012/2013,49,HHS Region 6,4 wk ahead,7.7
+2012,49,2012/2013,49,HHS Region 7,Season onset,47
+2012,49,2012/2013,49,HHS Region 7,Season peak week,52
+2012,49,2012/2013,49,HHS Region 7,Season peak percentage,6.7
+2012,49,2012/2013,49,HHS Region 7,1 wk ahead,2.8
+2012,49,2012/2013,49,HHS Region 7,2 wk ahead,4.1
+2012,49,2012/2013,49,HHS Region 7,3 wk ahead,6.7
+2012,49,2012/2013,49,HHS Region 7,4 wk ahead,5.8
+2012,49,2012/2013,49,HHS Region 8,Season onset,50
+2012,49,2012/2013,49,HHS Region 8,Season peak week,52
+2012,49,2012/2013,49,HHS Region 8,Season peak week,3
+2012,49,2012/2013,49,HHS Region 8,Season peak percentage,4.1
+2012,49,2012/2013,49,HHS Region 8,1 wk ahead,2.4
+2012,49,2012/2013,49,HHS Region 8,2 wk ahead,3.2
+2012,49,2012/2013,49,HHS Region 8,3 wk ahead,4.1
+2012,49,2012/2013,49,HHS Region 8,4 wk ahead,3.7
+2012,49,2012/2013,49,HHS Region 9,Season onset,2
+2012,49,2012/2013,49,HHS Region 9,Season peak week,4
+2012,49,2012/2013,49,HHS Region 9,Season peak percentage,5.6
+2012,49,2012/2013,49,HHS Region 9,1 wk ahead,2.5
+2012,49,2012/2013,49,HHS Region 9,2 wk ahead,3.1
+2012,49,2012/2013,49,HHS Region 9,3 wk ahead,4.8
+2012,49,2012/2013,49,HHS Region 9,4 wk ahead,3.4
+2012,49,2012/2013,49,HHS Region 10,Season onset,50
+2012,49,2012/2013,49,HHS Region 10,Season peak week,4
+2012,49,2012/2013,49,HHS Region 10,Season peak percentage,3.7
+2012,49,2012/2013,49,HHS Region 10,1 wk ahead,1.6
+2012,49,2012/2013,49,HHS Region 10,2 wk ahead,1.5
+2012,49,2012/2013,49,HHS Region 10,3 wk ahead,3.4
+2012,49,2012/2013,49,HHS Region 10,4 wk ahead,2.8
+2012,50,2012/2013,50,US National,Season onset,47
+2012,50,2012/2013,50,US National,Season peak week,52
+2012,50,2012/2013,50,US National,Season peak percentage,6.1
+2012,50,2012/2013,50,US National,1 wk ahead,4.3
+2012,50,2012/2013,50,US National,2 wk ahead,6.1
+2012,50,2012/2013,50,US National,3 wk ahead,4.6
+2012,50,2012/2013,50,US National,4 wk ahead,4.3
+2012,50,2012/2013,50,HHS Region 1,Season onset,49
+2012,50,2012/2013,50,HHS Region 1,Season peak week,52
+2012,50,2012/2013,50,HHS Region 1,Season peak percentage,3.9
+2012,50,2012/2013,50,HHS Region 1,1 wk ahead,2.6
+2012,50,2012/2013,50,HHS Region 1,2 wk ahead,3.9
+2012,50,2012/2013,50,HHS Region 1,3 wk ahead,3.2
+2012,50,2012/2013,50,HHS Region 1,4 wk ahead,3.3
+2012,50,2012/2013,50,HHS Region 2,Season onset,48
+2012,50,2012/2013,50,HHS Region 2,Season peak week,52
+2012,50,2012/2013,50,HHS Region 2,Season peak percentage,5.5
+2012,50,2012/2013,50,HHS Region 2,1 wk ahead,3.8
+2012,50,2012/2013,50,HHS Region 2,2 wk ahead,5.5
+2012,50,2012/2013,50,HHS Region 2,3 wk ahead,4.5
+2012,50,2012/2013,50,HHS Region 2,4 wk ahead,4.8
+2012,50,2012/2013,50,HHS Region 3,Season onset,49
+2012,50,2012/2013,50,HHS Region 3,Season peak week,52
+2012,50,2012/2013,50,HHS Region 3,Season peak percentage,7.1
+2012,50,2012/2013,50,HHS Region 3,1 wk ahead,4.5
+2012,50,2012/2013,50,HHS Region 3,2 wk ahead,7.1
+2012,50,2012/2013,50,HHS Region 3,3 wk ahead,4.8
+2012,50,2012/2013,50,HHS Region 3,4 wk ahead,5.1
+2012,50,2012/2013,50,HHS Region 4,Season onset,47
+2012,50,2012/2013,50,HHS Region 4,Season peak week,52
+2012,50,2012/2013,50,HHS Region 4,Season peak percentage,6.3
+2012,50,2012/2013,50,HHS Region 4,1 wk ahead,5
+2012,50,2012/2013,50,HHS Region 4,2 wk ahead,6.3
+2012,50,2012/2013,50,HHS Region 4,3 wk ahead,4.5
+2012,50,2012/2013,50,HHS Region 4,4 wk ahead,3.5
+2012,50,2012/2013,50,HHS Region 5,Season onset,47
+2012,50,2012/2013,50,HHS Region 5,Season peak week,52
+2012,50,2012/2013,50,HHS Region 5,Season peak percentage,5.7
+2012,50,2012/2013,50,HHS Region 5,1 wk ahead,4.2
+2012,50,2012/2013,50,HHS Region 5,2 wk ahead,5.7
+2012,50,2012/2013,50,HHS Region 5,3 wk ahead,4.5
+2012,50,2012/2013,50,HHS Region 5,4 wk ahead,3.8
+2012,50,2012/2013,50,HHS Region 6,Season onset,47
+2012,50,2012/2013,50,HHS Region 6,Season peak week,52
+2012,50,2012/2013,50,HHS Region 6,Season peak percentage,9.3
+2012,50,2012/2013,50,HHS Region 6,1 wk ahead,7.2
+2012,50,2012/2013,50,HHS Region 6,2 wk ahead,9.3
+2012,50,2012/2013,50,HHS Region 6,3 wk ahead,7.7
+2012,50,2012/2013,50,HHS Region 6,4 wk ahead,7.3
+2012,50,2012/2013,50,HHS Region 7,Season onset,47
+2012,50,2012/2013,50,HHS Region 7,Season peak week,52
+2012,50,2012/2013,50,HHS Region 7,Season peak percentage,6.7
+2012,50,2012/2013,50,HHS Region 7,1 wk ahead,4.1
+2012,50,2012/2013,50,HHS Region 7,2 wk ahead,6.7
+2012,50,2012/2013,50,HHS Region 7,3 wk ahead,5.8
+2012,50,2012/2013,50,HHS Region 7,4 wk ahead,5.1
+2012,50,2012/2013,50,HHS Region 8,Season onset,50
+2012,50,2012/2013,50,HHS Region 8,Season peak week,52
+2012,50,2012/2013,50,HHS Region 8,Season peak week,3
+2012,50,2012/2013,50,HHS Region 8,Season peak percentage,4.1
+2012,50,2012/2013,50,HHS Region 8,1 wk ahead,3.2
+2012,50,2012/2013,50,HHS Region 8,2 wk ahead,4.1
+2012,50,2012/2013,50,HHS Region 8,3 wk ahead,3.7
+2012,50,2012/2013,50,HHS Region 8,4 wk ahead,4
+2012,50,2012/2013,50,HHS Region 9,Season onset,2
+2012,50,2012/2013,50,HHS Region 9,Season peak week,4
+2012,50,2012/2013,50,HHS Region 9,Season peak percentage,5.6
+2012,50,2012/2013,50,HHS Region 9,1 wk ahead,3.1
+2012,50,2012/2013,50,HHS Region 9,2 wk ahead,4.8
+2012,50,2012/2013,50,HHS Region 9,3 wk ahead,3.4
+2012,50,2012/2013,50,HHS Region 9,4 wk ahead,3.5
+2012,50,2012/2013,50,HHS Region 10,Season onset,50
+2012,50,2012/2013,50,HHS Region 10,Season peak week,4
+2012,50,2012/2013,50,HHS Region 10,Season peak percentage,3.7
+2012,50,2012/2013,50,HHS Region 10,1 wk ahead,1.5
+2012,50,2012/2013,50,HHS Region 10,2 wk ahead,3.4
+2012,50,2012/2013,50,HHS Region 10,3 wk ahead,2.8
+2012,50,2012/2013,50,HHS Region 10,4 wk ahead,2.6
+2012,51,2012/2013,51,US National,Season onset,47
+2012,51,2012/2013,51,US National,Season peak week,52
+2012,51,2012/2013,51,US National,Season peak percentage,6.1
+2012,51,2012/2013,51,US National,1 wk ahead,6.1
+2012,51,2012/2013,51,US National,2 wk ahead,4.6
+2012,51,2012/2013,51,US National,3 wk ahead,4.3
+2012,51,2012/2013,51,US National,4 wk ahead,4.5
+2012,51,2012/2013,51,HHS Region 1,Season onset,49
+2012,51,2012/2013,51,HHS Region 1,Season peak week,52
+2012,51,2012/2013,51,HHS Region 1,Season peak percentage,3.9
+2012,51,2012/2013,51,HHS Region 1,1 wk ahead,3.9
+2012,51,2012/2013,51,HHS Region 1,2 wk ahead,3.2
+2012,51,2012/2013,51,HHS Region 1,3 wk ahead,3.3
+2012,51,2012/2013,51,HHS Region 1,4 wk ahead,3
+2012,51,2012/2013,51,HHS Region 2,Season onset,48
+2012,51,2012/2013,51,HHS Region 2,Season peak week,52
+2012,51,2012/2013,51,HHS Region 2,Season peak percentage,5.5
+2012,51,2012/2013,51,HHS Region 2,1 wk ahead,5.5
+2012,51,2012/2013,51,HHS Region 2,2 wk ahead,4.5
+2012,51,2012/2013,51,HHS Region 2,3 wk ahead,4.8
+2012,51,2012/2013,51,HHS Region 2,4 wk ahead,5.3
+2012,51,2012/2013,51,HHS Region 3,Season onset,49
+2012,51,2012/2013,51,HHS Region 3,Season peak week,52
+2012,51,2012/2013,51,HHS Region 3,Season peak percentage,7.1
+2012,51,2012/2013,51,HHS Region 3,1 wk ahead,7.1
+2012,51,2012/2013,51,HHS Region 3,2 wk ahead,4.8
+2012,51,2012/2013,51,HHS Region 3,3 wk ahead,5.1
+2012,51,2012/2013,51,HHS Region 3,4 wk ahead,5.2
+2012,51,2012/2013,51,HHS Region 4,Season onset,47
+2012,51,2012/2013,51,HHS Region 4,Season peak week,52
+2012,51,2012/2013,51,HHS Region 4,Season peak percentage,6.3
+2012,51,2012/2013,51,HHS Region 4,1 wk ahead,6.3
+2012,51,2012/2013,51,HHS Region 4,2 wk ahead,4.5
+2012,51,2012/2013,51,HHS Region 4,3 wk ahead,3.5
+2012,51,2012/2013,51,HHS Region 4,4 wk ahead,3.1
+2012,51,2012/2013,51,HHS Region 5,Season onset,47
+2012,51,2012/2013,51,HHS Region 5,Season peak week,52
+2012,51,2012/2013,51,HHS Region 5,Season peak percentage,5.7
+2012,51,2012/2013,51,HHS Region 5,1 wk ahead,5.7
+2012,51,2012/2013,51,HHS Region 5,2 wk ahead,4.5
+2012,51,2012/2013,51,HHS Region 5,3 wk ahead,3.8
+2012,51,2012/2013,51,HHS Region 5,4 wk ahead,3.7
+2012,51,2012/2013,51,HHS Region 6,Season onset,47
+2012,51,2012/2013,51,HHS Region 6,Season peak week,52
+2012,51,2012/2013,51,HHS Region 6,Season peak percentage,9.3
+2012,51,2012/2013,51,HHS Region 6,1 wk ahead,9.3
+2012,51,2012/2013,51,HHS Region 6,2 wk ahead,7.7
+2012,51,2012/2013,51,HHS Region 6,3 wk ahead,7.3
+2012,51,2012/2013,51,HHS Region 6,4 wk ahead,7.4
+2012,51,2012/2013,51,HHS Region 7,Season onset,47
+2012,51,2012/2013,51,HHS Region 7,Season peak week,52
+2012,51,2012/2013,51,HHS Region 7,Season peak percentage,6.7
+2012,51,2012/2013,51,HHS Region 7,1 wk ahead,6.7
+2012,51,2012/2013,51,HHS Region 7,2 wk ahead,5.8
+2012,51,2012/2013,51,HHS Region 7,3 wk ahead,5.1
+2012,51,2012/2013,51,HHS Region 7,4 wk ahead,5.2
+2012,51,2012/2013,51,HHS Region 8,Season onset,50
+2012,51,2012/2013,51,HHS Region 8,Season peak week,52
+2012,51,2012/2013,51,HHS Region 8,Season peak week,3
+2012,51,2012/2013,51,HHS Region 8,Season peak percentage,4.1
+2012,51,2012/2013,51,HHS Region 8,1 wk ahead,4.1
+2012,51,2012/2013,51,HHS Region 8,2 wk ahead,3.7
+2012,51,2012/2013,51,HHS Region 8,3 wk ahead,4
+2012,51,2012/2013,51,HHS Region 8,4 wk ahead,4.1
+2012,51,2012/2013,51,HHS Region 9,Season onset,2
+2012,51,2012/2013,51,HHS Region 9,Season peak week,4
+2012,51,2012/2013,51,HHS Region 9,Season peak percentage,5.6
+2012,51,2012/2013,51,HHS Region 9,1 wk ahead,4.8
+2012,51,2012/2013,51,HHS Region 9,2 wk ahead,3.4
+2012,51,2012/2013,51,HHS Region 9,3 wk ahead,3.5
+2012,51,2012/2013,51,HHS Region 9,4 wk ahead,4.7
+2012,51,2012/2013,51,HHS Region 10,Season onset,50
+2012,51,2012/2013,51,HHS Region 10,Season peak week,4
+2012,51,2012/2013,51,HHS Region 10,Season peak percentage,3.7
+2012,51,2012/2013,51,HHS Region 10,1 wk ahead,3.4
+2012,51,2012/2013,51,HHS Region 10,2 wk ahead,2.8
+2012,51,2012/2013,51,HHS Region 10,3 wk ahead,2.6
+2012,51,2012/2013,51,HHS Region 10,4 wk ahead,3
+2012,52,2012/2013,52,US National,Season onset,47
+2012,52,2012/2013,52,US National,Season peak week,52
+2012,52,2012/2013,52,US National,Season peak percentage,6.1
+2012,52,2012/2013,52,US National,1 wk ahead,4.6
+2012,52,2012/2013,52,US National,2 wk ahead,4.3
+2012,52,2012/2013,52,US National,3 wk ahead,4.5
+2012,52,2012/2013,52,US National,4 wk ahead,4.2
+2012,52,2012/2013,52,HHS Region 1,Season onset,49
+2012,52,2012/2013,52,HHS Region 1,Season peak week,52
+2012,52,2012/2013,52,HHS Region 1,Season peak percentage,3.9
+2012,52,2012/2013,52,HHS Region 1,1 wk ahead,3.2
+2012,52,2012/2013,52,HHS Region 1,2 wk ahead,3.3
+2012,52,2012/2013,52,HHS Region 1,3 wk ahead,3
+2012,52,2012/2013,52,HHS Region 1,4 wk ahead,2.5
+2012,52,2012/2013,52,HHS Region 2,Season onset,48
+2012,52,2012/2013,52,HHS Region 2,Season peak week,52
+2012,52,2012/2013,52,HHS Region 2,Season peak percentage,5.5
+2012,52,2012/2013,52,HHS Region 2,1 wk ahead,4.5
+2012,52,2012/2013,52,HHS Region 2,2 wk ahead,4.8
+2012,52,2012/2013,52,HHS Region 2,3 wk ahead,5.3
+2012,52,2012/2013,52,HHS Region 2,4 wk ahead,4.6
+2012,52,2012/2013,52,HHS Region 3,Season onset,49
+2012,52,2012/2013,52,HHS Region 3,Season peak week,52
+2012,52,2012/2013,52,HHS Region 3,Season peak percentage,7.1
+2012,52,2012/2013,52,HHS Region 3,1 wk ahead,4.8
+2012,52,2012/2013,52,HHS Region 3,2 wk ahead,5.1
+2012,52,2012/2013,52,HHS Region 3,3 wk ahead,5.2
+2012,52,2012/2013,52,HHS Region 3,4 wk ahead,3.6
+2012,52,2012/2013,52,HHS Region 4,Season onset,47
+2012,52,2012/2013,52,HHS Region 4,Season peak week,52
+2012,52,2012/2013,52,HHS Region 4,Season peak percentage,6.3
+2012,52,2012/2013,52,HHS Region 4,1 wk ahead,4.5
+2012,52,2012/2013,52,HHS Region 4,2 wk ahead,3.5
+2012,52,2012/2013,52,HHS Region 4,3 wk ahead,3.1
+2012,52,2012/2013,52,HHS Region 4,4 wk ahead,2.5
+2012,52,2012/2013,52,HHS Region 5,Season onset,47
+2012,52,2012/2013,52,HHS Region 5,Season peak week,52
+2012,52,2012/2013,52,HHS Region 5,Season peak percentage,5.7
+2012,52,2012/2013,52,HHS Region 5,1 wk ahead,4.5
+2012,52,2012/2013,52,HHS Region 5,2 wk ahead,3.8
+2012,52,2012/2013,52,HHS Region 5,3 wk ahead,3.7
+2012,52,2012/2013,52,HHS Region 5,4 wk ahead,3.3
+2012,52,2012/2013,52,HHS Region 6,Season onset,47
+2012,52,2012/2013,52,HHS Region 6,Season peak week,52
+2012,52,2012/2013,52,HHS Region 6,Season peak percentage,9.3
+2012,52,2012/2013,52,HHS Region 6,1 wk ahead,7.7
+2012,52,2012/2013,52,HHS Region 6,2 wk ahead,7.3
+2012,52,2012/2013,52,HHS Region 6,3 wk ahead,7.4
+2012,52,2012/2013,52,HHS Region 6,4 wk ahead,7.1
+2012,52,2012/2013,52,HHS Region 7,Season onset,47
+2012,52,2012/2013,52,HHS Region 7,Season peak week,52
+2012,52,2012/2013,52,HHS Region 7,Season peak percentage,6.7
+2012,52,2012/2013,52,HHS Region 7,1 wk ahead,5.8
+2012,52,2012/2013,52,HHS Region 7,2 wk ahead,5.1
+2012,52,2012/2013,52,HHS Region 7,3 wk ahead,5.2
+2012,52,2012/2013,52,HHS Region 7,4 wk ahead,5.3
+2012,52,2012/2013,52,HHS Region 8,Season onset,50
+2012,52,2012/2013,52,HHS Region 8,Season peak week,52
+2012,52,2012/2013,52,HHS Region 8,Season peak week,3
+2012,52,2012/2013,52,HHS Region 8,Season peak percentage,4.1
+2012,52,2012/2013,52,HHS Region 8,1 wk ahead,3.7
+2012,52,2012/2013,52,HHS Region 8,2 wk ahead,4
+2012,52,2012/2013,52,HHS Region 8,3 wk ahead,4.1
+2012,52,2012/2013,52,HHS Region 8,4 wk ahead,4
+2012,52,2012/2013,52,HHS Region 9,Season onset,2
+2012,52,2012/2013,52,HHS Region 9,Season peak week,4
+2012,52,2012/2013,52,HHS Region 9,Season peak percentage,5.6
+2012,52,2012/2013,52,HHS Region 9,1 wk ahead,3.4
+2012,52,2012/2013,52,HHS Region 9,2 wk ahead,3.5
+2012,52,2012/2013,52,HHS Region 9,3 wk ahead,4.7
+2012,52,2012/2013,52,HHS Region 9,4 wk ahead,5.6
+2012,52,2012/2013,52,HHS Region 10,Season onset,50
+2012,52,2012/2013,52,HHS Region 10,Season peak week,4
+2012,52,2012/2013,52,HHS Region 10,Season peak percentage,3.7
+2012,52,2012/2013,52,HHS Region 10,1 wk ahead,2.8
+2012,52,2012/2013,52,HHS Region 10,2 wk ahead,2.6
+2012,52,2012/2013,52,HHS Region 10,3 wk ahead,3
+2012,52,2012/2013,52,HHS Region 10,4 wk ahead,3.7
+2013,1,2012/2013,53,US National,Season onset,47
+2013,1,2012/2013,53,US National,Season peak week,52
+2013,1,2012/2013,53,US National,Season peak percentage,6.1
+2013,1,2012/2013,53,US National,1 wk ahead,4.3
+2013,1,2012/2013,53,US National,2 wk ahead,4.5
+2013,1,2012/2013,53,US National,3 wk ahead,4.2
+2013,1,2012/2013,53,US National,4 wk ahead,3.8
+2013,1,2012/2013,53,HHS Region 1,Season onset,49
+2013,1,2012/2013,53,HHS Region 1,Season peak week,52
+2013,1,2012/2013,53,HHS Region 1,Season peak percentage,3.9
+2013,1,2012/2013,53,HHS Region 1,1 wk ahead,3.3
+2013,1,2012/2013,53,HHS Region 1,2 wk ahead,3
+2013,1,2012/2013,53,HHS Region 1,3 wk ahead,2.5
+2013,1,2012/2013,53,HHS Region 1,4 wk ahead,2.2
+2013,1,2012/2013,53,HHS Region 2,Season onset,48
+2013,1,2012/2013,53,HHS Region 2,Season peak week,52
+2013,1,2012/2013,53,HHS Region 2,Season peak percentage,5.5
+2013,1,2012/2013,53,HHS Region 2,1 wk ahead,4.8
+2013,1,2012/2013,53,HHS Region 2,2 wk ahead,5.3
+2013,1,2012/2013,53,HHS Region 2,3 wk ahead,4.6
+2013,1,2012/2013,53,HHS Region 2,4 wk ahead,3.8
+2013,1,2012/2013,53,HHS Region 3,Season onset,49
+2013,1,2012/2013,53,HHS Region 3,Season peak week,52
+2013,1,2012/2013,53,HHS Region 3,Season peak percentage,7.1
+2013,1,2012/2013,53,HHS Region 3,1 wk ahead,5.1
+2013,1,2012/2013,53,HHS Region 3,2 wk ahead,5.2
+2013,1,2012/2013,53,HHS Region 3,3 wk ahead,3.6
+2013,1,2012/2013,53,HHS Region 3,4 wk ahead,3.1
+2013,1,2012/2013,53,HHS Region 4,Season onset,47
+2013,1,2012/2013,53,HHS Region 4,Season peak week,52
+2013,1,2012/2013,53,HHS Region 4,Season peak percentage,6.3
+2013,1,2012/2013,53,HHS Region 4,1 wk ahead,3.5
+2013,1,2012/2013,53,HHS Region 4,2 wk ahead,3.1
+2013,1,2012/2013,53,HHS Region 4,3 wk ahead,2.5
+2013,1,2012/2013,53,HHS Region 4,4 wk ahead,2.5
+2013,1,2012/2013,53,HHS Region 5,Season onset,47
+2013,1,2012/2013,53,HHS Region 5,Season peak week,52
+2013,1,2012/2013,53,HHS Region 5,Season peak percentage,5.7
+2013,1,2012/2013,53,HHS Region 5,1 wk ahead,3.8
+2013,1,2012/2013,53,HHS Region 5,2 wk ahead,3.7
+2013,1,2012/2013,53,HHS Region 5,3 wk ahead,3.3
+2013,1,2012/2013,53,HHS Region 5,4 wk ahead,3
+2013,1,2012/2013,53,HHS Region 6,Season onset,47
+2013,1,2012/2013,53,HHS Region 6,Season peak week,52
+2013,1,2012/2013,53,HHS Region 6,Season peak percentage,9.3
+2013,1,2012/2013,53,HHS Region 6,1 wk ahead,7.3
+2013,1,2012/2013,53,HHS Region 6,2 wk ahead,7.4
+2013,1,2012/2013,53,HHS Region 6,3 wk ahead,7.1
+2013,1,2012/2013,53,HHS Region 6,4 wk ahead,5.8
+2013,1,2012/2013,53,HHS Region 7,Season onset,47
+2013,1,2012/2013,53,HHS Region 7,Season peak week,52
+2013,1,2012/2013,53,HHS Region 7,Season peak percentage,6.7
+2013,1,2012/2013,53,HHS Region 7,1 wk ahead,5.1
+2013,1,2012/2013,53,HHS Region 7,2 wk ahead,5.2
+2013,1,2012/2013,53,HHS Region 7,3 wk ahead,5.3
+2013,1,2012/2013,53,HHS Region 7,4 wk ahead,5.2
+2013,1,2012/2013,53,HHS Region 8,Season onset,50
+2013,1,2012/2013,53,HHS Region 8,Season peak week,52
+2013,1,2012/2013,53,HHS Region 8,Season peak week,3
+2013,1,2012/2013,53,HHS Region 8,Season peak percentage,4.1
+2013,1,2012/2013,53,HHS Region 8,1 wk ahead,4
+2013,1,2012/2013,53,HHS Region 8,2 wk ahead,4.1
+2013,1,2012/2013,53,HHS Region 8,3 wk ahead,4
+2013,1,2012/2013,53,HHS Region 8,4 wk ahead,3.4
+2013,1,2012/2013,53,HHS Region 9,Season onset,2
+2013,1,2012/2013,53,HHS Region 9,Season peak week,4
+2013,1,2012/2013,53,HHS Region 9,Season peak percentage,5.6
+2013,1,2012/2013,53,HHS Region 9,1 wk ahead,3.5
+2013,1,2012/2013,53,HHS Region 9,2 wk ahead,4.7
+2013,1,2012/2013,53,HHS Region 9,3 wk ahead,5.6
+2013,1,2012/2013,53,HHS Region 9,4 wk ahead,5.5
+2013,1,2012/2013,53,HHS Region 10,Season onset,50
+2013,1,2012/2013,53,HHS Region 10,Season peak week,4
+2013,1,2012/2013,53,HHS Region 10,Season peak percentage,3.7
+2013,1,2012/2013,53,HHS Region 10,1 wk ahead,2.6
+2013,1,2012/2013,53,HHS Region 10,2 wk ahead,3
+2013,1,2012/2013,53,HHS Region 10,3 wk ahead,3.7
+2013,1,2012/2013,53,HHS Region 10,4 wk ahead,2.8
+2013,2,2012/2013,54,US National,Season onset,47
+2013,2,2012/2013,54,US National,Season peak week,52
+2013,2,2012/2013,54,US National,Season peak percentage,6.1
+2013,2,2012/2013,54,US National,1 wk ahead,4.5
+2013,2,2012/2013,54,US National,2 wk ahead,4.2
+2013,2,2012/2013,54,US National,3 wk ahead,3.8
+2013,2,2012/2013,54,US National,4 wk ahead,3.3
+2013,2,2012/2013,54,HHS Region 1,Season onset,49
+2013,2,2012/2013,54,HHS Region 1,Season peak week,52
+2013,2,2012/2013,54,HHS Region 1,Season peak percentage,3.9
+2013,2,2012/2013,54,HHS Region 1,1 wk ahead,3
+2013,2,2012/2013,54,HHS Region 1,2 wk ahead,2.5
+2013,2,2012/2013,54,HHS Region 1,3 wk ahead,2.2
+2013,2,2012/2013,54,HHS Region 1,4 wk ahead,1.9
+2013,2,2012/2013,54,HHS Region 2,Season onset,48
+2013,2,2012/2013,54,HHS Region 2,Season peak week,52
+2013,2,2012/2013,54,HHS Region 2,Season peak percentage,5.5
+2013,2,2012/2013,54,HHS Region 2,1 wk ahead,5.3
+2013,2,2012/2013,54,HHS Region 2,2 wk ahead,4.6
+2013,2,2012/2013,54,HHS Region 2,3 wk ahead,3.8
+2013,2,2012/2013,54,HHS Region 2,4 wk ahead,3.6
+2013,2,2012/2013,54,HHS Region 3,Season onset,49
+2013,2,2012/2013,54,HHS Region 3,Season peak week,52
+2013,2,2012/2013,54,HHS Region 3,Season peak percentage,7.1
+2013,2,2012/2013,54,HHS Region 3,1 wk ahead,5.2
+2013,2,2012/2013,54,HHS Region 3,2 wk ahead,3.6
+2013,2,2012/2013,54,HHS Region 3,3 wk ahead,3.1
+2013,2,2012/2013,54,HHS Region 3,4 wk ahead,2.6
+2013,2,2012/2013,54,HHS Region 4,Season onset,47
+2013,2,2012/2013,54,HHS Region 4,Season peak week,52
+2013,2,2012/2013,54,HHS Region 4,Season peak percentage,6.3
+2013,2,2012/2013,54,HHS Region 4,1 wk ahead,3.1
+2013,2,2012/2013,54,HHS Region 4,2 wk ahead,2.5
+2013,2,2012/2013,54,HHS Region 4,3 wk ahead,2.5
+2013,2,2012/2013,54,HHS Region 4,4 wk ahead,2.3
+2013,2,2012/2013,54,HHS Region 5,Season onset,47
+2013,2,2012/2013,54,HHS Region 5,Season peak week,52
+2013,2,2012/2013,54,HHS Region 5,Season peak percentage,5.7
+2013,2,2012/2013,54,HHS Region 5,1 wk ahead,3.7
+2013,2,2012/2013,54,HHS Region 5,2 wk ahead,3.3
+2013,2,2012/2013,54,HHS Region 5,3 wk ahead,3
+2013,2,2012/2013,54,HHS Region 5,4 wk ahead,2.7
+2013,2,2012/2013,54,HHS Region 6,Season onset,47
+2013,2,2012/2013,54,HHS Region 6,Season peak week,52
+2013,2,2012/2013,54,HHS Region 6,Season peak percentage,9.3
+2013,2,2012/2013,54,HHS Region 6,1 wk ahead,7.4
+2013,2,2012/2013,54,HHS Region 6,2 wk ahead,7.1
+2013,2,2012/2013,54,HHS Region 6,3 wk ahead,5.8
+2013,2,2012/2013,54,HHS Region 6,4 wk ahead,4.5
+2013,2,2012/2013,54,HHS Region 7,Season onset,47
+2013,2,2012/2013,54,HHS Region 7,Season peak week,52
+2013,2,2012/2013,54,HHS Region 7,Season peak percentage,6.7
+2013,2,2012/2013,54,HHS Region 7,1 wk ahead,5.2
+2013,2,2012/2013,54,HHS Region 7,2 wk ahead,5.3
+2013,2,2012/2013,54,HHS Region 7,3 wk ahead,5.2
+2013,2,2012/2013,54,HHS Region 7,4 wk ahead,4.3
+2013,2,2012/2013,54,HHS Region 8,Season onset,50
+2013,2,2012/2013,54,HHS Region 8,Season peak week,52
+2013,2,2012/2013,54,HHS Region 8,Season peak week,3
+2013,2,2012/2013,54,HHS Region 8,Season peak percentage,4.1
+2013,2,2012/2013,54,HHS Region 8,1 wk ahead,4.1
+2013,2,2012/2013,54,HHS Region 8,2 wk ahead,4
+2013,2,2012/2013,54,HHS Region 8,3 wk ahead,3.4
+2013,2,2012/2013,54,HHS Region 8,4 wk ahead,3
+2013,2,2012/2013,54,HHS Region 9,Season onset,2
+2013,2,2012/2013,54,HHS Region 9,Season peak week,4
+2013,2,2012/2013,54,HHS Region 9,Season peak percentage,5.6
+2013,2,2012/2013,54,HHS Region 9,1 wk ahead,4.7
+2013,2,2012/2013,54,HHS Region 9,2 wk ahead,5.6
+2013,2,2012/2013,54,HHS Region 9,3 wk ahead,5.5
+2013,2,2012/2013,54,HHS Region 9,4 wk ahead,5
+2013,2,2012/2013,54,HHS Region 10,Season onset,50
+2013,2,2012/2013,54,HHS Region 10,Season peak week,4
+2013,2,2012/2013,54,HHS Region 10,Season peak percentage,3.7
+2013,2,2012/2013,54,HHS Region 10,1 wk ahead,3
+2013,2,2012/2013,54,HHS Region 10,2 wk ahead,3.7
+2013,2,2012/2013,54,HHS Region 10,3 wk ahead,2.8
+2013,2,2012/2013,54,HHS Region 10,4 wk ahead,2.4
+2013,3,2012/2013,55,US National,Season onset,47
+2013,3,2012/2013,55,US National,Season peak week,52
+2013,3,2012/2013,55,US National,Season peak percentage,6.1
+2013,3,2012/2013,55,US National,1 wk ahead,4.2
+2013,3,2012/2013,55,US National,2 wk ahead,3.8
+2013,3,2012/2013,55,US National,3 wk ahead,3.3
+2013,3,2012/2013,55,US National,4 wk ahead,3
+2013,3,2012/2013,55,HHS Region 1,Season onset,49
+2013,3,2012/2013,55,HHS Region 1,Season peak week,52
+2013,3,2012/2013,55,HHS Region 1,Season peak percentage,3.9
+2013,3,2012/2013,55,HHS Region 1,1 wk ahead,2.5
+2013,3,2012/2013,55,HHS Region 1,2 wk ahead,2.2
+2013,3,2012/2013,55,HHS Region 1,3 wk ahead,1.9
+2013,3,2012/2013,55,HHS Region 1,4 wk ahead,1.6
+2013,3,2012/2013,55,HHS Region 2,Season onset,48
+2013,3,2012/2013,55,HHS Region 2,Season peak week,52
+2013,3,2012/2013,55,HHS Region 2,Season peak percentage,5.5
+2013,3,2012/2013,55,HHS Region 2,1 wk ahead,4.6
+2013,3,2012/2013,55,HHS Region 2,2 wk ahead,3.8
+2013,3,2012/2013,55,HHS Region 2,3 wk ahead,3.6
+2013,3,2012/2013,55,HHS Region 2,4 wk ahead,3.7
+2013,3,2012/2013,55,HHS Region 3,Season onset,49
+2013,3,2012/2013,55,HHS Region 3,Season peak week,52
+2013,3,2012/2013,55,HHS Region 3,Season peak percentage,7.1
+2013,3,2012/2013,55,HHS Region 3,1 wk ahead,3.6
+2013,3,2012/2013,55,HHS Region 3,2 wk ahead,3.1
+2013,3,2012/2013,55,HHS Region 3,3 wk ahead,2.6
+2013,3,2012/2013,55,HHS Region 3,4 wk ahead,2.8
+2013,3,2012/2013,55,HHS Region 4,Season onset,47
+2013,3,2012/2013,55,HHS Region 4,Season peak week,52
+2013,3,2012/2013,55,HHS Region 4,Season peak percentage,6.3
+2013,3,2012/2013,55,HHS Region 4,1 wk ahead,2.5
+2013,3,2012/2013,55,HHS Region 4,2 wk ahead,2.5
+2013,3,2012/2013,55,HHS Region 4,3 wk ahead,2.3
+2013,3,2012/2013,55,HHS Region 4,4 wk ahead,2.2
+2013,3,2012/2013,55,HHS Region 5,Season onset,47
+2013,3,2012/2013,55,HHS Region 5,Season peak week,52
+2013,3,2012/2013,55,HHS Region 5,Season peak percentage,5.7
+2013,3,2012/2013,55,HHS Region 5,1 wk ahead,3.3
+2013,3,2012/2013,55,HHS Region 5,2 wk ahead,3
+2013,3,2012/2013,55,HHS Region 5,3 wk ahead,2.7
+2013,3,2012/2013,55,HHS Region 5,4 wk ahead,2.4
+2013,3,2012/2013,55,HHS Region 6,Season onset,47
+2013,3,2012/2013,55,HHS Region 6,Season peak week,52
+2013,3,2012/2013,55,HHS Region 6,Season peak percentage,9.3
+2013,3,2012/2013,55,HHS Region 6,1 wk ahead,7.1
+2013,3,2012/2013,55,HHS Region 6,2 wk ahead,5.8
+2013,3,2012/2013,55,HHS Region 6,3 wk ahead,4.5
+2013,3,2012/2013,55,HHS Region 6,4 wk ahead,3.9
+2013,3,2012/2013,55,HHS Region 7,Season onset,47
+2013,3,2012/2013,55,HHS Region 7,Season peak week,52
+2013,3,2012/2013,55,HHS Region 7,Season peak percentage,6.7
+2013,3,2012/2013,55,HHS Region 7,1 wk ahead,5.3
+2013,3,2012/2013,55,HHS Region 7,2 wk ahead,5.2
+2013,3,2012/2013,55,HHS Region 7,3 wk ahead,4.3
+2013,3,2012/2013,55,HHS Region 7,4 wk ahead,3.4
+2013,3,2012/2013,55,HHS Region 8,Season onset,50
+2013,3,2012/2013,55,HHS Region 8,Season peak week,52
+2013,3,2012/2013,55,HHS Region 8,Season peak week,3
+2013,3,2012/2013,55,HHS Region 8,Season peak percentage,4.1
+2013,3,2012/2013,55,HHS Region 8,1 wk ahead,4
+2013,3,2012/2013,55,HHS Region 8,2 wk ahead,3.4
+2013,3,2012/2013,55,HHS Region 8,3 wk ahead,3
+2013,3,2012/2013,55,HHS Region 8,4 wk ahead,2.6
+2013,3,2012/2013,55,HHS Region 9,Season onset,2
+2013,3,2012/2013,55,HHS Region 9,Season peak week,4
+2013,3,2012/2013,55,HHS Region 9,Season peak percentage,5.6
+2013,3,2012/2013,55,HHS Region 9,1 wk ahead,5.6
+2013,3,2012/2013,55,HHS Region 9,2 wk ahead,5.5
+2013,3,2012/2013,55,HHS Region 9,3 wk ahead,5
+2013,3,2012/2013,55,HHS Region 9,4 wk ahead,4.5
+2013,3,2012/2013,55,HHS Region 10,Season onset,50
+2013,3,2012/2013,55,HHS Region 10,Season peak week,4
+2013,3,2012/2013,55,HHS Region 10,Season peak percentage,3.7
+2013,3,2012/2013,55,HHS Region 10,1 wk ahead,3.7
+2013,3,2012/2013,55,HHS Region 10,2 wk ahead,2.8
+2013,3,2012/2013,55,HHS Region 10,3 wk ahead,2.4
+2013,3,2012/2013,55,HHS Region 10,4 wk ahead,2.1
+2013,4,2012/2013,56,US National,Season onset,47
+2013,4,2012/2013,56,US National,Season peak week,52
+2013,4,2012/2013,56,US National,Season peak percentage,6.1
+2013,4,2012/2013,56,US National,1 wk ahead,3.8
+2013,4,2012/2013,56,US National,2 wk ahead,3.3
+2013,4,2012/2013,56,US National,3 wk ahead,3
+2013,4,2012/2013,56,US National,4 wk ahead,2.7
+2013,4,2012/2013,56,HHS Region 1,Season onset,49
+2013,4,2012/2013,56,HHS Region 1,Season peak week,52
+2013,4,2012/2013,56,HHS Region 1,Season peak percentage,3.9
+2013,4,2012/2013,56,HHS Region 1,1 wk ahead,2.2
+2013,4,2012/2013,56,HHS Region 1,2 wk ahead,1.9
+2013,4,2012/2013,56,HHS Region 1,3 wk ahead,1.6
+2013,4,2012/2013,56,HHS Region 1,4 wk ahead,1.5
+2013,4,2012/2013,56,HHS Region 2,Season onset,48
+2013,4,2012/2013,56,HHS Region 2,Season peak week,52
+2013,4,2012/2013,56,HHS Region 2,Season peak percentage,5.5
+2013,4,2012/2013,56,HHS Region 2,1 wk ahead,3.8
+2013,4,2012/2013,56,HHS Region 2,2 wk ahead,3.6
+2013,4,2012/2013,56,HHS Region 2,3 wk ahead,3.7
+2013,4,2012/2013,56,HHS Region 2,4 wk ahead,3.4
+2013,4,2012/2013,56,HHS Region 3,Season onset,49
+2013,4,2012/2013,56,HHS Region 3,Season peak week,52
+2013,4,2012/2013,56,HHS Region 3,Season peak percentage,7.1
+2013,4,2012/2013,56,HHS Region 3,1 wk ahead,3.1
+2013,4,2012/2013,56,HHS Region 3,2 wk ahead,2.6
+2013,4,2012/2013,56,HHS Region 3,3 wk ahead,2.8
+2013,4,2012/2013,56,HHS Region 3,4 wk ahead,2.6
+2013,4,2012/2013,56,HHS Region 4,Season onset,47
+2013,4,2012/2013,56,HHS Region 4,Season peak week,52
+2013,4,2012/2013,56,HHS Region 4,Season peak percentage,6.3
+2013,4,2012/2013,56,HHS Region 4,1 wk ahead,2.5
+2013,4,2012/2013,56,HHS Region 4,2 wk ahead,2.3
+2013,4,2012/2013,56,HHS Region 4,3 wk ahead,2.2
+2013,4,2012/2013,56,HHS Region 4,4 wk ahead,2
+2013,4,2012/2013,56,HHS Region 5,Season onset,47
+2013,4,2012/2013,56,HHS Region 5,Season peak week,52
+2013,4,2012/2013,56,HHS Region 5,Season peak percentage,5.7
+2013,4,2012/2013,56,HHS Region 5,1 wk ahead,3
+2013,4,2012/2013,56,HHS Region 5,2 wk ahead,2.7
+2013,4,2012/2013,56,HHS Region 5,3 wk ahead,2.4
+2013,4,2012/2013,56,HHS Region 5,4 wk ahead,2.3
+2013,4,2012/2013,56,HHS Region 6,Season onset,47
+2013,4,2012/2013,56,HHS Region 6,Season peak week,52
+2013,4,2012/2013,56,HHS Region 6,Season peak percentage,9.3
+2013,4,2012/2013,56,HHS Region 6,1 wk ahead,5.8
+2013,4,2012/2013,56,HHS Region 6,2 wk ahead,4.5
+2013,4,2012/2013,56,HHS Region 6,3 wk ahead,3.9
+2013,4,2012/2013,56,HHS Region 6,4 wk ahead,3.3
+2013,4,2012/2013,56,HHS Region 7,Season onset,47
+2013,4,2012/2013,56,HHS Region 7,Season peak week,52
+2013,4,2012/2013,56,HHS Region 7,Season peak percentage,6.7
+2013,4,2012/2013,56,HHS Region 7,1 wk ahead,5.2
+2013,4,2012/2013,56,HHS Region 7,2 wk ahead,4.3
+2013,4,2012/2013,56,HHS Region 7,3 wk ahead,3.4
+2013,4,2012/2013,56,HHS Region 7,4 wk ahead,3.1
+2013,4,2012/2013,56,HHS Region 8,Season onset,50
+2013,4,2012/2013,56,HHS Region 8,Season peak week,52
+2013,4,2012/2013,56,HHS Region 8,Season peak week,3
+2013,4,2012/2013,56,HHS Region 8,Season peak percentage,4.1
+2013,4,2012/2013,56,HHS Region 8,1 wk ahead,3.4
+2013,4,2012/2013,56,HHS Region 8,2 wk ahead,3
+2013,4,2012/2013,56,HHS Region 8,3 wk ahead,2.6
+2013,4,2012/2013,56,HHS Region 8,4 wk ahead,2.2
+2013,4,2012/2013,56,HHS Region 9,Season onset,2
+2013,4,2012/2013,56,HHS Region 9,Season peak week,4
+2013,4,2012/2013,56,HHS Region 9,Season peak percentage,5.6
+2013,4,2012/2013,56,HHS Region 9,1 wk ahead,5.5
+2013,4,2012/2013,56,HHS Region 9,2 wk ahead,5
+2013,4,2012/2013,56,HHS Region 9,3 wk ahead,4.5
+2013,4,2012/2013,56,HHS Region 9,4 wk ahead,3.8
+2013,4,2012/2013,56,HHS Region 10,Season onset,50
+2013,4,2012/2013,56,HHS Region 10,Season peak week,4
+2013,4,2012/2013,56,HHS Region 10,Season peak percentage,3.7
+2013,4,2012/2013,56,HHS Region 10,1 wk ahead,2.8
+2013,4,2012/2013,56,HHS Region 10,2 wk ahead,2.4
+2013,4,2012/2013,56,HHS Region 10,3 wk ahead,2.1
+2013,4,2012/2013,56,HHS Region 10,4 wk ahead,1.9
+2013,5,2012/2013,57,US National,Season onset,47
+2013,5,2012/2013,57,US National,Season peak week,52
+2013,5,2012/2013,57,US National,Season peak percentage,6.1
+2013,5,2012/2013,57,US National,1 wk ahead,3.3
+2013,5,2012/2013,57,US National,2 wk ahead,3
+2013,5,2012/2013,57,US National,3 wk ahead,2.7
+2013,5,2012/2013,57,US National,4 wk ahead,2.5
+2013,5,2012/2013,57,HHS Region 1,Season onset,49
+2013,5,2012/2013,57,HHS Region 1,Season peak week,52
+2013,5,2012/2013,57,HHS Region 1,Season peak percentage,3.9
+2013,5,2012/2013,57,HHS Region 1,1 wk ahead,1.9
+2013,5,2012/2013,57,HHS Region 1,2 wk ahead,1.6
+2013,5,2012/2013,57,HHS Region 1,3 wk ahead,1.5
+2013,5,2012/2013,57,HHS Region 1,4 wk ahead,1.3
+2013,5,2012/2013,57,HHS Region 2,Season onset,48
+2013,5,2012/2013,57,HHS Region 2,Season peak week,52
+2013,5,2012/2013,57,HHS Region 2,Season peak percentage,5.5
+2013,5,2012/2013,57,HHS Region 2,1 wk ahead,3.6
+2013,5,2012/2013,57,HHS Region 2,2 wk ahead,3.7
+2013,5,2012/2013,57,HHS Region 2,3 wk ahead,3.4
+2013,5,2012/2013,57,HHS Region 2,4 wk ahead,2.8
+2013,5,2012/2013,57,HHS Region 3,Season onset,49
+2013,5,2012/2013,57,HHS Region 3,Season peak week,52
+2013,5,2012/2013,57,HHS Region 3,Season peak percentage,7.1
+2013,5,2012/2013,57,HHS Region 3,1 wk ahead,2.6
+2013,5,2012/2013,57,HHS Region 3,2 wk ahead,2.8
+2013,5,2012/2013,57,HHS Region 3,3 wk ahead,2.6
+2013,5,2012/2013,57,HHS Region 3,4 wk ahead,2.6
+2013,5,2012/2013,57,HHS Region 4,Season onset,47
+2013,5,2012/2013,57,HHS Region 4,Season peak week,52
+2013,5,2012/2013,57,HHS Region 4,Season peak percentage,6.3
+2013,5,2012/2013,57,HHS Region 4,1 wk ahead,2.3
+2013,5,2012/2013,57,HHS Region 4,2 wk ahead,2.2
+2013,5,2012/2013,57,HHS Region 4,3 wk ahead,2
+2013,5,2012/2013,57,HHS Region 4,4 wk ahead,1.9
+2013,5,2012/2013,57,HHS Region 5,Season onset,47
+2013,5,2012/2013,57,HHS Region 5,Season peak week,52
+2013,5,2012/2013,57,HHS Region 5,Season peak percentage,5.7
+2013,5,2012/2013,57,HHS Region 5,1 wk ahead,2.7
+2013,5,2012/2013,57,HHS Region 5,2 wk ahead,2.4
+2013,5,2012/2013,57,HHS Region 5,3 wk ahead,2.3
+2013,5,2012/2013,57,HHS Region 5,4 wk ahead,2.1
+2013,5,2012/2013,57,HHS Region 6,Season onset,47
+2013,5,2012/2013,57,HHS Region 6,Season peak week,52
+2013,5,2012/2013,57,HHS Region 6,Season peak percentage,9.3
+2013,5,2012/2013,57,HHS Region 6,1 wk ahead,4.5
+2013,5,2012/2013,57,HHS Region 6,2 wk ahead,3.9
+2013,5,2012/2013,57,HHS Region 6,3 wk ahead,3.3
+2013,5,2012/2013,57,HHS Region 6,4 wk ahead,3.2
+2013,5,2012/2013,57,HHS Region 7,Season onset,47
+2013,5,2012/2013,57,HHS Region 7,Season peak week,52
+2013,5,2012/2013,57,HHS Region 7,Season peak percentage,6.7
+2013,5,2012/2013,57,HHS Region 7,1 wk ahead,4.3
+2013,5,2012/2013,57,HHS Region 7,2 wk ahead,3.4
+2013,5,2012/2013,57,HHS Region 7,3 wk ahead,3.1
+2013,5,2012/2013,57,HHS Region 7,4 wk ahead,2.4
+2013,5,2012/2013,57,HHS Region 8,Season onset,50
+2013,5,2012/2013,57,HHS Region 8,Season peak week,52
+2013,5,2012/2013,57,HHS Region 8,Season peak week,3
+2013,5,2012/2013,57,HHS Region 8,Season peak percentage,4.1
+2013,5,2012/2013,57,HHS Region 8,1 wk ahead,3
+2013,5,2012/2013,57,HHS Region 8,2 wk ahead,2.6
+2013,5,2012/2013,57,HHS Region 8,3 wk ahead,2.2
+2013,5,2012/2013,57,HHS Region 8,4 wk ahead,2.1
+2013,5,2012/2013,57,HHS Region 9,Season onset,2
+2013,5,2012/2013,57,HHS Region 9,Season peak week,4
+2013,5,2012/2013,57,HHS Region 9,Season peak percentage,5.6
+2013,5,2012/2013,57,HHS Region 9,1 wk ahead,5
+2013,5,2012/2013,57,HHS Region 9,2 wk ahead,4.5
+2013,5,2012/2013,57,HHS Region 9,3 wk ahead,3.8
+2013,5,2012/2013,57,HHS Region 9,4 wk ahead,3.5
+2013,5,2012/2013,57,HHS Region 10,Season onset,50
+2013,5,2012/2013,57,HHS Region 10,Season peak week,4
+2013,5,2012/2013,57,HHS Region 10,Season peak percentage,3.7
+2013,5,2012/2013,57,HHS Region 10,1 wk ahead,2.4
+2013,5,2012/2013,57,HHS Region 10,2 wk ahead,2.1
+2013,5,2012/2013,57,HHS Region 10,3 wk ahead,1.9
+2013,5,2012/2013,57,HHS Region 10,4 wk ahead,1.4
+2013,6,2012/2013,58,US National,Season onset,47
+2013,6,2012/2013,58,US National,Season peak week,52
+2013,6,2012/2013,58,US National,Season peak percentage,6.1
+2013,6,2012/2013,58,US National,1 wk ahead,3
+2013,6,2012/2013,58,US National,2 wk ahead,2.7
+2013,6,2012/2013,58,US National,3 wk ahead,2.5
+2013,6,2012/2013,58,US National,4 wk ahead,2.6
+2013,6,2012/2013,58,HHS Region 1,Season onset,49
+2013,6,2012/2013,58,HHS Region 1,Season peak week,52
+2013,6,2012/2013,58,HHS Region 1,Season peak percentage,3.9
+2013,6,2012/2013,58,HHS Region 1,1 wk ahead,1.6
+2013,6,2012/2013,58,HHS Region 1,2 wk ahead,1.5
+2013,6,2012/2013,58,HHS Region 1,3 wk ahead,1.3
+2013,6,2012/2013,58,HHS Region 1,4 wk ahead,1.3
+2013,6,2012/2013,58,HHS Region 2,Season onset,48
+2013,6,2012/2013,58,HHS Region 2,Season peak week,52
+2013,6,2012/2013,58,HHS Region 2,Season peak percentage,5.5
+2013,6,2012/2013,58,HHS Region 2,1 wk ahead,3.7
+2013,6,2012/2013,58,HHS Region 2,2 wk ahead,3.4
+2013,6,2012/2013,58,HHS Region 2,3 wk ahead,2.8
+2013,6,2012/2013,58,HHS Region 2,4 wk ahead,3
+2013,6,2012/2013,58,HHS Region 3,Season onset,49
+2013,6,2012/2013,58,HHS Region 3,Season peak week,52
+2013,6,2012/2013,58,HHS Region 3,Season peak percentage,7.1
+2013,6,2012/2013,58,HHS Region 3,1 wk ahead,2.8
+2013,6,2012/2013,58,HHS Region 3,2 wk ahead,2.6
+2013,6,2012/2013,58,HHS Region 3,3 wk ahead,2.6
+2013,6,2012/2013,58,HHS Region 3,4 wk ahead,3.3
+2013,6,2012/2013,58,HHS Region 4,Season onset,47
+2013,6,2012/2013,58,HHS Region 4,Season peak week,52
+2013,6,2012/2013,58,HHS Region 4,Season peak percentage,6.3
+2013,6,2012/2013,58,HHS Region 4,1 wk ahead,2.2
+2013,6,2012/2013,58,HHS Region 4,2 wk ahead,2
+2013,6,2012/2013,58,HHS Region 4,3 wk ahead,1.9
+2013,6,2012/2013,58,HHS Region 4,4 wk ahead,2.2
+2013,6,2012/2013,58,HHS Region 5,Season onset,47
+2013,6,2012/2013,58,HHS Region 5,Season peak week,52
+2013,6,2012/2013,58,HHS Region 5,Season peak percentage,5.7
+2013,6,2012/2013,58,HHS Region 5,1 wk ahead,2.4
+2013,6,2012/2013,58,HHS Region 5,2 wk ahead,2.3
+2013,6,2012/2013,58,HHS Region 5,3 wk ahead,2.1
+2013,6,2012/2013,58,HHS Region 5,4 wk ahead,2
+2013,6,2012/2013,58,HHS Region 6,Season onset,47
+2013,6,2012/2013,58,HHS Region 6,Season peak week,52
+2013,6,2012/2013,58,HHS Region 6,Season peak percentage,9.3
+2013,6,2012/2013,58,HHS Region 6,1 wk ahead,3.9
+2013,6,2012/2013,58,HHS Region 6,2 wk ahead,3.3
+2013,6,2012/2013,58,HHS Region 6,3 wk ahead,3.2
+2013,6,2012/2013,58,HHS Region 6,4 wk ahead,3.1
+2013,6,2012/2013,58,HHS Region 7,Season onset,47
+2013,6,2012/2013,58,HHS Region 7,Season peak week,52
+2013,6,2012/2013,58,HHS Region 7,Season peak percentage,6.7
+2013,6,2012/2013,58,HHS Region 7,1 wk ahead,3.4
+2013,6,2012/2013,58,HHS Region 7,2 wk ahead,3.1
+2013,6,2012/2013,58,HHS Region 7,3 wk ahead,2.4
+2013,6,2012/2013,58,HHS Region 7,4 wk ahead,2.3
+2013,6,2012/2013,58,HHS Region 8,Season onset,50
+2013,6,2012/2013,58,HHS Region 8,Season peak week,52
+2013,6,2012/2013,58,HHS Region 8,Season peak week,3
+2013,6,2012/2013,58,HHS Region 8,Season peak percentage,4.1
+2013,6,2012/2013,58,HHS Region 8,1 wk ahead,2.6
+2013,6,2012/2013,58,HHS Region 8,2 wk ahead,2.2
+2013,6,2012/2013,58,HHS Region 8,3 wk ahead,2.1
+2013,6,2012/2013,58,HHS Region 8,4 wk ahead,1.8
+2013,6,2012/2013,58,HHS Region 9,Season onset,2
+2013,6,2012/2013,58,HHS Region 9,Season peak week,4
+2013,6,2012/2013,58,HHS Region 9,Season peak percentage,5.6
+2013,6,2012/2013,58,HHS Region 9,1 wk ahead,4.5
+2013,6,2012/2013,58,HHS Region 9,2 wk ahead,3.8
+2013,6,2012/2013,58,HHS Region 9,3 wk ahead,3.5
+2013,6,2012/2013,58,HHS Region 9,4 wk ahead,3.6
+2013,6,2012/2013,58,HHS Region 10,Season onset,50
+2013,6,2012/2013,58,HHS Region 10,Season peak week,4
+2013,6,2012/2013,58,HHS Region 10,Season peak percentage,3.7
+2013,6,2012/2013,58,HHS Region 10,1 wk ahead,2.1
+2013,6,2012/2013,58,HHS Region 10,2 wk ahead,1.9
+2013,6,2012/2013,58,HHS Region 10,3 wk ahead,1.4
+2013,6,2012/2013,58,HHS Region 10,4 wk ahead,1
+2013,7,2012/2013,59,US National,Season onset,47
+2013,7,2012/2013,59,US National,Season peak week,52
+2013,7,2012/2013,59,US National,Season peak percentage,6.1
+2013,7,2012/2013,59,US National,1 wk ahead,2.7
+2013,7,2012/2013,59,US National,2 wk ahead,2.5
+2013,7,2012/2013,59,US National,3 wk ahead,2.6
+2013,7,2012/2013,59,US National,4 wk ahead,2.4
+2013,7,2012/2013,59,HHS Region 1,Season onset,49
+2013,7,2012/2013,59,HHS Region 1,Season peak week,52
+2013,7,2012/2013,59,HHS Region 1,Season peak percentage,3.9
+2013,7,2012/2013,59,HHS Region 1,1 wk ahead,1.5
+2013,7,2012/2013,59,HHS Region 1,2 wk ahead,1.3
+2013,7,2012/2013,59,HHS Region 1,3 wk ahead,1.3
+2013,7,2012/2013,59,HHS Region 1,4 wk ahead,1.2
+2013,7,2012/2013,59,HHS Region 2,Season onset,48
+2013,7,2012/2013,59,HHS Region 2,Season peak week,52
+2013,7,2012/2013,59,HHS Region 2,Season peak percentage,5.5
+2013,7,2012/2013,59,HHS Region 2,1 wk ahead,3.4
+2013,7,2012/2013,59,HHS Region 2,2 wk ahead,2.8
+2013,7,2012/2013,59,HHS Region 2,3 wk ahead,3
+2013,7,2012/2013,59,HHS Region 2,4 wk ahead,2.9
+2013,7,2012/2013,59,HHS Region 3,Season onset,49
+2013,7,2012/2013,59,HHS Region 3,Season peak week,52
+2013,7,2012/2013,59,HHS Region 3,Season peak percentage,7.1
+2013,7,2012/2013,59,HHS Region 3,1 wk ahead,2.6
+2013,7,2012/2013,59,HHS Region 3,2 wk ahead,2.6
+2013,7,2012/2013,59,HHS Region 3,3 wk ahead,3.3
+2013,7,2012/2013,59,HHS Region 3,4 wk ahead,2.6
+2013,7,2012/2013,59,HHS Region 4,Season onset,47
+2013,7,2012/2013,59,HHS Region 4,Season peak week,52
+2013,7,2012/2013,59,HHS Region 4,Season peak percentage,6.3
+2013,7,2012/2013,59,HHS Region 4,1 wk ahead,2
+2013,7,2012/2013,59,HHS Region 4,2 wk ahead,1.9
+2013,7,2012/2013,59,HHS Region 4,3 wk ahead,2.2
+2013,7,2012/2013,59,HHS Region 4,4 wk ahead,2
+2013,7,2012/2013,59,HHS Region 5,Season onset,47
+2013,7,2012/2013,59,HHS Region 5,Season peak week,52
+2013,7,2012/2013,59,HHS Region 5,Season peak percentage,5.7
+2013,7,2012/2013,59,HHS Region 5,1 wk ahead,2.3
+2013,7,2012/2013,59,HHS Region 5,2 wk ahead,2.1
+2013,7,2012/2013,59,HHS Region 5,3 wk ahead,2
+2013,7,2012/2013,59,HHS Region 5,4 wk ahead,2.1
+2013,7,2012/2013,59,HHS Region 6,Season onset,47
+2013,7,2012/2013,59,HHS Region 6,Season peak week,52
+2013,7,2012/2013,59,HHS Region 6,Season peak percentage,9.3
+2013,7,2012/2013,59,HHS Region 6,1 wk ahead,3.3
+2013,7,2012/2013,59,HHS Region 6,2 wk ahead,3.2
+2013,7,2012/2013,59,HHS Region 6,3 wk ahead,3.1
+2013,7,2012/2013,59,HHS Region 6,4 wk ahead,3
+2013,7,2012/2013,59,HHS Region 7,Season onset,47
+2013,7,2012/2013,59,HHS Region 7,Season peak week,52
+2013,7,2012/2013,59,HHS Region 7,Season peak percentage,6.7
+2013,7,2012/2013,59,HHS Region 7,1 wk ahead,3.1
+2013,7,2012/2013,59,HHS Region 7,2 wk ahead,2.4
+2013,7,2012/2013,59,HHS Region 7,3 wk ahead,2.3
+2013,7,2012/2013,59,HHS Region 7,4 wk ahead,1.9
+2013,7,2012/2013,59,HHS Region 8,Season onset,50
+2013,7,2012/2013,59,HHS Region 8,Season peak week,52
+2013,7,2012/2013,59,HHS Region 8,Season peak week,3
+2013,7,2012/2013,59,HHS Region 8,Season peak percentage,4.1
+2013,7,2012/2013,59,HHS Region 8,1 wk ahead,2.2
+2013,7,2012/2013,59,HHS Region 8,2 wk ahead,2.1
+2013,7,2012/2013,59,HHS Region 8,3 wk ahead,1.8
+2013,7,2012/2013,59,HHS Region 8,4 wk ahead,1.8
+2013,7,2012/2013,59,HHS Region 9,Season onset,2
+2013,7,2012/2013,59,HHS Region 9,Season peak week,4
+2013,7,2012/2013,59,HHS Region 9,Season peak percentage,5.6
+2013,7,2012/2013,59,HHS Region 9,1 wk ahead,3.8
+2013,7,2012/2013,59,HHS Region 9,2 wk ahead,3.5
+2013,7,2012/2013,59,HHS Region 9,3 wk ahead,3.6
+2013,7,2012/2013,59,HHS Region 9,4 wk ahead,3.1
+2013,7,2012/2013,59,HHS Region 10,Season onset,50
+2013,7,2012/2013,59,HHS Region 10,Season peak week,4
+2013,7,2012/2013,59,HHS Region 10,Season peak percentage,3.7
+2013,7,2012/2013,59,HHS Region 10,1 wk ahead,1.9
+2013,7,2012/2013,59,HHS Region 10,2 wk ahead,1.4
+2013,7,2012/2013,59,HHS Region 10,3 wk ahead,1
+2013,7,2012/2013,59,HHS Region 10,4 wk ahead,1.1
+2013,8,2012/2013,60,US National,Season onset,47
+2013,8,2012/2013,60,US National,Season peak week,52
+2013,8,2012/2013,60,US National,Season peak percentage,6.1
+2013,8,2012/2013,60,US National,1 wk ahead,2.5
+2013,8,2012/2013,60,US National,2 wk ahead,2.6
+2013,8,2012/2013,60,US National,3 wk ahead,2.4
+2013,8,2012/2013,60,US National,4 wk ahead,2.1
+2013,8,2012/2013,60,HHS Region 1,Season onset,49
+2013,8,2012/2013,60,HHS Region 1,Season peak week,52
+2013,8,2012/2013,60,HHS Region 1,Season peak percentage,3.9
+2013,8,2012/2013,60,HHS Region 1,1 wk ahead,1.3
+2013,8,2012/2013,60,HHS Region 1,2 wk ahead,1.3
+2013,8,2012/2013,60,HHS Region 1,3 wk ahead,1.2
+2013,8,2012/2013,60,HHS Region 1,4 wk ahead,1.2
+2013,8,2012/2013,60,HHS Region 2,Season onset,48
+2013,8,2012/2013,60,HHS Region 2,Season peak week,52
+2013,8,2012/2013,60,HHS Region 2,Season peak percentage,5.5
+2013,8,2012/2013,60,HHS Region 2,1 wk ahead,2.8
+2013,8,2012/2013,60,HHS Region 2,2 wk ahead,3
+2013,8,2012/2013,60,HHS Region 2,3 wk ahead,2.9
+2013,8,2012/2013,60,HHS Region 2,4 wk ahead,2.5
+2013,8,2012/2013,60,HHS Region 3,Season onset,49
+2013,8,2012/2013,60,HHS Region 3,Season peak week,52
+2013,8,2012/2013,60,HHS Region 3,Season peak percentage,7.1
+2013,8,2012/2013,60,HHS Region 3,1 wk ahead,2.6
+2013,8,2012/2013,60,HHS Region 3,2 wk ahead,3.3
+2013,8,2012/2013,60,HHS Region 3,3 wk ahead,2.6
+2013,8,2012/2013,60,HHS Region 3,4 wk ahead,2.2
+2013,8,2012/2013,60,HHS Region 4,Season onset,47
+2013,8,2012/2013,60,HHS Region 4,Season peak week,52
+2013,8,2012/2013,60,HHS Region 4,Season peak percentage,6.3
+2013,8,2012/2013,60,HHS Region 4,1 wk ahead,1.9
+2013,8,2012/2013,60,HHS Region 4,2 wk ahead,2.2
+2013,8,2012/2013,60,HHS Region 4,3 wk ahead,2
+2013,8,2012/2013,60,HHS Region 4,4 wk ahead,1.8
+2013,8,2012/2013,60,HHS Region 5,Season onset,47
+2013,8,2012/2013,60,HHS Region 5,Season peak week,52
+2013,8,2012/2013,60,HHS Region 5,Season peak percentage,5.7
+2013,8,2012/2013,60,HHS Region 5,1 wk ahead,2.1
+2013,8,2012/2013,60,HHS Region 5,2 wk ahead,2
+2013,8,2012/2013,60,HHS Region 5,3 wk ahead,2.1
+2013,8,2012/2013,60,HHS Region 5,4 wk ahead,1.8
+2013,8,2012/2013,60,HHS Region 6,Season onset,47
+2013,8,2012/2013,60,HHS Region 6,Season peak week,52
+2013,8,2012/2013,60,HHS Region 6,Season peak percentage,9.3
+2013,8,2012/2013,60,HHS Region 6,1 wk ahead,3.2
+2013,8,2012/2013,60,HHS Region 6,2 wk ahead,3.1
+2013,8,2012/2013,60,HHS Region 6,3 wk ahead,3
+2013,8,2012/2013,60,HHS Region 6,4 wk ahead,2.6
+2013,8,2012/2013,60,HHS Region 7,Season onset,47
+2013,8,2012/2013,60,HHS Region 7,Season peak week,52
+2013,8,2012/2013,60,HHS Region 7,Season peak percentage,6.7
+2013,8,2012/2013,60,HHS Region 7,1 wk ahead,2.4
+2013,8,2012/2013,60,HHS Region 7,2 wk ahead,2.3
+2013,8,2012/2013,60,HHS Region 7,3 wk ahead,1.9
+2013,8,2012/2013,60,HHS Region 7,4 wk ahead,1.5
+2013,8,2012/2013,60,HHS Region 8,Season onset,50
+2013,8,2012/2013,60,HHS Region 8,Season peak week,52
+2013,8,2012/2013,60,HHS Region 8,Season peak week,3
+2013,8,2012/2013,60,HHS Region 8,Season peak percentage,4.1
+2013,8,2012/2013,60,HHS Region 8,1 wk ahead,2.1
+2013,8,2012/2013,60,HHS Region 8,2 wk ahead,1.8
+2013,8,2012/2013,60,HHS Region 8,3 wk ahead,1.8
+2013,8,2012/2013,60,HHS Region 8,4 wk ahead,1.2
+2013,8,2012/2013,60,HHS Region 9,Season onset,2
+2013,8,2012/2013,60,HHS Region 9,Season peak week,4
+2013,8,2012/2013,60,HHS Region 9,Season peak percentage,5.6
+2013,8,2012/2013,60,HHS Region 9,1 wk ahead,3.5
+2013,8,2012/2013,60,HHS Region 9,2 wk ahead,3.6
+2013,8,2012/2013,60,HHS Region 9,3 wk ahead,3.1
+2013,8,2012/2013,60,HHS Region 9,4 wk ahead,2.9
+2013,8,2012/2013,60,HHS Region 10,Season onset,50
+2013,8,2012/2013,60,HHS Region 10,Season peak week,4
+2013,8,2012/2013,60,HHS Region 10,Season peak percentage,3.7
+2013,8,2012/2013,60,HHS Region 10,1 wk ahead,1.4
+2013,8,2012/2013,60,HHS Region 10,2 wk ahead,1
+2013,8,2012/2013,60,HHS Region 10,3 wk ahead,1.1
+2013,8,2012/2013,60,HHS Region 10,4 wk ahead,0.7
+2013,9,2012/2013,61,US National,Season onset,47
+2013,9,2012/2013,61,US National,Season peak week,52
+2013,9,2012/2013,61,US National,Season peak percentage,6.1
+2013,9,2012/2013,61,US National,1 wk ahead,2.6
+2013,9,2012/2013,61,US National,2 wk ahead,2.4
+2013,9,2012/2013,61,US National,3 wk ahead,2.1
+2013,9,2012/2013,61,US National,4 wk ahead,1.9
+2013,9,2012/2013,61,HHS Region 1,Season onset,49
+2013,9,2012/2013,61,HHS Region 1,Season peak week,52
+2013,9,2012/2013,61,HHS Region 1,Season peak percentage,3.9
+2013,9,2012/2013,61,HHS Region 1,1 wk ahead,1.3
+2013,9,2012/2013,61,HHS Region 1,2 wk ahead,1.2
+2013,9,2012/2013,61,HHS Region 1,3 wk ahead,1.2
+2013,9,2012/2013,61,HHS Region 1,4 wk ahead,1.2
+2013,9,2012/2013,61,HHS Region 2,Season onset,48
+2013,9,2012/2013,61,HHS Region 2,Season peak week,52
+2013,9,2012/2013,61,HHS Region 2,Season peak percentage,5.5
+2013,9,2012/2013,61,HHS Region 2,1 wk ahead,3
+2013,9,2012/2013,61,HHS Region 2,2 wk ahead,2.9
+2013,9,2012/2013,61,HHS Region 2,3 wk ahead,2.5
+2013,9,2012/2013,61,HHS Region 2,4 wk ahead,2.2
+2013,9,2012/2013,61,HHS Region 3,Season onset,49
+2013,9,2012/2013,61,HHS Region 3,Season peak week,52
+2013,9,2012/2013,61,HHS Region 3,Season peak percentage,7.1
+2013,9,2012/2013,61,HHS Region 3,1 wk ahead,3.3
+2013,9,2012/2013,61,HHS Region 3,2 wk ahead,2.6
+2013,9,2012/2013,61,HHS Region 3,3 wk ahead,2.2
+2013,9,2012/2013,61,HHS Region 3,4 wk ahead,2.1
+2013,9,2012/2013,61,HHS Region 4,Season onset,47
+2013,9,2012/2013,61,HHS Region 4,Season peak week,52
+2013,9,2012/2013,61,HHS Region 4,Season peak percentage,6.3
+2013,9,2012/2013,61,HHS Region 4,1 wk ahead,2.2
+2013,9,2012/2013,61,HHS Region 4,2 wk ahead,2
+2013,9,2012/2013,61,HHS Region 4,3 wk ahead,1.8
+2013,9,2012/2013,61,HHS Region 4,4 wk ahead,1.7
+2013,9,2012/2013,61,HHS Region 5,Season onset,47
+2013,9,2012/2013,61,HHS Region 5,Season peak week,52
+2013,9,2012/2013,61,HHS Region 5,Season peak percentage,5.7
+2013,9,2012/2013,61,HHS Region 5,1 wk ahead,2
+2013,9,2012/2013,61,HHS Region 5,2 wk ahead,2.1
+2013,9,2012/2013,61,HHS Region 5,3 wk ahead,1.8
+2013,9,2012/2013,61,HHS Region 5,4 wk ahead,1.6
+2013,9,2012/2013,61,HHS Region 6,Season onset,47
+2013,9,2012/2013,61,HHS Region 6,Season peak week,52
+2013,9,2012/2013,61,HHS Region 6,Season peak percentage,9.3
+2013,9,2012/2013,61,HHS Region 6,1 wk ahead,3.1
+2013,9,2012/2013,61,HHS Region 6,2 wk ahead,3
+2013,9,2012/2013,61,HHS Region 6,3 wk ahead,2.6
+2013,9,2012/2013,61,HHS Region 6,4 wk ahead,2.3
+2013,9,2012/2013,61,HHS Region 7,Season onset,47
+2013,9,2012/2013,61,HHS Region 7,Season peak week,52
+2013,9,2012/2013,61,HHS Region 7,Season peak percentage,6.7
+2013,9,2012/2013,61,HHS Region 7,1 wk ahead,2.3
+2013,9,2012/2013,61,HHS Region 7,2 wk ahead,1.9
+2013,9,2012/2013,61,HHS Region 7,3 wk ahead,1.5
+2013,9,2012/2013,61,HHS Region 7,4 wk ahead,1.5
+2013,9,2012/2013,61,HHS Region 8,Season onset,50
+2013,9,2012/2013,61,HHS Region 8,Season peak week,52
+2013,9,2012/2013,61,HHS Region 8,Season peak week,3
+2013,9,2012/2013,61,HHS Region 8,Season peak percentage,4.1
+2013,9,2012/2013,61,HHS Region 8,1 wk ahead,1.8
+2013,9,2012/2013,61,HHS Region 8,2 wk ahead,1.8
+2013,9,2012/2013,61,HHS Region 8,3 wk ahead,1.2
+2013,9,2012/2013,61,HHS Region 8,4 wk ahead,1.2
+2013,9,2012/2013,61,HHS Region 9,Season onset,2
+2013,9,2012/2013,61,HHS Region 9,Season peak week,4
+2013,9,2012/2013,61,HHS Region 9,Season peak percentage,5.6
+2013,9,2012/2013,61,HHS Region 9,1 wk ahead,3.6
+2013,9,2012/2013,61,HHS Region 9,2 wk ahead,3.1
+2013,9,2012/2013,61,HHS Region 9,3 wk ahead,2.9
+2013,9,2012/2013,61,HHS Region 9,4 wk ahead,2.6
+2013,9,2012/2013,61,HHS Region 10,Season onset,50
+2013,9,2012/2013,61,HHS Region 10,Season peak week,4
+2013,9,2012/2013,61,HHS Region 10,Season peak percentage,3.7
+2013,9,2012/2013,61,HHS Region 10,1 wk ahead,1
+2013,9,2012/2013,61,HHS Region 10,2 wk ahead,1.1
+2013,9,2012/2013,61,HHS Region 10,3 wk ahead,0.7
+2013,9,2012/2013,61,HHS Region 10,4 wk ahead,0.7
+2013,10,2012/2013,62,US National,Season onset,47
+2013,10,2012/2013,62,US National,Season peak week,52
+2013,10,2012/2013,62,US National,Season peak percentage,6.1
+2013,10,2012/2013,62,US National,1 wk ahead,2.4
+2013,10,2012/2013,62,US National,2 wk ahead,2.1
+2013,10,2012/2013,62,US National,3 wk ahead,1.9
+2013,10,2012/2013,62,US National,4 wk ahead,1.7
+2013,10,2012/2013,62,HHS Region 1,Season onset,49
+2013,10,2012/2013,62,HHS Region 1,Season peak week,52
+2013,10,2012/2013,62,HHS Region 1,Season peak percentage,3.9
+2013,10,2012/2013,62,HHS Region 1,1 wk ahead,1.2
+2013,10,2012/2013,62,HHS Region 1,2 wk ahead,1.2
+2013,10,2012/2013,62,HHS Region 1,3 wk ahead,1.2
+2013,10,2012/2013,62,HHS Region 1,4 wk ahead,1.2
+2013,10,2012/2013,62,HHS Region 2,Season onset,48
+2013,10,2012/2013,62,HHS Region 2,Season peak week,52
+2013,10,2012/2013,62,HHS Region 2,Season peak percentage,5.5
+2013,10,2012/2013,62,HHS Region 2,1 wk ahead,2.9
+2013,10,2012/2013,62,HHS Region 2,2 wk ahead,2.5
+2013,10,2012/2013,62,HHS Region 2,3 wk ahead,2.2
+2013,10,2012/2013,62,HHS Region 2,4 wk ahead,1.9
+2013,10,2012/2013,62,HHS Region 3,Season onset,49
+2013,10,2012/2013,62,HHS Region 3,Season peak week,52
+2013,10,2012/2013,62,HHS Region 3,Season peak percentage,7.1
+2013,10,2012/2013,62,HHS Region 3,1 wk ahead,2.6
+2013,10,2012/2013,62,HHS Region 3,2 wk ahead,2.2
+2013,10,2012/2013,62,HHS Region 3,3 wk ahead,2.1
+2013,10,2012/2013,62,HHS Region 3,4 wk ahead,1.7
+2013,10,2012/2013,62,HHS Region 4,Season onset,47
+2013,10,2012/2013,62,HHS Region 4,Season peak week,52
+2013,10,2012/2013,62,HHS Region 4,Season peak percentage,6.3
+2013,10,2012/2013,62,HHS Region 4,1 wk ahead,2
+2013,10,2012/2013,62,HHS Region 4,2 wk ahead,1.8
+2013,10,2012/2013,62,HHS Region 4,3 wk ahead,1.7
+2013,10,2012/2013,62,HHS Region 4,4 wk ahead,1.4
+2013,10,2012/2013,62,HHS Region 5,Season onset,47
+2013,10,2012/2013,62,HHS Region 5,Season peak week,52
+2013,10,2012/2013,62,HHS Region 5,Season peak percentage,5.7
+2013,10,2012/2013,62,HHS Region 5,1 wk ahead,2.1
+2013,10,2012/2013,62,HHS Region 5,2 wk ahead,1.8
+2013,10,2012/2013,62,HHS Region 5,3 wk ahead,1.6
+2013,10,2012/2013,62,HHS Region 5,4 wk ahead,1.4
+2013,10,2012/2013,62,HHS Region 6,Season onset,47
+2013,10,2012/2013,62,HHS Region 6,Season peak week,52
+2013,10,2012/2013,62,HHS Region 6,Season peak percentage,9.3
+2013,10,2012/2013,62,HHS Region 6,1 wk ahead,3
+2013,10,2012/2013,62,HHS Region 6,2 wk ahead,2.6
+2013,10,2012/2013,62,HHS Region 6,3 wk ahead,2.3
+2013,10,2012/2013,62,HHS Region 6,4 wk ahead,2.2
+2013,10,2012/2013,62,HHS Region 7,Season onset,47
+2013,10,2012/2013,62,HHS Region 7,Season peak week,52
+2013,10,2012/2013,62,HHS Region 7,Season peak percentage,6.7
+2013,10,2012/2013,62,HHS Region 7,1 wk ahead,1.9
+2013,10,2012/2013,62,HHS Region 7,2 wk ahead,1.5
+2013,10,2012/2013,62,HHS Region 7,3 wk ahead,1.5
+2013,10,2012/2013,62,HHS Region 7,4 wk ahead,1.1
+2013,10,2012/2013,62,HHS Region 8,Season onset,50
+2013,10,2012/2013,62,HHS Region 8,Season peak week,52
+2013,10,2012/2013,62,HHS Region 8,Season peak week,3
+2013,10,2012/2013,62,HHS Region 8,Season peak percentage,4.1
+2013,10,2012/2013,62,HHS Region 8,1 wk ahead,1.8
+2013,10,2012/2013,62,HHS Region 8,2 wk ahead,1.2
+2013,10,2012/2013,62,HHS Region 8,3 wk ahead,1.2
+2013,10,2012/2013,62,HHS Region 8,4 wk ahead,1.2
+2013,10,2012/2013,62,HHS Region 9,Season onset,2
+2013,10,2012/2013,62,HHS Region 9,Season peak week,4
+2013,10,2012/2013,62,HHS Region 9,Season peak percentage,5.6
+2013,10,2012/2013,62,HHS Region 9,1 wk ahead,3.1
+2013,10,2012/2013,62,HHS Region 9,2 wk ahead,2.9
+2013,10,2012/2013,62,HHS Region 9,3 wk ahead,2.6
+2013,10,2012/2013,62,HHS Region 9,4 wk ahead,2.2
+2013,10,2012/2013,62,HHS Region 10,Season onset,50
+2013,10,2012/2013,62,HHS Region 10,Season peak week,4
+2013,10,2012/2013,62,HHS Region 10,Season peak percentage,3.7
+2013,10,2012/2013,62,HHS Region 10,1 wk ahead,1.1
+2013,10,2012/2013,62,HHS Region 10,2 wk ahead,0.7
+2013,10,2012/2013,62,HHS Region 10,3 wk ahead,0.7
+2013,10,2012/2013,62,HHS Region 10,4 wk ahead,0.7
+2013,11,2012/2013,63,US National,Season onset,47
+2013,11,2012/2013,63,US National,Season peak week,52
+2013,11,2012/2013,63,US National,Season peak percentage,6.1
+2013,11,2012/2013,63,US National,1 wk ahead,2.1
+2013,11,2012/2013,63,US National,2 wk ahead,1.9
+2013,11,2012/2013,63,US National,3 wk ahead,1.7
+2013,11,2012/2013,63,US National,4 wk ahead,1.4
+2013,11,2012/2013,63,HHS Region 1,Season onset,49
+2013,11,2012/2013,63,HHS Region 1,Season peak week,52
+2013,11,2012/2013,63,HHS Region 1,Season peak percentage,3.9
+2013,11,2012/2013,63,HHS Region 1,1 wk ahead,1.2
+2013,11,2012/2013,63,HHS Region 1,2 wk ahead,1.2
+2013,11,2012/2013,63,HHS Region 1,3 wk ahead,1.2
+2013,11,2012/2013,63,HHS Region 1,4 wk ahead,1.2
+2013,11,2012/2013,63,HHS Region 2,Season onset,48
+2013,11,2012/2013,63,HHS Region 2,Season peak week,52
+2013,11,2012/2013,63,HHS Region 2,Season peak percentage,5.5
+2013,11,2012/2013,63,HHS Region 2,1 wk ahead,2.5
+2013,11,2012/2013,63,HHS Region 2,2 wk ahead,2.2
+2013,11,2012/2013,63,HHS Region 2,3 wk ahead,1.9
+2013,11,2012/2013,63,HHS Region 2,4 wk ahead,1.6
+2013,11,2012/2013,63,HHS Region 3,Season onset,49
+2013,11,2012/2013,63,HHS Region 3,Season peak week,52
+2013,11,2012/2013,63,HHS Region 3,Season peak percentage,7.1
+2013,11,2012/2013,63,HHS Region 3,1 wk ahead,2.2
+2013,11,2012/2013,63,HHS Region 3,2 wk ahead,2.1
+2013,11,2012/2013,63,HHS Region 3,3 wk ahead,1.7
+2013,11,2012/2013,63,HHS Region 3,4 wk ahead,1.5
+2013,11,2012/2013,63,HHS Region 4,Season onset,47
+2013,11,2012/2013,63,HHS Region 4,Season peak week,52
+2013,11,2012/2013,63,HHS Region 4,Season peak percentage,6.3
+2013,11,2012/2013,63,HHS Region 4,1 wk ahead,1.8
+2013,11,2012/2013,63,HHS Region 4,2 wk ahead,1.7
+2013,11,2012/2013,63,HHS Region 4,3 wk ahead,1.4
+2013,11,2012/2013,63,HHS Region 4,4 wk ahead,1.2
+2013,11,2012/2013,63,HHS Region 5,Season onset,47
+2013,11,2012/2013,63,HHS Region 5,Season peak week,52
+2013,11,2012/2013,63,HHS Region 5,Season peak percentage,5.7
+2013,11,2012/2013,63,HHS Region 5,1 wk ahead,1.8
+2013,11,2012/2013,63,HHS Region 5,2 wk ahead,1.6
+2013,11,2012/2013,63,HHS Region 5,3 wk ahead,1.4
+2013,11,2012/2013,63,HHS Region 5,4 wk ahead,1.2
+2013,11,2012/2013,63,HHS Region 6,Season onset,47
+2013,11,2012/2013,63,HHS Region 6,Season peak week,52
+2013,11,2012/2013,63,HHS Region 6,Season peak percentage,9.3
+2013,11,2012/2013,63,HHS Region 6,1 wk ahead,2.6
+2013,11,2012/2013,63,HHS Region 6,2 wk ahead,2.3
+2013,11,2012/2013,63,HHS Region 6,3 wk ahead,2.2
+2013,11,2012/2013,63,HHS Region 6,4 wk ahead,2
+2013,11,2012/2013,63,HHS Region 7,Season onset,47
+2013,11,2012/2013,63,HHS Region 7,Season peak week,52
+2013,11,2012/2013,63,HHS Region 7,Season peak percentage,6.7
+2013,11,2012/2013,63,HHS Region 7,1 wk ahead,1.5
+2013,11,2012/2013,63,HHS Region 7,2 wk ahead,1.5
+2013,11,2012/2013,63,HHS Region 7,3 wk ahead,1.1
+2013,11,2012/2013,63,HHS Region 7,4 wk ahead,1
+2013,11,2012/2013,63,HHS Region 8,Season onset,50
+2013,11,2012/2013,63,HHS Region 8,Season peak week,52
+2013,11,2012/2013,63,HHS Region 8,Season peak week,3
+2013,11,2012/2013,63,HHS Region 8,Season peak percentage,4.1
+2013,11,2012/2013,63,HHS Region 8,1 wk ahead,1.2
+2013,11,2012/2013,63,HHS Region 8,2 wk ahead,1.2
+2013,11,2012/2013,63,HHS Region 8,3 wk ahead,1.2
+2013,11,2012/2013,63,HHS Region 8,4 wk ahead,1
+2013,11,2012/2013,63,HHS Region 9,Season onset,2
+2013,11,2012/2013,63,HHS Region 9,Season peak week,4
+2013,11,2012/2013,63,HHS Region 9,Season peak percentage,5.6
+2013,11,2012/2013,63,HHS Region 9,1 wk ahead,2.9
+2013,11,2012/2013,63,HHS Region 9,2 wk ahead,2.6
+2013,11,2012/2013,63,HHS Region 9,3 wk ahead,2.2
+2013,11,2012/2013,63,HHS Region 9,4 wk ahead,1.9
+2013,11,2012/2013,63,HHS Region 10,Season onset,50
+2013,11,2012/2013,63,HHS Region 10,Season peak week,4
+2013,11,2012/2013,63,HHS Region 10,Season peak percentage,3.7
+2013,11,2012/2013,63,HHS Region 10,1 wk ahead,0.7
+2013,11,2012/2013,63,HHS Region 10,2 wk ahead,0.7
+2013,11,2012/2013,63,HHS Region 10,3 wk ahead,0.7
+2013,11,2012/2013,63,HHS Region 10,4 wk ahead,0.4
+2013,12,2012/2013,64,US National,Season onset,47
+2013,12,2012/2013,64,US National,Season peak week,52
+2013,12,2012/2013,64,US National,Season peak percentage,6.1
+2013,12,2012/2013,64,US National,1 wk ahead,1.9
+2013,12,2012/2013,64,US National,2 wk ahead,1.7
+2013,12,2012/2013,64,US National,3 wk ahead,1.4
+2013,12,2012/2013,64,US National,4 wk ahead,1.3
+2013,12,2012/2013,64,HHS Region 1,Season onset,49
+2013,12,2012/2013,64,HHS Region 1,Season peak week,52
+2013,12,2012/2013,64,HHS Region 1,Season peak percentage,3.9
+2013,12,2012/2013,64,HHS Region 1,1 wk ahead,1.2
+2013,12,2012/2013,64,HHS Region 1,2 wk ahead,1.2
+2013,12,2012/2013,64,HHS Region 1,3 wk ahead,1.2
+2013,12,2012/2013,64,HHS Region 1,4 wk ahead,1.1
+2013,12,2012/2013,64,HHS Region 2,Season onset,48
+2013,12,2012/2013,64,HHS Region 2,Season peak week,52
+2013,12,2012/2013,64,HHS Region 2,Season peak percentage,5.5
+2013,12,2012/2013,64,HHS Region 2,1 wk ahead,2.2
+2013,12,2012/2013,64,HHS Region 2,2 wk ahead,1.9
+2013,12,2012/2013,64,HHS Region 2,3 wk ahead,1.6
+2013,12,2012/2013,64,HHS Region 2,4 wk ahead,1.4
+2013,12,2012/2013,64,HHS Region 3,Season onset,49
+2013,12,2012/2013,64,HHS Region 3,Season peak week,52
+2013,12,2012/2013,64,HHS Region 3,Season peak percentage,7.1
+2013,12,2012/2013,64,HHS Region 3,1 wk ahead,2.1
+2013,12,2012/2013,64,HHS Region 3,2 wk ahead,1.7
+2013,12,2012/2013,64,HHS Region 3,3 wk ahead,1.5
+2013,12,2012/2013,64,HHS Region 3,4 wk ahead,1.1
+2013,12,2012/2013,64,HHS Region 4,Season onset,47
+2013,12,2012/2013,64,HHS Region 4,Season peak week,52
+2013,12,2012/2013,64,HHS Region 4,Season peak percentage,6.3
+2013,12,2012/2013,64,HHS Region 4,1 wk ahead,1.7
+2013,12,2012/2013,64,HHS Region 4,2 wk ahead,1.4
+2013,12,2012/2013,64,HHS Region 4,3 wk ahead,1.2
+2013,12,2012/2013,64,HHS Region 4,4 wk ahead,1
+2013,12,2012/2013,64,HHS Region 5,Season onset,47
+2013,12,2012/2013,64,HHS Region 5,Season peak week,52
+2013,12,2012/2013,64,HHS Region 5,Season peak percentage,5.7
+2013,12,2012/2013,64,HHS Region 5,1 wk ahead,1.6
+2013,12,2012/2013,64,HHS Region 5,2 wk ahead,1.4
+2013,12,2012/2013,64,HHS Region 5,3 wk ahead,1.2
+2013,12,2012/2013,64,HHS Region 5,4 wk ahead,1.1
+2013,12,2012/2013,64,HHS Region 6,Season onset,47
+2013,12,2012/2013,64,HHS Region 6,Season peak week,52
+2013,12,2012/2013,64,HHS Region 6,Season peak percentage,9.3
+2013,12,2012/2013,64,HHS Region 6,1 wk ahead,2.3
+2013,12,2012/2013,64,HHS Region 6,2 wk ahead,2.2
+2013,12,2012/2013,64,HHS Region 6,3 wk ahead,2
+2013,12,2012/2013,64,HHS Region 6,4 wk ahead,2
+2013,12,2012/2013,64,HHS Region 7,Season onset,47
+2013,12,2012/2013,64,HHS Region 7,Season peak week,52
+2013,12,2012/2013,64,HHS Region 7,Season peak percentage,6.7
+2013,12,2012/2013,64,HHS Region 7,1 wk ahead,1.5
+2013,12,2012/2013,64,HHS Region 7,2 wk ahead,1.1
+2013,12,2012/2013,64,HHS Region 7,3 wk ahead,1
+2013,12,2012/2013,64,HHS Region 7,4 wk ahead,0.9
+2013,12,2012/2013,64,HHS Region 8,Season onset,50
+2013,12,2012/2013,64,HHS Region 8,Season peak week,52
+2013,12,2012/2013,64,HHS Region 8,Season peak week,3
+2013,12,2012/2013,64,HHS Region 8,Season peak percentage,4.1
+2013,12,2012/2013,64,HHS Region 8,1 wk ahead,1.2
+2013,12,2012/2013,64,HHS Region 8,2 wk ahead,1.2
+2013,12,2012/2013,64,HHS Region 8,3 wk ahead,1
+2013,12,2012/2013,64,HHS Region 8,4 wk ahead,1
+2013,12,2012/2013,64,HHS Region 9,Season onset,2
+2013,12,2012/2013,64,HHS Region 9,Season peak week,4
+2013,12,2012/2013,64,HHS Region 9,Season peak percentage,5.6
+2013,12,2012/2013,64,HHS Region 9,1 wk ahead,2.6
+2013,12,2012/2013,64,HHS Region 9,2 wk ahead,2.2
+2013,12,2012/2013,64,HHS Region 9,3 wk ahead,1.9
+2013,12,2012/2013,64,HHS Region 9,4 wk ahead,1.7
+2013,12,2012/2013,64,HHS Region 10,Season onset,50
+2013,12,2012/2013,64,HHS Region 10,Season peak week,4
+2013,12,2012/2013,64,HHS Region 10,Season peak percentage,3.7
+2013,12,2012/2013,64,HHS Region 10,1 wk ahead,0.7
+2013,12,2012/2013,64,HHS Region 10,2 wk ahead,0.7
+2013,12,2012/2013,64,HHS Region 10,3 wk ahead,0.4
+2013,12,2012/2013,64,HHS Region 10,4 wk ahead,0.4
+2013,13,2012/2013,65,US National,Season onset,47
+2013,13,2012/2013,65,US National,Season peak week,52
+2013,13,2012/2013,65,US National,Season peak percentage,6.1
+2013,13,2012/2013,65,US National,1 wk ahead,1.7
+2013,13,2012/2013,65,US National,2 wk ahead,1.4
+2013,13,2012/2013,65,US National,3 wk ahead,1.3
+2013,13,2012/2013,65,US National,4 wk ahead,1.2
+2013,13,2012/2013,65,HHS Region 1,Season onset,49
+2013,13,2012/2013,65,HHS Region 1,Season peak week,52
+2013,13,2012/2013,65,HHS Region 1,Season peak percentage,3.9
+2013,13,2012/2013,65,HHS Region 1,1 wk ahead,1.2
+2013,13,2012/2013,65,HHS Region 1,2 wk ahead,1.2
+2013,13,2012/2013,65,HHS Region 1,3 wk ahead,1.1
+2013,13,2012/2013,65,HHS Region 1,4 wk ahead,0.8
+2013,13,2012/2013,65,HHS Region 2,Season onset,48
+2013,13,2012/2013,65,HHS Region 2,Season peak week,52
+2013,13,2012/2013,65,HHS Region 2,Season peak percentage,5.5
+2013,13,2012/2013,65,HHS Region 2,1 wk ahead,1.9
+2013,13,2012/2013,65,HHS Region 2,2 wk ahead,1.6
+2013,13,2012/2013,65,HHS Region 2,3 wk ahead,1.4
+2013,13,2012/2013,65,HHS Region 2,4 wk ahead,1.5
+2013,13,2012/2013,65,HHS Region 3,Season onset,49
+2013,13,2012/2013,65,HHS Region 3,Season peak week,52
+2013,13,2012/2013,65,HHS Region 3,Season peak percentage,7.1
+2013,13,2012/2013,65,HHS Region 3,1 wk ahead,1.7
+2013,13,2012/2013,65,HHS Region 3,2 wk ahead,1.5
+2013,13,2012/2013,65,HHS Region 3,3 wk ahead,1.1
+2013,13,2012/2013,65,HHS Region 3,4 wk ahead,1.1
+2013,13,2012/2013,65,HHS Region 4,Season onset,47
+2013,13,2012/2013,65,HHS Region 4,Season peak week,52
+2013,13,2012/2013,65,HHS Region 4,Season peak percentage,6.3
+2013,13,2012/2013,65,HHS Region 4,1 wk ahead,1.4
+2013,13,2012/2013,65,HHS Region 4,2 wk ahead,1.2
+2013,13,2012/2013,65,HHS Region 4,3 wk ahead,1
+2013,13,2012/2013,65,HHS Region 4,4 wk ahead,0.9
+2013,13,2012/2013,65,HHS Region 5,Season onset,47
+2013,13,2012/2013,65,HHS Region 5,Season peak week,52
+2013,13,2012/2013,65,HHS Region 5,Season peak percentage,5.7
+2013,13,2012/2013,65,HHS Region 5,1 wk ahead,1.4
+2013,13,2012/2013,65,HHS Region 5,2 wk ahead,1.2
+2013,13,2012/2013,65,HHS Region 5,3 wk ahead,1.1
+2013,13,2012/2013,65,HHS Region 5,4 wk ahead,1
+2013,13,2012/2013,65,HHS Region 6,Season onset,47
+2013,13,2012/2013,65,HHS Region 6,Season peak week,52
+2013,13,2012/2013,65,HHS Region 6,Season peak percentage,9.3
+2013,13,2012/2013,65,HHS Region 6,1 wk ahead,2.2
+2013,13,2012/2013,65,HHS Region 6,2 wk ahead,2
+2013,13,2012/2013,65,HHS Region 6,3 wk ahead,2
+2013,13,2012/2013,65,HHS Region 6,4 wk ahead,1.9
+2013,13,2012/2013,65,HHS Region 7,Season onset,47
+2013,13,2012/2013,65,HHS Region 7,Season peak week,52
+2013,13,2012/2013,65,HHS Region 7,Season peak percentage,6.7
+2013,13,2012/2013,65,HHS Region 7,1 wk ahead,1.1
+2013,13,2012/2013,65,HHS Region 7,2 wk ahead,1
+2013,13,2012/2013,65,HHS Region 7,3 wk ahead,0.9
+2013,13,2012/2013,65,HHS Region 7,4 wk ahead,0.9
+2013,13,2012/2013,65,HHS Region 8,Season onset,50
+2013,13,2012/2013,65,HHS Region 8,Season peak week,52
+2013,13,2012/2013,65,HHS Region 8,Season peak week,3
+2013,13,2012/2013,65,HHS Region 8,Season peak percentage,4.1
+2013,13,2012/2013,65,HHS Region 8,1 wk ahead,1.2
+2013,13,2012/2013,65,HHS Region 8,2 wk ahead,1
+2013,13,2012/2013,65,HHS Region 8,3 wk ahead,1
+2013,13,2012/2013,65,HHS Region 8,4 wk ahead,1
+2013,13,2012/2013,65,HHS Region 9,Season onset,2
+2013,13,2012/2013,65,HHS Region 9,Season peak week,4
+2013,13,2012/2013,65,HHS Region 9,Season peak percentage,5.6
+2013,13,2012/2013,65,HHS Region 9,1 wk ahead,2.2
+2013,13,2012/2013,65,HHS Region 9,2 wk ahead,1.9
+2013,13,2012/2013,65,HHS Region 9,3 wk ahead,1.7
+2013,13,2012/2013,65,HHS Region 9,4 wk ahead,1.6
+2013,13,2012/2013,65,HHS Region 10,Season onset,50
+2013,13,2012/2013,65,HHS Region 10,Season peak week,4
+2013,13,2012/2013,65,HHS Region 10,Season peak percentage,3.7
+2013,13,2012/2013,65,HHS Region 10,1 wk ahead,0.7
+2013,13,2012/2013,65,HHS Region 10,2 wk ahead,0.4
+2013,13,2012/2013,65,HHS Region 10,3 wk ahead,0.4
+2013,13,2012/2013,65,HHS Region 10,4 wk ahead,0.4
+2013,14,2012/2013,66,US National,Season onset,47
+2013,14,2012/2013,66,US National,Season peak week,52
+2013,14,2012/2013,66,US National,Season peak percentage,6.1
+2013,14,2012/2013,66,US National,1 wk ahead,1.4
+2013,14,2012/2013,66,US National,2 wk ahead,1.3
+2013,14,2012/2013,66,US National,3 wk ahead,1.2
+2013,14,2012/2013,66,US National,4 wk ahead,1.1
+2013,14,2012/2013,66,HHS Region 1,Season onset,49
+2013,14,2012/2013,66,HHS Region 1,Season peak week,52
+2013,14,2012/2013,66,HHS Region 1,Season peak percentage,3.9
+2013,14,2012/2013,66,HHS Region 1,1 wk ahead,1.2
+2013,14,2012/2013,66,HHS Region 1,2 wk ahead,1.1
+2013,14,2012/2013,66,HHS Region 1,3 wk ahead,0.8
+2013,14,2012/2013,66,HHS Region 1,4 wk ahead,0.8
+2013,14,2012/2013,66,HHS Region 2,Season onset,48
+2013,14,2012/2013,66,HHS Region 2,Season peak week,52
+2013,14,2012/2013,66,HHS Region 2,Season peak percentage,5.5
+2013,14,2012/2013,66,HHS Region 2,1 wk ahead,1.6
+2013,14,2012/2013,66,HHS Region 2,2 wk ahead,1.4
+2013,14,2012/2013,66,HHS Region 2,3 wk ahead,1.5
+2013,14,2012/2013,66,HHS Region 2,4 wk ahead,1.4
+2013,14,2012/2013,66,HHS Region 3,Season onset,49
+2013,14,2012/2013,66,HHS Region 3,Season peak week,52
+2013,14,2012/2013,66,HHS Region 3,Season peak percentage,7.1
+2013,14,2012/2013,66,HHS Region 3,1 wk ahead,1.5
+2013,14,2012/2013,66,HHS Region 3,2 wk ahead,1.1
+2013,14,2012/2013,66,HHS Region 3,3 wk ahead,1.1
+2013,14,2012/2013,66,HHS Region 3,4 wk ahead,1.1
+2013,14,2012/2013,66,HHS Region 4,Season onset,47
+2013,14,2012/2013,66,HHS Region 4,Season peak week,52
+2013,14,2012/2013,66,HHS Region 4,Season peak percentage,6.3
+2013,14,2012/2013,66,HHS Region 4,1 wk ahead,1.2
+2013,14,2012/2013,66,HHS Region 4,2 wk ahead,1
+2013,14,2012/2013,66,HHS Region 4,3 wk ahead,0.9
+2013,14,2012/2013,66,HHS Region 4,4 wk ahead,0.7
+2013,14,2012/2013,66,HHS Region 5,Season onset,47
+2013,14,2012/2013,66,HHS Region 5,Season peak week,52
+2013,14,2012/2013,66,HHS Region 5,Season peak percentage,5.7
+2013,14,2012/2013,66,HHS Region 5,1 wk ahead,1.2
+2013,14,2012/2013,66,HHS Region 5,2 wk ahead,1.1
+2013,14,2012/2013,66,HHS Region 5,3 wk ahead,1
+2013,14,2012/2013,66,HHS Region 5,4 wk ahead,0.8
+2013,14,2012/2013,66,HHS Region 6,Season onset,47
+2013,14,2012/2013,66,HHS Region 6,Season peak week,52
+2013,14,2012/2013,66,HHS Region 6,Season peak percentage,9.3
+2013,14,2012/2013,66,HHS Region 6,1 wk ahead,2
+2013,14,2012/2013,66,HHS Region 6,2 wk ahead,2
+2013,14,2012/2013,66,HHS Region 6,3 wk ahead,1.9
+2013,14,2012/2013,66,HHS Region 6,4 wk ahead,1.7
+2013,14,2012/2013,66,HHS Region 7,Season onset,47
+2013,14,2012/2013,66,HHS Region 7,Season peak week,52
+2013,14,2012/2013,66,HHS Region 7,Season peak percentage,6.7
+2013,14,2012/2013,66,HHS Region 7,1 wk ahead,1
+2013,14,2012/2013,66,HHS Region 7,2 wk ahead,0.9
+2013,14,2012/2013,66,HHS Region 7,3 wk ahead,0.9
+2013,14,2012/2013,66,HHS Region 7,4 wk ahead,0.8
+2013,14,2012/2013,66,HHS Region 8,Season onset,50
+2013,14,2012/2013,66,HHS Region 8,Season peak week,52
+2013,14,2012/2013,66,HHS Region 8,Season peak week,3
+2013,14,2012/2013,66,HHS Region 8,Season peak percentage,4.1
+2013,14,2012/2013,66,HHS Region 8,1 wk ahead,1
+2013,14,2012/2013,66,HHS Region 8,2 wk ahead,1
+2013,14,2012/2013,66,HHS Region 8,3 wk ahead,1
+2013,14,2012/2013,66,HHS Region 8,4 wk ahead,1
+2013,14,2012/2013,66,HHS Region 9,Season onset,2
+2013,14,2012/2013,66,HHS Region 9,Season peak week,4
+2013,14,2012/2013,66,HHS Region 9,Season peak percentage,5.6
+2013,14,2012/2013,66,HHS Region 9,1 wk ahead,1.9
+2013,14,2012/2013,66,HHS Region 9,2 wk ahead,1.7
+2013,14,2012/2013,66,HHS Region 9,3 wk ahead,1.6
+2013,14,2012/2013,66,HHS Region 9,4 wk ahead,1.6
+2013,14,2012/2013,66,HHS Region 10,Season onset,50
+2013,14,2012/2013,66,HHS Region 10,Season peak week,4
+2013,14,2012/2013,66,HHS Region 10,Season peak percentage,3.7
+2013,14,2012/2013,66,HHS Region 10,1 wk ahead,0.4
+2013,14,2012/2013,66,HHS Region 10,2 wk ahead,0.4
+2013,14,2012/2013,66,HHS Region 10,3 wk ahead,0.4
+2013,14,2012/2013,66,HHS Region 10,4 wk ahead,0.4
+2013,15,2012/2013,67,US National,Season onset,47
+2013,15,2012/2013,67,US National,Season peak week,52
+2013,15,2012/2013,67,US National,Season peak percentage,6.1
+2013,15,2012/2013,67,US National,1 wk ahead,1.3
+2013,15,2012/2013,67,US National,2 wk ahead,1.2
+2013,15,2012/2013,67,US National,3 wk ahead,1.1
+2013,15,2012/2013,67,US National,4 wk ahead,1.1
+2013,15,2012/2013,67,HHS Region 1,Season onset,49
+2013,15,2012/2013,67,HHS Region 1,Season peak week,52
+2013,15,2012/2013,67,HHS Region 1,Season peak percentage,3.9
+2013,15,2012/2013,67,HHS Region 1,1 wk ahead,1.1
+2013,15,2012/2013,67,HHS Region 1,2 wk ahead,0.8
+2013,15,2012/2013,67,HHS Region 1,3 wk ahead,0.8
+2013,15,2012/2013,67,HHS Region 1,4 wk ahead,0.7
+2013,15,2012/2013,67,HHS Region 2,Season onset,48
+2013,15,2012/2013,67,HHS Region 2,Season peak week,52
+2013,15,2012/2013,67,HHS Region 2,Season peak percentage,5.5
+2013,15,2012/2013,67,HHS Region 2,1 wk ahead,1.4
+2013,15,2012/2013,67,HHS Region 2,2 wk ahead,1.5
+2013,15,2012/2013,67,HHS Region 2,3 wk ahead,1.4
+2013,15,2012/2013,67,HHS Region 2,4 wk ahead,1.3
+2013,15,2012/2013,67,HHS Region 3,Season onset,49
+2013,15,2012/2013,67,HHS Region 3,Season peak week,52
+2013,15,2012/2013,67,HHS Region 3,Season peak percentage,7.1
+2013,15,2012/2013,67,HHS Region 3,1 wk ahead,1.1
+2013,15,2012/2013,67,HHS Region 3,2 wk ahead,1.1
+2013,15,2012/2013,67,HHS Region 3,3 wk ahead,1.1
+2013,15,2012/2013,67,HHS Region 3,4 wk ahead,1.3
+2013,15,2012/2013,67,HHS Region 4,Season onset,47
+2013,15,2012/2013,67,HHS Region 4,Season peak week,52
+2013,15,2012/2013,67,HHS Region 4,Season peak percentage,6.3
+2013,15,2012/2013,67,HHS Region 4,1 wk ahead,1
+2013,15,2012/2013,67,HHS Region 4,2 wk ahead,0.9
+2013,15,2012/2013,67,HHS Region 4,3 wk ahead,0.7
+2013,15,2012/2013,67,HHS Region 4,4 wk ahead,0.7
+2013,15,2012/2013,67,HHS Region 5,Season onset,47
+2013,15,2012/2013,67,HHS Region 5,Season peak week,52
+2013,15,2012/2013,67,HHS Region 5,Season peak percentage,5.7
+2013,15,2012/2013,67,HHS Region 5,1 wk ahead,1.1
+2013,15,2012/2013,67,HHS Region 5,2 wk ahead,1
+2013,15,2012/2013,67,HHS Region 5,3 wk ahead,0.8
+2013,15,2012/2013,67,HHS Region 5,4 wk ahead,0.9
+2013,15,2012/2013,67,HHS Region 6,Season onset,47
+2013,15,2012/2013,67,HHS Region 6,Season peak week,52
+2013,15,2012/2013,67,HHS Region 6,Season peak percentage,9.3
+2013,15,2012/2013,67,HHS Region 6,1 wk ahead,2
+2013,15,2012/2013,67,HHS Region 6,2 wk ahead,1.9
+2013,15,2012/2013,67,HHS Region 6,3 wk ahead,1.7
+2013,15,2012/2013,67,HHS Region 6,4 wk ahead,1.7
+2013,15,2012/2013,67,HHS Region 7,Season onset,47
+2013,15,2012/2013,67,HHS Region 7,Season peak week,52
+2013,15,2012/2013,67,HHS Region 7,Season peak percentage,6.7
+2013,15,2012/2013,67,HHS Region 7,1 wk ahead,0.9
+2013,15,2012/2013,67,HHS Region 7,2 wk ahead,0.9
+2013,15,2012/2013,67,HHS Region 7,3 wk ahead,0.8
+2013,15,2012/2013,67,HHS Region 7,4 wk ahead,0.8
+2013,15,2012/2013,67,HHS Region 8,Season onset,50
+2013,15,2012/2013,67,HHS Region 8,Season peak week,52
+2013,15,2012/2013,67,HHS Region 8,Season peak week,3
+2013,15,2012/2013,67,HHS Region 8,Season peak percentage,4.1
+2013,15,2012/2013,67,HHS Region 8,1 wk ahead,1
+2013,15,2012/2013,67,HHS Region 8,2 wk ahead,1
+2013,15,2012/2013,67,HHS Region 8,3 wk ahead,1
+2013,15,2012/2013,67,HHS Region 8,4 wk ahead,0.9
+2013,15,2012/2013,67,HHS Region 9,Season onset,2
+2013,15,2012/2013,67,HHS Region 9,Season peak week,4
+2013,15,2012/2013,67,HHS Region 9,Season peak percentage,5.6
+2013,15,2012/2013,67,HHS Region 9,1 wk ahead,1.7
+2013,15,2012/2013,67,HHS Region 9,2 wk ahead,1.6
+2013,15,2012/2013,67,HHS Region 9,3 wk ahead,1.6
+2013,15,2012/2013,67,HHS Region 9,4 wk ahead,1.5
+2013,15,2012/2013,67,HHS Region 10,Season onset,50
+2013,15,2012/2013,67,HHS Region 10,Season peak week,4
+2013,15,2012/2013,67,HHS Region 10,Season peak percentage,3.7
+2013,15,2012/2013,67,HHS Region 10,1 wk ahead,0.4
+2013,15,2012/2013,67,HHS Region 10,2 wk ahead,0.4
+2013,15,2012/2013,67,HHS Region 10,3 wk ahead,0.4
+2013,15,2012/2013,67,HHS Region 10,4 wk ahead,0.2
+2013,16,2012/2013,68,US National,Season onset,47
+2013,16,2012/2013,68,US National,Season peak week,52
+2013,16,2012/2013,68,US National,Season peak percentage,6.1
+2013,16,2012/2013,68,US National,1 wk ahead,1.2
+2013,16,2012/2013,68,US National,2 wk ahead,1.1
+2013,16,2012/2013,68,US National,3 wk ahead,1.1
+2013,16,2012/2013,68,US National,4 wk ahead,1.1
+2013,16,2012/2013,68,HHS Region 1,Season onset,49
+2013,16,2012/2013,68,HHS Region 1,Season peak week,52
+2013,16,2012/2013,68,HHS Region 1,Season peak percentage,3.9
+2013,16,2012/2013,68,HHS Region 1,1 wk ahead,0.8
+2013,16,2012/2013,68,HHS Region 1,2 wk ahead,0.8
+2013,16,2012/2013,68,HHS Region 1,3 wk ahead,0.7
+2013,16,2012/2013,68,HHS Region 1,4 wk ahead,0.6
+2013,16,2012/2013,68,HHS Region 2,Season onset,48
+2013,16,2012/2013,68,HHS Region 2,Season peak week,52
+2013,16,2012/2013,68,HHS Region 2,Season peak percentage,5.5
+2013,16,2012/2013,68,HHS Region 2,1 wk ahead,1.5
+2013,16,2012/2013,68,HHS Region 2,2 wk ahead,1.4
+2013,16,2012/2013,68,HHS Region 2,3 wk ahead,1.3
+2013,16,2012/2013,68,HHS Region 2,4 wk ahead,1.3
+2013,16,2012/2013,68,HHS Region 3,Season onset,49
+2013,16,2012/2013,68,HHS Region 3,Season peak week,52
+2013,16,2012/2013,68,HHS Region 3,Season peak percentage,7.1
+2013,16,2012/2013,68,HHS Region 3,1 wk ahead,1.1
+2013,16,2012/2013,68,HHS Region 3,2 wk ahead,1.1
+2013,16,2012/2013,68,HHS Region 3,3 wk ahead,1.3
+2013,16,2012/2013,68,HHS Region 3,4 wk ahead,1.1
+2013,16,2012/2013,68,HHS Region 4,Season onset,47
+2013,16,2012/2013,68,HHS Region 4,Season peak week,52
+2013,16,2012/2013,68,HHS Region 4,Season peak percentage,6.3
+2013,16,2012/2013,68,HHS Region 4,1 wk ahead,0.9
+2013,16,2012/2013,68,HHS Region 4,2 wk ahead,0.7
+2013,16,2012/2013,68,HHS Region 4,3 wk ahead,0.7
+2013,16,2012/2013,68,HHS Region 4,4 wk ahead,0.8
+2013,16,2012/2013,68,HHS Region 5,Season onset,47
+2013,16,2012/2013,68,HHS Region 5,Season peak week,52
+2013,16,2012/2013,68,HHS Region 5,Season peak percentage,5.7
+2013,16,2012/2013,68,HHS Region 5,1 wk ahead,1
+2013,16,2012/2013,68,HHS Region 5,2 wk ahead,0.8
+2013,16,2012/2013,68,HHS Region 5,3 wk ahead,0.9
+2013,16,2012/2013,68,HHS Region 5,4 wk ahead,0.9
+2013,16,2012/2013,68,HHS Region 6,Season onset,47
+2013,16,2012/2013,68,HHS Region 6,Season peak week,52
+2013,16,2012/2013,68,HHS Region 6,Season peak percentage,9.3
+2013,16,2012/2013,68,HHS Region 6,1 wk ahead,1.9
+2013,16,2012/2013,68,HHS Region 6,2 wk ahead,1.7
+2013,16,2012/2013,68,HHS Region 6,3 wk ahead,1.7
+2013,16,2012/2013,68,HHS Region 6,4 wk ahead,1.6
+2013,16,2012/2013,68,HHS Region 7,Season onset,47
+2013,16,2012/2013,68,HHS Region 7,Season peak week,52
+2013,16,2012/2013,68,HHS Region 7,Season peak percentage,6.7
+2013,16,2012/2013,68,HHS Region 7,1 wk ahead,0.9
+2013,16,2012/2013,68,HHS Region 7,2 wk ahead,0.8
+2013,16,2012/2013,68,HHS Region 7,3 wk ahead,0.8
+2013,16,2012/2013,68,HHS Region 7,4 wk ahead,0.6
+2013,16,2012/2013,68,HHS Region 8,Season onset,50
+2013,16,2012/2013,68,HHS Region 8,Season peak week,52
+2013,16,2012/2013,68,HHS Region 8,Season peak week,3
+2013,16,2012/2013,68,HHS Region 8,Season peak percentage,4.1
+2013,16,2012/2013,68,HHS Region 8,1 wk ahead,1
+2013,16,2012/2013,68,HHS Region 8,2 wk ahead,1
+2013,16,2012/2013,68,HHS Region 8,3 wk ahead,0.9
+2013,16,2012/2013,68,HHS Region 8,4 wk ahead,0.7
+2013,16,2012/2013,68,HHS Region 9,Season onset,2
+2013,16,2012/2013,68,HHS Region 9,Season peak week,4
+2013,16,2012/2013,68,HHS Region 9,Season peak percentage,5.6
+2013,16,2012/2013,68,HHS Region 9,1 wk ahead,1.6
+2013,16,2012/2013,68,HHS Region 9,2 wk ahead,1.6
+2013,16,2012/2013,68,HHS Region 9,3 wk ahead,1.5
+2013,16,2012/2013,68,HHS Region 9,4 wk ahead,1.6
+2013,16,2012/2013,68,HHS Region 10,Season onset,50
+2013,16,2012/2013,68,HHS Region 10,Season peak week,4
+2013,16,2012/2013,68,HHS Region 10,Season peak percentage,3.7
+2013,16,2012/2013,68,HHS Region 10,1 wk ahead,0.4
+2013,16,2012/2013,68,HHS Region 10,2 wk ahead,0.4
+2013,16,2012/2013,68,HHS Region 10,3 wk ahead,0.2
+2013,16,2012/2013,68,HHS Region 10,4 wk ahead,0.3
+2013,17,2012/2013,69,US National,Season onset,47
+2013,17,2012/2013,69,US National,Season peak week,52
+2013,17,2012/2013,69,US National,Season peak percentage,6.1
+2013,17,2012/2013,69,US National,1 wk ahead,1.1
+2013,17,2012/2013,69,US National,2 wk ahead,1.1
+2013,17,2012/2013,69,US National,3 wk ahead,1.1
+2013,17,2012/2013,69,US National,4 wk ahead,1
+2013,17,2012/2013,69,HHS Region 1,Season onset,49
+2013,17,2012/2013,69,HHS Region 1,Season peak week,52
+2013,17,2012/2013,69,HHS Region 1,Season peak percentage,3.9
+2013,17,2012/2013,69,HHS Region 1,1 wk ahead,0.8
+2013,17,2012/2013,69,HHS Region 1,2 wk ahead,0.7
+2013,17,2012/2013,69,HHS Region 1,3 wk ahead,0.6
+2013,17,2012/2013,69,HHS Region 1,4 wk ahead,0.6
+2013,17,2012/2013,69,HHS Region 2,Season onset,48
+2013,17,2012/2013,69,HHS Region 2,Season peak week,52
+2013,17,2012/2013,69,HHS Region 2,Season peak percentage,5.5
+2013,17,2012/2013,69,HHS Region 2,1 wk ahead,1.4
+2013,17,2012/2013,69,HHS Region 2,2 wk ahead,1.3
+2013,17,2012/2013,69,HHS Region 2,3 wk ahead,1.3
+2013,17,2012/2013,69,HHS Region 2,4 wk ahead,1.2
+2013,17,2012/2013,69,HHS Region 3,Season onset,49
+2013,17,2012/2013,69,HHS Region 3,Season peak week,52
+2013,17,2012/2013,69,HHS Region 3,Season peak percentage,7.1
+2013,17,2012/2013,69,HHS Region 3,1 wk ahead,1.1
+2013,17,2012/2013,69,HHS Region 3,2 wk ahead,1.3
+2013,17,2012/2013,69,HHS Region 3,3 wk ahead,1.1
+2013,17,2012/2013,69,HHS Region 3,4 wk ahead,1.1
+2013,17,2012/2013,69,HHS Region 4,Season onset,47
+2013,17,2012/2013,69,HHS Region 4,Season peak week,52
+2013,17,2012/2013,69,HHS Region 4,Season peak percentage,6.3
+2013,17,2012/2013,69,HHS Region 4,1 wk ahead,0.7
+2013,17,2012/2013,69,HHS Region 4,2 wk ahead,0.7
+2013,17,2012/2013,69,HHS Region 4,3 wk ahead,0.8
+2013,17,2012/2013,69,HHS Region 4,4 wk ahead,0.8
+2013,17,2012/2013,69,HHS Region 5,Season onset,47
+2013,17,2012/2013,69,HHS Region 5,Season peak week,52
+2013,17,2012/2013,69,HHS Region 5,Season peak percentage,5.7
+2013,17,2012/2013,69,HHS Region 5,1 wk ahead,0.8
+2013,17,2012/2013,69,HHS Region 5,2 wk ahead,0.9
+2013,17,2012/2013,69,HHS Region 5,3 wk ahead,0.9
+2013,17,2012/2013,69,HHS Region 5,4 wk ahead,0.8
+2013,17,2012/2013,69,HHS Region 6,Season onset,47
+2013,17,2012/2013,69,HHS Region 6,Season peak week,52
+2013,17,2012/2013,69,HHS Region 6,Season peak percentage,9.3
+2013,17,2012/2013,69,HHS Region 6,1 wk ahead,1.7
+2013,17,2012/2013,69,HHS Region 6,2 wk ahead,1.7
+2013,17,2012/2013,69,HHS Region 6,3 wk ahead,1.6
+2013,17,2012/2013,69,HHS Region 6,4 wk ahead,1.5
+2013,17,2012/2013,69,HHS Region 7,Season onset,47
+2013,17,2012/2013,69,HHS Region 7,Season peak week,52
+2013,17,2012/2013,69,HHS Region 7,Season peak percentage,6.7
+2013,17,2012/2013,69,HHS Region 7,1 wk ahead,0.8
+2013,17,2012/2013,69,HHS Region 7,2 wk ahead,0.8
+2013,17,2012/2013,69,HHS Region 7,3 wk ahead,0.6
+2013,17,2012/2013,69,HHS Region 7,4 wk ahead,0.7
+2013,17,2012/2013,69,HHS Region 8,Season onset,50
+2013,17,2012/2013,69,HHS Region 8,Season peak week,52
+2013,17,2012/2013,69,HHS Region 8,Season peak week,3
+2013,17,2012/2013,69,HHS Region 8,Season peak percentage,4.1
+2013,17,2012/2013,69,HHS Region 8,1 wk ahead,1
+2013,17,2012/2013,69,HHS Region 8,2 wk ahead,0.9
+2013,17,2012/2013,69,HHS Region 8,3 wk ahead,0.7
+2013,17,2012/2013,69,HHS Region 8,4 wk ahead,0.8
+2013,17,2012/2013,69,HHS Region 9,Season onset,2
+2013,17,2012/2013,69,HHS Region 9,Season peak week,4
+2013,17,2012/2013,69,HHS Region 9,Season peak percentage,5.6
+2013,17,2012/2013,69,HHS Region 9,1 wk ahead,1.6
+2013,17,2012/2013,69,HHS Region 9,2 wk ahead,1.5
+2013,17,2012/2013,69,HHS Region 9,3 wk ahead,1.6
+2013,17,2012/2013,69,HHS Region 9,4 wk ahead,1.4
+2013,17,2012/2013,69,HHS Region 10,Season onset,50
+2013,17,2012/2013,69,HHS Region 10,Season peak week,4
+2013,17,2012/2013,69,HHS Region 10,Season peak percentage,3.7
+2013,17,2012/2013,69,HHS Region 10,1 wk ahead,0.4
+2013,17,2012/2013,69,HHS Region 10,2 wk ahead,0.2
+2013,17,2012/2013,69,HHS Region 10,3 wk ahead,0.3
+2013,17,2012/2013,69,HHS Region 10,4 wk ahead,0.3
+2013,18,2012/2013,70,US National,Season onset,47
+2013,18,2012/2013,70,US National,Season peak week,52
+2013,18,2012/2013,70,US National,Season peak percentage,6.1
+2013,18,2012/2013,70,US National,1 wk ahead,1.1
+2013,18,2012/2013,70,US National,2 wk ahead,1.1
+2013,18,2012/2013,70,US National,3 wk ahead,1
+2013,18,2012/2013,70,US National,4 wk ahead,1
+2013,18,2012/2013,70,HHS Region 1,Season onset,49
+2013,18,2012/2013,70,HHS Region 1,Season peak week,52
+2013,18,2012/2013,70,HHS Region 1,Season peak percentage,3.9
+2013,18,2012/2013,70,HHS Region 1,1 wk ahead,0.7
+2013,18,2012/2013,70,HHS Region 1,2 wk ahead,0.6
+2013,18,2012/2013,70,HHS Region 1,3 wk ahead,0.6
+2013,18,2012/2013,70,HHS Region 1,4 wk ahead,0.6
+2013,18,2012/2013,70,HHS Region 2,Season onset,48
+2013,18,2012/2013,70,HHS Region 2,Season peak week,52
+2013,18,2012/2013,70,HHS Region 2,Season peak percentage,5.5
+2013,18,2012/2013,70,HHS Region 2,1 wk ahead,1.3
+2013,18,2012/2013,70,HHS Region 2,2 wk ahead,1.3
+2013,18,2012/2013,70,HHS Region 2,3 wk ahead,1.2
+2013,18,2012/2013,70,HHS Region 2,4 wk ahead,1.4
+2013,18,2012/2013,70,HHS Region 3,Season onset,49
+2013,18,2012/2013,70,HHS Region 3,Season peak week,52
+2013,18,2012/2013,70,HHS Region 3,Season peak percentage,7.1
+2013,18,2012/2013,70,HHS Region 3,1 wk ahead,1.3
+2013,18,2012/2013,70,HHS Region 3,2 wk ahead,1.1
+2013,18,2012/2013,70,HHS Region 3,3 wk ahead,1.1
+2013,18,2012/2013,70,HHS Region 3,4 wk ahead,1.3
+2013,18,2012/2013,70,HHS Region 4,Season onset,47
+2013,18,2012/2013,70,HHS Region 4,Season peak week,52
+2013,18,2012/2013,70,HHS Region 4,Season peak percentage,6.3
+2013,18,2012/2013,70,HHS Region 4,1 wk ahead,0.7
+2013,18,2012/2013,70,HHS Region 4,2 wk ahead,0.8
+2013,18,2012/2013,70,HHS Region 4,3 wk ahead,0.8
+2013,18,2012/2013,70,HHS Region 4,4 wk ahead,0.6
+2013,18,2012/2013,70,HHS Region 5,Season onset,47
+2013,18,2012/2013,70,HHS Region 5,Season peak week,52
+2013,18,2012/2013,70,HHS Region 5,Season peak percentage,5.7
+2013,18,2012/2013,70,HHS Region 5,1 wk ahead,0.9
+2013,18,2012/2013,70,HHS Region 5,2 wk ahead,0.9
+2013,18,2012/2013,70,HHS Region 5,3 wk ahead,0.8
+2013,18,2012/2013,70,HHS Region 5,4 wk ahead,1
+2013,18,2012/2013,70,HHS Region 6,Season onset,47
+2013,18,2012/2013,70,HHS Region 6,Season peak week,52
+2013,18,2012/2013,70,HHS Region 6,Season peak percentage,9.3
+2013,18,2012/2013,70,HHS Region 6,1 wk ahead,1.7
+2013,18,2012/2013,70,HHS Region 6,2 wk ahead,1.6
+2013,18,2012/2013,70,HHS Region 6,3 wk ahead,1.5
+2013,18,2012/2013,70,HHS Region 6,4 wk ahead,1.5
+2013,18,2012/2013,70,HHS Region 7,Season onset,47
+2013,18,2012/2013,70,HHS Region 7,Season peak week,52
+2013,18,2012/2013,70,HHS Region 7,Season peak percentage,6.7
+2013,18,2012/2013,70,HHS Region 7,1 wk ahead,0.8
+2013,18,2012/2013,70,HHS Region 7,2 wk ahead,0.6
+2013,18,2012/2013,70,HHS Region 7,3 wk ahead,0.7
+2013,18,2012/2013,70,HHS Region 7,4 wk ahead,0.8
+2013,18,2012/2013,70,HHS Region 8,Season onset,50
+2013,18,2012/2013,70,HHS Region 8,Season peak week,52
+2013,18,2012/2013,70,HHS Region 8,Season peak week,3
+2013,18,2012/2013,70,HHS Region 8,Season peak percentage,4.1
+2013,18,2012/2013,70,HHS Region 8,1 wk ahead,0.9
+2013,18,2012/2013,70,HHS Region 8,2 wk ahead,0.7
+2013,18,2012/2013,70,HHS Region 8,3 wk ahead,0.8
+2013,18,2012/2013,70,HHS Region 8,4 wk ahead,0.8
+2013,18,2012/2013,70,HHS Region 9,Season onset,2
+2013,18,2012/2013,70,HHS Region 9,Season peak week,4
+2013,18,2012/2013,70,HHS Region 9,Season peak percentage,5.6
+2013,18,2012/2013,70,HHS Region 9,1 wk ahead,1.5
+2013,18,2012/2013,70,HHS Region 9,2 wk ahead,1.6
+2013,18,2012/2013,70,HHS Region 9,3 wk ahead,1.4
+2013,18,2012/2013,70,HHS Region 9,4 wk ahead,1.4
+2013,18,2012/2013,70,HHS Region 10,Season onset,50
+2013,18,2012/2013,70,HHS Region 10,Season peak week,4
+2013,18,2012/2013,70,HHS Region 10,Season peak percentage,3.7
+2013,18,2012/2013,70,HHS Region 10,1 wk ahead,0.2
+2013,18,2012/2013,70,HHS Region 10,2 wk ahead,0.3
+2013,18,2012/2013,70,HHS Region 10,3 wk ahead,0.3
+2013,18,2012/2013,70,HHS Region 10,4 wk ahead,0.3
+2013,19,2012/2013,71,US National,Season onset,47
+2013,19,2012/2013,71,US National,Season peak week,52
+2013,19,2012/2013,71,US National,Season peak percentage,6.1
+2013,19,2012/2013,71,US National,1 wk ahead,1.1
+2013,19,2012/2013,71,US National,2 wk ahead,1
+2013,19,2012/2013,71,US National,3 wk ahead,1
+2013,19,2012/2013,71,US National,4 wk ahead,0.9
+2013,19,2012/2013,71,HHS Region 1,Season onset,49
+2013,19,2012/2013,71,HHS Region 1,Season peak week,52
+2013,19,2012/2013,71,HHS Region 1,Season peak percentage,3.9
+2013,19,2012/2013,71,HHS Region 1,1 wk ahead,0.6
+2013,19,2012/2013,71,HHS Region 1,2 wk ahead,0.6
+2013,19,2012/2013,71,HHS Region 1,3 wk ahead,0.6
+2013,19,2012/2013,71,HHS Region 1,4 wk ahead,0.4
+2013,19,2012/2013,71,HHS Region 2,Season onset,48
+2013,19,2012/2013,71,HHS Region 2,Season peak week,52
+2013,19,2012/2013,71,HHS Region 2,Season peak percentage,5.5
+2013,19,2012/2013,71,HHS Region 2,1 wk ahead,1.3
+2013,19,2012/2013,71,HHS Region 2,2 wk ahead,1.2
+2013,19,2012/2013,71,HHS Region 2,3 wk ahead,1.4
+2013,19,2012/2013,71,HHS Region 2,4 wk ahead,1.1
+2013,19,2012/2013,71,HHS Region 3,Season onset,49
+2013,19,2012/2013,71,HHS Region 3,Season peak week,52
+2013,19,2012/2013,71,HHS Region 3,Season peak percentage,7.1
+2013,19,2012/2013,71,HHS Region 3,1 wk ahead,1.1
+2013,19,2012/2013,71,HHS Region 3,2 wk ahead,1.1
+2013,19,2012/2013,71,HHS Region 3,3 wk ahead,1.3
+2013,19,2012/2013,71,HHS Region 3,4 wk ahead,1
+2013,19,2012/2013,71,HHS Region 4,Season onset,47
+2013,19,2012/2013,71,HHS Region 4,Season peak week,52
+2013,19,2012/2013,71,HHS Region 4,Season peak percentage,6.3
+2013,19,2012/2013,71,HHS Region 4,1 wk ahead,0.8
+2013,19,2012/2013,71,HHS Region 4,2 wk ahead,0.8
+2013,19,2012/2013,71,HHS Region 4,3 wk ahead,0.6
+2013,19,2012/2013,71,HHS Region 4,4 wk ahead,0.6
+2013,19,2012/2013,71,HHS Region 5,Season onset,47
+2013,19,2012/2013,71,HHS Region 5,Season peak week,52
+2013,19,2012/2013,71,HHS Region 5,Season peak percentage,5.7
+2013,19,2012/2013,71,HHS Region 5,1 wk ahead,0.9
+2013,19,2012/2013,71,HHS Region 5,2 wk ahead,0.8
+2013,19,2012/2013,71,HHS Region 5,3 wk ahead,1
+2013,19,2012/2013,71,HHS Region 5,4 wk ahead,0.9
+2013,19,2012/2013,71,HHS Region 6,Season onset,47
+2013,19,2012/2013,71,HHS Region 6,Season peak week,52
+2013,19,2012/2013,71,HHS Region 6,Season peak percentage,9.3
+2013,19,2012/2013,71,HHS Region 6,1 wk ahead,1.6
+2013,19,2012/2013,71,HHS Region 6,2 wk ahead,1.5
+2013,19,2012/2013,71,HHS Region 6,3 wk ahead,1.5
+2013,19,2012/2013,71,HHS Region 6,4 wk ahead,1.3
+2013,19,2012/2013,71,HHS Region 7,Season onset,47
+2013,19,2012/2013,71,HHS Region 7,Season peak week,52
+2013,19,2012/2013,71,HHS Region 7,Season peak percentage,6.7
+2013,19,2012/2013,71,HHS Region 7,1 wk ahead,0.6
+2013,19,2012/2013,71,HHS Region 7,2 wk ahead,0.7
+2013,19,2012/2013,71,HHS Region 7,3 wk ahead,0.8
+2013,19,2012/2013,71,HHS Region 7,4 wk ahead,0.2
+2013,19,2012/2013,71,HHS Region 8,Season onset,50
+2013,19,2012/2013,71,HHS Region 8,Season peak week,52
+2013,19,2012/2013,71,HHS Region 8,Season peak week,3
+2013,19,2012/2013,71,HHS Region 8,Season peak percentage,4.1
+2013,19,2012/2013,71,HHS Region 8,1 wk ahead,0.7
+2013,19,2012/2013,71,HHS Region 8,2 wk ahead,0.8
+2013,19,2012/2013,71,HHS Region 8,3 wk ahead,0.8
+2013,19,2012/2013,71,HHS Region 8,4 wk ahead,0.7
+2013,19,2012/2013,71,HHS Region 9,Season onset,2
+2013,19,2012/2013,71,HHS Region 9,Season peak week,4
+2013,19,2012/2013,71,HHS Region 9,Season peak percentage,5.6
+2013,19,2012/2013,71,HHS Region 9,1 wk ahead,1.6
+2013,19,2012/2013,71,HHS Region 9,2 wk ahead,1.4
+2013,19,2012/2013,71,HHS Region 9,3 wk ahead,1.4
+2013,19,2012/2013,71,HHS Region 9,4 wk ahead,1.4
+2013,19,2012/2013,71,HHS Region 10,Season onset,50
+2013,19,2012/2013,71,HHS Region 10,Season peak week,4
+2013,19,2012/2013,71,HHS Region 10,Season peak percentage,3.7
+2013,19,2012/2013,71,HHS Region 10,1 wk ahead,0.3
+2013,19,2012/2013,71,HHS Region 10,2 wk ahead,0.3
+2013,19,2012/2013,71,HHS Region 10,3 wk ahead,0.3
+2013,19,2012/2013,71,HHS Region 10,4 wk ahead,0.3
+2013,20,2012/2013,72,US National,Season onset,47
+2013,20,2012/2013,72,US National,Season peak week,52
+2013,20,2012/2013,72,US National,Season peak percentage,6.1
+2013,20,2012/2013,72,US National,1 wk ahead,1
+2013,20,2012/2013,72,US National,2 wk ahead,1
+2013,20,2012/2013,72,US National,3 wk ahead,0.9
+2013,20,2012/2013,72,US National,4 wk ahead,0.9
+2013,20,2012/2013,72,HHS Region 1,Season onset,49
+2013,20,2012/2013,72,HHS Region 1,Season peak week,52
+2013,20,2012/2013,72,HHS Region 1,Season peak percentage,3.9
+2013,20,2012/2013,72,HHS Region 1,1 wk ahead,0.6
+2013,20,2012/2013,72,HHS Region 1,2 wk ahead,0.6
+2013,20,2012/2013,72,HHS Region 1,3 wk ahead,0.4
+2013,20,2012/2013,72,HHS Region 1,4 wk ahead,0.5
+2013,20,2012/2013,72,HHS Region 2,Season onset,48
+2013,20,2012/2013,72,HHS Region 2,Season peak week,52
+2013,20,2012/2013,72,HHS Region 2,Season peak percentage,5.5
+2013,20,2012/2013,72,HHS Region 2,1 wk ahead,1.2
+2013,20,2012/2013,72,HHS Region 2,2 wk ahead,1.4
+2013,20,2012/2013,72,HHS Region 2,3 wk ahead,1.1
+2013,20,2012/2013,72,HHS Region 2,4 wk ahead,1.2
+2013,20,2012/2013,72,HHS Region 3,Season onset,49
+2013,20,2012/2013,72,HHS Region 3,Season peak week,52
+2013,20,2012/2013,72,HHS Region 3,Season peak percentage,7.1
+2013,20,2012/2013,72,HHS Region 3,1 wk ahead,1.1
+2013,20,2012/2013,72,HHS Region 3,2 wk ahead,1.3
+2013,20,2012/2013,72,HHS Region 3,3 wk ahead,1
+2013,20,2012/2013,72,HHS Region 3,4 wk ahead,1.2
+2013,20,2012/2013,72,HHS Region 4,Season onset,47
+2013,20,2012/2013,72,HHS Region 4,Season peak week,52
+2013,20,2012/2013,72,HHS Region 4,Season peak percentage,6.3
+2013,20,2012/2013,72,HHS Region 4,1 wk ahead,0.8
+2013,20,2012/2013,72,HHS Region 4,2 wk ahead,0.6
+2013,20,2012/2013,72,HHS Region 4,3 wk ahead,0.6
+2013,20,2012/2013,72,HHS Region 4,4 wk ahead,0.5
+2013,20,2012/2013,72,HHS Region 5,Season onset,47
+2013,20,2012/2013,72,HHS Region 5,Season peak week,52
+2013,20,2012/2013,72,HHS Region 5,Season peak percentage,5.7
+2013,20,2012/2013,72,HHS Region 5,1 wk ahead,0.8
+2013,20,2012/2013,72,HHS Region 5,2 wk ahead,1
+2013,20,2012/2013,72,HHS Region 5,3 wk ahead,0.9
+2013,20,2012/2013,72,HHS Region 5,4 wk ahead,0.9
+2013,20,2012/2013,72,HHS Region 6,Season onset,47
+2013,20,2012/2013,72,HHS Region 6,Season peak week,52
+2013,20,2012/2013,72,HHS Region 6,Season peak percentage,9.3
+2013,20,2012/2013,72,HHS Region 6,1 wk ahead,1.5
+2013,20,2012/2013,72,HHS Region 6,2 wk ahead,1.5
+2013,20,2012/2013,72,HHS Region 6,3 wk ahead,1.3
+2013,20,2012/2013,72,HHS Region 6,4 wk ahead,1.2
+2013,20,2012/2013,72,HHS Region 7,Season onset,47
+2013,20,2012/2013,72,HHS Region 7,Season peak week,52
+2013,20,2012/2013,72,HHS Region 7,Season peak percentage,6.7
+2013,20,2012/2013,72,HHS Region 7,1 wk ahead,0.7
+2013,20,2012/2013,72,HHS Region 7,2 wk ahead,0.8
+2013,20,2012/2013,72,HHS Region 7,3 wk ahead,0.2
+2013,20,2012/2013,72,HHS Region 7,4 wk ahead,0.2
+2013,20,2012/2013,72,HHS Region 8,Season onset,50
+2013,20,2012/2013,72,HHS Region 8,Season peak week,52
+2013,20,2012/2013,72,HHS Region 8,Season peak week,3
+2013,20,2012/2013,72,HHS Region 8,Season peak percentage,4.1
+2013,20,2012/2013,72,HHS Region 8,1 wk ahead,0.8
+2013,20,2012/2013,72,HHS Region 8,2 wk ahead,0.8
+2013,20,2012/2013,72,HHS Region 8,3 wk ahead,0.7
+2013,20,2012/2013,72,HHS Region 8,4 wk ahead,0.7
+2013,20,2012/2013,72,HHS Region 9,Season onset,2
+2013,20,2012/2013,72,HHS Region 9,Season peak week,4
+2013,20,2012/2013,72,HHS Region 9,Season peak percentage,5.6
+2013,20,2012/2013,72,HHS Region 9,1 wk ahead,1.4
+2013,20,2012/2013,72,HHS Region 9,2 wk ahead,1.4
+2013,20,2012/2013,72,HHS Region 9,3 wk ahead,1.4
+2013,20,2012/2013,72,HHS Region 9,4 wk ahead,1.5
+2013,20,2012/2013,72,HHS Region 10,Season onset,50
+2013,20,2012/2013,72,HHS Region 10,Season peak week,4
+2013,20,2012/2013,72,HHS Region 10,Season peak percentage,3.7
+2013,20,2012/2013,72,HHS Region 10,1 wk ahead,0.3
+2013,20,2012/2013,72,HHS Region 10,2 wk ahead,0.3
+2013,20,2012/2013,72,HHS Region 10,3 wk ahead,0.3
+2013,20,2012/2013,72,HHS Region 10,4 wk ahead,0.3
+2013,40,2013/2014,40,US National,Season onset,48
+2013,40,2013/2014,40,US National,Season peak week,52
+2013,40,2013/2014,40,US National,Season peak percentage,4.6
+2013,40,2013/2014,40,US National,1 wk ahead,1.3
+2013,40,2013/2014,40,US National,2 wk ahead,1.3
+2013,40,2013/2014,40,US National,3 wk ahead,1.4
+2013,40,2013/2014,40,US National,4 wk ahead,1.5
+2013,40,2013/2014,40,HHS Region 1,Season onset,51
+2013,40,2013/2014,40,HHS Region 1,Season peak week,6
+2013,40,2013/2014,40,HHS Region 1,Season peak percentage,2.2
+2013,40,2013/2014,40,HHS Region 1,1 wk ahead,0.7
+2013,40,2013/2014,40,HHS Region 1,2 wk ahead,0.7
+2013,40,2013/2014,40,HHS Region 1,3 wk ahead,0.8
+2013,40,2013/2014,40,HHS Region 1,4 wk ahead,0.9
+2013,40,2013/2014,40,HHS Region 2,Season onset,51
+2013,40,2013/2014,40,HHS Region 2,Season peak week,6
+2013,40,2013/2014,40,HHS Region 2,Season peak week,13
+2013,40,2013/2014,40,HHS Region 2,Season peak percentage,3.4
+2013,40,2013/2014,40,HHS Region 2,1 wk ahead,1.7
+2013,40,2013/2014,40,HHS Region 2,2 wk ahead,1.9
+2013,40,2013/2014,40,HHS Region 2,3 wk ahead,1.7
+2013,40,2013/2014,40,HHS Region 2,4 wk ahead,2
+2013,40,2013/2014,40,HHS Region 3,Season onset,51
+2013,40,2013/2014,40,HHS Region 3,Season peak week,1
+2013,40,2013/2014,40,HHS Region 3,Season peak percentage,3.6
+2013,40,2013/2014,40,HHS Region 3,1 wk ahead,1.1
+2013,40,2013/2014,40,HHS Region 3,2 wk ahead,1
+2013,40,2013/2014,40,HHS Region 3,3 wk ahead,1.1
+2013,40,2013/2014,40,HHS Region 3,4 wk ahead,1.1
+2013,40,2013/2014,40,HHS Region 4,Season onset,48
+2013,40,2013/2014,40,HHS Region 4,Season peak week,52
+2013,40,2013/2014,40,HHS Region 4,Season peak percentage,4.6
+2013,40,2013/2014,40,HHS Region 4,1 wk ahead,1
+2013,40,2013/2014,40,HHS Region 4,2 wk ahead,1
+2013,40,2013/2014,40,HHS Region 4,3 wk ahead,1.2
+2013,40,2013/2014,40,HHS Region 4,4 wk ahead,1.3
+2013,40,2013/2014,40,HHS Region 5,Season onset,48
+2013,40,2013/2014,40,HHS Region 5,Season peak week,52
+2013,40,2013/2014,40,HHS Region 5,Season peak percentage,3.6
+2013,40,2013/2014,40,HHS Region 5,1 wk ahead,1
+2013,40,2013/2014,40,HHS Region 5,2 wk ahead,1
+2013,40,2013/2014,40,HHS Region 5,3 wk ahead,1.1
+2013,40,2013/2014,40,HHS Region 5,4 wk ahead,1.2
+2013,40,2013/2014,40,HHS Region 6,Season onset,45
+2013,40,2013/2014,40,HHS Region 6,Season peak week,52
+2013,40,2013/2014,40,HHS Region 6,Season peak percentage,9.9
+2013,40,2013/2014,40,HHS Region 6,1 wk ahead,2.2
+2013,40,2013/2014,40,HHS Region 6,2 wk ahead,2.4
+2013,40,2013/2014,40,HHS Region 6,3 wk ahead,2.4
+2013,40,2013/2014,40,HHS Region 6,4 wk ahead,2.5
+2013,40,2013/2014,40,HHS Region 7,Season onset,51
+2013,40,2013/2014,40,HHS Region 7,Season peak week,52
+2013,40,2013/2014,40,HHS Region 7,Season peak percentage,4.5
+2013,40,2013/2014,40,HHS Region 7,1 wk ahead,0.8
+2013,40,2013/2014,40,HHS Region 7,2 wk ahead,0.7
+2013,40,2013/2014,40,HHS Region 7,3 wk ahead,0.9
+2013,40,2013/2014,40,HHS Region 7,4 wk ahead,0.8
+2013,40,2013/2014,40,HHS Region 8,Season onset,49
+2013,40,2013/2014,40,HHS Region 8,Season peak week,52
+2013,40,2013/2014,40,HHS Region 8,Season peak percentage,3.7
+2013,40,2013/2014,40,HHS Region 8,1 wk ahead,0.7
+2013,40,2013/2014,40,HHS Region 8,2 wk ahead,0.6
+2013,40,2013/2014,40,HHS Region 8,3 wk ahead,0.8
+2013,40,2013/2014,40,HHS Region 8,4 wk ahead,0.7
+2013,40,2013/2014,40,HHS Region 9,Season onset,51
+2013,40,2013/2014,40,HHS Region 9,Season peak week,1
+2013,40,2013/2014,40,HHS Region 9,Season peak week,4
+2013,40,2013/2014,40,HHS Region 9,Season peak percentage,4.6
+2013,40,2013/2014,40,HHS Region 9,1 wk ahead,1.6
+2013,40,2013/2014,40,HHS Region 9,2 wk ahead,1.6
+2013,40,2013/2014,40,HHS Region 9,3 wk ahead,1.6
+2013,40,2013/2014,40,HHS Region 9,4 wk ahead,1.8
+2013,40,2013/2014,40,HHS Region 10,Season onset,51
+2013,40,2013/2014,40,HHS Region 10,Season peak week,1
+2013,40,2013/2014,40,HHS Region 10,Season peak percentage,4
+2013,40,2013/2014,40,HHS Region 10,1 wk ahead,0.4
+2013,40,2013/2014,40,HHS Region 10,2 wk ahead,0.5
+2013,40,2013/2014,40,HHS Region 10,3 wk ahead,0.5
+2013,40,2013/2014,40,HHS Region 10,4 wk ahead,0.5
+2013,41,2013/2014,41,US National,Season onset,48
+2013,41,2013/2014,41,US National,Season peak week,52
+2013,41,2013/2014,41,US National,Season peak percentage,4.6
+2013,41,2013/2014,41,US National,1 wk ahead,1.3
+2013,41,2013/2014,41,US National,2 wk ahead,1.4
+2013,41,2013/2014,41,US National,3 wk ahead,1.5
+2013,41,2013/2014,41,US National,4 wk ahead,1.6
+2013,41,2013/2014,41,HHS Region 1,Season onset,51
+2013,41,2013/2014,41,HHS Region 1,Season peak week,6
+2013,41,2013/2014,41,HHS Region 1,Season peak percentage,2.2
+2013,41,2013/2014,41,HHS Region 1,1 wk ahead,0.7
+2013,41,2013/2014,41,HHS Region 1,2 wk ahead,0.8
+2013,41,2013/2014,41,HHS Region 1,3 wk ahead,0.9
+2013,41,2013/2014,41,HHS Region 1,4 wk ahead,1
+2013,41,2013/2014,41,HHS Region 2,Season onset,51
+2013,41,2013/2014,41,HHS Region 2,Season peak week,6
+2013,41,2013/2014,41,HHS Region 2,Season peak week,13
+2013,41,2013/2014,41,HHS Region 2,Season peak percentage,3.4
+2013,41,2013/2014,41,HHS Region 2,1 wk ahead,1.9
+2013,41,2013/2014,41,HHS Region 2,2 wk ahead,1.7
+2013,41,2013/2014,41,HHS Region 2,3 wk ahead,2
+2013,41,2013/2014,41,HHS Region 2,4 wk ahead,1.8
+2013,41,2013/2014,41,HHS Region 3,Season onset,51
+2013,41,2013/2014,41,HHS Region 3,Season peak week,1
+2013,41,2013/2014,41,HHS Region 3,Season peak percentage,3.6
+2013,41,2013/2014,41,HHS Region 3,1 wk ahead,1
+2013,41,2013/2014,41,HHS Region 3,2 wk ahead,1.1
+2013,41,2013/2014,41,HHS Region 3,3 wk ahead,1.1
+2013,41,2013/2014,41,HHS Region 3,4 wk ahead,1.1
+2013,41,2013/2014,41,HHS Region 4,Season onset,48
+2013,41,2013/2014,41,HHS Region 4,Season peak week,52
+2013,41,2013/2014,41,HHS Region 4,Season peak percentage,4.6
+2013,41,2013/2014,41,HHS Region 4,1 wk ahead,1
+2013,41,2013/2014,41,HHS Region 4,2 wk ahead,1.2
+2013,41,2013/2014,41,HHS Region 4,3 wk ahead,1.3
+2013,41,2013/2014,41,HHS Region 4,4 wk ahead,1.5
+2013,41,2013/2014,41,HHS Region 5,Season onset,48
+2013,41,2013/2014,41,HHS Region 5,Season peak week,52
+2013,41,2013/2014,41,HHS Region 5,Season peak percentage,3.6
+2013,41,2013/2014,41,HHS Region 5,1 wk ahead,1
+2013,41,2013/2014,41,HHS Region 5,2 wk ahead,1.1
+2013,41,2013/2014,41,HHS Region 5,3 wk ahead,1.2
+2013,41,2013/2014,41,HHS Region 5,4 wk ahead,1.2
+2013,41,2013/2014,41,HHS Region 6,Season onset,45
+2013,41,2013/2014,41,HHS Region 6,Season peak week,52
+2013,41,2013/2014,41,HHS Region 6,Season peak percentage,9.9
+2013,41,2013/2014,41,HHS Region 6,1 wk ahead,2.4
+2013,41,2013/2014,41,HHS Region 6,2 wk ahead,2.4
+2013,41,2013/2014,41,HHS Region 6,3 wk ahead,2.5
+2013,41,2013/2014,41,HHS Region 6,4 wk ahead,2.9
+2013,41,2013/2014,41,HHS Region 7,Season onset,51
+2013,41,2013/2014,41,HHS Region 7,Season peak week,52
+2013,41,2013/2014,41,HHS Region 7,Season peak percentage,4.5
+2013,41,2013/2014,41,HHS Region 7,1 wk ahead,0.7
+2013,41,2013/2014,41,HHS Region 7,2 wk ahead,0.9
+2013,41,2013/2014,41,HHS Region 7,3 wk ahead,0.8
+2013,41,2013/2014,41,HHS Region 7,4 wk ahead,0.9
+2013,41,2013/2014,41,HHS Region 8,Season onset,49
+2013,41,2013/2014,41,HHS Region 8,Season peak week,52
+2013,41,2013/2014,41,HHS Region 8,Season peak percentage,3.7
+2013,41,2013/2014,41,HHS Region 8,1 wk ahead,0.6
+2013,41,2013/2014,41,HHS Region 8,2 wk ahead,0.8
+2013,41,2013/2014,41,HHS Region 8,3 wk ahead,0.7
+2013,41,2013/2014,41,HHS Region 8,4 wk ahead,0.8
+2013,41,2013/2014,41,HHS Region 9,Season onset,51
+2013,41,2013/2014,41,HHS Region 9,Season peak week,1
+2013,41,2013/2014,41,HHS Region 9,Season peak week,4
+2013,41,2013/2014,41,HHS Region 9,Season peak percentage,4.6
+2013,41,2013/2014,41,HHS Region 9,1 wk ahead,1.6
+2013,41,2013/2014,41,HHS Region 9,2 wk ahead,1.6
+2013,41,2013/2014,41,HHS Region 9,3 wk ahead,1.8
+2013,41,2013/2014,41,HHS Region 9,4 wk ahead,2.1
+2013,41,2013/2014,41,HHS Region 10,Season onset,51
+2013,41,2013/2014,41,HHS Region 10,Season peak week,1
+2013,41,2013/2014,41,HHS Region 10,Season peak percentage,4
+2013,41,2013/2014,41,HHS Region 10,1 wk ahead,0.5
+2013,41,2013/2014,41,HHS Region 10,2 wk ahead,0.5
+2013,41,2013/2014,41,HHS Region 10,3 wk ahead,0.5
+2013,41,2013/2014,41,HHS Region 10,4 wk ahead,0.4
+2013,42,2013/2014,42,US National,Season onset,48
+2013,42,2013/2014,42,US National,Season peak week,52
+2013,42,2013/2014,42,US National,Season peak percentage,4.6
+2013,42,2013/2014,42,US National,1 wk ahead,1.4
+2013,42,2013/2014,42,US National,2 wk ahead,1.5
+2013,42,2013/2014,42,US National,3 wk ahead,1.6
+2013,42,2013/2014,42,US National,4 wk ahead,1.6
+2013,42,2013/2014,42,HHS Region 1,Season onset,51
+2013,42,2013/2014,42,HHS Region 1,Season peak week,6
+2013,42,2013/2014,42,HHS Region 1,Season peak percentage,2.2
+2013,42,2013/2014,42,HHS Region 1,1 wk ahead,0.8
+2013,42,2013/2014,42,HHS Region 1,2 wk ahead,0.9
+2013,42,2013/2014,42,HHS Region 1,3 wk ahead,1
+2013,42,2013/2014,42,HHS Region 1,4 wk ahead,0.9
+2013,42,2013/2014,42,HHS Region 2,Season onset,51
+2013,42,2013/2014,42,HHS Region 2,Season peak week,6
+2013,42,2013/2014,42,HHS Region 2,Season peak week,13
+2013,42,2013/2014,42,HHS Region 2,Season peak percentage,3.4
+2013,42,2013/2014,42,HHS Region 2,1 wk ahead,1.7
+2013,42,2013/2014,42,HHS Region 2,2 wk ahead,2
+2013,42,2013/2014,42,HHS Region 2,3 wk ahead,1.8
+2013,42,2013/2014,42,HHS Region 2,4 wk ahead,1.5
+2013,42,2013/2014,42,HHS Region 3,Season onset,51
+2013,42,2013/2014,42,HHS Region 3,Season peak week,1
+2013,42,2013/2014,42,HHS Region 3,Season peak percentage,3.6
+2013,42,2013/2014,42,HHS Region 3,1 wk ahead,1.1
+2013,42,2013/2014,42,HHS Region 3,2 wk ahead,1.1
+2013,42,2013/2014,42,HHS Region 3,3 wk ahead,1.1
+2013,42,2013/2014,42,HHS Region 3,4 wk ahead,1.3
+2013,42,2013/2014,42,HHS Region 4,Season onset,48
+2013,42,2013/2014,42,HHS Region 4,Season peak week,52
+2013,42,2013/2014,42,HHS Region 4,Season peak percentage,4.6
+2013,42,2013/2014,42,HHS Region 4,1 wk ahead,1.2
+2013,42,2013/2014,42,HHS Region 4,2 wk ahead,1.3
+2013,42,2013/2014,42,HHS Region 4,3 wk ahead,1.5
+2013,42,2013/2014,42,HHS Region 4,4 wk ahead,1.5
+2013,42,2013/2014,42,HHS Region 5,Season onset,48
+2013,42,2013/2014,42,HHS Region 5,Season peak week,52
+2013,42,2013/2014,42,HHS Region 5,Season peak percentage,3.6
+2013,42,2013/2014,42,HHS Region 5,1 wk ahead,1.1
+2013,42,2013/2014,42,HHS Region 5,2 wk ahead,1.2
+2013,42,2013/2014,42,HHS Region 5,3 wk ahead,1.2
+2013,42,2013/2014,42,HHS Region 5,4 wk ahead,1.2
+2013,42,2013/2014,42,HHS Region 6,Season onset,45
+2013,42,2013/2014,42,HHS Region 6,Season peak week,52
+2013,42,2013/2014,42,HHS Region 6,Season peak percentage,9.9
+2013,42,2013/2014,42,HHS Region 6,1 wk ahead,2.4
+2013,42,2013/2014,42,HHS Region 6,2 wk ahead,2.5
+2013,42,2013/2014,42,HHS Region 6,3 wk ahead,2.9
+2013,42,2013/2014,42,HHS Region 6,4 wk ahead,3.3
+2013,42,2013/2014,42,HHS Region 7,Season onset,51
+2013,42,2013/2014,42,HHS Region 7,Season peak week,52
+2013,42,2013/2014,42,HHS Region 7,Season peak percentage,4.5
+2013,42,2013/2014,42,HHS Region 7,1 wk ahead,0.9
+2013,42,2013/2014,42,HHS Region 7,2 wk ahead,0.8
+2013,42,2013/2014,42,HHS Region 7,3 wk ahead,0.9
+2013,42,2013/2014,42,HHS Region 7,4 wk ahead,0.9
+2013,42,2013/2014,42,HHS Region 8,Season onset,49
+2013,42,2013/2014,42,HHS Region 8,Season peak week,52
+2013,42,2013/2014,42,HHS Region 8,Season peak percentage,3.7
+2013,42,2013/2014,42,HHS Region 8,1 wk ahead,0.8
+2013,42,2013/2014,42,HHS Region 8,2 wk ahead,0.7
+2013,42,2013/2014,42,HHS Region 8,3 wk ahead,0.8
+2013,42,2013/2014,42,HHS Region 8,4 wk ahead,0.7
+2013,42,2013/2014,42,HHS Region 9,Season onset,51
+2013,42,2013/2014,42,HHS Region 9,Season peak week,1
+2013,42,2013/2014,42,HHS Region 9,Season peak week,4
+2013,42,2013/2014,42,HHS Region 9,Season peak percentage,4.6
+2013,42,2013/2014,42,HHS Region 9,1 wk ahead,1.6
+2013,42,2013/2014,42,HHS Region 9,2 wk ahead,1.8
+2013,42,2013/2014,42,HHS Region 9,3 wk ahead,2.1
+2013,42,2013/2014,42,HHS Region 9,4 wk ahead,2
+2013,42,2013/2014,42,HHS Region 10,Season onset,51
+2013,42,2013/2014,42,HHS Region 10,Season peak week,1
+2013,42,2013/2014,42,HHS Region 10,Season peak percentage,4
+2013,42,2013/2014,42,HHS Region 10,1 wk ahead,0.5
+2013,42,2013/2014,42,HHS Region 10,2 wk ahead,0.5
+2013,42,2013/2014,42,HHS Region 10,3 wk ahead,0.4
+2013,42,2013/2014,42,HHS Region 10,4 wk ahead,0.5
+2013,43,2013/2014,43,US National,Season onset,48
+2013,43,2013/2014,43,US National,Season peak week,52
+2013,43,2013/2014,43,US National,Season peak percentage,4.6
+2013,43,2013/2014,43,US National,1 wk ahead,1.5
+2013,43,2013/2014,43,US National,2 wk ahead,1.6
+2013,43,2013/2014,43,US National,3 wk ahead,1.6
+2013,43,2013/2014,43,US National,4 wk ahead,1.7
+2013,43,2013/2014,43,HHS Region 1,Season onset,51
+2013,43,2013/2014,43,HHS Region 1,Season peak week,6
+2013,43,2013/2014,43,HHS Region 1,Season peak percentage,2.2
+2013,43,2013/2014,43,HHS Region 1,1 wk ahead,0.9
+2013,43,2013/2014,43,HHS Region 1,2 wk ahead,1
+2013,43,2013/2014,43,HHS Region 1,3 wk ahead,0.9
+2013,43,2013/2014,43,HHS Region 1,4 wk ahead,0.7
+2013,43,2013/2014,43,HHS Region 2,Season onset,51
+2013,43,2013/2014,43,HHS Region 2,Season peak week,6
+2013,43,2013/2014,43,HHS Region 2,Season peak week,13
+2013,43,2013/2014,43,HHS Region 2,Season peak percentage,3.4
+2013,43,2013/2014,43,HHS Region 2,1 wk ahead,2
+2013,43,2013/2014,43,HHS Region 2,2 wk ahead,1.8
+2013,43,2013/2014,43,HHS Region 2,3 wk ahead,1.5
+2013,43,2013/2014,43,HHS Region 2,4 wk ahead,1.8
+2013,43,2013/2014,43,HHS Region 3,Season onset,51
+2013,43,2013/2014,43,HHS Region 3,Season peak week,1
+2013,43,2013/2014,43,HHS Region 3,Season peak percentage,3.6
+2013,43,2013/2014,43,HHS Region 3,1 wk ahead,1.1
+2013,43,2013/2014,43,HHS Region 3,2 wk ahead,1.1
+2013,43,2013/2014,43,HHS Region 3,3 wk ahead,1.3
+2013,43,2013/2014,43,HHS Region 3,4 wk ahead,1.2
+2013,43,2013/2014,43,HHS Region 4,Season onset,48
+2013,43,2013/2014,43,HHS Region 4,Season peak week,52
+2013,43,2013/2014,43,HHS Region 4,Season peak percentage,4.6
+2013,43,2013/2014,43,HHS Region 4,1 wk ahead,1.3
+2013,43,2013/2014,43,HHS Region 4,2 wk ahead,1.5
+2013,43,2013/2014,43,HHS Region 4,3 wk ahead,1.5
+2013,43,2013/2014,43,HHS Region 4,4 wk ahead,1.7
+2013,43,2013/2014,43,HHS Region 5,Season onset,48
+2013,43,2013/2014,43,HHS Region 5,Season peak week,52
+2013,43,2013/2014,43,HHS Region 5,Season peak percentage,3.6
+2013,43,2013/2014,43,HHS Region 5,1 wk ahead,1.2
+2013,43,2013/2014,43,HHS Region 5,2 wk ahead,1.2
+2013,43,2013/2014,43,HHS Region 5,3 wk ahead,1.2
+2013,43,2013/2014,43,HHS Region 5,4 wk ahead,1.2
+2013,43,2013/2014,43,HHS Region 6,Season onset,45
+2013,43,2013/2014,43,HHS Region 6,Season peak week,52
+2013,43,2013/2014,43,HHS Region 6,Season peak percentage,9.9
+2013,43,2013/2014,43,HHS Region 6,1 wk ahead,2.5
+2013,43,2013/2014,43,HHS Region 6,2 wk ahead,2.9
+2013,43,2013/2014,43,HHS Region 6,3 wk ahead,3.3
+2013,43,2013/2014,43,HHS Region 6,4 wk ahead,3.7
+2013,43,2013/2014,43,HHS Region 7,Season onset,51
+2013,43,2013/2014,43,HHS Region 7,Season peak week,52
+2013,43,2013/2014,43,HHS Region 7,Season peak percentage,4.5
+2013,43,2013/2014,43,HHS Region 7,1 wk ahead,0.8
+2013,43,2013/2014,43,HHS Region 7,2 wk ahead,0.9
+2013,43,2013/2014,43,HHS Region 7,3 wk ahead,0.9
+2013,43,2013/2014,43,HHS Region 7,4 wk ahead,1
+2013,43,2013/2014,43,HHS Region 8,Season onset,49
+2013,43,2013/2014,43,HHS Region 8,Season peak week,52
+2013,43,2013/2014,43,HHS Region 8,Season peak percentage,3.7
+2013,43,2013/2014,43,HHS Region 8,1 wk ahead,0.7
+2013,43,2013/2014,43,HHS Region 8,2 wk ahead,0.8
+2013,43,2013/2014,43,HHS Region 8,3 wk ahead,0.7
+2013,43,2013/2014,43,HHS Region 8,4 wk ahead,1
+2013,43,2013/2014,43,HHS Region 9,Season onset,51
+2013,43,2013/2014,43,HHS Region 9,Season peak week,1
+2013,43,2013/2014,43,HHS Region 9,Season peak week,4
+2013,43,2013/2014,43,HHS Region 9,Season peak percentage,4.6
+2013,43,2013/2014,43,HHS Region 9,1 wk ahead,1.8
+2013,43,2013/2014,43,HHS Region 9,2 wk ahead,2.1
+2013,43,2013/2014,43,HHS Region 9,3 wk ahead,2
+2013,43,2013/2014,43,HHS Region 9,4 wk ahead,2
+2013,43,2013/2014,43,HHS Region 10,Season onset,51
+2013,43,2013/2014,43,HHS Region 10,Season peak week,1
+2013,43,2013/2014,43,HHS Region 10,Season peak percentage,4
+2013,43,2013/2014,43,HHS Region 10,1 wk ahead,0.5
+2013,43,2013/2014,43,HHS Region 10,2 wk ahead,0.4
+2013,43,2013/2014,43,HHS Region 10,3 wk ahead,0.5
+2013,43,2013/2014,43,HHS Region 10,4 wk ahead,0.5
+2013,44,2013/2014,44,US National,Season onset,48
+2013,44,2013/2014,44,US National,Season peak week,52
+2013,44,2013/2014,44,US National,Season peak percentage,4.6
+2013,44,2013/2014,44,US National,1 wk ahead,1.6
+2013,44,2013/2014,44,US National,2 wk ahead,1.6
+2013,44,2013/2014,44,US National,3 wk ahead,1.7
+2013,44,2013/2014,44,US National,4 wk ahead,2.1
+2013,44,2013/2014,44,HHS Region 1,Season onset,51
+2013,44,2013/2014,44,HHS Region 1,Season peak week,6
+2013,44,2013/2014,44,HHS Region 1,Season peak percentage,2.2
+2013,44,2013/2014,44,HHS Region 1,1 wk ahead,1
+2013,44,2013/2014,44,HHS Region 1,2 wk ahead,0.9
+2013,44,2013/2014,44,HHS Region 1,3 wk ahead,0.7
+2013,44,2013/2014,44,HHS Region 1,4 wk ahead,0.9
+2013,44,2013/2014,44,HHS Region 2,Season onset,51
+2013,44,2013/2014,44,HHS Region 2,Season peak week,6
+2013,44,2013/2014,44,HHS Region 2,Season peak week,13
+2013,44,2013/2014,44,HHS Region 2,Season peak percentage,3.4
+2013,44,2013/2014,44,HHS Region 2,1 wk ahead,1.8
+2013,44,2013/2014,44,HHS Region 2,2 wk ahead,1.5
+2013,44,2013/2014,44,HHS Region 2,3 wk ahead,1.8
+2013,44,2013/2014,44,HHS Region 2,4 wk ahead,2
+2013,44,2013/2014,44,HHS Region 3,Season onset,51
+2013,44,2013/2014,44,HHS Region 3,Season peak week,1
+2013,44,2013/2014,44,HHS Region 3,Season peak percentage,3.6
+2013,44,2013/2014,44,HHS Region 3,1 wk ahead,1.1
+2013,44,2013/2014,44,HHS Region 3,2 wk ahead,1.3
+2013,44,2013/2014,44,HHS Region 3,3 wk ahead,1.2
+2013,44,2013/2014,44,HHS Region 3,4 wk ahead,1.5
+2013,44,2013/2014,44,HHS Region 4,Season onset,48
+2013,44,2013/2014,44,HHS Region 4,Season peak week,52
+2013,44,2013/2014,44,HHS Region 4,Season peak percentage,4.6
+2013,44,2013/2014,44,HHS Region 4,1 wk ahead,1.5
+2013,44,2013/2014,44,HHS Region 4,2 wk ahead,1.5
+2013,44,2013/2014,44,HHS Region 4,3 wk ahead,1.7
+2013,44,2013/2014,44,HHS Region 4,4 wk ahead,2.2
+2013,44,2013/2014,44,HHS Region 5,Season onset,48
+2013,44,2013/2014,44,HHS Region 5,Season peak week,52
+2013,44,2013/2014,44,HHS Region 5,Season peak percentage,3.6
+2013,44,2013/2014,44,HHS Region 5,1 wk ahead,1.2
+2013,44,2013/2014,44,HHS Region 5,2 wk ahead,1.2
+2013,44,2013/2014,44,HHS Region 5,3 wk ahead,1.2
+2013,44,2013/2014,44,HHS Region 5,4 wk ahead,1.7
+2013,44,2013/2014,44,HHS Region 6,Season onset,45
+2013,44,2013/2014,44,HHS Region 6,Season peak week,52
+2013,44,2013/2014,44,HHS Region 6,Season peak percentage,9.9
+2013,44,2013/2014,44,HHS Region 6,1 wk ahead,2.9
+2013,44,2013/2014,44,HHS Region 6,2 wk ahead,3.3
+2013,44,2013/2014,44,HHS Region 6,3 wk ahead,3.7
+2013,44,2013/2014,44,HHS Region 6,4 wk ahead,4.4
+2013,44,2013/2014,44,HHS Region 7,Season onset,51
+2013,44,2013/2014,44,HHS Region 7,Season peak week,52
+2013,44,2013/2014,44,HHS Region 7,Season peak percentage,4.5
+2013,44,2013/2014,44,HHS Region 7,1 wk ahead,0.9
+2013,44,2013/2014,44,HHS Region 7,2 wk ahead,0.9
+2013,44,2013/2014,44,HHS Region 7,3 wk ahead,1
+2013,44,2013/2014,44,HHS Region 7,4 wk ahead,1.1
+2013,44,2013/2014,44,HHS Region 8,Season onset,49
+2013,44,2013/2014,44,HHS Region 8,Season peak week,52
+2013,44,2013/2014,44,HHS Region 8,Season peak percentage,3.7
+2013,44,2013/2014,44,HHS Region 8,1 wk ahead,0.8
+2013,44,2013/2014,44,HHS Region 8,2 wk ahead,0.7
+2013,44,2013/2014,44,HHS Region 8,3 wk ahead,1
+2013,44,2013/2014,44,HHS Region 8,4 wk ahead,1
+2013,44,2013/2014,44,HHS Region 9,Season onset,51
+2013,44,2013/2014,44,HHS Region 9,Season peak week,1
+2013,44,2013/2014,44,HHS Region 9,Season peak week,4
+2013,44,2013/2014,44,HHS Region 9,Season peak percentage,4.6
+2013,44,2013/2014,44,HHS Region 9,1 wk ahead,2.1
+2013,44,2013/2014,44,HHS Region 9,2 wk ahead,2
+2013,44,2013/2014,44,HHS Region 9,3 wk ahead,2
+2013,44,2013/2014,44,HHS Region 9,4 wk ahead,2.3
+2013,44,2013/2014,44,HHS Region 10,Season onset,51
+2013,44,2013/2014,44,HHS Region 10,Season peak week,1
+2013,44,2013/2014,44,HHS Region 10,Season peak percentage,4
+2013,44,2013/2014,44,HHS Region 10,1 wk ahead,0.4
+2013,44,2013/2014,44,HHS Region 10,2 wk ahead,0.5
+2013,44,2013/2014,44,HHS Region 10,3 wk ahead,0.5
+2013,44,2013/2014,44,HHS Region 10,4 wk ahead,0.7
+2013,45,2013/2014,45,US National,Season onset,48
+2013,45,2013/2014,45,US National,Season peak week,52
+2013,45,2013/2014,45,US National,Season peak percentage,4.6
+2013,45,2013/2014,45,US National,1 wk ahead,1.6
+2013,45,2013/2014,45,US National,2 wk ahead,1.7
+2013,45,2013/2014,45,US National,3 wk ahead,2.1
+2013,45,2013/2014,45,US National,4 wk ahead,2.2
+2013,45,2013/2014,45,HHS Region 1,Season onset,51
+2013,45,2013/2014,45,HHS Region 1,Season peak week,6
+2013,45,2013/2014,45,HHS Region 1,Season peak percentage,2.2
+2013,45,2013/2014,45,HHS Region 1,1 wk ahead,0.9
+2013,45,2013/2014,45,HHS Region 1,2 wk ahead,0.7
+2013,45,2013/2014,45,HHS Region 1,3 wk ahead,0.9
+2013,45,2013/2014,45,HHS Region 1,4 wk ahead,0.8
+2013,45,2013/2014,45,HHS Region 2,Season onset,51
+2013,45,2013/2014,45,HHS Region 2,Season peak week,6
+2013,45,2013/2014,45,HHS Region 2,Season peak week,13
+2013,45,2013/2014,45,HHS Region 2,Season peak percentage,3.4
+2013,45,2013/2014,45,HHS Region 2,1 wk ahead,1.5
+2013,45,2013/2014,45,HHS Region 2,2 wk ahead,1.8
+2013,45,2013/2014,45,HHS Region 2,3 wk ahead,2
+2013,45,2013/2014,45,HHS Region 2,4 wk ahead,2
+2013,45,2013/2014,45,HHS Region 3,Season onset,51
+2013,45,2013/2014,45,HHS Region 3,Season peak week,1
+2013,45,2013/2014,45,HHS Region 3,Season peak percentage,3.6
+2013,45,2013/2014,45,HHS Region 3,1 wk ahead,1.3
+2013,45,2013/2014,45,HHS Region 3,2 wk ahead,1.2
+2013,45,2013/2014,45,HHS Region 3,3 wk ahead,1.5
+2013,45,2013/2014,45,HHS Region 3,4 wk ahead,1.5
+2013,45,2013/2014,45,HHS Region 4,Season onset,48
+2013,45,2013/2014,45,HHS Region 4,Season peak week,52
+2013,45,2013/2014,45,HHS Region 4,Season peak percentage,4.6
+2013,45,2013/2014,45,HHS Region 4,1 wk ahead,1.5
+2013,45,2013/2014,45,HHS Region 4,2 wk ahead,1.7
+2013,45,2013/2014,45,HHS Region 4,3 wk ahead,2.2
+2013,45,2013/2014,45,HHS Region 4,4 wk ahead,2.3
+2013,45,2013/2014,45,HHS Region 5,Season onset,48
+2013,45,2013/2014,45,HHS Region 5,Season peak week,52
+2013,45,2013/2014,45,HHS Region 5,Season peak percentage,3.6
+2013,45,2013/2014,45,HHS Region 5,1 wk ahead,1.2
+2013,45,2013/2014,45,HHS Region 5,2 wk ahead,1.2
+2013,45,2013/2014,45,HHS Region 5,3 wk ahead,1.7
+2013,45,2013/2014,45,HHS Region 5,4 wk ahead,1.6
+2013,45,2013/2014,45,HHS Region 6,Season onset,45
+2013,45,2013/2014,45,HHS Region 6,Season peak week,52
+2013,45,2013/2014,45,HHS Region 6,Season peak percentage,9.9
+2013,45,2013/2014,45,HHS Region 6,1 wk ahead,3.3
+2013,45,2013/2014,45,HHS Region 6,2 wk ahead,3.7
+2013,45,2013/2014,45,HHS Region 6,3 wk ahead,4.4
+2013,45,2013/2014,45,HHS Region 6,4 wk ahead,4.9
+2013,45,2013/2014,45,HHS Region 7,Season onset,51
+2013,45,2013/2014,45,HHS Region 7,Season peak week,52
+2013,45,2013/2014,45,HHS Region 7,Season peak percentage,4.5
+2013,45,2013/2014,45,HHS Region 7,1 wk ahead,0.9
+2013,45,2013/2014,45,HHS Region 7,2 wk ahead,1
+2013,45,2013/2014,45,HHS Region 7,3 wk ahead,1.1
+2013,45,2013/2014,45,HHS Region 7,4 wk ahead,1.3
+2013,45,2013/2014,45,HHS Region 8,Season onset,49
+2013,45,2013/2014,45,HHS Region 8,Season peak week,52
+2013,45,2013/2014,45,HHS Region 8,Season peak percentage,3.7
+2013,45,2013/2014,45,HHS Region 8,1 wk ahead,0.7
+2013,45,2013/2014,45,HHS Region 8,2 wk ahead,1
+2013,45,2013/2014,45,HHS Region 8,3 wk ahead,1
+2013,45,2013/2014,45,HHS Region 8,4 wk ahead,1.5
+2013,45,2013/2014,45,HHS Region 9,Season onset,51
+2013,45,2013/2014,45,HHS Region 9,Season peak week,1
+2013,45,2013/2014,45,HHS Region 9,Season peak week,4
+2013,45,2013/2014,45,HHS Region 9,Season peak percentage,4.6
+2013,45,2013/2014,45,HHS Region 9,1 wk ahead,2
+2013,45,2013/2014,45,HHS Region 9,2 wk ahead,2
+2013,45,2013/2014,45,HHS Region 9,3 wk ahead,2.3
+2013,45,2013/2014,45,HHS Region 9,4 wk ahead,2.1
+2013,45,2013/2014,45,HHS Region 10,Season onset,51
+2013,45,2013/2014,45,HHS Region 10,Season peak week,1
+2013,45,2013/2014,45,HHS Region 10,Season peak percentage,4
+2013,45,2013/2014,45,HHS Region 10,1 wk ahead,0.5
+2013,45,2013/2014,45,HHS Region 10,2 wk ahead,0.5
+2013,45,2013/2014,45,HHS Region 10,3 wk ahead,0.7
+2013,45,2013/2014,45,HHS Region 10,4 wk ahead,0.7
+2013,46,2013/2014,46,US National,Season onset,48
+2013,46,2013/2014,46,US National,Season peak week,52
+2013,46,2013/2014,46,US National,Season peak percentage,4.6
+2013,46,2013/2014,46,US National,1 wk ahead,1.7
+2013,46,2013/2014,46,US National,2 wk ahead,2.1
+2013,46,2013/2014,46,US National,3 wk ahead,2.2
+2013,46,2013/2014,46,US National,4 wk ahead,2.4
+2013,46,2013/2014,46,HHS Region 1,Season onset,51
+2013,46,2013/2014,46,HHS Region 1,Season peak week,6
+2013,46,2013/2014,46,HHS Region 1,Season peak percentage,2.2
+2013,46,2013/2014,46,HHS Region 1,1 wk ahead,0.7
+2013,46,2013/2014,46,HHS Region 1,2 wk ahead,0.9
+2013,46,2013/2014,46,HHS Region 1,3 wk ahead,0.8
+2013,46,2013/2014,46,HHS Region 1,4 wk ahead,1.1
+2013,46,2013/2014,46,HHS Region 2,Season onset,51
+2013,46,2013/2014,46,HHS Region 2,Season peak week,6
+2013,46,2013/2014,46,HHS Region 2,Season peak week,13
+2013,46,2013/2014,46,HHS Region 2,Season peak percentage,3.4
+2013,46,2013/2014,46,HHS Region 2,1 wk ahead,1.8
+2013,46,2013/2014,46,HHS Region 2,2 wk ahead,2
+2013,46,2013/2014,46,HHS Region 2,3 wk ahead,2
+2013,46,2013/2014,46,HHS Region 2,4 wk ahead,1.8
+2013,46,2013/2014,46,HHS Region 3,Season onset,51
+2013,46,2013/2014,46,HHS Region 3,Season peak week,1
+2013,46,2013/2014,46,HHS Region 3,Season peak percentage,3.6
+2013,46,2013/2014,46,HHS Region 3,1 wk ahead,1.2
+2013,46,2013/2014,46,HHS Region 3,2 wk ahead,1.5
+2013,46,2013/2014,46,HHS Region 3,3 wk ahead,1.5
+2013,46,2013/2014,46,HHS Region 3,4 wk ahead,1.6
+2013,46,2013/2014,46,HHS Region 4,Season onset,48
+2013,46,2013/2014,46,HHS Region 4,Season peak week,52
+2013,46,2013/2014,46,HHS Region 4,Season peak percentage,4.6
+2013,46,2013/2014,46,HHS Region 4,1 wk ahead,1.7
+2013,46,2013/2014,46,HHS Region 4,2 wk ahead,2.2
+2013,46,2013/2014,46,HHS Region 4,3 wk ahead,2.3
+2013,46,2013/2014,46,HHS Region 4,4 wk ahead,2.4
+2013,46,2013/2014,46,HHS Region 5,Season onset,48
+2013,46,2013/2014,46,HHS Region 5,Season peak week,52
+2013,46,2013/2014,46,HHS Region 5,Season peak percentage,3.6
+2013,46,2013/2014,46,HHS Region 5,1 wk ahead,1.2
+2013,46,2013/2014,46,HHS Region 5,2 wk ahead,1.7
+2013,46,2013/2014,46,HHS Region 5,3 wk ahead,1.6
+2013,46,2013/2014,46,HHS Region 5,4 wk ahead,1.7
+2013,46,2013/2014,46,HHS Region 6,Season onset,45
+2013,46,2013/2014,46,HHS Region 6,Season peak week,52
+2013,46,2013/2014,46,HHS Region 6,Season peak percentage,9.9
+2013,46,2013/2014,46,HHS Region 6,1 wk ahead,3.7
+2013,46,2013/2014,46,HHS Region 6,2 wk ahead,4.4
+2013,46,2013/2014,46,HHS Region 6,3 wk ahead,4.9
+2013,46,2013/2014,46,HHS Region 6,4 wk ahead,5.6
+2013,46,2013/2014,46,HHS Region 7,Season onset,51
+2013,46,2013/2014,46,HHS Region 7,Season peak week,52
+2013,46,2013/2014,46,HHS Region 7,Season peak percentage,4.5
+2013,46,2013/2014,46,HHS Region 7,1 wk ahead,1
+2013,46,2013/2014,46,HHS Region 7,2 wk ahead,1.1
+2013,46,2013/2014,46,HHS Region 7,3 wk ahead,1.3
+2013,46,2013/2014,46,HHS Region 7,4 wk ahead,1.5
+2013,46,2013/2014,46,HHS Region 8,Season onset,49
+2013,46,2013/2014,46,HHS Region 8,Season peak week,52
+2013,46,2013/2014,46,HHS Region 8,Season peak percentage,3.7
+2013,46,2013/2014,46,HHS Region 8,1 wk ahead,1
+2013,46,2013/2014,46,HHS Region 8,2 wk ahead,1
+2013,46,2013/2014,46,HHS Region 8,3 wk ahead,1.5
+2013,46,2013/2014,46,HHS Region 8,4 wk ahead,1.6
+2013,46,2013/2014,46,HHS Region 9,Season onset,51
+2013,46,2013/2014,46,HHS Region 9,Season peak week,1
+2013,46,2013/2014,46,HHS Region 9,Season peak week,4
+2013,46,2013/2014,46,HHS Region 9,Season peak percentage,4.6
+2013,46,2013/2014,46,HHS Region 9,1 wk ahead,2
+2013,46,2013/2014,46,HHS Region 9,2 wk ahead,2.3
+2013,46,2013/2014,46,HHS Region 9,3 wk ahead,2.1
+2013,46,2013/2014,46,HHS Region 9,4 wk ahead,2.5
+2013,46,2013/2014,46,HHS Region 10,Season onset,51
+2013,46,2013/2014,46,HHS Region 10,Season peak week,1
+2013,46,2013/2014,46,HHS Region 10,Season peak percentage,4
+2013,46,2013/2014,46,HHS Region 10,1 wk ahead,0.5
+2013,46,2013/2014,46,HHS Region 10,2 wk ahead,0.7
+2013,46,2013/2014,46,HHS Region 10,3 wk ahead,0.7
+2013,46,2013/2014,46,HHS Region 10,4 wk ahead,0.9
+2013,47,2013/2014,47,US National,Season onset,48
+2013,47,2013/2014,47,US National,Season peak week,52
+2013,47,2013/2014,47,US National,Season peak percentage,4.6
+2013,47,2013/2014,47,US National,1 wk ahead,2.1
+2013,47,2013/2014,47,US National,2 wk ahead,2.2
+2013,47,2013/2014,47,US National,3 wk ahead,2.4
+2013,47,2013/2014,47,US National,4 wk ahead,3.2
+2013,47,2013/2014,47,HHS Region 1,Season onset,51
+2013,47,2013/2014,47,HHS Region 1,Season peak week,6
+2013,47,2013/2014,47,HHS Region 1,Season peak percentage,2.2
+2013,47,2013/2014,47,HHS Region 1,1 wk ahead,0.9
+2013,47,2013/2014,47,HHS Region 1,2 wk ahead,0.8
+2013,47,2013/2014,47,HHS Region 1,3 wk ahead,1.1
+2013,47,2013/2014,47,HHS Region 1,4 wk ahead,1.2
+2013,47,2013/2014,47,HHS Region 2,Season onset,51
+2013,47,2013/2014,47,HHS Region 2,Season peak week,6
+2013,47,2013/2014,47,HHS Region 2,Season peak week,13
+2013,47,2013/2014,47,HHS Region 2,Season peak percentage,3.4
+2013,47,2013/2014,47,HHS Region 2,1 wk ahead,2
+2013,47,2013/2014,47,HHS Region 2,2 wk ahead,2
+2013,47,2013/2014,47,HHS Region 2,3 wk ahead,1.8
+2013,47,2013/2014,47,HHS Region 2,4 wk ahead,2.2
+2013,47,2013/2014,47,HHS Region 3,Season onset,51
+2013,47,2013/2014,47,HHS Region 3,Season peak week,1
+2013,47,2013/2014,47,HHS Region 3,Season peak percentage,3.6
+2013,47,2013/2014,47,HHS Region 3,1 wk ahead,1.5
+2013,47,2013/2014,47,HHS Region 3,2 wk ahead,1.5
+2013,47,2013/2014,47,HHS Region 3,3 wk ahead,1.6
+2013,47,2013/2014,47,HHS Region 3,4 wk ahead,2.2
+2013,47,2013/2014,47,HHS Region 4,Season onset,48
+2013,47,2013/2014,47,HHS Region 4,Season peak week,52
+2013,47,2013/2014,47,HHS Region 4,Season peak percentage,4.6
+2013,47,2013/2014,47,HHS Region 4,1 wk ahead,2.2
+2013,47,2013/2014,47,HHS Region 4,2 wk ahead,2.3
+2013,47,2013/2014,47,HHS Region 4,3 wk ahead,2.4
+2013,47,2013/2014,47,HHS Region 4,4 wk ahead,3.2
+2013,47,2013/2014,47,HHS Region 5,Season onset,48
+2013,47,2013/2014,47,HHS Region 5,Season peak week,52
+2013,47,2013/2014,47,HHS Region 5,Season peak percentage,3.6
+2013,47,2013/2014,47,HHS Region 5,1 wk ahead,1.7
+2013,47,2013/2014,47,HHS Region 5,2 wk ahead,1.6
+2013,47,2013/2014,47,HHS Region 5,3 wk ahead,1.7
+2013,47,2013/2014,47,HHS Region 5,4 wk ahead,2.1
+2013,47,2013/2014,47,HHS Region 6,Season onset,45
+2013,47,2013/2014,47,HHS Region 6,Season peak week,52
+2013,47,2013/2014,47,HHS Region 6,Season peak percentage,9.9
+2013,47,2013/2014,47,HHS Region 6,1 wk ahead,4.4
+2013,47,2013/2014,47,HHS Region 6,2 wk ahead,4.9
+2013,47,2013/2014,47,HHS Region 6,3 wk ahead,5.6
+2013,47,2013/2014,47,HHS Region 6,4 wk ahead,8
+2013,47,2013/2014,47,HHS Region 7,Season onset,51
+2013,47,2013/2014,47,HHS Region 7,Season peak week,52
+2013,47,2013/2014,47,HHS Region 7,Season peak percentage,4.5
+2013,47,2013/2014,47,HHS Region 7,1 wk ahead,1.1
+2013,47,2013/2014,47,HHS Region 7,2 wk ahead,1.3
+2013,47,2013/2014,47,HHS Region 7,3 wk ahead,1.5
+2013,47,2013/2014,47,HHS Region 7,4 wk ahead,2.8
+2013,47,2013/2014,47,HHS Region 8,Season onset,49
+2013,47,2013/2014,47,HHS Region 8,Season peak week,52
+2013,47,2013/2014,47,HHS Region 8,Season peak percentage,3.7
+2013,47,2013/2014,47,HHS Region 8,1 wk ahead,1
+2013,47,2013/2014,47,HHS Region 8,2 wk ahead,1.5
+2013,47,2013/2014,47,HHS Region 8,3 wk ahead,1.6
+2013,47,2013/2014,47,HHS Region 8,4 wk ahead,2
+2013,47,2013/2014,47,HHS Region 9,Season onset,51
+2013,47,2013/2014,47,HHS Region 9,Season peak week,1
+2013,47,2013/2014,47,HHS Region 9,Season peak week,4
+2013,47,2013/2014,47,HHS Region 9,Season peak percentage,4.6
+2013,47,2013/2014,47,HHS Region 9,1 wk ahead,2.3
+2013,47,2013/2014,47,HHS Region 9,2 wk ahead,2.1
+2013,47,2013/2014,47,HHS Region 9,3 wk ahead,2.5
+2013,47,2013/2014,47,HHS Region 9,4 wk ahead,2.9
+2013,47,2013/2014,47,HHS Region 10,Season onset,51
+2013,47,2013/2014,47,HHS Region 10,Season peak week,1
+2013,47,2013/2014,47,HHS Region 10,Season peak percentage,4
+2013,47,2013/2014,47,HHS Region 10,1 wk ahead,0.7
+2013,47,2013/2014,47,HHS Region 10,2 wk ahead,0.7
+2013,47,2013/2014,47,HHS Region 10,3 wk ahead,0.9
+2013,47,2013/2014,47,HHS Region 10,4 wk ahead,1.5
+2013,48,2013/2014,48,US National,Season onset,48
+2013,48,2013/2014,48,US National,Season peak week,52
+2013,48,2013/2014,48,US National,Season peak percentage,4.6
+2013,48,2013/2014,48,US National,1 wk ahead,2.2
+2013,48,2013/2014,48,US National,2 wk ahead,2.4
+2013,48,2013/2014,48,US National,3 wk ahead,3.2
+2013,48,2013/2014,48,US National,4 wk ahead,4.6
+2013,48,2013/2014,48,HHS Region 1,Season onset,51
+2013,48,2013/2014,48,HHS Region 1,Season peak week,6
+2013,48,2013/2014,48,HHS Region 1,Season peak percentage,2.2
+2013,48,2013/2014,48,HHS Region 1,1 wk ahead,0.8
+2013,48,2013/2014,48,HHS Region 1,2 wk ahead,1.1
+2013,48,2013/2014,48,HHS Region 1,3 wk ahead,1.2
+2013,48,2013/2014,48,HHS Region 1,4 wk ahead,1.6
+2013,48,2013/2014,48,HHS Region 2,Season onset,51
+2013,48,2013/2014,48,HHS Region 2,Season peak week,6
+2013,48,2013/2014,48,HHS Region 2,Season peak week,13
+2013,48,2013/2014,48,HHS Region 2,Season peak percentage,3.4
+2013,48,2013/2014,48,HHS Region 2,1 wk ahead,2
+2013,48,2013/2014,48,HHS Region 2,2 wk ahead,1.8
+2013,48,2013/2014,48,HHS Region 2,3 wk ahead,2.2
+2013,48,2013/2014,48,HHS Region 2,4 wk ahead,2.9
+2013,48,2013/2014,48,HHS Region 3,Season onset,51
+2013,48,2013/2014,48,HHS Region 3,Season peak week,1
+2013,48,2013/2014,48,HHS Region 3,Season peak percentage,3.6
+2013,48,2013/2014,48,HHS Region 3,1 wk ahead,1.5
+2013,48,2013/2014,48,HHS Region 3,2 wk ahead,1.6
+2013,48,2013/2014,48,HHS Region 3,3 wk ahead,2.2
+2013,48,2013/2014,48,HHS Region 3,4 wk ahead,3.3
+2013,48,2013/2014,48,HHS Region 4,Season onset,48
+2013,48,2013/2014,48,HHS Region 4,Season peak week,52
+2013,48,2013/2014,48,HHS Region 4,Season peak percentage,4.6
+2013,48,2013/2014,48,HHS Region 4,1 wk ahead,2.3
+2013,48,2013/2014,48,HHS Region 4,2 wk ahead,2.4
+2013,48,2013/2014,48,HHS Region 4,3 wk ahead,3.2
+2013,48,2013/2014,48,HHS Region 4,4 wk ahead,4.6
+2013,48,2013/2014,48,HHS Region 5,Season onset,48
+2013,48,2013/2014,48,HHS Region 5,Season peak week,52
+2013,48,2013/2014,48,HHS Region 5,Season peak percentage,3.6
+2013,48,2013/2014,48,HHS Region 5,1 wk ahead,1.6
+2013,48,2013/2014,48,HHS Region 5,2 wk ahead,1.7
+2013,48,2013/2014,48,HHS Region 5,3 wk ahead,2.1
+2013,48,2013/2014,48,HHS Region 5,4 wk ahead,3.6
+2013,48,2013/2014,48,HHS Region 6,Season onset,45
+2013,48,2013/2014,48,HHS Region 6,Season peak week,52
+2013,48,2013/2014,48,HHS Region 6,Season peak percentage,9.9
+2013,48,2013/2014,48,HHS Region 6,1 wk ahead,4.9
+2013,48,2013/2014,48,HHS Region 6,2 wk ahead,5.6
+2013,48,2013/2014,48,HHS Region 6,3 wk ahead,8
+2013,48,2013/2014,48,HHS Region 6,4 wk ahead,9.9
+2013,48,2013/2014,48,HHS Region 7,Season onset,51
+2013,48,2013/2014,48,HHS Region 7,Season peak week,52
+2013,48,2013/2014,48,HHS Region 7,Season peak percentage,4.5
+2013,48,2013/2014,48,HHS Region 7,1 wk ahead,1.3
+2013,48,2013/2014,48,HHS Region 7,2 wk ahead,1.5
+2013,48,2013/2014,48,HHS Region 7,3 wk ahead,2.8
+2013,48,2013/2014,48,HHS Region 7,4 wk ahead,4.5
+2013,48,2013/2014,48,HHS Region 8,Season onset,49
+2013,48,2013/2014,48,HHS Region 8,Season peak week,52
+2013,48,2013/2014,48,HHS Region 8,Season peak percentage,3.7
+2013,48,2013/2014,48,HHS Region 8,1 wk ahead,1.5
+2013,48,2013/2014,48,HHS Region 8,2 wk ahead,1.6
+2013,48,2013/2014,48,HHS Region 8,3 wk ahead,2
+2013,48,2013/2014,48,HHS Region 8,4 wk ahead,3.7
+2013,48,2013/2014,48,HHS Region 9,Season onset,51
+2013,48,2013/2014,48,HHS Region 9,Season peak week,1
+2013,48,2013/2014,48,HHS Region 9,Season peak week,4
+2013,48,2013/2014,48,HHS Region 9,Season peak percentage,4.6
+2013,48,2013/2014,48,HHS Region 9,1 wk ahead,2.1
+2013,48,2013/2014,48,HHS Region 9,2 wk ahead,2.5
+2013,48,2013/2014,48,HHS Region 9,3 wk ahead,2.9
+2013,48,2013/2014,48,HHS Region 9,4 wk ahead,4.5
+2013,48,2013/2014,48,HHS Region 10,Season onset,51
+2013,48,2013/2014,48,HHS Region 10,Season peak week,1
+2013,48,2013/2014,48,HHS Region 10,Season peak percentage,4
+2013,48,2013/2014,48,HHS Region 10,1 wk ahead,0.7
+2013,48,2013/2014,48,HHS Region 10,2 wk ahead,0.9
+2013,48,2013/2014,48,HHS Region 10,3 wk ahead,1.5
+2013,48,2013/2014,48,HHS Region 10,4 wk ahead,3.6
+2013,49,2013/2014,49,US National,Season onset,48
+2013,49,2013/2014,49,US National,Season peak week,52
+2013,49,2013/2014,49,US National,Season peak percentage,4.6
+2013,49,2013/2014,49,US National,1 wk ahead,2.4
+2013,49,2013/2014,49,US National,2 wk ahead,3.2
+2013,49,2013/2014,49,US National,3 wk ahead,4.6
+2013,49,2013/2014,49,US National,4 wk ahead,4.3
+2013,49,2013/2014,49,HHS Region 1,Season onset,51
+2013,49,2013/2014,49,HHS Region 1,Season peak week,6
+2013,49,2013/2014,49,HHS Region 1,Season peak percentage,2.2
+2013,49,2013/2014,49,HHS Region 1,1 wk ahead,1.1
+2013,49,2013/2014,49,HHS Region 1,2 wk ahead,1.2
+2013,49,2013/2014,49,HHS Region 1,3 wk ahead,1.6
+2013,49,2013/2014,49,HHS Region 1,4 wk ahead,1.6
+2013,49,2013/2014,49,HHS Region 2,Season onset,51
+2013,49,2013/2014,49,HHS Region 2,Season peak week,6
+2013,49,2013/2014,49,HHS Region 2,Season peak week,13
+2013,49,2013/2014,49,HHS Region 2,Season peak percentage,3.4
+2013,49,2013/2014,49,HHS Region 2,1 wk ahead,1.8
+2013,49,2013/2014,49,HHS Region 2,2 wk ahead,2.2
+2013,49,2013/2014,49,HHS Region 2,3 wk ahead,2.9
+2013,49,2013/2014,49,HHS Region 2,4 wk ahead,3.3
+2013,49,2013/2014,49,HHS Region 3,Season onset,51
+2013,49,2013/2014,49,HHS Region 3,Season peak week,1
+2013,49,2013/2014,49,HHS Region 3,Season peak percentage,3.6
+2013,49,2013/2014,49,HHS Region 3,1 wk ahead,1.6
+2013,49,2013/2014,49,HHS Region 3,2 wk ahead,2.2
+2013,49,2013/2014,49,HHS Region 3,3 wk ahead,3.3
+2013,49,2013/2014,49,HHS Region 3,4 wk ahead,3.6
+2013,49,2013/2014,49,HHS Region 4,Season onset,48
+2013,49,2013/2014,49,HHS Region 4,Season peak week,52
+2013,49,2013/2014,49,HHS Region 4,Season peak percentage,4.6
+2013,49,2013/2014,49,HHS Region 4,1 wk ahead,2.4
+2013,49,2013/2014,49,HHS Region 4,2 wk ahead,3.2
+2013,49,2013/2014,49,HHS Region 4,3 wk ahead,4.6
+2013,49,2013/2014,49,HHS Region 4,4 wk ahead,3.9
+2013,49,2013/2014,49,HHS Region 5,Season onset,48
+2013,49,2013/2014,49,HHS Region 5,Season peak week,52
+2013,49,2013/2014,49,HHS Region 5,Season peak percentage,3.6
+2013,49,2013/2014,49,HHS Region 5,1 wk ahead,1.7
+2013,49,2013/2014,49,HHS Region 5,2 wk ahead,2.1
+2013,49,2013/2014,49,HHS Region 5,3 wk ahead,3.6
+2013,49,2013/2014,49,HHS Region 5,4 wk ahead,3.4
+2013,49,2013/2014,49,HHS Region 6,Season onset,45
+2013,49,2013/2014,49,HHS Region 6,Season peak week,52
+2013,49,2013/2014,49,HHS Region 6,Season peak percentage,9.9
+2013,49,2013/2014,49,HHS Region 6,1 wk ahead,5.6
+2013,49,2013/2014,49,HHS Region 6,2 wk ahead,8
+2013,49,2013/2014,49,HHS Region 6,3 wk ahead,9.9
+2013,49,2013/2014,49,HHS Region 6,4 wk ahead,8.7
+2013,49,2013/2014,49,HHS Region 7,Season onset,51
+2013,49,2013/2014,49,HHS Region 7,Season peak week,52
+2013,49,2013/2014,49,HHS Region 7,Season peak percentage,4.5
+2013,49,2013/2014,49,HHS Region 7,1 wk ahead,1.5
+2013,49,2013/2014,49,HHS Region 7,2 wk ahead,2.8
+2013,49,2013/2014,49,HHS Region 7,3 wk ahead,4.5
+2013,49,2013/2014,49,HHS Region 7,4 wk ahead,4.1
+2013,49,2013/2014,49,HHS Region 8,Season onset,49
+2013,49,2013/2014,49,HHS Region 8,Season peak week,52
+2013,49,2013/2014,49,HHS Region 8,Season peak percentage,3.7
+2013,49,2013/2014,49,HHS Region 8,1 wk ahead,1.6
+2013,49,2013/2014,49,HHS Region 8,2 wk ahead,2
+2013,49,2013/2014,49,HHS Region 8,3 wk ahead,3.7
+2013,49,2013/2014,49,HHS Region 8,4 wk ahead,3
+2013,49,2013/2014,49,HHS Region 9,Season onset,51
+2013,49,2013/2014,49,HHS Region 9,Season peak week,1
+2013,49,2013/2014,49,HHS Region 9,Season peak week,4
+2013,49,2013/2014,49,HHS Region 9,Season peak percentage,4.6
+2013,49,2013/2014,49,HHS Region 9,1 wk ahead,2.5
+2013,49,2013/2014,49,HHS Region 9,2 wk ahead,2.9
+2013,49,2013/2014,49,HHS Region 9,3 wk ahead,4.5
+2013,49,2013/2014,49,HHS Region 9,4 wk ahead,4.6
+2013,49,2013/2014,49,HHS Region 10,Season onset,51
+2013,49,2013/2014,49,HHS Region 10,Season peak week,1
+2013,49,2013/2014,49,HHS Region 10,Season peak percentage,4
+2013,49,2013/2014,49,HHS Region 10,1 wk ahead,0.9
+2013,49,2013/2014,49,HHS Region 10,2 wk ahead,1.5
+2013,49,2013/2014,49,HHS Region 10,3 wk ahead,3.6
+2013,49,2013/2014,49,HHS Region 10,4 wk ahead,4
+2013,50,2013/2014,50,US National,Season onset,48
+2013,50,2013/2014,50,US National,Season peak week,52
+2013,50,2013/2014,50,US National,Season peak percentage,4.6
+2013,50,2013/2014,50,US National,1 wk ahead,3.2
+2013,50,2013/2014,50,US National,2 wk ahead,4.6
+2013,50,2013/2014,50,US National,3 wk ahead,4.3
+2013,50,2013/2014,50,US National,4 wk ahead,3.6
+2013,50,2013/2014,50,HHS Region 1,Season onset,51
+2013,50,2013/2014,50,HHS Region 1,Season peak week,6
+2013,50,2013/2014,50,HHS Region 1,Season peak percentage,2.2
+2013,50,2013/2014,50,HHS Region 1,1 wk ahead,1.2
+2013,50,2013/2014,50,HHS Region 1,2 wk ahead,1.6
+2013,50,2013/2014,50,HHS Region 1,3 wk ahead,1.6
+2013,50,2013/2014,50,HHS Region 1,4 wk ahead,1.4
+2013,50,2013/2014,50,HHS Region 2,Season onset,51
+2013,50,2013/2014,50,HHS Region 2,Season peak week,6
+2013,50,2013/2014,50,HHS Region 2,Season peak week,13
+2013,50,2013/2014,50,HHS Region 2,Season peak percentage,3.4
+2013,50,2013/2014,50,HHS Region 2,1 wk ahead,2.2
+2013,50,2013/2014,50,HHS Region 2,2 wk ahead,2.9
+2013,50,2013/2014,50,HHS Region 2,3 wk ahead,3.3
+2013,50,2013/2014,50,HHS Region 2,4 wk ahead,2.7
+2013,50,2013/2014,50,HHS Region 3,Season onset,51
+2013,50,2013/2014,50,HHS Region 3,Season peak week,1
+2013,50,2013/2014,50,HHS Region 3,Season peak percentage,3.6
+2013,50,2013/2014,50,HHS Region 3,1 wk ahead,2.2
+2013,50,2013/2014,50,HHS Region 3,2 wk ahead,3.3
+2013,50,2013/2014,50,HHS Region 3,3 wk ahead,3.6
+2013,50,2013/2014,50,HHS Region 3,4 wk ahead,3.2
+2013,50,2013/2014,50,HHS Region 4,Season onset,48
+2013,50,2013/2014,50,HHS Region 4,Season peak week,52
+2013,50,2013/2014,50,HHS Region 4,Season peak percentage,4.6
+2013,50,2013/2014,50,HHS Region 4,1 wk ahead,3.2
+2013,50,2013/2014,50,HHS Region 4,2 wk ahead,4.6
+2013,50,2013/2014,50,HHS Region 4,3 wk ahead,3.9
+2013,50,2013/2014,50,HHS Region 4,4 wk ahead,3.1
+2013,50,2013/2014,50,HHS Region 5,Season onset,48
+2013,50,2013/2014,50,HHS Region 5,Season peak week,52
+2013,50,2013/2014,50,HHS Region 5,Season peak percentage,3.6
+2013,50,2013/2014,50,HHS Region 5,1 wk ahead,2.1
+2013,50,2013/2014,50,HHS Region 5,2 wk ahead,3.6
+2013,50,2013/2014,50,HHS Region 5,3 wk ahead,3.4
+2013,50,2013/2014,50,HHS Region 5,4 wk ahead,2.8
+2013,50,2013/2014,50,HHS Region 6,Season onset,45
+2013,50,2013/2014,50,HHS Region 6,Season peak week,52
+2013,50,2013/2014,50,HHS Region 6,Season peak percentage,9.9
+2013,50,2013/2014,50,HHS Region 6,1 wk ahead,8
+2013,50,2013/2014,50,HHS Region 6,2 wk ahead,9.9
+2013,50,2013/2014,50,HHS Region 6,3 wk ahead,8.7
+2013,50,2013/2014,50,HHS Region 6,4 wk ahead,6.9
+2013,50,2013/2014,50,HHS Region 7,Season onset,51
+2013,50,2013/2014,50,HHS Region 7,Season peak week,52
+2013,50,2013/2014,50,HHS Region 7,Season peak percentage,4.5
+2013,50,2013/2014,50,HHS Region 7,1 wk ahead,2.8
+2013,50,2013/2014,50,HHS Region 7,2 wk ahead,4.5
+2013,50,2013/2014,50,HHS Region 7,3 wk ahead,4.1
+2013,50,2013/2014,50,HHS Region 7,4 wk ahead,3
+2013,50,2013/2014,50,HHS Region 8,Season onset,49
+2013,50,2013/2014,50,HHS Region 8,Season peak week,52
+2013,50,2013/2014,50,HHS Region 8,Season peak percentage,3.7
+2013,50,2013/2014,50,HHS Region 8,1 wk ahead,2
+2013,50,2013/2014,50,HHS Region 8,2 wk ahead,3.7
+2013,50,2013/2014,50,HHS Region 8,3 wk ahead,3
+2013,50,2013/2014,50,HHS Region 8,4 wk ahead,2.6
+2013,50,2013/2014,50,HHS Region 9,Season onset,51
+2013,50,2013/2014,50,HHS Region 9,Season peak week,1
+2013,50,2013/2014,50,HHS Region 9,Season peak week,4
+2013,50,2013/2014,50,HHS Region 9,Season peak percentage,4.6
+2013,50,2013/2014,50,HHS Region 9,1 wk ahead,2.9
+2013,50,2013/2014,50,HHS Region 9,2 wk ahead,4.5
+2013,50,2013/2014,50,HHS Region 9,3 wk ahead,4.6
+2013,50,2013/2014,50,HHS Region 9,4 wk ahead,4.2
+2013,50,2013/2014,50,HHS Region 10,Season onset,51
+2013,50,2013/2014,50,HHS Region 10,Season peak week,1
+2013,50,2013/2014,50,HHS Region 10,Season peak percentage,4
+2013,50,2013/2014,50,HHS Region 10,1 wk ahead,1.5
+2013,50,2013/2014,50,HHS Region 10,2 wk ahead,3.6
+2013,50,2013/2014,50,HHS Region 10,3 wk ahead,4
+2013,50,2013/2014,50,HHS Region 10,4 wk ahead,3.4
+2013,51,2013/2014,51,US National,Season onset,48
+2013,51,2013/2014,51,US National,Season peak week,52
+2013,51,2013/2014,51,US National,Season peak percentage,4.6
+2013,51,2013/2014,51,US National,1 wk ahead,4.6
+2013,51,2013/2014,51,US National,2 wk ahead,4.3
+2013,51,2013/2014,51,US National,3 wk ahead,3.6
+2013,51,2013/2014,51,US National,4 wk ahead,3.4
+2013,51,2013/2014,51,HHS Region 1,Season onset,51
+2013,51,2013/2014,51,HHS Region 1,Season peak week,6
+2013,51,2013/2014,51,HHS Region 1,Season peak percentage,2.2
+2013,51,2013/2014,51,HHS Region 1,1 wk ahead,1.6
+2013,51,2013/2014,51,HHS Region 1,2 wk ahead,1.6
+2013,51,2013/2014,51,HHS Region 1,3 wk ahead,1.4
+2013,51,2013/2014,51,HHS Region 1,4 wk ahead,1.7
+2013,51,2013/2014,51,HHS Region 2,Season onset,51
+2013,51,2013/2014,51,HHS Region 2,Season peak week,6
+2013,51,2013/2014,51,HHS Region 2,Season peak week,13
+2013,51,2013/2014,51,HHS Region 2,Season peak percentage,3.4
+2013,51,2013/2014,51,HHS Region 2,1 wk ahead,2.9
+2013,51,2013/2014,51,HHS Region 2,2 wk ahead,3.3
+2013,51,2013/2014,51,HHS Region 2,3 wk ahead,2.7
+2013,51,2013/2014,51,HHS Region 2,4 wk ahead,3.1
+2013,51,2013/2014,51,HHS Region 3,Season onset,51
+2013,51,2013/2014,51,HHS Region 3,Season peak week,1
+2013,51,2013/2014,51,HHS Region 3,Season peak percentage,3.6
+2013,51,2013/2014,51,HHS Region 3,1 wk ahead,3.3
+2013,51,2013/2014,51,HHS Region 3,2 wk ahead,3.6
+2013,51,2013/2014,51,HHS Region 3,3 wk ahead,3.2
+2013,51,2013/2014,51,HHS Region 3,4 wk ahead,3.4
+2013,51,2013/2014,51,HHS Region 4,Season onset,48
+2013,51,2013/2014,51,HHS Region 4,Season peak week,52
+2013,51,2013/2014,51,HHS Region 4,Season peak percentage,4.6
+2013,51,2013/2014,51,HHS Region 4,1 wk ahead,4.6
+2013,51,2013/2014,51,HHS Region 4,2 wk ahead,3.9
+2013,51,2013/2014,51,HHS Region 4,3 wk ahead,3.1
+2013,51,2013/2014,51,HHS Region 4,4 wk ahead,2.8
+2013,51,2013/2014,51,HHS Region 5,Season onset,48
+2013,51,2013/2014,51,HHS Region 5,Season peak week,52
+2013,51,2013/2014,51,HHS Region 5,Season peak percentage,3.6
+2013,51,2013/2014,51,HHS Region 5,1 wk ahead,3.6
+2013,51,2013/2014,51,HHS Region 5,2 wk ahead,3.4
+2013,51,2013/2014,51,HHS Region 5,3 wk ahead,2.8
+2013,51,2013/2014,51,HHS Region 5,4 wk ahead,2.5
+2013,51,2013/2014,51,HHS Region 6,Season onset,45
+2013,51,2013/2014,51,HHS Region 6,Season peak week,52
+2013,51,2013/2014,51,HHS Region 6,Season peak percentage,9.9
+2013,51,2013/2014,51,HHS Region 6,1 wk ahead,9.9
+2013,51,2013/2014,51,HHS Region 6,2 wk ahead,8.7
+2013,51,2013/2014,51,HHS Region 6,3 wk ahead,6.9
+2013,51,2013/2014,51,HHS Region 6,4 wk ahead,5.8
+2013,51,2013/2014,51,HHS Region 7,Season onset,51
+2013,51,2013/2014,51,HHS Region 7,Season peak week,52
+2013,51,2013/2014,51,HHS Region 7,Season peak percentage,4.5
+2013,51,2013/2014,51,HHS Region 7,1 wk ahead,4.5
+2013,51,2013/2014,51,HHS Region 7,2 wk ahead,4.1
+2013,51,2013/2014,51,HHS Region 7,3 wk ahead,3
+2013,51,2013/2014,51,HHS Region 7,4 wk ahead,3.1
+2013,51,2013/2014,51,HHS Region 8,Season onset,49
+2013,51,2013/2014,51,HHS Region 8,Season peak week,52
+2013,51,2013/2014,51,HHS Region 8,Season peak percentage,3.7
+2013,51,2013/2014,51,HHS Region 8,1 wk ahead,3.7
+2013,51,2013/2014,51,HHS Region 8,2 wk ahead,3
+2013,51,2013/2014,51,HHS Region 8,3 wk ahead,2.6
+2013,51,2013/2014,51,HHS Region 8,4 wk ahead,2.3
+2013,51,2013/2014,51,HHS Region 9,Season onset,51
+2013,51,2013/2014,51,HHS Region 9,Season peak week,1
+2013,51,2013/2014,51,HHS Region 9,Season peak week,4
+2013,51,2013/2014,51,HHS Region 9,Season peak percentage,4.6
+2013,51,2013/2014,51,HHS Region 9,1 wk ahead,4.5
+2013,51,2013/2014,51,HHS Region 9,2 wk ahead,4.6
+2013,51,2013/2014,51,HHS Region 9,3 wk ahead,4.2
+2013,51,2013/2014,51,HHS Region 9,4 wk ahead,4.2
+2013,51,2013/2014,51,HHS Region 10,Season onset,51
+2013,51,2013/2014,51,HHS Region 10,Season peak week,1
+2013,51,2013/2014,51,HHS Region 10,Season peak percentage,4
+2013,51,2013/2014,51,HHS Region 10,1 wk ahead,3.6
+2013,51,2013/2014,51,HHS Region 10,2 wk ahead,4
+2013,51,2013/2014,51,HHS Region 10,3 wk ahead,3.4
+2013,51,2013/2014,51,HHS Region 10,4 wk ahead,2.8
+2013,52,2013/2014,52,US National,Season onset,48
+2013,52,2013/2014,52,US National,Season peak week,52
+2013,52,2013/2014,52,US National,Season peak percentage,4.6
+2013,52,2013/2014,52,US National,1 wk ahead,4.3
+2013,52,2013/2014,52,US National,2 wk ahead,3.6
+2013,52,2013/2014,52,US National,3 wk ahead,3.4
+2013,52,2013/2014,52,US National,4 wk ahead,3.4
+2013,52,2013/2014,52,HHS Region 1,Season onset,51
+2013,52,2013/2014,52,HHS Region 1,Season peak week,6
+2013,52,2013/2014,52,HHS Region 1,Season peak percentage,2.2
+2013,52,2013/2014,52,HHS Region 1,1 wk ahead,1.6
+2013,52,2013/2014,52,HHS Region 1,2 wk ahead,1.4
+2013,52,2013/2014,52,HHS Region 1,3 wk ahead,1.7
+2013,52,2013/2014,52,HHS Region 1,4 wk ahead,1.9
+2013,52,2013/2014,52,HHS Region 2,Season onset,51
+2013,52,2013/2014,52,HHS Region 2,Season peak week,6
+2013,52,2013/2014,52,HHS Region 2,Season peak week,13
+2013,52,2013/2014,52,HHS Region 2,Season peak percentage,3.4
+2013,52,2013/2014,52,HHS Region 2,1 wk ahead,3.3
+2013,52,2013/2014,52,HHS Region 2,2 wk ahead,2.7
+2013,52,2013/2014,52,HHS Region 2,3 wk ahead,3.1
+2013,52,2013/2014,52,HHS Region 2,4 wk ahead,3
+2013,52,2013/2014,52,HHS Region 3,Season onset,51
+2013,52,2013/2014,52,HHS Region 3,Season peak week,1
+2013,52,2013/2014,52,HHS Region 3,Season peak percentage,3.6
+2013,52,2013/2014,52,HHS Region 3,1 wk ahead,3.6
+2013,52,2013/2014,52,HHS Region 3,2 wk ahead,3.2
+2013,52,2013/2014,52,HHS Region 3,3 wk ahead,3.4
+2013,52,2013/2014,52,HHS Region 3,4 wk ahead,3.5
+2013,52,2013/2014,52,HHS Region 4,Season onset,48
+2013,52,2013/2014,52,HHS Region 4,Season peak week,52
+2013,52,2013/2014,52,HHS Region 4,Season peak percentage,4.6
+2013,52,2013/2014,52,HHS Region 4,1 wk ahead,3.9
+2013,52,2013/2014,52,HHS Region 4,2 wk ahead,3.1
+2013,52,2013/2014,52,HHS Region 4,3 wk ahead,2.8
+2013,52,2013/2014,52,HHS Region 4,4 wk ahead,2.9
+2013,52,2013/2014,52,HHS Region 5,Season onset,48
+2013,52,2013/2014,52,HHS Region 5,Season peak week,52
+2013,52,2013/2014,52,HHS Region 5,Season peak percentage,3.6
+2013,52,2013/2014,52,HHS Region 5,1 wk ahead,3.4
+2013,52,2013/2014,52,HHS Region 5,2 wk ahead,2.8
+2013,52,2013/2014,52,HHS Region 5,3 wk ahead,2.5
+2013,52,2013/2014,52,HHS Region 5,4 wk ahead,2.6
+2013,52,2013/2014,52,HHS Region 6,Season onset,45
+2013,52,2013/2014,52,HHS Region 6,Season peak week,52
+2013,52,2013/2014,52,HHS Region 6,Season peak percentage,9.9
+2013,52,2013/2014,52,HHS Region 6,1 wk ahead,8.7
+2013,52,2013/2014,52,HHS Region 6,2 wk ahead,6.9
+2013,52,2013/2014,52,HHS Region 6,3 wk ahead,5.8
+2013,52,2013/2014,52,HHS Region 6,4 wk ahead,5.3
+2013,52,2013/2014,52,HHS Region 7,Season onset,51
+2013,52,2013/2014,52,HHS Region 7,Season peak week,52
+2013,52,2013/2014,52,HHS Region 7,Season peak percentage,4.5
+2013,52,2013/2014,52,HHS Region 7,1 wk ahead,4.1
+2013,52,2013/2014,52,HHS Region 7,2 wk ahead,3
+2013,52,2013/2014,52,HHS Region 7,3 wk ahead,3.1
+2013,52,2013/2014,52,HHS Region 7,4 wk ahead,3
+2013,52,2013/2014,52,HHS Region 8,Season onset,49
+2013,52,2013/2014,52,HHS Region 8,Season peak week,52
+2013,52,2013/2014,52,HHS Region 8,Season peak percentage,3.7
+2013,52,2013/2014,52,HHS Region 8,1 wk ahead,3
+2013,52,2013/2014,52,HHS Region 8,2 wk ahead,2.6
+2013,52,2013/2014,52,HHS Region 8,3 wk ahead,2.3
+2013,52,2013/2014,52,HHS Region 8,4 wk ahead,2.1
+2013,52,2013/2014,52,HHS Region 9,Season onset,51
+2013,52,2013/2014,52,HHS Region 9,Season peak week,1
+2013,52,2013/2014,52,HHS Region 9,Season peak week,4
+2013,52,2013/2014,52,HHS Region 9,Season peak percentage,4.6
+2013,52,2013/2014,52,HHS Region 9,1 wk ahead,4.6
+2013,52,2013/2014,52,HHS Region 9,2 wk ahead,4.2
+2013,52,2013/2014,52,HHS Region 9,3 wk ahead,4.2
+2013,52,2013/2014,52,HHS Region 9,4 wk ahead,4.6
+2013,52,2013/2014,52,HHS Region 10,Season onset,51
+2013,52,2013/2014,52,HHS Region 10,Season peak week,1
+2013,52,2013/2014,52,HHS Region 10,Season peak percentage,4
+2013,52,2013/2014,52,HHS Region 10,1 wk ahead,4
+2013,52,2013/2014,52,HHS Region 10,2 wk ahead,3.4
+2013,52,2013/2014,52,HHS Region 10,3 wk ahead,2.8
+2013,52,2013/2014,52,HHS Region 10,4 wk ahead,2.4
+2014,1,2013/2014,53,US National,Season onset,48
+2014,1,2013/2014,53,US National,Season peak week,52
+2014,1,2013/2014,53,US National,Season peak percentage,4.6
+2014,1,2013/2014,53,US National,1 wk ahead,3.6
+2014,1,2013/2014,53,US National,2 wk ahead,3.4
+2014,1,2013/2014,53,US National,3 wk ahead,3.4
+2014,1,2013/2014,53,US National,4 wk ahead,3.1
+2014,1,2013/2014,53,HHS Region 1,Season onset,51
+2014,1,2013/2014,53,HHS Region 1,Season peak week,6
+2014,1,2013/2014,53,HHS Region 1,Season peak percentage,2.2
+2014,1,2013/2014,53,HHS Region 1,1 wk ahead,1.4
+2014,1,2013/2014,53,HHS Region 1,2 wk ahead,1.7
+2014,1,2013/2014,53,HHS Region 1,3 wk ahead,1.9
+2014,1,2013/2014,53,HHS Region 1,4 wk ahead,2
+2014,1,2013/2014,53,HHS Region 2,Season onset,51
+2014,1,2013/2014,53,HHS Region 2,Season peak week,6
+2014,1,2013/2014,53,HHS Region 2,Season peak week,13
+2014,1,2013/2014,53,HHS Region 2,Season peak percentage,3.4
+2014,1,2013/2014,53,HHS Region 2,1 wk ahead,2.7
+2014,1,2013/2014,53,HHS Region 2,2 wk ahead,3.1
+2014,1,2013/2014,53,HHS Region 2,3 wk ahead,3
+2014,1,2013/2014,53,HHS Region 2,4 wk ahead,3.3
+2014,1,2013/2014,53,HHS Region 3,Season onset,51
+2014,1,2013/2014,53,HHS Region 3,Season peak week,1
+2014,1,2013/2014,53,HHS Region 3,Season peak percentage,3.6
+2014,1,2013/2014,53,HHS Region 3,1 wk ahead,3.2
+2014,1,2013/2014,53,HHS Region 3,2 wk ahead,3.4
+2014,1,2013/2014,53,HHS Region 3,3 wk ahead,3.5
+2014,1,2013/2014,53,HHS Region 3,4 wk ahead,3
+2014,1,2013/2014,53,HHS Region 4,Season onset,48
+2014,1,2013/2014,53,HHS Region 4,Season peak week,52
+2014,1,2013/2014,53,HHS Region 4,Season peak percentage,4.6
+2014,1,2013/2014,53,HHS Region 4,1 wk ahead,3.1
+2014,1,2013/2014,53,HHS Region 4,2 wk ahead,2.8
+2014,1,2013/2014,53,HHS Region 4,3 wk ahead,2.9
+2014,1,2013/2014,53,HHS Region 4,4 wk ahead,2.7
+2014,1,2013/2014,53,HHS Region 5,Season onset,48
+2014,1,2013/2014,53,HHS Region 5,Season peak week,52
+2014,1,2013/2014,53,HHS Region 5,Season peak percentage,3.6
+2014,1,2013/2014,53,HHS Region 5,1 wk ahead,2.8
+2014,1,2013/2014,53,HHS Region 5,2 wk ahead,2.5
+2014,1,2013/2014,53,HHS Region 5,3 wk ahead,2.6
+2014,1,2013/2014,53,HHS Region 5,4 wk ahead,2.2
+2014,1,2013/2014,53,HHS Region 6,Season onset,45
+2014,1,2013/2014,53,HHS Region 6,Season peak week,52
+2014,1,2013/2014,53,HHS Region 6,Season peak percentage,9.9
+2014,1,2013/2014,53,HHS Region 6,1 wk ahead,6.9
+2014,1,2013/2014,53,HHS Region 6,2 wk ahead,5.8
+2014,1,2013/2014,53,HHS Region 6,3 wk ahead,5.3
+2014,1,2013/2014,53,HHS Region 6,4 wk ahead,5.2
+2014,1,2013/2014,53,HHS Region 7,Season onset,51
+2014,1,2013/2014,53,HHS Region 7,Season peak week,52
+2014,1,2013/2014,53,HHS Region 7,Season peak percentage,4.5
+2014,1,2013/2014,53,HHS Region 7,1 wk ahead,3
+2014,1,2013/2014,53,HHS Region 7,2 wk ahead,3.1
+2014,1,2013/2014,53,HHS Region 7,3 wk ahead,3
+2014,1,2013/2014,53,HHS Region 7,4 wk ahead,2.8
+2014,1,2013/2014,53,HHS Region 8,Season onset,49
+2014,1,2013/2014,53,HHS Region 8,Season peak week,52
+2014,1,2013/2014,53,HHS Region 8,Season peak percentage,3.7
+2014,1,2013/2014,53,HHS Region 8,1 wk ahead,2.6
+2014,1,2013/2014,53,HHS Region 8,2 wk ahead,2.3
+2014,1,2013/2014,53,HHS Region 8,3 wk ahead,2.1
+2014,1,2013/2014,53,HHS Region 8,4 wk ahead,1.8
+2014,1,2013/2014,53,HHS Region 9,Season onset,51
+2014,1,2013/2014,53,HHS Region 9,Season peak week,1
+2014,1,2013/2014,53,HHS Region 9,Season peak week,4
+2014,1,2013/2014,53,HHS Region 9,Season peak percentage,4.6
+2014,1,2013/2014,53,HHS Region 9,1 wk ahead,4.2
+2014,1,2013/2014,53,HHS Region 9,2 wk ahead,4.2
+2014,1,2013/2014,53,HHS Region 9,3 wk ahead,4.6
+2014,1,2013/2014,53,HHS Region 9,4 wk ahead,4
+2014,1,2013/2014,53,HHS Region 10,Season onset,51
+2014,1,2013/2014,53,HHS Region 10,Season peak week,1
+2014,1,2013/2014,53,HHS Region 10,Season peak percentage,4
+2014,1,2013/2014,53,HHS Region 10,1 wk ahead,3.4
+2014,1,2013/2014,53,HHS Region 10,2 wk ahead,2.8
+2014,1,2013/2014,53,HHS Region 10,3 wk ahead,2.4
+2014,1,2013/2014,53,HHS Region 10,4 wk ahead,1.8
+2014,2,2013/2014,54,US National,Season onset,48
+2014,2,2013/2014,54,US National,Season peak week,52
+2014,2,2013/2014,54,US National,Season peak percentage,4.6
+2014,2,2013/2014,54,US National,1 wk ahead,3.4
+2014,2,2013/2014,54,US National,2 wk ahead,3.4
+2014,2,2013/2014,54,US National,3 wk ahead,3.1
+2014,2,2013/2014,54,US National,4 wk ahead,2.8
+2014,2,2013/2014,54,HHS Region 1,Season onset,51
+2014,2,2013/2014,54,HHS Region 1,Season peak week,6
+2014,2,2013/2014,54,HHS Region 1,Season peak percentage,2.2
+2014,2,2013/2014,54,HHS Region 1,1 wk ahead,1.7
+2014,2,2013/2014,54,HHS Region 1,2 wk ahead,1.9
+2014,2,2013/2014,54,HHS Region 1,3 wk ahead,2
+2014,2,2013/2014,54,HHS Region 1,4 wk ahead,2.2
+2014,2,2013/2014,54,HHS Region 2,Season onset,51
+2014,2,2013/2014,54,HHS Region 2,Season peak week,6
+2014,2,2013/2014,54,HHS Region 2,Season peak week,13
+2014,2,2013/2014,54,HHS Region 2,Season peak percentage,3.4
+2014,2,2013/2014,54,HHS Region 2,1 wk ahead,3.1
+2014,2,2013/2014,54,HHS Region 2,2 wk ahead,3
+2014,2,2013/2014,54,HHS Region 2,3 wk ahead,3.3
+2014,2,2013/2014,54,HHS Region 2,4 wk ahead,3.4
+2014,2,2013/2014,54,HHS Region 3,Season onset,51
+2014,2,2013/2014,54,HHS Region 3,Season peak week,1
+2014,2,2013/2014,54,HHS Region 3,Season peak percentage,3.6
+2014,2,2013/2014,54,HHS Region 3,1 wk ahead,3.4
+2014,2,2013/2014,54,HHS Region 3,2 wk ahead,3.5
+2014,2,2013/2014,54,HHS Region 3,3 wk ahead,3
+2014,2,2013/2014,54,HHS Region 3,4 wk ahead,2.8
+2014,2,2013/2014,54,HHS Region 4,Season onset,48
+2014,2,2013/2014,54,HHS Region 4,Season peak week,52
+2014,2,2013/2014,54,HHS Region 4,Season peak percentage,4.6
+2014,2,2013/2014,54,HHS Region 4,1 wk ahead,2.8
+2014,2,2013/2014,54,HHS Region 4,2 wk ahead,2.9
+2014,2,2013/2014,54,HHS Region 4,3 wk ahead,2.7
+2014,2,2013/2014,54,HHS Region 4,4 wk ahead,2.2
+2014,2,2013/2014,54,HHS Region 5,Season onset,48
+2014,2,2013/2014,54,HHS Region 5,Season peak week,52
+2014,2,2013/2014,54,HHS Region 5,Season peak percentage,3.6
+2014,2,2013/2014,54,HHS Region 5,1 wk ahead,2.5
+2014,2,2013/2014,54,HHS Region 5,2 wk ahead,2.6
+2014,2,2013/2014,54,HHS Region 5,3 wk ahead,2.2
+2014,2,2013/2014,54,HHS Region 5,4 wk ahead,2
+2014,2,2013/2014,54,HHS Region 6,Season onset,45
+2014,2,2013/2014,54,HHS Region 6,Season peak week,52
+2014,2,2013/2014,54,HHS Region 6,Season peak percentage,9.9
+2014,2,2013/2014,54,HHS Region 6,1 wk ahead,5.8
+2014,2,2013/2014,54,HHS Region 6,2 wk ahead,5.3
+2014,2,2013/2014,54,HHS Region 6,3 wk ahead,5.2
+2014,2,2013/2014,54,HHS Region 6,4 wk ahead,4.6
+2014,2,2013/2014,54,HHS Region 7,Season onset,51
+2014,2,2013/2014,54,HHS Region 7,Season peak week,52
+2014,2,2013/2014,54,HHS Region 7,Season peak percentage,4.5
+2014,2,2013/2014,54,HHS Region 7,1 wk ahead,3.1
+2014,2,2013/2014,54,HHS Region 7,2 wk ahead,3
+2014,2,2013/2014,54,HHS Region 7,3 wk ahead,2.8
+2014,2,2013/2014,54,HHS Region 7,4 wk ahead,2.1
+2014,2,2013/2014,54,HHS Region 8,Season onset,49
+2014,2,2013/2014,54,HHS Region 8,Season peak week,52
+2014,2,2013/2014,54,HHS Region 8,Season peak percentage,3.7
+2014,2,2013/2014,54,HHS Region 8,1 wk ahead,2.3
+2014,2,2013/2014,54,HHS Region 8,2 wk ahead,2.1
+2014,2,2013/2014,54,HHS Region 8,3 wk ahead,1.8
+2014,2,2013/2014,54,HHS Region 8,4 wk ahead,1.8
+2014,2,2013/2014,54,HHS Region 9,Season onset,51
+2014,2,2013/2014,54,HHS Region 9,Season peak week,1
+2014,2,2013/2014,54,HHS Region 9,Season peak week,4
+2014,2,2013/2014,54,HHS Region 9,Season peak percentage,4.6
+2014,2,2013/2014,54,HHS Region 9,1 wk ahead,4.2
+2014,2,2013/2014,54,HHS Region 9,2 wk ahead,4.6
+2014,2,2013/2014,54,HHS Region 9,3 wk ahead,4
+2014,2,2013/2014,54,HHS Region 9,4 wk ahead,3.6
+2014,2,2013/2014,54,HHS Region 10,Season onset,51
+2014,2,2013/2014,54,HHS Region 10,Season peak week,1
+2014,2,2013/2014,54,HHS Region 10,Season peak percentage,4
+2014,2,2013/2014,54,HHS Region 10,1 wk ahead,2.8
+2014,2,2013/2014,54,HHS Region 10,2 wk ahead,2.4
+2014,2,2013/2014,54,HHS Region 10,3 wk ahead,1.8
+2014,2,2013/2014,54,HHS Region 10,4 wk ahead,1.6
+2014,3,2013/2014,55,US National,Season onset,48
+2014,3,2013/2014,55,US National,Season peak week,52
+2014,3,2013/2014,55,US National,Season peak percentage,4.6
+2014,3,2013/2014,55,US National,1 wk ahead,3.4
+2014,3,2013/2014,55,US National,2 wk ahead,3.1
+2014,3,2013/2014,55,US National,3 wk ahead,2.8
+2014,3,2013/2014,55,US National,4 wk ahead,2.5
+2014,3,2013/2014,55,HHS Region 1,Season onset,51
+2014,3,2013/2014,55,HHS Region 1,Season peak week,6
+2014,3,2013/2014,55,HHS Region 1,Season peak percentage,2.2
+2014,3,2013/2014,55,HHS Region 1,1 wk ahead,1.9
+2014,3,2013/2014,55,HHS Region 1,2 wk ahead,2
+2014,3,2013/2014,55,HHS Region 1,3 wk ahead,2.2
+2014,3,2013/2014,55,HHS Region 1,4 wk ahead,1.8
+2014,3,2013/2014,55,HHS Region 2,Season onset,51
+2014,3,2013/2014,55,HHS Region 2,Season peak week,6
+2014,3,2013/2014,55,HHS Region 2,Season peak week,13
+2014,3,2013/2014,55,HHS Region 2,Season peak percentage,3.4
+2014,3,2013/2014,55,HHS Region 2,1 wk ahead,3
+2014,3,2013/2014,55,HHS Region 2,2 wk ahead,3.3
+2014,3,2013/2014,55,HHS Region 2,3 wk ahead,3.4
+2014,3,2013/2014,55,HHS Region 2,4 wk ahead,3.1
+2014,3,2013/2014,55,HHS Region 3,Season onset,51
+2014,3,2013/2014,55,HHS Region 3,Season peak week,1
+2014,3,2013/2014,55,HHS Region 3,Season peak percentage,3.6
+2014,3,2013/2014,55,HHS Region 3,1 wk ahead,3.5
+2014,3,2013/2014,55,HHS Region 3,2 wk ahead,3
+2014,3,2013/2014,55,HHS Region 3,3 wk ahead,2.8
+2014,3,2013/2014,55,HHS Region 3,4 wk ahead,2.4
+2014,3,2013/2014,55,HHS Region 4,Season onset,48
+2014,3,2013/2014,55,HHS Region 4,Season peak week,52
+2014,3,2013/2014,55,HHS Region 4,Season peak percentage,4.6
+2014,3,2013/2014,55,HHS Region 4,1 wk ahead,2.9
+2014,3,2013/2014,55,HHS Region 4,2 wk ahead,2.7
+2014,3,2013/2014,55,HHS Region 4,3 wk ahead,2.2
+2014,3,2013/2014,55,HHS Region 4,4 wk ahead,2
+2014,3,2013/2014,55,HHS Region 5,Season onset,48
+2014,3,2013/2014,55,HHS Region 5,Season peak week,52
+2014,3,2013/2014,55,HHS Region 5,Season peak percentage,3.6
+2014,3,2013/2014,55,HHS Region 5,1 wk ahead,2.6
+2014,3,2013/2014,55,HHS Region 5,2 wk ahead,2.2
+2014,3,2013/2014,55,HHS Region 5,3 wk ahead,2
+2014,3,2013/2014,55,HHS Region 5,4 wk ahead,1.9
+2014,3,2013/2014,55,HHS Region 6,Season onset,45
+2014,3,2013/2014,55,HHS Region 6,Season peak week,52
+2014,3,2013/2014,55,HHS Region 6,Season peak percentage,9.9
+2014,3,2013/2014,55,HHS Region 6,1 wk ahead,5.3
+2014,3,2013/2014,55,HHS Region 6,2 wk ahead,5.2
+2014,3,2013/2014,55,HHS Region 6,3 wk ahead,4.6
+2014,3,2013/2014,55,HHS Region 6,4 wk ahead,3.9
+2014,3,2013/2014,55,HHS Region 7,Season onset,51
+2014,3,2013/2014,55,HHS Region 7,Season peak week,52
+2014,3,2013/2014,55,HHS Region 7,Season peak percentage,4.5
+2014,3,2013/2014,55,HHS Region 7,1 wk ahead,3
+2014,3,2013/2014,55,HHS Region 7,2 wk ahead,2.8
+2014,3,2013/2014,55,HHS Region 7,3 wk ahead,2.1
+2014,3,2013/2014,55,HHS Region 7,4 wk ahead,1.6
+2014,3,2013/2014,55,HHS Region 8,Season onset,49
+2014,3,2013/2014,55,HHS Region 8,Season peak week,52
+2014,3,2013/2014,55,HHS Region 8,Season peak percentage,3.7
+2014,3,2013/2014,55,HHS Region 8,1 wk ahead,2.1
+2014,3,2013/2014,55,HHS Region 8,2 wk ahead,1.8
+2014,3,2013/2014,55,HHS Region 8,3 wk ahead,1.8
+2014,3,2013/2014,55,HHS Region 8,4 wk ahead,1.5
+2014,3,2013/2014,55,HHS Region 9,Season onset,51
+2014,3,2013/2014,55,HHS Region 9,Season peak week,1
+2014,3,2013/2014,55,HHS Region 9,Season peak week,4
+2014,3,2013/2014,55,HHS Region 9,Season peak percentage,4.6
+2014,3,2013/2014,55,HHS Region 9,1 wk ahead,4.6
+2014,3,2013/2014,55,HHS Region 9,2 wk ahead,4
+2014,3,2013/2014,55,HHS Region 9,3 wk ahead,3.6
+2014,3,2013/2014,55,HHS Region 9,4 wk ahead,3.3
+2014,3,2013/2014,55,HHS Region 10,Season onset,51
+2014,3,2013/2014,55,HHS Region 10,Season peak week,1
+2014,3,2013/2014,55,HHS Region 10,Season peak percentage,4
+2014,3,2013/2014,55,HHS Region 10,1 wk ahead,2.4
+2014,3,2013/2014,55,HHS Region 10,2 wk ahead,1.8
+2014,3,2013/2014,55,HHS Region 10,3 wk ahead,1.6
+2014,3,2013/2014,55,HHS Region 10,4 wk ahead,1.2
+2014,4,2013/2014,56,US National,Season onset,48
+2014,4,2013/2014,56,US National,Season peak week,52
+2014,4,2013/2014,56,US National,Season peak percentage,4.6
+2014,4,2013/2014,56,US National,1 wk ahead,3.1
+2014,4,2013/2014,56,US National,2 wk ahead,2.8
+2014,4,2013/2014,56,US National,3 wk ahead,2.5
+2014,4,2013/2014,56,US National,4 wk ahead,2.3
+2014,4,2013/2014,56,HHS Region 1,Season onset,51
+2014,4,2013/2014,56,HHS Region 1,Season peak week,6
+2014,4,2013/2014,56,HHS Region 1,Season peak percentage,2.2
+2014,4,2013/2014,56,HHS Region 1,1 wk ahead,2
+2014,4,2013/2014,56,HHS Region 1,2 wk ahead,2.2
+2014,4,2013/2014,56,HHS Region 1,3 wk ahead,1.8
+2014,4,2013/2014,56,HHS Region 1,4 wk ahead,1.8
+2014,4,2013/2014,56,HHS Region 2,Season onset,51
+2014,4,2013/2014,56,HHS Region 2,Season peak week,6
+2014,4,2013/2014,56,HHS Region 2,Season peak week,13
+2014,4,2013/2014,56,HHS Region 2,Season peak percentage,3.4
+2014,4,2013/2014,56,HHS Region 2,1 wk ahead,3.3
+2014,4,2013/2014,56,HHS Region 2,2 wk ahead,3.4
+2014,4,2013/2014,56,HHS Region 2,3 wk ahead,3.1
+2014,4,2013/2014,56,HHS Region 2,4 wk ahead,2.4
+2014,4,2013/2014,56,HHS Region 3,Season onset,51
+2014,4,2013/2014,56,HHS Region 3,Season peak week,1
+2014,4,2013/2014,56,HHS Region 3,Season peak percentage,3.6
+2014,4,2013/2014,56,HHS Region 3,1 wk ahead,3
+2014,4,2013/2014,56,HHS Region 3,2 wk ahead,2.8
+2014,4,2013/2014,56,HHS Region 3,3 wk ahead,2.4
+2014,4,2013/2014,56,HHS Region 3,4 wk ahead,2.1
+2014,4,2013/2014,56,HHS Region 4,Season onset,48
+2014,4,2013/2014,56,HHS Region 4,Season peak week,52
+2014,4,2013/2014,56,HHS Region 4,Season peak percentage,4.6
+2014,4,2013/2014,56,HHS Region 4,1 wk ahead,2.7
+2014,4,2013/2014,56,HHS Region 4,2 wk ahead,2.2
+2014,4,2013/2014,56,HHS Region 4,3 wk ahead,2
+2014,4,2013/2014,56,HHS Region 4,4 wk ahead,1.5
+2014,4,2013/2014,56,HHS Region 5,Season onset,48
+2014,4,2013/2014,56,HHS Region 5,Season peak week,52
+2014,4,2013/2014,56,HHS Region 5,Season peak percentage,3.6
+2014,4,2013/2014,56,HHS Region 5,1 wk ahead,2.2
+2014,4,2013/2014,56,HHS Region 5,2 wk ahead,2
+2014,4,2013/2014,56,HHS Region 5,3 wk ahead,1.9
+2014,4,2013/2014,56,HHS Region 5,4 wk ahead,2
+2014,4,2013/2014,56,HHS Region 6,Season onset,45
+2014,4,2013/2014,56,HHS Region 6,Season peak week,52
+2014,4,2013/2014,56,HHS Region 6,Season peak percentage,9.9
+2014,4,2013/2014,56,HHS Region 6,1 wk ahead,5.2
+2014,4,2013/2014,56,HHS Region 6,2 wk ahead,4.6
+2014,4,2013/2014,56,HHS Region 6,3 wk ahead,3.9
+2014,4,2013/2014,56,HHS Region 6,4 wk ahead,3.8
+2014,4,2013/2014,56,HHS Region 7,Season onset,51
+2014,4,2013/2014,56,HHS Region 7,Season peak week,52
+2014,4,2013/2014,56,HHS Region 7,Season peak percentage,4.5
+2014,4,2013/2014,56,HHS Region 7,1 wk ahead,2.8
+2014,4,2013/2014,56,HHS Region 7,2 wk ahead,2.1
+2014,4,2013/2014,56,HHS Region 7,3 wk ahead,1.6
+2014,4,2013/2014,56,HHS Region 7,4 wk ahead,1.4
+2014,4,2013/2014,56,HHS Region 8,Season onset,49
+2014,4,2013/2014,56,HHS Region 8,Season peak week,52
+2014,4,2013/2014,56,HHS Region 8,Season peak percentage,3.7
+2014,4,2013/2014,56,HHS Region 8,1 wk ahead,1.8
+2014,4,2013/2014,56,HHS Region 8,2 wk ahead,1.8
+2014,4,2013/2014,56,HHS Region 8,3 wk ahead,1.5
+2014,4,2013/2014,56,HHS Region 8,4 wk ahead,1.5
+2014,4,2013/2014,56,HHS Region 9,Season onset,51
+2014,4,2013/2014,56,HHS Region 9,Season peak week,1
+2014,4,2013/2014,56,HHS Region 9,Season peak week,4
+2014,4,2013/2014,56,HHS Region 9,Season peak percentage,4.6
+2014,4,2013/2014,56,HHS Region 9,1 wk ahead,4
+2014,4,2013/2014,56,HHS Region 9,2 wk ahead,3.6
+2014,4,2013/2014,56,HHS Region 9,3 wk ahead,3.3
+2014,4,2013/2014,56,HHS Region 9,4 wk ahead,3.2
+2014,4,2013/2014,56,HHS Region 10,Season onset,51
+2014,4,2013/2014,56,HHS Region 10,Season peak week,1
+2014,4,2013/2014,56,HHS Region 10,Season peak percentage,4
+2014,4,2013/2014,56,HHS Region 10,1 wk ahead,1.8
+2014,4,2013/2014,56,HHS Region 10,2 wk ahead,1.6
+2014,4,2013/2014,56,HHS Region 10,3 wk ahead,1.2
+2014,4,2013/2014,56,HHS Region 10,4 wk ahead,1.3
+2014,5,2013/2014,57,US National,Season onset,48
+2014,5,2013/2014,57,US National,Season peak week,52
+2014,5,2013/2014,57,US National,Season peak percentage,4.6
+2014,5,2013/2014,57,US National,1 wk ahead,2.8
+2014,5,2013/2014,57,US National,2 wk ahead,2.5
+2014,5,2013/2014,57,US National,3 wk ahead,2.3
+2014,5,2013/2014,57,US National,4 wk ahead,2.1
+2014,5,2013/2014,57,HHS Region 1,Season onset,51
+2014,5,2013/2014,57,HHS Region 1,Season peak week,6
+2014,5,2013/2014,57,HHS Region 1,Season peak percentage,2.2
+2014,5,2013/2014,57,HHS Region 1,1 wk ahead,2.2
+2014,5,2013/2014,57,HHS Region 1,2 wk ahead,1.8
+2014,5,2013/2014,57,HHS Region 1,3 wk ahead,1.8
+2014,5,2013/2014,57,HHS Region 1,4 wk ahead,1.5
+2014,5,2013/2014,57,HHS Region 2,Season onset,51
+2014,5,2013/2014,57,HHS Region 2,Season peak week,6
+2014,5,2013/2014,57,HHS Region 2,Season peak week,13
+2014,5,2013/2014,57,HHS Region 2,Season peak percentage,3.4
+2014,5,2013/2014,57,HHS Region 2,1 wk ahead,3.4
+2014,5,2013/2014,57,HHS Region 2,2 wk ahead,3.1
+2014,5,2013/2014,57,HHS Region 2,3 wk ahead,2.4
+2014,5,2013/2014,57,HHS Region 2,4 wk ahead,2.3
+2014,5,2013/2014,57,HHS Region 3,Season onset,51
+2014,5,2013/2014,57,HHS Region 3,Season peak week,1
+2014,5,2013/2014,57,HHS Region 3,Season peak percentage,3.6
+2014,5,2013/2014,57,HHS Region 3,1 wk ahead,2.8
+2014,5,2013/2014,57,HHS Region 3,2 wk ahead,2.4
+2014,5,2013/2014,57,HHS Region 3,3 wk ahead,2.1
+2014,5,2013/2014,57,HHS Region 3,4 wk ahead,2
+2014,5,2013/2014,57,HHS Region 4,Season onset,48
+2014,5,2013/2014,57,HHS Region 4,Season peak week,52
+2014,5,2013/2014,57,HHS Region 4,Season peak percentage,4.6
+2014,5,2013/2014,57,HHS Region 4,1 wk ahead,2.2
+2014,5,2013/2014,57,HHS Region 4,2 wk ahead,2
+2014,5,2013/2014,57,HHS Region 4,3 wk ahead,1.5
+2014,5,2013/2014,57,HHS Region 4,4 wk ahead,1.4
+2014,5,2013/2014,57,HHS Region 5,Season onset,48
+2014,5,2013/2014,57,HHS Region 5,Season peak week,52
+2014,5,2013/2014,57,HHS Region 5,Season peak percentage,3.6
+2014,5,2013/2014,57,HHS Region 5,1 wk ahead,2
+2014,5,2013/2014,57,HHS Region 5,2 wk ahead,1.9
+2014,5,2013/2014,57,HHS Region 5,3 wk ahead,2
+2014,5,2013/2014,57,HHS Region 5,4 wk ahead,1.8
+2014,5,2013/2014,57,HHS Region 6,Season onset,45
+2014,5,2013/2014,57,HHS Region 6,Season peak week,52
+2014,5,2013/2014,57,HHS Region 6,Season peak percentage,9.9
+2014,5,2013/2014,57,HHS Region 6,1 wk ahead,4.6
+2014,5,2013/2014,57,HHS Region 6,2 wk ahead,3.9
+2014,5,2013/2014,57,HHS Region 6,3 wk ahead,3.8
+2014,5,2013/2014,57,HHS Region 6,4 wk ahead,3.6
+2014,5,2013/2014,57,HHS Region 7,Season onset,51
+2014,5,2013/2014,57,HHS Region 7,Season peak week,52
+2014,5,2013/2014,57,HHS Region 7,Season peak percentage,4.5
+2014,5,2013/2014,57,HHS Region 7,1 wk ahead,2.1
+2014,5,2013/2014,57,HHS Region 7,2 wk ahead,1.6
+2014,5,2013/2014,57,HHS Region 7,3 wk ahead,1.4
+2014,5,2013/2014,57,HHS Region 7,4 wk ahead,1.2
+2014,5,2013/2014,57,HHS Region 8,Season onset,49
+2014,5,2013/2014,57,HHS Region 8,Season peak week,52
+2014,5,2013/2014,57,HHS Region 8,Season peak percentage,3.7
+2014,5,2013/2014,57,HHS Region 8,1 wk ahead,1.8
+2014,5,2013/2014,57,HHS Region 8,2 wk ahead,1.5
+2014,5,2013/2014,57,HHS Region 8,3 wk ahead,1.5
+2014,5,2013/2014,57,HHS Region 8,4 wk ahead,1.2
+2014,5,2013/2014,57,HHS Region 9,Season onset,51
+2014,5,2013/2014,57,HHS Region 9,Season peak week,1
+2014,5,2013/2014,57,HHS Region 9,Season peak week,4
+2014,5,2013/2014,57,HHS Region 9,Season peak percentage,4.6
+2014,5,2013/2014,57,HHS Region 9,1 wk ahead,3.6
+2014,5,2013/2014,57,HHS Region 9,2 wk ahead,3.3
+2014,5,2013/2014,57,HHS Region 9,3 wk ahead,3.2
+2014,5,2013/2014,57,HHS Region 9,4 wk ahead,2.9
+2014,5,2013/2014,57,HHS Region 10,Season onset,51
+2014,5,2013/2014,57,HHS Region 10,Season peak week,1
+2014,5,2013/2014,57,HHS Region 10,Season peak percentage,4
+2014,5,2013/2014,57,HHS Region 10,1 wk ahead,1.6
+2014,5,2013/2014,57,HHS Region 10,2 wk ahead,1.2
+2014,5,2013/2014,57,HHS Region 10,3 wk ahead,1.3
+2014,5,2013/2014,57,HHS Region 10,4 wk ahead,0.7
+2014,6,2013/2014,58,US National,Season onset,48
+2014,6,2013/2014,58,US National,Season peak week,52
+2014,6,2013/2014,58,US National,Season peak percentage,4.6
+2014,6,2013/2014,58,US National,1 wk ahead,2.5
+2014,6,2013/2014,58,US National,2 wk ahead,2.3
+2014,6,2013/2014,58,US National,3 wk ahead,2.1
+2014,6,2013/2014,58,US National,4 wk ahead,2
+2014,6,2013/2014,58,HHS Region 1,Season onset,51
+2014,6,2013/2014,58,HHS Region 1,Season peak week,6
+2014,6,2013/2014,58,HHS Region 1,Season peak percentage,2.2
+2014,6,2013/2014,58,HHS Region 1,1 wk ahead,1.8
+2014,6,2013/2014,58,HHS Region 1,2 wk ahead,1.8
+2014,6,2013/2014,58,HHS Region 1,3 wk ahead,1.5
+2014,6,2013/2014,58,HHS Region 1,4 wk ahead,1.5
+2014,6,2013/2014,58,HHS Region 2,Season onset,51
+2014,6,2013/2014,58,HHS Region 2,Season peak week,6
+2014,6,2013/2014,58,HHS Region 2,Season peak week,13
+2014,6,2013/2014,58,HHS Region 2,Season peak percentage,3.4
+2014,6,2013/2014,58,HHS Region 2,1 wk ahead,3.1
+2014,6,2013/2014,58,HHS Region 2,2 wk ahead,2.4
+2014,6,2013/2014,58,HHS Region 2,3 wk ahead,2.3
+2014,6,2013/2014,58,HHS Region 2,4 wk ahead,2.3
+2014,6,2013/2014,58,HHS Region 3,Season onset,51
+2014,6,2013/2014,58,HHS Region 3,Season peak week,1
+2014,6,2013/2014,58,HHS Region 3,Season peak percentage,3.6
+2014,6,2013/2014,58,HHS Region 3,1 wk ahead,2.4
+2014,6,2013/2014,58,HHS Region 3,2 wk ahead,2.1
+2014,6,2013/2014,58,HHS Region 3,3 wk ahead,2
+2014,6,2013/2014,58,HHS Region 3,4 wk ahead,1.8
+2014,6,2013/2014,58,HHS Region 4,Season onset,48
+2014,6,2013/2014,58,HHS Region 4,Season peak week,52
+2014,6,2013/2014,58,HHS Region 4,Season peak percentage,4.6
+2014,6,2013/2014,58,HHS Region 4,1 wk ahead,2
+2014,6,2013/2014,58,HHS Region 4,2 wk ahead,1.5
+2014,6,2013/2014,58,HHS Region 4,3 wk ahead,1.4
+2014,6,2013/2014,58,HHS Region 4,4 wk ahead,1.4
+2014,6,2013/2014,58,HHS Region 5,Season onset,48
+2014,6,2013/2014,58,HHS Region 5,Season peak week,52
+2014,6,2013/2014,58,HHS Region 5,Season peak percentage,3.6
+2014,6,2013/2014,58,HHS Region 5,1 wk ahead,1.9
+2014,6,2013/2014,58,HHS Region 5,2 wk ahead,2
+2014,6,2013/2014,58,HHS Region 5,3 wk ahead,1.8
+2014,6,2013/2014,58,HHS Region 5,4 wk ahead,1.8
+2014,6,2013/2014,58,HHS Region 6,Season onset,45
+2014,6,2013/2014,58,HHS Region 6,Season peak week,52
+2014,6,2013/2014,58,HHS Region 6,Season peak percentage,9.9
+2014,6,2013/2014,58,HHS Region 6,1 wk ahead,3.9
+2014,6,2013/2014,58,HHS Region 6,2 wk ahead,3.8
+2014,6,2013/2014,58,HHS Region 6,3 wk ahead,3.6
+2014,6,2013/2014,58,HHS Region 6,4 wk ahead,3.4
+2014,6,2013/2014,58,HHS Region 7,Season onset,51
+2014,6,2013/2014,58,HHS Region 7,Season peak week,52
+2014,6,2013/2014,58,HHS Region 7,Season peak percentage,4.5
+2014,6,2013/2014,58,HHS Region 7,1 wk ahead,1.6
+2014,6,2013/2014,58,HHS Region 7,2 wk ahead,1.4
+2014,6,2013/2014,58,HHS Region 7,3 wk ahead,1.2
+2014,6,2013/2014,58,HHS Region 7,4 wk ahead,1.1
+2014,6,2013/2014,58,HHS Region 8,Season onset,49
+2014,6,2013/2014,58,HHS Region 8,Season peak week,52
+2014,6,2013/2014,58,HHS Region 8,Season peak percentage,3.7
+2014,6,2013/2014,58,HHS Region 8,1 wk ahead,1.5
+2014,6,2013/2014,58,HHS Region 8,2 wk ahead,1.5
+2014,6,2013/2014,58,HHS Region 8,3 wk ahead,1.2
+2014,6,2013/2014,58,HHS Region 8,4 wk ahead,1.4
+2014,6,2013/2014,58,HHS Region 9,Season onset,51
+2014,6,2013/2014,58,HHS Region 9,Season peak week,1
+2014,6,2013/2014,58,HHS Region 9,Season peak week,4
+2014,6,2013/2014,58,HHS Region 9,Season peak percentage,4.6
+2014,6,2013/2014,58,HHS Region 9,1 wk ahead,3.3
+2014,6,2013/2014,58,HHS Region 9,2 wk ahead,3.2
+2014,6,2013/2014,58,HHS Region 9,3 wk ahead,2.9
+2014,6,2013/2014,58,HHS Region 9,4 wk ahead,2.6
+2014,6,2013/2014,58,HHS Region 10,Season onset,51
+2014,6,2013/2014,58,HHS Region 10,Season peak week,1
+2014,6,2013/2014,58,HHS Region 10,Season peak percentage,4
+2014,6,2013/2014,58,HHS Region 10,1 wk ahead,1.2
+2014,6,2013/2014,58,HHS Region 10,2 wk ahead,1.3
+2014,6,2013/2014,58,HHS Region 10,3 wk ahead,0.7
+2014,6,2013/2014,58,HHS Region 10,4 wk ahead,0.8
+2014,7,2013/2014,59,US National,Season onset,48
+2014,7,2013/2014,59,US National,Season peak week,52
+2014,7,2013/2014,59,US National,Season peak percentage,4.6
+2014,7,2013/2014,59,US National,1 wk ahead,2.3
+2014,7,2013/2014,59,US National,2 wk ahead,2.1
+2014,7,2013/2014,59,US National,3 wk ahead,2
+2014,7,2013/2014,59,US National,4 wk ahead,1.8
+2014,7,2013/2014,59,HHS Region 1,Season onset,51
+2014,7,2013/2014,59,HHS Region 1,Season peak week,6
+2014,7,2013/2014,59,HHS Region 1,Season peak percentage,2.2
+2014,7,2013/2014,59,HHS Region 1,1 wk ahead,1.8
+2014,7,2013/2014,59,HHS Region 1,2 wk ahead,1.5
+2014,7,2013/2014,59,HHS Region 1,3 wk ahead,1.5
+2014,7,2013/2014,59,HHS Region 1,4 wk ahead,1.4
+2014,7,2013/2014,59,HHS Region 2,Season onset,51
+2014,7,2013/2014,59,HHS Region 2,Season peak week,6
+2014,7,2013/2014,59,HHS Region 2,Season peak week,13
+2014,7,2013/2014,59,HHS Region 2,Season peak percentage,3.4
+2014,7,2013/2014,59,HHS Region 2,1 wk ahead,2.4
+2014,7,2013/2014,59,HHS Region 2,2 wk ahead,2.3
+2014,7,2013/2014,59,HHS Region 2,3 wk ahead,2.3
+2014,7,2013/2014,59,HHS Region 2,4 wk ahead,2.5
+2014,7,2013/2014,59,HHS Region 3,Season onset,51
+2014,7,2013/2014,59,HHS Region 3,Season peak week,1
+2014,7,2013/2014,59,HHS Region 3,Season peak percentage,3.6
+2014,7,2013/2014,59,HHS Region 3,1 wk ahead,2.1
+2014,7,2013/2014,59,HHS Region 3,2 wk ahead,2
+2014,7,2013/2014,59,HHS Region 3,3 wk ahead,1.8
+2014,7,2013/2014,59,HHS Region 3,4 wk ahead,1.6
+2014,7,2013/2014,59,HHS Region 4,Season onset,48
+2014,7,2013/2014,59,HHS Region 4,Season peak week,52
+2014,7,2013/2014,59,HHS Region 4,Season peak percentage,4.6
+2014,7,2013/2014,59,HHS Region 4,1 wk ahead,1.5
+2014,7,2013/2014,59,HHS Region 4,2 wk ahead,1.4
+2014,7,2013/2014,59,HHS Region 4,3 wk ahead,1.4
+2014,7,2013/2014,59,HHS Region 4,4 wk ahead,1.1
+2014,7,2013/2014,59,HHS Region 5,Season onset,48
+2014,7,2013/2014,59,HHS Region 5,Season peak week,52
+2014,7,2013/2014,59,HHS Region 5,Season peak percentage,3.6
+2014,7,2013/2014,59,HHS Region 5,1 wk ahead,2
+2014,7,2013/2014,59,HHS Region 5,2 wk ahead,1.8
+2014,7,2013/2014,59,HHS Region 5,3 wk ahead,1.8
+2014,7,2013/2014,59,HHS Region 5,4 wk ahead,1.6
+2014,7,2013/2014,59,HHS Region 6,Season onset,45
+2014,7,2013/2014,59,HHS Region 6,Season peak week,52
+2014,7,2013/2014,59,HHS Region 6,Season peak percentage,9.9
+2014,7,2013/2014,59,HHS Region 6,1 wk ahead,3.8
+2014,7,2013/2014,59,HHS Region 6,2 wk ahead,3.6
+2014,7,2013/2014,59,HHS Region 6,3 wk ahead,3.4
+2014,7,2013/2014,59,HHS Region 6,4 wk ahead,3.2
+2014,7,2013/2014,59,HHS Region 7,Season onset,51
+2014,7,2013/2014,59,HHS Region 7,Season peak week,52
+2014,7,2013/2014,59,HHS Region 7,Season peak percentage,4.5
+2014,7,2013/2014,59,HHS Region 7,1 wk ahead,1.4
+2014,7,2013/2014,59,HHS Region 7,2 wk ahead,1.2
+2014,7,2013/2014,59,HHS Region 7,3 wk ahead,1.1
+2014,7,2013/2014,59,HHS Region 7,4 wk ahead,1.4
+2014,7,2013/2014,59,HHS Region 8,Season onset,49
+2014,7,2013/2014,59,HHS Region 8,Season peak week,52
+2014,7,2013/2014,59,HHS Region 8,Season peak percentage,3.7
+2014,7,2013/2014,59,HHS Region 8,1 wk ahead,1.5
+2014,7,2013/2014,59,HHS Region 8,2 wk ahead,1.2
+2014,7,2013/2014,59,HHS Region 8,3 wk ahead,1.4
+2014,7,2013/2014,59,HHS Region 8,4 wk ahead,1.1
+2014,7,2013/2014,59,HHS Region 9,Season onset,51
+2014,7,2013/2014,59,HHS Region 9,Season peak week,1
+2014,7,2013/2014,59,HHS Region 9,Season peak week,4
+2014,7,2013/2014,59,HHS Region 9,Season peak percentage,4.6
+2014,7,2013/2014,59,HHS Region 9,1 wk ahead,3.2
+2014,7,2013/2014,59,HHS Region 9,2 wk ahead,2.9
+2014,7,2013/2014,59,HHS Region 9,3 wk ahead,2.6
+2014,7,2013/2014,59,HHS Region 9,4 wk ahead,2.2
+2014,7,2013/2014,59,HHS Region 10,Season onset,51
+2014,7,2013/2014,59,HHS Region 10,Season peak week,1
+2014,7,2013/2014,59,HHS Region 10,Season peak percentage,4
+2014,7,2013/2014,59,HHS Region 10,1 wk ahead,1.3
+2014,7,2013/2014,59,HHS Region 10,2 wk ahead,0.7
+2014,7,2013/2014,59,HHS Region 10,3 wk ahead,0.8
+2014,7,2013/2014,59,HHS Region 10,4 wk ahead,0.6
+2014,8,2013/2014,60,US National,Season onset,48
+2014,8,2013/2014,60,US National,Season peak week,52
+2014,8,2013/2014,60,US National,Season peak percentage,4.6
+2014,8,2013/2014,60,US National,1 wk ahead,2.1
+2014,8,2013/2014,60,US National,2 wk ahead,2
+2014,8,2013/2014,60,US National,3 wk ahead,1.8
+2014,8,2013/2014,60,US National,4 wk ahead,1.8
+2014,8,2013/2014,60,HHS Region 1,Season onset,51
+2014,8,2013/2014,60,HHS Region 1,Season peak week,6
+2014,8,2013/2014,60,HHS Region 1,Season peak percentage,2.2
+2014,8,2013/2014,60,HHS Region 1,1 wk ahead,1.5
+2014,8,2013/2014,60,HHS Region 1,2 wk ahead,1.5
+2014,8,2013/2014,60,HHS Region 1,3 wk ahead,1.4
+2014,8,2013/2014,60,HHS Region 1,4 wk ahead,1.7
+2014,8,2013/2014,60,HHS Region 2,Season onset,51
+2014,8,2013/2014,60,HHS Region 2,Season peak week,6
+2014,8,2013/2014,60,HHS Region 2,Season peak week,13
+2014,8,2013/2014,60,HHS Region 2,Season peak percentage,3.4
+2014,8,2013/2014,60,HHS Region 2,1 wk ahead,2.3
+2014,8,2013/2014,60,HHS Region 2,2 wk ahead,2.3
+2014,8,2013/2014,60,HHS Region 2,3 wk ahead,2.5
+2014,8,2013/2014,60,HHS Region 2,4 wk ahead,2.9
+2014,8,2013/2014,60,HHS Region 3,Season onset,51
+2014,8,2013/2014,60,HHS Region 3,Season peak week,1
+2014,8,2013/2014,60,HHS Region 3,Season peak percentage,3.6
+2014,8,2013/2014,60,HHS Region 3,1 wk ahead,2
+2014,8,2013/2014,60,HHS Region 3,2 wk ahead,1.8
+2014,8,2013/2014,60,HHS Region 3,3 wk ahead,1.6
+2014,8,2013/2014,60,HHS Region 3,4 wk ahead,1.7
+2014,8,2013/2014,60,HHS Region 4,Season onset,48
+2014,8,2013/2014,60,HHS Region 4,Season peak week,52
+2014,8,2013/2014,60,HHS Region 4,Season peak percentage,4.6
+2014,8,2013/2014,60,HHS Region 4,1 wk ahead,1.4
+2014,8,2013/2014,60,HHS Region 4,2 wk ahead,1.4
+2014,8,2013/2014,60,HHS Region 4,3 wk ahead,1.1
+2014,8,2013/2014,60,HHS Region 4,4 wk ahead,1
+2014,8,2013/2014,60,HHS Region 5,Season onset,48
+2014,8,2013/2014,60,HHS Region 5,Season peak week,52
+2014,8,2013/2014,60,HHS Region 5,Season peak percentage,3.6
+2014,8,2013/2014,60,HHS Region 5,1 wk ahead,1.8
+2014,8,2013/2014,60,HHS Region 5,2 wk ahead,1.8
+2014,8,2013/2014,60,HHS Region 5,3 wk ahead,1.6
+2014,8,2013/2014,60,HHS Region 5,4 wk ahead,1.6
+2014,8,2013/2014,60,HHS Region 6,Season onset,45
+2014,8,2013/2014,60,HHS Region 6,Season peak week,52
+2014,8,2013/2014,60,HHS Region 6,Season peak percentage,9.9
+2014,8,2013/2014,60,HHS Region 6,1 wk ahead,3.6
+2014,8,2013/2014,60,HHS Region 6,2 wk ahead,3.4
+2014,8,2013/2014,60,HHS Region 6,3 wk ahead,3.2
+2014,8,2013/2014,60,HHS Region 6,4 wk ahead,3
+2014,8,2013/2014,60,HHS Region 7,Season onset,51
+2014,8,2013/2014,60,HHS Region 7,Season peak week,52
+2014,8,2013/2014,60,HHS Region 7,Season peak percentage,4.5
+2014,8,2013/2014,60,HHS Region 7,1 wk ahead,1.2
+2014,8,2013/2014,60,HHS Region 7,2 wk ahead,1.1
+2014,8,2013/2014,60,HHS Region 7,3 wk ahead,1.4
+2014,8,2013/2014,60,HHS Region 7,4 wk ahead,1
+2014,8,2013/2014,60,HHS Region 8,Season onset,49
+2014,8,2013/2014,60,HHS Region 8,Season peak week,52
+2014,8,2013/2014,60,HHS Region 8,Season peak percentage,3.7
+2014,8,2013/2014,60,HHS Region 8,1 wk ahead,1.2
+2014,8,2013/2014,60,HHS Region 8,2 wk ahead,1.4
+2014,8,2013/2014,60,HHS Region 8,3 wk ahead,1.1
+2014,8,2013/2014,60,HHS Region 8,4 wk ahead,1
+2014,8,2013/2014,60,HHS Region 9,Season onset,51
+2014,8,2013/2014,60,HHS Region 9,Season peak week,1
+2014,8,2013/2014,60,HHS Region 9,Season peak week,4
+2014,8,2013/2014,60,HHS Region 9,Season peak percentage,4.6
+2014,8,2013/2014,60,HHS Region 9,1 wk ahead,2.9
+2014,8,2013/2014,60,HHS Region 9,2 wk ahead,2.6
+2014,8,2013/2014,60,HHS Region 9,3 wk ahead,2.2
+2014,8,2013/2014,60,HHS Region 9,4 wk ahead,2.2
+2014,8,2013/2014,60,HHS Region 10,Season onset,51
+2014,8,2013/2014,60,HHS Region 10,Season peak week,1
+2014,8,2013/2014,60,HHS Region 10,Season peak percentage,4
+2014,8,2013/2014,60,HHS Region 10,1 wk ahead,0.7
+2014,8,2013/2014,60,HHS Region 10,2 wk ahead,0.8
+2014,8,2013/2014,60,HHS Region 10,3 wk ahead,0.6
+2014,8,2013/2014,60,HHS Region 10,4 wk ahead,0.8
+2014,9,2013/2014,61,US National,Season onset,48
+2014,9,2013/2014,61,US National,Season peak week,52
+2014,9,2013/2014,61,US National,Season peak percentage,4.6
+2014,9,2013/2014,61,US National,1 wk ahead,2
+2014,9,2013/2014,61,US National,2 wk ahead,1.8
+2014,9,2013/2014,61,US National,3 wk ahead,1.8
+2014,9,2013/2014,61,US National,4 wk ahead,1.8
+2014,9,2013/2014,61,HHS Region 1,Season onset,51
+2014,9,2013/2014,61,HHS Region 1,Season peak week,6
+2014,9,2013/2014,61,HHS Region 1,Season peak percentage,2.2
+2014,9,2013/2014,61,HHS Region 1,1 wk ahead,1.5
+2014,9,2013/2014,61,HHS Region 1,2 wk ahead,1.4
+2014,9,2013/2014,61,HHS Region 1,3 wk ahead,1.7
+2014,9,2013/2014,61,HHS Region 1,4 wk ahead,1.6
+2014,9,2013/2014,61,HHS Region 2,Season onset,51
+2014,9,2013/2014,61,HHS Region 2,Season peak week,6
+2014,9,2013/2014,61,HHS Region 2,Season peak week,13
+2014,9,2013/2014,61,HHS Region 2,Season peak percentage,3.4
+2014,9,2013/2014,61,HHS Region 2,1 wk ahead,2.3
+2014,9,2013/2014,61,HHS Region 2,2 wk ahead,2.5
+2014,9,2013/2014,61,HHS Region 2,3 wk ahead,2.9
+2014,9,2013/2014,61,HHS Region 2,4 wk ahead,3.4
+2014,9,2013/2014,61,HHS Region 3,Season onset,51
+2014,9,2013/2014,61,HHS Region 3,Season peak week,1
+2014,9,2013/2014,61,HHS Region 3,Season peak percentage,3.6
+2014,9,2013/2014,61,HHS Region 3,1 wk ahead,1.8
+2014,9,2013/2014,61,HHS Region 3,2 wk ahead,1.6
+2014,9,2013/2014,61,HHS Region 3,3 wk ahead,1.7
+2014,9,2013/2014,61,HHS Region 3,4 wk ahead,1.8
+2014,9,2013/2014,61,HHS Region 4,Season onset,48
+2014,9,2013/2014,61,HHS Region 4,Season peak week,52
+2014,9,2013/2014,61,HHS Region 4,Season peak percentage,4.6
+2014,9,2013/2014,61,HHS Region 4,1 wk ahead,1.4
+2014,9,2013/2014,61,HHS Region 4,2 wk ahead,1.1
+2014,9,2013/2014,61,HHS Region 4,3 wk ahead,1
+2014,9,2013/2014,61,HHS Region 4,4 wk ahead,1
+2014,9,2013/2014,61,HHS Region 5,Season onset,48
+2014,9,2013/2014,61,HHS Region 5,Season peak week,52
+2014,9,2013/2014,61,HHS Region 5,Season peak percentage,3.6
+2014,9,2013/2014,61,HHS Region 5,1 wk ahead,1.8
+2014,9,2013/2014,61,HHS Region 5,2 wk ahead,1.6
+2014,9,2013/2014,61,HHS Region 5,3 wk ahead,1.6
+2014,9,2013/2014,61,HHS Region 5,4 wk ahead,1.5
+2014,9,2013/2014,61,HHS Region 6,Season onset,45
+2014,9,2013/2014,61,HHS Region 6,Season peak week,52
+2014,9,2013/2014,61,HHS Region 6,Season peak percentage,9.9
+2014,9,2013/2014,61,HHS Region 6,1 wk ahead,3.4
+2014,9,2013/2014,61,HHS Region 6,2 wk ahead,3.2
+2014,9,2013/2014,61,HHS Region 6,3 wk ahead,3
+2014,9,2013/2014,61,HHS Region 6,4 wk ahead,2.9
+2014,9,2013/2014,61,HHS Region 7,Season onset,51
+2014,9,2013/2014,61,HHS Region 7,Season peak week,52
+2014,9,2013/2014,61,HHS Region 7,Season peak percentage,4.5
+2014,9,2013/2014,61,HHS Region 7,1 wk ahead,1.1
+2014,9,2013/2014,61,HHS Region 7,2 wk ahead,1.4
+2014,9,2013/2014,61,HHS Region 7,3 wk ahead,1
+2014,9,2013/2014,61,HHS Region 7,4 wk ahead,0.8
+2014,9,2013/2014,61,HHS Region 8,Season onset,49
+2014,9,2013/2014,61,HHS Region 8,Season peak week,52
+2014,9,2013/2014,61,HHS Region 8,Season peak percentage,3.7
+2014,9,2013/2014,61,HHS Region 8,1 wk ahead,1.4
+2014,9,2013/2014,61,HHS Region 8,2 wk ahead,1.1
+2014,9,2013/2014,61,HHS Region 8,3 wk ahead,1
+2014,9,2013/2014,61,HHS Region 8,4 wk ahead,0.9
+2014,9,2013/2014,61,HHS Region 9,Season onset,51
+2014,9,2013/2014,61,HHS Region 9,Season peak week,1
+2014,9,2013/2014,61,HHS Region 9,Season peak week,4
+2014,9,2013/2014,61,HHS Region 9,Season peak percentage,4.6
+2014,9,2013/2014,61,HHS Region 9,1 wk ahead,2.6
+2014,9,2013/2014,61,HHS Region 9,2 wk ahead,2.2
+2014,9,2013/2014,61,HHS Region 9,3 wk ahead,2.2
+2014,9,2013/2014,61,HHS Region 9,4 wk ahead,1.9
+2014,9,2013/2014,61,HHS Region 10,Season onset,51
+2014,9,2013/2014,61,HHS Region 10,Season peak week,1
+2014,9,2013/2014,61,HHS Region 10,Season peak percentage,4
+2014,9,2013/2014,61,HHS Region 10,1 wk ahead,0.8
+2014,9,2013/2014,61,HHS Region 10,2 wk ahead,0.6
+2014,9,2013/2014,61,HHS Region 10,3 wk ahead,0.8
+2014,9,2013/2014,61,HHS Region 10,4 wk ahead,0.7
+2014,10,2013/2014,62,US National,Season onset,48
+2014,10,2013/2014,62,US National,Season peak week,52
+2014,10,2013/2014,62,US National,Season peak percentage,4.6
+2014,10,2013/2014,62,US National,1 wk ahead,1.8
+2014,10,2013/2014,62,US National,2 wk ahead,1.8
+2014,10,2013/2014,62,US National,3 wk ahead,1.8
+2014,10,2013/2014,62,US National,4 wk ahead,1.7
+2014,10,2013/2014,62,HHS Region 1,Season onset,51
+2014,10,2013/2014,62,HHS Region 1,Season peak week,6
+2014,10,2013/2014,62,HHS Region 1,Season peak percentage,2.2
+2014,10,2013/2014,62,HHS Region 1,1 wk ahead,1.4
+2014,10,2013/2014,62,HHS Region 1,2 wk ahead,1.7
+2014,10,2013/2014,62,HHS Region 1,3 wk ahead,1.6
+2014,10,2013/2014,62,HHS Region 1,4 wk ahead,1.8
+2014,10,2013/2014,62,HHS Region 2,Season onset,51
+2014,10,2013/2014,62,HHS Region 2,Season peak week,6
+2014,10,2013/2014,62,HHS Region 2,Season peak week,13
+2014,10,2013/2014,62,HHS Region 2,Season peak percentage,3.4
+2014,10,2013/2014,62,HHS Region 2,1 wk ahead,2.5
+2014,10,2013/2014,62,HHS Region 2,2 wk ahead,2.9
+2014,10,2013/2014,62,HHS Region 2,3 wk ahead,3.4
+2014,10,2013/2014,62,HHS Region 2,4 wk ahead,3.3
+2014,10,2013/2014,62,HHS Region 3,Season onset,51
+2014,10,2013/2014,62,HHS Region 3,Season peak week,1
+2014,10,2013/2014,62,HHS Region 3,Season peak percentage,3.6
+2014,10,2013/2014,62,HHS Region 3,1 wk ahead,1.6
+2014,10,2013/2014,62,HHS Region 3,2 wk ahead,1.7
+2014,10,2013/2014,62,HHS Region 3,3 wk ahead,1.8
+2014,10,2013/2014,62,HHS Region 3,4 wk ahead,1.9
+2014,10,2013/2014,62,HHS Region 4,Season onset,48
+2014,10,2013/2014,62,HHS Region 4,Season peak week,52
+2014,10,2013/2014,62,HHS Region 4,Season peak percentage,4.6
+2014,10,2013/2014,62,HHS Region 4,1 wk ahead,1.1
+2014,10,2013/2014,62,HHS Region 4,2 wk ahead,1
+2014,10,2013/2014,62,HHS Region 4,3 wk ahead,1
+2014,10,2013/2014,62,HHS Region 4,4 wk ahead,0.9
+2014,10,2013/2014,62,HHS Region 5,Season onset,48
+2014,10,2013/2014,62,HHS Region 5,Season peak week,52
+2014,10,2013/2014,62,HHS Region 5,Season peak percentage,3.6
+2014,10,2013/2014,62,HHS Region 5,1 wk ahead,1.6
+2014,10,2013/2014,62,HHS Region 5,2 wk ahead,1.6
+2014,10,2013/2014,62,HHS Region 5,3 wk ahead,1.5
+2014,10,2013/2014,62,HHS Region 5,4 wk ahead,1.5
+2014,10,2013/2014,62,HHS Region 6,Season onset,45
+2014,10,2013/2014,62,HHS Region 6,Season peak week,52
+2014,10,2013/2014,62,HHS Region 6,Season peak percentage,9.9
+2014,10,2013/2014,62,HHS Region 6,1 wk ahead,3.2
+2014,10,2013/2014,62,HHS Region 6,2 wk ahead,3
+2014,10,2013/2014,62,HHS Region 6,3 wk ahead,2.9
+2014,10,2013/2014,62,HHS Region 6,4 wk ahead,2.8
+2014,10,2013/2014,62,HHS Region 7,Season onset,51
+2014,10,2013/2014,62,HHS Region 7,Season peak week,52
+2014,10,2013/2014,62,HHS Region 7,Season peak percentage,4.5
+2014,10,2013/2014,62,HHS Region 7,1 wk ahead,1.4
+2014,10,2013/2014,62,HHS Region 7,2 wk ahead,1
+2014,10,2013/2014,62,HHS Region 7,3 wk ahead,0.8
+2014,10,2013/2014,62,HHS Region 7,4 wk ahead,1
+2014,10,2013/2014,62,HHS Region 8,Season onset,49
+2014,10,2013/2014,62,HHS Region 8,Season peak week,52
+2014,10,2013/2014,62,HHS Region 8,Season peak percentage,3.7
+2014,10,2013/2014,62,HHS Region 8,1 wk ahead,1.1
+2014,10,2013/2014,62,HHS Region 8,2 wk ahead,1
+2014,10,2013/2014,62,HHS Region 8,3 wk ahead,0.9
+2014,10,2013/2014,62,HHS Region 8,4 wk ahead,0.9
+2014,10,2013/2014,62,HHS Region 9,Season onset,51
+2014,10,2013/2014,62,HHS Region 9,Season peak week,1
+2014,10,2013/2014,62,HHS Region 9,Season peak week,4
+2014,10,2013/2014,62,HHS Region 9,Season peak percentage,4.6
+2014,10,2013/2014,62,HHS Region 9,1 wk ahead,2.2
+2014,10,2013/2014,62,HHS Region 9,2 wk ahead,2.2
+2014,10,2013/2014,62,HHS Region 9,3 wk ahead,1.9
+2014,10,2013/2014,62,HHS Region 9,4 wk ahead,1.9
+2014,10,2013/2014,62,HHS Region 10,Season onset,51
+2014,10,2013/2014,62,HHS Region 10,Season peak week,1
+2014,10,2013/2014,62,HHS Region 10,Season peak percentage,4
+2014,10,2013/2014,62,HHS Region 10,1 wk ahead,0.6
+2014,10,2013/2014,62,HHS Region 10,2 wk ahead,0.8
+2014,10,2013/2014,62,HHS Region 10,3 wk ahead,0.7
+2014,10,2013/2014,62,HHS Region 10,4 wk ahead,0.8
+2014,11,2013/2014,63,US National,Season onset,48
+2014,11,2013/2014,63,US National,Season peak week,52
+2014,11,2013/2014,63,US National,Season peak percentage,4.6
+2014,11,2013/2014,63,US National,1 wk ahead,1.8
+2014,11,2013/2014,63,US National,2 wk ahead,1.8
+2014,11,2013/2014,63,US National,3 wk ahead,1.7
+2014,11,2013/2014,63,US National,4 wk ahead,1.7
+2014,11,2013/2014,63,HHS Region 1,Season onset,51
+2014,11,2013/2014,63,HHS Region 1,Season peak week,6
+2014,11,2013/2014,63,HHS Region 1,Season peak percentage,2.2
+2014,11,2013/2014,63,HHS Region 1,1 wk ahead,1.7
+2014,11,2013/2014,63,HHS Region 1,2 wk ahead,1.6
+2014,11,2013/2014,63,HHS Region 1,3 wk ahead,1.8
+2014,11,2013/2014,63,HHS Region 1,4 wk ahead,2
+2014,11,2013/2014,63,HHS Region 2,Season onset,51
+2014,11,2013/2014,63,HHS Region 2,Season peak week,6
+2014,11,2013/2014,63,HHS Region 2,Season peak week,13
+2014,11,2013/2014,63,HHS Region 2,Season peak percentage,3.4
+2014,11,2013/2014,63,HHS Region 2,1 wk ahead,2.9
+2014,11,2013/2014,63,HHS Region 2,2 wk ahead,3.4
+2014,11,2013/2014,63,HHS Region 2,3 wk ahead,3.3
+2014,11,2013/2014,63,HHS Region 2,4 wk ahead,3.2
+2014,11,2013/2014,63,HHS Region 3,Season onset,51
+2014,11,2013/2014,63,HHS Region 3,Season peak week,1
+2014,11,2013/2014,63,HHS Region 3,Season peak percentage,3.6
+2014,11,2013/2014,63,HHS Region 3,1 wk ahead,1.7
+2014,11,2013/2014,63,HHS Region 3,2 wk ahead,1.8
+2014,11,2013/2014,63,HHS Region 3,3 wk ahead,1.9
+2014,11,2013/2014,63,HHS Region 3,4 wk ahead,1.7
+2014,11,2013/2014,63,HHS Region 4,Season onset,48
+2014,11,2013/2014,63,HHS Region 4,Season peak week,52
+2014,11,2013/2014,63,HHS Region 4,Season peak percentage,4.6
+2014,11,2013/2014,63,HHS Region 4,1 wk ahead,1
+2014,11,2013/2014,63,HHS Region 4,2 wk ahead,1
+2014,11,2013/2014,63,HHS Region 4,3 wk ahead,0.9
+2014,11,2013/2014,63,HHS Region 4,4 wk ahead,0.8
+2014,11,2013/2014,63,HHS Region 5,Season onset,48
+2014,11,2013/2014,63,HHS Region 5,Season peak week,52
+2014,11,2013/2014,63,HHS Region 5,Season peak percentage,3.6
+2014,11,2013/2014,63,HHS Region 5,1 wk ahead,1.6
+2014,11,2013/2014,63,HHS Region 5,2 wk ahead,1.5
+2014,11,2013/2014,63,HHS Region 5,3 wk ahead,1.5
+2014,11,2013/2014,63,HHS Region 5,4 wk ahead,1.3
+2014,11,2013/2014,63,HHS Region 6,Season onset,45
+2014,11,2013/2014,63,HHS Region 6,Season peak week,52
+2014,11,2013/2014,63,HHS Region 6,Season peak percentage,9.9
+2014,11,2013/2014,63,HHS Region 6,1 wk ahead,3
+2014,11,2013/2014,63,HHS Region 6,2 wk ahead,2.9
+2014,11,2013/2014,63,HHS Region 6,3 wk ahead,2.8
+2014,11,2013/2014,63,HHS Region 6,4 wk ahead,2.9
+2014,11,2013/2014,63,HHS Region 7,Season onset,51
+2014,11,2013/2014,63,HHS Region 7,Season peak week,52
+2014,11,2013/2014,63,HHS Region 7,Season peak percentage,4.5
+2014,11,2013/2014,63,HHS Region 7,1 wk ahead,1
+2014,11,2013/2014,63,HHS Region 7,2 wk ahead,0.8
+2014,11,2013/2014,63,HHS Region 7,3 wk ahead,1
+2014,11,2013/2014,63,HHS Region 7,4 wk ahead,0.7
+2014,11,2013/2014,63,HHS Region 8,Season onset,49
+2014,11,2013/2014,63,HHS Region 8,Season peak week,52
+2014,11,2013/2014,63,HHS Region 8,Season peak percentage,3.7
+2014,11,2013/2014,63,HHS Region 8,1 wk ahead,1
+2014,11,2013/2014,63,HHS Region 8,2 wk ahead,0.9
+2014,11,2013/2014,63,HHS Region 8,3 wk ahead,0.9
+2014,11,2013/2014,63,HHS Region 8,4 wk ahead,0.9
+2014,11,2013/2014,63,HHS Region 9,Season onset,51
+2014,11,2013/2014,63,HHS Region 9,Season peak week,1
+2014,11,2013/2014,63,HHS Region 9,Season peak week,4
+2014,11,2013/2014,63,HHS Region 9,Season peak percentage,4.6
+2014,11,2013/2014,63,HHS Region 9,1 wk ahead,2.2
+2014,11,2013/2014,63,HHS Region 9,2 wk ahead,1.9
+2014,11,2013/2014,63,HHS Region 9,3 wk ahead,1.9
+2014,11,2013/2014,63,HHS Region 9,4 wk ahead,1.7
+2014,11,2013/2014,63,HHS Region 10,Season onset,51
+2014,11,2013/2014,63,HHS Region 10,Season peak week,1
+2014,11,2013/2014,63,HHS Region 10,Season peak percentage,4
+2014,11,2013/2014,63,HHS Region 10,1 wk ahead,0.8
+2014,11,2013/2014,63,HHS Region 10,2 wk ahead,0.7
+2014,11,2013/2014,63,HHS Region 10,3 wk ahead,0.8
+2014,11,2013/2014,63,HHS Region 10,4 wk ahead,0.6
+2014,12,2013/2014,64,US National,Season onset,48
+2014,12,2013/2014,64,US National,Season peak week,52
+2014,12,2013/2014,64,US National,Season peak percentage,4.6
+2014,12,2013/2014,64,US National,1 wk ahead,1.8
+2014,12,2013/2014,64,US National,2 wk ahead,1.7
+2014,12,2013/2014,64,US National,3 wk ahead,1.7
+2014,12,2013/2014,64,US National,4 wk ahead,1.5
+2014,12,2013/2014,64,HHS Region 1,Season onset,51
+2014,12,2013/2014,64,HHS Region 1,Season peak week,6
+2014,12,2013/2014,64,HHS Region 1,Season peak percentage,2.2
+2014,12,2013/2014,64,HHS Region 1,1 wk ahead,1.6
+2014,12,2013/2014,64,HHS Region 1,2 wk ahead,1.8
+2014,12,2013/2014,64,HHS Region 1,3 wk ahead,2
+2014,12,2013/2014,64,HHS Region 1,4 wk ahead,1.7
+2014,12,2013/2014,64,HHS Region 2,Season onset,51
+2014,12,2013/2014,64,HHS Region 2,Season peak week,6
+2014,12,2013/2014,64,HHS Region 2,Season peak week,13
+2014,12,2013/2014,64,HHS Region 2,Season peak percentage,3.4
+2014,12,2013/2014,64,HHS Region 2,1 wk ahead,3.4
+2014,12,2013/2014,64,HHS Region 2,2 wk ahead,3.3
+2014,12,2013/2014,64,HHS Region 2,3 wk ahead,3.2
+2014,12,2013/2014,64,HHS Region 2,4 wk ahead,2.6
+2014,12,2013/2014,64,HHS Region 3,Season onset,51
+2014,12,2013/2014,64,HHS Region 3,Season peak week,1
+2014,12,2013/2014,64,HHS Region 3,Season peak percentage,3.6
+2014,12,2013/2014,64,HHS Region 3,1 wk ahead,1.8
+2014,12,2013/2014,64,HHS Region 3,2 wk ahead,1.9
+2014,12,2013/2014,64,HHS Region 3,3 wk ahead,1.7
+2014,12,2013/2014,64,HHS Region 3,4 wk ahead,1.3
+2014,12,2013/2014,64,HHS Region 4,Season onset,48
+2014,12,2013/2014,64,HHS Region 4,Season peak week,52
+2014,12,2013/2014,64,HHS Region 4,Season peak percentage,4.6
+2014,12,2013/2014,64,HHS Region 4,1 wk ahead,1
+2014,12,2013/2014,64,HHS Region 4,2 wk ahead,0.9
+2014,12,2013/2014,64,HHS Region 4,3 wk ahead,0.8
+2014,12,2013/2014,64,HHS Region 4,4 wk ahead,0.8
+2014,12,2013/2014,64,HHS Region 5,Season onset,48
+2014,12,2013/2014,64,HHS Region 5,Season peak week,52
+2014,12,2013/2014,64,HHS Region 5,Season peak percentage,3.6
+2014,12,2013/2014,64,HHS Region 5,1 wk ahead,1.5
+2014,12,2013/2014,64,HHS Region 5,2 wk ahead,1.5
+2014,12,2013/2014,64,HHS Region 5,3 wk ahead,1.3
+2014,12,2013/2014,64,HHS Region 5,4 wk ahead,1.2
+2014,12,2013/2014,64,HHS Region 6,Season onset,45
+2014,12,2013/2014,64,HHS Region 6,Season peak week,52
+2014,12,2013/2014,64,HHS Region 6,Season peak percentage,9.9
+2014,12,2013/2014,64,HHS Region 6,1 wk ahead,2.9
+2014,12,2013/2014,64,HHS Region 6,2 wk ahead,2.8
+2014,12,2013/2014,64,HHS Region 6,3 wk ahead,2.9
+2014,12,2013/2014,64,HHS Region 6,4 wk ahead,2.6
+2014,12,2013/2014,64,HHS Region 7,Season onset,51
+2014,12,2013/2014,64,HHS Region 7,Season peak week,52
+2014,12,2013/2014,64,HHS Region 7,Season peak percentage,4.5
+2014,12,2013/2014,64,HHS Region 7,1 wk ahead,0.8
+2014,12,2013/2014,64,HHS Region 7,2 wk ahead,1
+2014,12,2013/2014,64,HHS Region 7,3 wk ahead,0.7
+2014,12,2013/2014,64,HHS Region 7,4 wk ahead,0.6
+2014,12,2013/2014,64,HHS Region 8,Season onset,49
+2014,12,2013/2014,64,HHS Region 8,Season peak week,52
+2014,12,2013/2014,64,HHS Region 8,Season peak percentage,3.7
+2014,12,2013/2014,64,HHS Region 8,1 wk ahead,0.9
+2014,12,2013/2014,64,HHS Region 8,2 wk ahead,0.9
+2014,12,2013/2014,64,HHS Region 8,3 wk ahead,0.9
+2014,12,2013/2014,64,HHS Region 8,4 wk ahead,0.8
+2014,12,2013/2014,64,HHS Region 9,Season onset,51
+2014,12,2013/2014,64,HHS Region 9,Season peak week,1
+2014,12,2013/2014,64,HHS Region 9,Season peak week,4
+2014,12,2013/2014,64,HHS Region 9,Season peak percentage,4.6
+2014,12,2013/2014,64,HHS Region 9,1 wk ahead,1.9
+2014,12,2013/2014,64,HHS Region 9,2 wk ahead,1.9
+2014,12,2013/2014,64,HHS Region 9,3 wk ahead,1.7
+2014,12,2013/2014,64,HHS Region 9,4 wk ahead,1.8
+2014,12,2013/2014,64,HHS Region 10,Season onset,51
+2014,12,2013/2014,64,HHS Region 10,Season peak week,1
+2014,12,2013/2014,64,HHS Region 10,Season peak percentage,4
+2014,12,2013/2014,64,HHS Region 10,1 wk ahead,0.7
+2014,12,2013/2014,64,HHS Region 10,2 wk ahead,0.8
+2014,12,2013/2014,64,HHS Region 10,3 wk ahead,0.6
+2014,12,2013/2014,64,HHS Region 10,4 wk ahead,0.8
+2014,13,2013/2014,65,US National,Season onset,48
+2014,13,2013/2014,65,US National,Season peak week,52
+2014,13,2013/2014,65,US National,Season peak percentage,4.6
+2014,13,2013/2014,65,US National,1 wk ahead,1.7
+2014,13,2013/2014,65,US National,2 wk ahead,1.7
+2014,13,2013/2014,65,US National,3 wk ahead,1.5
+2014,13,2013/2014,65,US National,4 wk ahead,1.4
+2014,13,2013/2014,65,HHS Region 1,Season onset,51
+2014,13,2013/2014,65,HHS Region 1,Season peak week,6
+2014,13,2013/2014,65,HHS Region 1,Season peak percentage,2.2
+2014,13,2013/2014,65,HHS Region 1,1 wk ahead,1.8
+2014,13,2013/2014,65,HHS Region 1,2 wk ahead,2
+2014,13,2013/2014,65,HHS Region 1,3 wk ahead,1.7
+2014,13,2013/2014,65,HHS Region 1,4 wk ahead,1.6
+2014,13,2013/2014,65,HHS Region 2,Season onset,51
+2014,13,2013/2014,65,HHS Region 2,Season peak week,6
+2014,13,2013/2014,65,HHS Region 2,Season peak week,13
+2014,13,2013/2014,65,HHS Region 2,Season peak percentage,3.4
+2014,13,2013/2014,65,HHS Region 2,1 wk ahead,3.3
+2014,13,2013/2014,65,HHS Region 2,2 wk ahead,3.2
+2014,13,2013/2014,65,HHS Region 2,3 wk ahead,2.6
+2014,13,2013/2014,65,HHS Region 2,4 wk ahead,2.3
+2014,13,2013/2014,65,HHS Region 3,Season onset,51
+2014,13,2013/2014,65,HHS Region 3,Season peak week,1
+2014,13,2013/2014,65,HHS Region 3,Season peak percentage,3.6
+2014,13,2013/2014,65,HHS Region 3,1 wk ahead,1.9
+2014,13,2013/2014,65,HHS Region 3,2 wk ahead,1.7
+2014,13,2013/2014,65,HHS Region 3,3 wk ahead,1.3
+2014,13,2013/2014,65,HHS Region 3,4 wk ahead,1.2
+2014,13,2013/2014,65,HHS Region 4,Season onset,48
+2014,13,2013/2014,65,HHS Region 4,Season peak week,52
+2014,13,2013/2014,65,HHS Region 4,Season peak percentage,4.6
+2014,13,2013/2014,65,HHS Region 4,1 wk ahead,0.9
+2014,13,2013/2014,65,HHS Region 4,2 wk ahead,0.8
+2014,13,2013/2014,65,HHS Region 4,3 wk ahead,0.8
+2014,13,2013/2014,65,HHS Region 4,4 wk ahead,0.8
+2014,13,2013/2014,65,HHS Region 5,Season onset,48
+2014,13,2013/2014,65,HHS Region 5,Season peak week,52
+2014,13,2013/2014,65,HHS Region 5,Season peak percentage,3.6
+2014,13,2013/2014,65,HHS Region 5,1 wk ahead,1.5
+2014,13,2013/2014,65,HHS Region 5,2 wk ahead,1.3
+2014,13,2013/2014,65,HHS Region 5,3 wk ahead,1.2
+2014,13,2013/2014,65,HHS Region 5,4 wk ahead,1.2
+2014,13,2013/2014,65,HHS Region 6,Season onset,45
+2014,13,2013/2014,65,HHS Region 6,Season peak week,52
+2014,13,2013/2014,65,HHS Region 6,Season peak percentage,9.9
+2014,13,2013/2014,65,HHS Region 6,1 wk ahead,2.8
+2014,13,2013/2014,65,HHS Region 6,2 wk ahead,2.9
+2014,13,2013/2014,65,HHS Region 6,3 wk ahead,2.6
+2014,13,2013/2014,65,HHS Region 6,4 wk ahead,2.5
+2014,13,2013/2014,65,HHS Region 7,Season onset,51
+2014,13,2013/2014,65,HHS Region 7,Season peak week,52
+2014,13,2013/2014,65,HHS Region 7,Season peak percentage,4.5
+2014,13,2013/2014,65,HHS Region 7,1 wk ahead,1
+2014,13,2013/2014,65,HHS Region 7,2 wk ahead,0.7
+2014,13,2013/2014,65,HHS Region 7,3 wk ahead,0.6
+2014,13,2013/2014,65,HHS Region 7,4 wk ahead,0.7
+2014,13,2013/2014,65,HHS Region 8,Season onset,49
+2014,13,2013/2014,65,HHS Region 8,Season peak week,52
+2014,13,2013/2014,65,HHS Region 8,Season peak percentage,3.7
+2014,13,2013/2014,65,HHS Region 8,1 wk ahead,0.9
+2014,13,2013/2014,65,HHS Region 8,2 wk ahead,0.9
+2014,13,2013/2014,65,HHS Region 8,3 wk ahead,0.8
+2014,13,2013/2014,65,HHS Region 8,4 wk ahead,1
+2014,13,2013/2014,65,HHS Region 9,Season onset,51
+2014,13,2013/2014,65,HHS Region 9,Season peak week,1
+2014,13,2013/2014,65,HHS Region 9,Season peak week,4
+2014,13,2013/2014,65,HHS Region 9,Season peak percentage,4.6
+2014,13,2013/2014,65,HHS Region 9,1 wk ahead,1.9
+2014,13,2013/2014,65,HHS Region 9,2 wk ahead,1.7
+2014,13,2013/2014,65,HHS Region 9,3 wk ahead,1.8
+2014,13,2013/2014,65,HHS Region 9,4 wk ahead,1.7
+2014,13,2013/2014,65,HHS Region 10,Season onset,51
+2014,13,2013/2014,65,HHS Region 10,Season peak week,1
+2014,13,2013/2014,65,HHS Region 10,Season peak percentage,4
+2014,13,2013/2014,65,HHS Region 10,1 wk ahead,0.8
+2014,13,2013/2014,65,HHS Region 10,2 wk ahead,0.6
+2014,13,2013/2014,65,HHS Region 10,3 wk ahead,0.8
+2014,13,2013/2014,65,HHS Region 10,4 wk ahead,0.8
+2014,14,2013/2014,66,US National,Season onset,48
+2014,14,2013/2014,66,US National,Season peak week,52
+2014,14,2013/2014,66,US National,Season peak percentage,4.6
+2014,14,2013/2014,66,US National,1 wk ahead,1.7
+2014,14,2013/2014,66,US National,2 wk ahead,1.5
+2014,14,2013/2014,66,US National,3 wk ahead,1.4
+2014,14,2013/2014,66,US National,4 wk ahead,1.3
+2014,14,2013/2014,66,HHS Region 1,Season onset,51
+2014,14,2013/2014,66,HHS Region 1,Season peak week,6
+2014,14,2013/2014,66,HHS Region 1,Season peak percentage,2.2
+2014,14,2013/2014,66,HHS Region 1,1 wk ahead,2
+2014,14,2013/2014,66,HHS Region 1,2 wk ahead,1.7
+2014,14,2013/2014,66,HHS Region 1,3 wk ahead,1.6
+2014,14,2013/2014,66,HHS Region 1,4 wk ahead,1.3
+2014,14,2013/2014,66,HHS Region 2,Season onset,51
+2014,14,2013/2014,66,HHS Region 2,Season peak week,6
+2014,14,2013/2014,66,HHS Region 2,Season peak week,13
+2014,14,2013/2014,66,HHS Region 2,Season peak percentage,3.4
+2014,14,2013/2014,66,HHS Region 2,1 wk ahead,3.2
+2014,14,2013/2014,66,HHS Region 2,2 wk ahead,2.6
+2014,14,2013/2014,66,HHS Region 2,3 wk ahead,2.3
+2014,14,2013/2014,66,HHS Region 2,4 wk ahead,1.9
+2014,14,2013/2014,66,HHS Region 3,Season onset,51
+2014,14,2013/2014,66,HHS Region 3,Season peak week,1
+2014,14,2013/2014,66,HHS Region 3,Season peak percentage,3.6
+2014,14,2013/2014,66,HHS Region 3,1 wk ahead,1.7
+2014,14,2013/2014,66,HHS Region 3,2 wk ahead,1.3
+2014,14,2013/2014,66,HHS Region 3,3 wk ahead,1.2
+2014,14,2013/2014,66,HHS Region 3,4 wk ahead,1.1
+2014,14,2013/2014,66,HHS Region 4,Season onset,48
+2014,14,2013/2014,66,HHS Region 4,Season peak week,52
+2014,14,2013/2014,66,HHS Region 4,Season peak percentage,4.6
+2014,14,2013/2014,66,HHS Region 4,1 wk ahead,0.8
+2014,14,2013/2014,66,HHS Region 4,2 wk ahead,0.8
+2014,14,2013/2014,66,HHS Region 4,3 wk ahead,0.8
+2014,14,2013/2014,66,HHS Region 4,4 wk ahead,0.7
+2014,14,2013/2014,66,HHS Region 5,Season onset,48
+2014,14,2013/2014,66,HHS Region 5,Season peak week,52
+2014,14,2013/2014,66,HHS Region 5,Season peak percentage,3.6
+2014,14,2013/2014,66,HHS Region 5,1 wk ahead,1.3
+2014,14,2013/2014,66,HHS Region 5,2 wk ahead,1.2
+2014,14,2013/2014,66,HHS Region 5,3 wk ahead,1.2
+2014,14,2013/2014,66,HHS Region 5,4 wk ahead,1.2
+2014,14,2013/2014,66,HHS Region 6,Season onset,45
+2014,14,2013/2014,66,HHS Region 6,Season peak week,52
+2014,14,2013/2014,66,HHS Region 6,Season peak percentage,9.9
+2014,14,2013/2014,66,HHS Region 6,1 wk ahead,2.9
+2014,14,2013/2014,66,HHS Region 6,2 wk ahead,2.6
+2014,14,2013/2014,66,HHS Region 6,3 wk ahead,2.5
+2014,14,2013/2014,66,HHS Region 6,4 wk ahead,2.1
+2014,14,2013/2014,66,HHS Region 7,Season onset,51
+2014,14,2013/2014,66,HHS Region 7,Season peak week,52
+2014,14,2013/2014,66,HHS Region 7,Season peak percentage,4.5
+2014,14,2013/2014,66,HHS Region 7,1 wk ahead,0.7
+2014,14,2013/2014,66,HHS Region 7,2 wk ahead,0.6
+2014,14,2013/2014,66,HHS Region 7,3 wk ahead,0.7
+2014,14,2013/2014,66,HHS Region 7,4 wk ahead,0.5
+2014,14,2013/2014,66,HHS Region 8,Season onset,49
+2014,14,2013/2014,66,HHS Region 8,Season peak week,52
+2014,14,2013/2014,66,HHS Region 8,Season peak percentage,3.7
+2014,14,2013/2014,66,HHS Region 8,1 wk ahead,0.9
+2014,14,2013/2014,66,HHS Region 8,2 wk ahead,0.8
+2014,14,2013/2014,66,HHS Region 8,3 wk ahead,1
+2014,14,2013/2014,66,HHS Region 8,4 wk ahead,0.8
+2014,14,2013/2014,66,HHS Region 9,Season onset,51
+2014,14,2013/2014,66,HHS Region 9,Season peak week,1
+2014,14,2013/2014,66,HHS Region 9,Season peak week,4
+2014,14,2013/2014,66,HHS Region 9,Season peak percentage,4.6
+2014,14,2013/2014,66,HHS Region 9,1 wk ahead,1.7
+2014,14,2013/2014,66,HHS Region 9,2 wk ahead,1.8
+2014,14,2013/2014,66,HHS Region 9,3 wk ahead,1.7
+2014,14,2013/2014,66,HHS Region 9,4 wk ahead,1.6
+2014,14,2013/2014,66,HHS Region 10,Season onset,51
+2014,14,2013/2014,66,HHS Region 10,Season peak week,1
+2014,14,2013/2014,66,HHS Region 10,Season peak percentage,4
+2014,14,2013/2014,66,HHS Region 10,1 wk ahead,0.6
+2014,14,2013/2014,66,HHS Region 10,2 wk ahead,0.8
+2014,14,2013/2014,66,HHS Region 10,3 wk ahead,0.8
+2014,14,2013/2014,66,HHS Region 10,4 wk ahead,0.5
+2014,15,2013/2014,67,US National,Season onset,48
+2014,15,2013/2014,67,US National,Season peak week,52
+2014,15,2013/2014,67,US National,Season peak percentage,4.6
+2014,15,2013/2014,67,US National,1 wk ahead,1.5
+2014,15,2013/2014,67,US National,2 wk ahead,1.4
+2014,15,2013/2014,67,US National,3 wk ahead,1.3
+2014,15,2013/2014,67,US National,4 wk ahead,1.4
+2014,15,2013/2014,67,HHS Region 1,Season onset,51
+2014,15,2013/2014,67,HHS Region 1,Season peak week,6
+2014,15,2013/2014,67,HHS Region 1,Season peak percentage,2.2
+2014,15,2013/2014,67,HHS Region 1,1 wk ahead,1.7
+2014,15,2013/2014,67,HHS Region 1,2 wk ahead,1.6
+2014,15,2013/2014,67,HHS Region 1,3 wk ahead,1.3
+2014,15,2013/2014,67,HHS Region 1,4 wk ahead,1.3
+2014,15,2013/2014,67,HHS Region 2,Season onset,51
+2014,15,2013/2014,67,HHS Region 2,Season peak week,6
+2014,15,2013/2014,67,HHS Region 2,Season peak week,13
+2014,15,2013/2014,67,HHS Region 2,Season peak percentage,3.4
+2014,15,2013/2014,67,HHS Region 2,1 wk ahead,2.6
+2014,15,2013/2014,67,HHS Region 2,2 wk ahead,2.3
+2014,15,2013/2014,67,HHS Region 2,3 wk ahead,1.9
+2014,15,2013/2014,67,HHS Region 2,4 wk ahead,2.3
+2014,15,2013/2014,67,HHS Region 3,Season onset,51
+2014,15,2013/2014,67,HHS Region 3,Season peak week,1
+2014,15,2013/2014,67,HHS Region 3,Season peak percentage,3.6
+2014,15,2013/2014,67,HHS Region 3,1 wk ahead,1.3
+2014,15,2013/2014,67,HHS Region 3,2 wk ahead,1.2
+2014,15,2013/2014,67,HHS Region 3,3 wk ahead,1.1
+2014,15,2013/2014,67,HHS Region 3,4 wk ahead,1.2
+2014,15,2013/2014,67,HHS Region 4,Season onset,48
+2014,15,2013/2014,67,HHS Region 4,Season peak week,52
+2014,15,2013/2014,67,HHS Region 4,Season peak percentage,4.6
+2014,15,2013/2014,67,HHS Region 4,1 wk ahead,0.8
+2014,15,2013/2014,67,HHS Region 4,2 wk ahead,0.8
+2014,15,2013/2014,67,HHS Region 4,3 wk ahead,0.7
+2014,15,2013/2014,67,HHS Region 4,4 wk ahead,0.8
+2014,15,2013/2014,67,HHS Region 5,Season onset,48
+2014,15,2013/2014,67,HHS Region 5,Season peak week,52
+2014,15,2013/2014,67,HHS Region 5,Season peak percentage,3.6
+2014,15,2013/2014,67,HHS Region 5,1 wk ahead,1.2
+2014,15,2013/2014,67,HHS Region 5,2 wk ahead,1.2
+2014,15,2013/2014,67,HHS Region 5,3 wk ahead,1.2
+2014,15,2013/2014,67,HHS Region 5,4 wk ahead,1.3
+2014,15,2013/2014,67,HHS Region 6,Season onset,45
+2014,15,2013/2014,67,HHS Region 6,Season peak week,52
+2014,15,2013/2014,67,HHS Region 6,Season peak percentage,9.9
+2014,15,2013/2014,67,HHS Region 6,1 wk ahead,2.6
+2014,15,2013/2014,67,HHS Region 6,2 wk ahead,2.5
+2014,15,2013/2014,67,HHS Region 6,3 wk ahead,2.1
+2014,15,2013/2014,67,HHS Region 6,4 wk ahead,2.1
+2014,15,2013/2014,67,HHS Region 7,Season onset,51
+2014,15,2013/2014,67,HHS Region 7,Season peak week,52
+2014,15,2013/2014,67,HHS Region 7,Season peak percentage,4.5
+2014,15,2013/2014,67,HHS Region 7,1 wk ahead,0.6
+2014,15,2013/2014,67,HHS Region 7,2 wk ahead,0.7
+2014,15,2013/2014,67,HHS Region 7,3 wk ahead,0.5
+2014,15,2013/2014,67,HHS Region 7,4 wk ahead,0.6
+2014,15,2013/2014,67,HHS Region 8,Season onset,49
+2014,15,2013/2014,67,HHS Region 8,Season peak week,52
+2014,15,2013/2014,67,HHS Region 8,Season peak percentage,3.7
+2014,15,2013/2014,67,HHS Region 8,1 wk ahead,0.8
+2014,15,2013/2014,67,HHS Region 8,2 wk ahead,1
+2014,15,2013/2014,67,HHS Region 8,3 wk ahead,0.8
+2014,15,2013/2014,67,HHS Region 8,4 wk ahead,0.6
+2014,15,2013/2014,67,HHS Region 9,Season onset,51
+2014,15,2013/2014,67,HHS Region 9,Season peak week,1
+2014,15,2013/2014,67,HHS Region 9,Season peak week,4
+2014,15,2013/2014,67,HHS Region 9,Season peak percentage,4.6
+2014,15,2013/2014,67,HHS Region 9,1 wk ahead,1.8
+2014,15,2013/2014,67,HHS Region 9,2 wk ahead,1.7
+2014,15,2013/2014,67,HHS Region 9,3 wk ahead,1.6
+2014,15,2013/2014,67,HHS Region 9,4 wk ahead,1.7
+2014,15,2013/2014,67,HHS Region 10,Season onset,51
+2014,15,2013/2014,67,HHS Region 10,Season peak week,1
+2014,15,2013/2014,67,HHS Region 10,Season peak percentage,4
+2014,15,2013/2014,67,HHS Region 10,1 wk ahead,0.8
+2014,15,2013/2014,67,HHS Region 10,2 wk ahead,0.8
+2014,15,2013/2014,67,HHS Region 10,3 wk ahead,0.5
+2014,15,2013/2014,67,HHS Region 10,4 wk ahead,0.8
+2014,16,2013/2014,68,US National,Season onset,48
+2014,16,2013/2014,68,US National,Season peak week,52
+2014,16,2013/2014,68,US National,Season peak percentage,4.6
+2014,16,2013/2014,68,US National,1 wk ahead,1.4
+2014,16,2013/2014,68,US National,2 wk ahead,1.3
+2014,16,2013/2014,68,US National,3 wk ahead,1.4
+2014,16,2013/2014,68,US National,4 wk ahead,1.3
+2014,16,2013/2014,68,HHS Region 1,Season onset,51
+2014,16,2013/2014,68,HHS Region 1,Season peak week,6
+2014,16,2013/2014,68,HHS Region 1,Season peak percentage,2.2
+2014,16,2013/2014,68,HHS Region 1,1 wk ahead,1.6
+2014,16,2013/2014,68,HHS Region 1,2 wk ahead,1.3
+2014,16,2013/2014,68,HHS Region 1,3 wk ahead,1.3
+2014,16,2013/2014,68,HHS Region 1,4 wk ahead,1
+2014,16,2013/2014,68,HHS Region 2,Season onset,51
+2014,16,2013/2014,68,HHS Region 2,Season peak week,6
+2014,16,2013/2014,68,HHS Region 2,Season peak week,13
+2014,16,2013/2014,68,HHS Region 2,Season peak percentage,3.4
+2014,16,2013/2014,68,HHS Region 2,1 wk ahead,2.3
+2014,16,2013/2014,68,HHS Region 2,2 wk ahead,1.9
+2014,16,2013/2014,68,HHS Region 2,3 wk ahead,2.3
+2014,16,2013/2014,68,HHS Region 2,4 wk ahead,2.1
+2014,16,2013/2014,68,HHS Region 3,Season onset,51
+2014,16,2013/2014,68,HHS Region 3,Season peak week,1
+2014,16,2013/2014,68,HHS Region 3,Season peak percentage,3.6
+2014,16,2013/2014,68,HHS Region 3,1 wk ahead,1.2
+2014,16,2013/2014,68,HHS Region 3,2 wk ahead,1.1
+2014,16,2013/2014,68,HHS Region 3,3 wk ahead,1.2
+2014,16,2013/2014,68,HHS Region 3,4 wk ahead,1.3
+2014,16,2013/2014,68,HHS Region 4,Season onset,48
+2014,16,2013/2014,68,HHS Region 4,Season peak week,52
+2014,16,2013/2014,68,HHS Region 4,Season peak percentage,4.6
+2014,16,2013/2014,68,HHS Region 4,1 wk ahead,0.8
+2014,16,2013/2014,68,HHS Region 4,2 wk ahead,0.7
+2014,16,2013/2014,68,HHS Region 4,3 wk ahead,0.8
+2014,16,2013/2014,68,HHS Region 4,4 wk ahead,0.7
+2014,16,2013/2014,68,HHS Region 5,Season onset,48
+2014,16,2013/2014,68,HHS Region 5,Season peak week,52
+2014,16,2013/2014,68,HHS Region 5,Season peak percentage,3.6
+2014,16,2013/2014,68,HHS Region 5,1 wk ahead,1.2
+2014,16,2013/2014,68,HHS Region 5,2 wk ahead,1.2
+2014,16,2013/2014,68,HHS Region 5,3 wk ahead,1.3
+2014,16,2013/2014,68,HHS Region 5,4 wk ahead,1.2
+2014,16,2013/2014,68,HHS Region 6,Season onset,45
+2014,16,2013/2014,68,HHS Region 6,Season peak week,52
+2014,16,2013/2014,68,HHS Region 6,Season peak percentage,9.9
+2014,16,2013/2014,68,HHS Region 6,1 wk ahead,2.5
+2014,16,2013/2014,68,HHS Region 6,2 wk ahead,2.1
+2014,16,2013/2014,68,HHS Region 6,3 wk ahead,2.1
+2014,16,2013/2014,68,HHS Region 6,4 wk ahead,2.4
+2014,16,2013/2014,68,HHS Region 7,Season onset,51
+2014,16,2013/2014,68,HHS Region 7,Season peak week,52
+2014,16,2013/2014,68,HHS Region 7,Season peak percentage,4.5
+2014,16,2013/2014,68,HHS Region 7,1 wk ahead,0.7
+2014,16,2013/2014,68,HHS Region 7,2 wk ahead,0.5
+2014,16,2013/2014,68,HHS Region 7,3 wk ahead,0.6
+2014,16,2013/2014,68,HHS Region 7,4 wk ahead,0.5
+2014,16,2013/2014,68,HHS Region 8,Season onset,49
+2014,16,2013/2014,68,HHS Region 8,Season peak week,52
+2014,16,2013/2014,68,HHS Region 8,Season peak percentage,3.7
+2014,16,2013/2014,68,HHS Region 8,1 wk ahead,1
+2014,16,2013/2014,68,HHS Region 8,2 wk ahead,0.8
+2014,16,2013/2014,68,HHS Region 8,3 wk ahead,0.6
+2014,16,2013/2014,68,HHS Region 8,4 wk ahead,0.7
+2014,16,2013/2014,68,HHS Region 9,Season onset,51
+2014,16,2013/2014,68,HHS Region 9,Season peak week,1
+2014,16,2013/2014,68,HHS Region 9,Season peak week,4
+2014,16,2013/2014,68,HHS Region 9,Season peak percentage,4.6
+2014,16,2013/2014,68,HHS Region 9,1 wk ahead,1.7
+2014,16,2013/2014,68,HHS Region 9,2 wk ahead,1.6
+2014,16,2013/2014,68,HHS Region 9,3 wk ahead,1.7
+2014,16,2013/2014,68,HHS Region 9,4 wk ahead,1.7
+2014,16,2013/2014,68,HHS Region 10,Season onset,51
+2014,16,2013/2014,68,HHS Region 10,Season peak week,1
+2014,16,2013/2014,68,HHS Region 10,Season peak percentage,4
+2014,16,2013/2014,68,HHS Region 10,1 wk ahead,0.8
+2014,16,2013/2014,68,HHS Region 10,2 wk ahead,0.5
+2014,16,2013/2014,68,HHS Region 10,3 wk ahead,0.8
+2014,16,2013/2014,68,HHS Region 10,4 wk ahead,0.6
+2014,17,2013/2014,69,US National,Season onset,48
+2014,17,2013/2014,69,US National,Season peak week,52
+2014,17,2013/2014,69,US National,Season peak percentage,4.6
+2014,17,2013/2014,69,US National,1 wk ahead,1.3
+2014,17,2013/2014,69,US National,2 wk ahead,1.4
+2014,17,2013/2014,69,US National,3 wk ahead,1.3
+2014,17,2013/2014,69,US National,4 wk ahead,1.3
+2014,17,2013/2014,69,HHS Region 1,Season onset,51
+2014,17,2013/2014,69,HHS Region 1,Season peak week,6
+2014,17,2013/2014,69,HHS Region 1,Season peak percentage,2.2
+2014,17,2013/2014,69,HHS Region 1,1 wk ahead,1.3
+2014,17,2013/2014,69,HHS Region 1,2 wk ahead,1.3
+2014,17,2013/2014,69,HHS Region 1,3 wk ahead,1
+2014,17,2013/2014,69,HHS Region 1,4 wk ahead,0.5
+2014,17,2013/2014,69,HHS Region 2,Season onset,51
+2014,17,2013/2014,69,HHS Region 2,Season peak week,6
+2014,17,2013/2014,69,HHS Region 2,Season peak week,13
+2014,17,2013/2014,69,HHS Region 2,Season peak percentage,3.4
+2014,17,2013/2014,69,HHS Region 2,1 wk ahead,1.9
+2014,17,2013/2014,69,HHS Region 2,2 wk ahead,2.3
+2014,17,2013/2014,69,HHS Region 2,3 wk ahead,2.1
+2014,17,2013/2014,69,HHS Region 2,4 wk ahead,1.9
+2014,17,2013/2014,69,HHS Region 3,Season onset,51
+2014,17,2013/2014,69,HHS Region 3,Season peak week,1
+2014,17,2013/2014,69,HHS Region 3,Season peak percentage,3.6
+2014,17,2013/2014,69,HHS Region 3,1 wk ahead,1.1
+2014,17,2013/2014,69,HHS Region 3,2 wk ahead,1.2
+2014,17,2013/2014,69,HHS Region 3,3 wk ahead,1.3
+2014,17,2013/2014,69,HHS Region 3,4 wk ahead,1.3
+2014,17,2013/2014,69,HHS Region 4,Season onset,48
+2014,17,2013/2014,69,HHS Region 4,Season peak week,52
+2014,17,2013/2014,69,HHS Region 4,Season peak percentage,4.6
+2014,17,2013/2014,69,HHS Region 4,1 wk ahead,0.7
+2014,17,2013/2014,69,HHS Region 4,2 wk ahead,0.8
+2014,17,2013/2014,69,HHS Region 4,3 wk ahead,0.7
+2014,17,2013/2014,69,HHS Region 4,4 wk ahead,0.8
+2014,17,2013/2014,69,HHS Region 5,Season onset,48
+2014,17,2013/2014,69,HHS Region 5,Season peak week,52
+2014,17,2013/2014,69,HHS Region 5,Season peak percentage,3.6
+2014,17,2013/2014,69,HHS Region 5,1 wk ahead,1.2
+2014,17,2013/2014,69,HHS Region 5,2 wk ahead,1.3
+2014,17,2013/2014,69,HHS Region 5,3 wk ahead,1.2
+2014,17,2013/2014,69,HHS Region 5,4 wk ahead,1.2
+2014,17,2013/2014,69,HHS Region 6,Season onset,45
+2014,17,2013/2014,69,HHS Region 6,Season peak week,52
+2014,17,2013/2014,69,HHS Region 6,Season peak percentage,9.9
+2014,17,2013/2014,69,HHS Region 6,1 wk ahead,2.1
+2014,17,2013/2014,69,HHS Region 6,2 wk ahead,2.1
+2014,17,2013/2014,69,HHS Region 6,3 wk ahead,2.4
+2014,17,2013/2014,69,HHS Region 6,4 wk ahead,2.2
+2014,17,2013/2014,69,HHS Region 7,Season onset,51
+2014,17,2013/2014,69,HHS Region 7,Season peak week,52
+2014,17,2013/2014,69,HHS Region 7,Season peak percentage,4.5
+2014,17,2013/2014,69,HHS Region 7,1 wk ahead,0.5
+2014,17,2013/2014,69,HHS Region 7,2 wk ahead,0.6
+2014,17,2013/2014,69,HHS Region 7,3 wk ahead,0.5
+2014,17,2013/2014,69,HHS Region 7,4 wk ahead,0.5
+2014,17,2013/2014,69,HHS Region 8,Season onset,49
+2014,17,2013/2014,69,HHS Region 8,Season peak week,52
+2014,17,2013/2014,69,HHS Region 8,Season peak percentage,3.7
+2014,17,2013/2014,69,HHS Region 8,1 wk ahead,0.8
+2014,17,2013/2014,69,HHS Region 8,2 wk ahead,0.6
+2014,17,2013/2014,69,HHS Region 8,3 wk ahead,0.7
+2014,17,2013/2014,69,HHS Region 8,4 wk ahead,0.6
+2014,17,2013/2014,69,HHS Region 9,Season onset,51
+2014,17,2013/2014,69,HHS Region 9,Season peak week,1
+2014,17,2013/2014,69,HHS Region 9,Season peak week,4
+2014,17,2013/2014,69,HHS Region 9,Season peak percentage,4.6
+2014,17,2013/2014,69,HHS Region 9,1 wk ahead,1.6
+2014,17,2013/2014,69,HHS Region 9,2 wk ahead,1.7
+2014,17,2013/2014,69,HHS Region 9,3 wk ahead,1.7
+2014,17,2013/2014,69,HHS Region 9,4 wk ahead,1.9
+2014,17,2013/2014,69,HHS Region 10,Season onset,51
+2014,17,2013/2014,69,HHS Region 10,Season peak week,1
+2014,17,2013/2014,69,HHS Region 10,Season peak percentage,4
+2014,17,2013/2014,69,HHS Region 10,1 wk ahead,0.5
+2014,17,2013/2014,69,HHS Region 10,2 wk ahead,0.8
+2014,17,2013/2014,69,HHS Region 10,3 wk ahead,0.6
+2014,17,2013/2014,69,HHS Region 10,4 wk ahead,0.6
+2014,18,2013/2014,70,US National,Season onset,48
+2014,18,2013/2014,70,US National,Season peak week,52
+2014,18,2013/2014,70,US National,Season peak percentage,4.6
+2014,18,2013/2014,70,US National,1 wk ahead,1.4
+2014,18,2013/2014,70,US National,2 wk ahead,1.3
+2014,18,2013/2014,70,US National,3 wk ahead,1.3
+2014,18,2013/2014,70,US National,4 wk ahead,1.2
+2014,18,2013/2014,70,HHS Region 1,Season onset,51
+2014,18,2013/2014,70,HHS Region 1,Season peak week,6
+2014,18,2013/2014,70,HHS Region 1,Season peak percentage,2.2
+2014,18,2013/2014,70,HHS Region 1,1 wk ahead,1.3
+2014,18,2013/2014,70,HHS Region 1,2 wk ahead,1
+2014,18,2013/2014,70,HHS Region 1,3 wk ahead,0.5
+2014,18,2013/2014,70,HHS Region 1,4 wk ahead,0.5
+2014,18,2013/2014,70,HHS Region 2,Season onset,51
+2014,18,2013/2014,70,HHS Region 2,Season peak week,6
+2014,18,2013/2014,70,HHS Region 2,Season peak week,13
+2014,18,2013/2014,70,HHS Region 2,Season peak percentage,3.4
+2014,18,2013/2014,70,HHS Region 2,1 wk ahead,2.3
+2014,18,2013/2014,70,HHS Region 2,2 wk ahead,2.1
+2014,18,2013/2014,70,HHS Region 2,3 wk ahead,1.9
+2014,18,2013/2014,70,HHS Region 2,4 wk ahead,2.1
+2014,18,2013/2014,70,HHS Region 3,Season onset,51
+2014,18,2013/2014,70,HHS Region 3,Season peak week,1
+2014,18,2013/2014,70,HHS Region 3,Season peak percentage,3.6
+2014,18,2013/2014,70,HHS Region 3,1 wk ahead,1.2
+2014,18,2013/2014,70,HHS Region 3,2 wk ahead,1.3
+2014,18,2013/2014,70,HHS Region 3,3 wk ahead,1.3
+2014,18,2013/2014,70,HHS Region 3,4 wk ahead,1.2
+2014,18,2013/2014,70,HHS Region 4,Season onset,48
+2014,18,2013/2014,70,HHS Region 4,Season peak week,52
+2014,18,2013/2014,70,HHS Region 4,Season peak percentage,4.6
+2014,18,2013/2014,70,HHS Region 4,1 wk ahead,0.8
+2014,18,2013/2014,70,HHS Region 4,2 wk ahead,0.7
+2014,18,2013/2014,70,HHS Region 4,3 wk ahead,0.8
+2014,18,2013/2014,70,HHS Region 4,4 wk ahead,0.7
+2014,18,2013/2014,70,HHS Region 5,Season onset,48
+2014,18,2013/2014,70,HHS Region 5,Season peak week,52
+2014,18,2013/2014,70,HHS Region 5,Season peak percentage,3.6
+2014,18,2013/2014,70,HHS Region 5,1 wk ahead,1.3
+2014,18,2013/2014,70,HHS Region 5,2 wk ahead,1.2
+2014,18,2013/2014,70,HHS Region 5,3 wk ahead,1.2
+2014,18,2013/2014,70,HHS Region 5,4 wk ahead,0.8
+2014,18,2013/2014,70,HHS Region 6,Season onset,45
+2014,18,2013/2014,70,HHS Region 6,Season peak week,52
+2014,18,2013/2014,70,HHS Region 6,Season peak percentage,9.9
+2014,18,2013/2014,70,HHS Region 6,1 wk ahead,2.1
+2014,18,2013/2014,70,HHS Region 6,2 wk ahead,2.4
+2014,18,2013/2014,70,HHS Region 6,3 wk ahead,2.2
+2014,18,2013/2014,70,HHS Region 6,4 wk ahead,2.2
+2014,18,2013/2014,70,HHS Region 7,Season onset,51
+2014,18,2013/2014,70,HHS Region 7,Season peak week,52
+2014,18,2013/2014,70,HHS Region 7,Season peak percentage,4.5
+2014,18,2013/2014,70,HHS Region 7,1 wk ahead,0.6
+2014,18,2013/2014,70,HHS Region 7,2 wk ahead,0.5
+2014,18,2013/2014,70,HHS Region 7,3 wk ahead,0.5
+2014,18,2013/2014,70,HHS Region 7,4 wk ahead,0.5
+2014,18,2013/2014,70,HHS Region 8,Season onset,49
+2014,18,2013/2014,70,HHS Region 8,Season peak week,52
+2014,18,2013/2014,70,HHS Region 8,Season peak percentage,3.7
+2014,18,2013/2014,70,HHS Region 8,1 wk ahead,0.6
+2014,18,2013/2014,70,HHS Region 8,2 wk ahead,0.7
+2014,18,2013/2014,70,HHS Region 8,3 wk ahead,0.6
+2014,18,2013/2014,70,HHS Region 8,4 wk ahead,0.6
+2014,18,2013/2014,70,HHS Region 9,Season onset,51
+2014,18,2013/2014,70,HHS Region 9,Season peak week,1
+2014,18,2013/2014,70,HHS Region 9,Season peak week,4
+2014,18,2013/2014,70,HHS Region 9,Season peak percentage,4.6
+2014,18,2013/2014,70,HHS Region 9,1 wk ahead,1.7
+2014,18,2013/2014,70,HHS Region 9,2 wk ahead,1.7
+2014,18,2013/2014,70,HHS Region 9,3 wk ahead,1.9
+2014,18,2013/2014,70,HHS Region 9,4 wk ahead,1.8
+2014,18,2013/2014,70,HHS Region 10,Season onset,51
+2014,18,2013/2014,70,HHS Region 10,Season peak week,1
+2014,18,2013/2014,70,HHS Region 10,Season peak percentage,4
+2014,18,2013/2014,70,HHS Region 10,1 wk ahead,0.8
+2014,18,2013/2014,70,HHS Region 10,2 wk ahead,0.6
+2014,18,2013/2014,70,HHS Region 10,3 wk ahead,0.6
+2014,18,2013/2014,70,HHS Region 10,4 wk ahead,0.4
+2014,19,2013/2014,71,US National,Season onset,48
+2014,19,2013/2014,71,US National,Season peak week,52
+2014,19,2013/2014,71,US National,Season peak percentage,4.6
+2014,19,2013/2014,71,US National,1 wk ahead,1.3
+2014,19,2013/2014,71,US National,2 wk ahead,1.3
+2014,19,2013/2014,71,US National,3 wk ahead,1.2
+2014,19,2013/2014,71,US National,4 wk ahead,1.2
+2014,19,2013/2014,71,HHS Region 1,Season onset,51
+2014,19,2013/2014,71,HHS Region 1,Season peak week,6
+2014,19,2013/2014,71,HHS Region 1,Season peak percentage,2.2
+2014,19,2013/2014,71,HHS Region 1,1 wk ahead,1
+2014,19,2013/2014,71,HHS Region 1,2 wk ahead,0.5
+2014,19,2013/2014,71,HHS Region 1,3 wk ahead,0.5
+2014,19,2013/2014,71,HHS Region 1,4 wk ahead,0.5
+2014,19,2013/2014,71,HHS Region 2,Season onset,51
+2014,19,2013/2014,71,HHS Region 2,Season peak week,6
+2014,19,2013/2014,71,HHS Region 2,Season peak week,13
+2014,19,2013/2014,71,HHS Region 2,Season peak percentage,3.4
+2014,19,2013/2014,71,HHS Region 2,1 wk ahead,2.1
+2014,19,2013/2014,71,HHS Region 2,2 wk ahead,1.9
+2014,19,2013/2014,71,HHS Region 2,3 wk ahead,2.1
+2014,19,2013/2014,71,HHS Region 2,4 wk ahead,2.3
+2014,19,2013/2014,71,HHS Region 3,Season onset,51
+2014,19,2013/2014,71,HHS Region 3,Season peak week,1
+2014,19,2013/2014,71,HHS Region 3,Season peak percentage,3.6
+2014,19,2013/2014,71,HHS Region 3,1 wk ahead,1.3
+2014,19,2013/2014,71,HHS Region 3,2 wk ahead,1.3
+2014,19,2013/2014,71,HHS Region 3,3 wk ahead,1.2
+2014,19,2013/2014,71,HHS Region 3,4 wk ahead,1.1
+2014,19,2013/2014,71,HHS Region 4,Season onset,48
+2014,19,2013/2014,71,HHS Region 4,Season peak week,52
+2014,19,2013/2014,71,HHS Region 4,Season peak percentage,4.6
+2014,19,2013/2014,71,HHS Region 4,1 wk ahead,0.7
+2014,19,2013/2014,71,HHS Region 4,2 wk ahead,0.8
+2014,19,2013/2014,71,HHS Region 4,3 wk ahead,0.7
+2014,19,2013/2014,71,HHS Region 4,4 wk ahead,0.8
+2014,19,2013/2014,71,HHS Region 5,Season onset,48
+2014,19,2013/2014,71,HHS Region 5,Season peak week,52
+2014,19,2013/2014,71,HHS Region 5,Season peak percentage,3.6
+2014,19,2013/2014,71,HHS Region 5,1 wk ahead,1.2
+2014,19,2013/2014,71,HHS Region 5,2 wk ahead,1.2
+2014,19,2013/2014,71,HHS Region 5,3 wk ahead,0.8
+2014,19,2013/2014,71,HHS Region 5,4 wk ahead,0.9
+2014,19,2013/2014,71,HHS Region 6,Season onset,45
+2014,19,2013/2014,71,HHS Region 6,Season peak week,52
+2014,19,2013/2014,71,HHS Region 6,Season peak percentage,9.9
+2014,19,2013/2014,71,HHS Region 6,1 wk ahead,2.4
+2014,19,2013/2014,71,HHS Region 6,2 wk ahead,2.2
+2014,19,2013/2014,71,HHS Region 6,3 wk ahead,2.2
+2014,19,2013/2014,71,HHS Region 6,4 wk ahead,2
+2014,19,2013/2014,71,HHS Region 7,Season onset,51
+2014,19,2013/2014,71,HHS Region 7,Season peak week,52
+2014,19,2013/2014,71,HHS Region 7,Season peak percentage,4.5
+2014,19,2013/2014,71,HHS Region 7,1 wk ahead,0.5
+2014,19,2013/2014,71,HHS Region 7,2 wk ahead,0.5
+2014,19,2013/2014,71,HHS Region 7,3 wk ahead,0.5
+2014,19,2013/2014,71,HHS Region 7,4 wk ahead,0.3
+2014,19,2013/2014,71,HHS Region 8,Season onset,49
+2014,19,2013/2014,71,HHS Region 8,Season peak week,52
+2014,19,2013/2014,71,HHS Region 8,Season peak percentage,3.7
+2014,19,2013/2014,71,HHS Region 8,1 wk ahead,0.7
+2014,19,2013/2014,71,HHS Region 8,2 wk ahead,0.6
+2014,19,2013/2014,71,HHS Region 8,3 wk ahead,0.6
+2014,19,2013/2014,71,HHS Region 8,4 wk ahead,0.4
+2014,19,2013/2014,71,HHS Region 9,Season onset,51
+2014,19,2013/2014,71,HHS Region 9,Season peak week,1
+2014,19,2013/2014,71,HHS Region 9,Season peak week,4
+2014,19,2013/2014,71,HHS Region 9,Season peak percentage,4.6
+2014,19,2013/2014,71,HHS Region 9,1 wk ahead,1.7
+2014,19,2013/2014,71,HHS Region 9,2 wk ahead,1.9
+2014,19,2013/2014,71,HHS Region 9,3 wk ahead,1.8
+2014,19,2013/2014,71,HHS Region 9,4 wk ahead,1.7
+2014,19,2013/2014,71,HHS Region 10,Season onset,51
+2014,19,2013/2014,71,HHS Region 10,Season peak week,1
+2014,19,2013/2014,71,HHS Region 10,Season peak percentage,4
+2014,19,2013/2014,71,HHS Region 10,1 wk ahead,0.6
+2014,19,2013/2014,71,HHS Region 10,2 wk ahead,0.6
+2014,19,2013/2014,71,HHS Region 10,3 wk ahead,0.4
+2014,19,2013/2014,71,HHS Region 10,4 wk ahead,0.4
+2014,20,2013/2014,72,US National,Season onset,48
+2014,20,2013/2014,72,US National,Season peak week,52
+2014,20,2013/2014,72,US National,Season peak percentage,4.6
+2014,20,2013/2014,72,US National,1 wk ahead,1.3
+2014,20,2013/2014,72,US National,2 wk ahead,1.2
+2014,20,2013/2014,72,US National,3 wk ahead,1.2
+2014,20,2013/2014,72,US National,4 wk ahead,1.1
+2014,20,2013/2014,72,HHS Region 1,Season onset,51
+2014,20,2013/2014,72,HHS Region 1,Season peak week,6
+2014,20,2013/2014,72,HHS Region 1,Season peak percentage,2.2
+2014,20,2013/2014,72,HHS Region 1,1 wk ahead,0.5
+2014,20,2013/2014,72,HHS Region 1,2 wk ahead,0.5
+2014,20,2013/2014,72,HHS Region 1,3 wk ahead,0.5
+2014,20,2013/2014,72,HHS Region 1,4 wk ahead,0.4
+2014,20,2013/2014,72,HHS Region 2,Season onset,51
+2014,20,2013/2014,72,HHS Region 2,Season peak week,6
+2014,20,2013/2014,72,HHS Region 2,Season peak week,13
+2014,20,2013/2014,72,HHS Region 2,Season peak percentage,3.4
+2014,20,2013/2014,72,HHS Region 2,1 wk ahead,1.9
+2014,20,2013/2014,72,HHS Region 2,2 wk ahead,2.1
+2014,20,2013/2014,72,HHS Region 2,3 wk ahead,2.3
+2014,20,2013/2014,72,HHS Region 2,4 wk ahead,2.4
+2014,20,2013/2014,72,HHS Region 3,Season onset,51
+2014,20,2013/2014,72,HHS Region 3,Season peak week,1
+2014,20,2013/2014,72,HHS Region 3,Season peak percentage,3.6
+2014,20,2013/2014,72,HHS Region 3,1 wk ahead,1.3
+2014,20,2013/2014,72,HHS Region 3,2 wk ahead,1.2
+2014,20,2013/2014,72,HHS Region 3,3 wk ahead,1.1
+2014,20,2013/2014,72,HHS Region 3,4 wk ahead,1
+2014,20,2013/2014,72,HHS Region 4,Season onset,48
+2014,20,2013/2014,72,HHS Region 4,Season peak week,52
+2014,20,2013/2014,72,HHS Region 4,Season peak percentage,4.6
+2014,20,2013/2014,72,HHS Region 4,1 wk ahead,0.8
+2014,20,2013/2014,72,HHS Region 4,2 wk ahead,0.7
+2014,20,2013/2014,72,HHS Region 4,3 wk ahead,0.8
+2014,20,2013/2014,72,HHS Region 4,4 wk ahead,0.7
+2014,20,2013/2014,72,HHS Region 5,Season onset,48
+2014,20,2013/2014,72,HHS Region 5,Season peak week,52
+2014,20,2013/2014,72,HHS Region 5,Season peak percentage,3.6
+2014,20,2013/2014,72,HHS Region 5,1 wk ahead,1.2
+2014,20,2013/2014,72,HHS Region 5,2 wk ahead,0.8
+2014,20,2013/2014,72,HHS Region 5,3 wk ahead,0.9
+2014,20,2013/2014,72,HHS Region 5,4 wk ahead,0.8
+2014,20,2013/2014,72,HHS Region 6,Season onset,45
+2014,20,2013/2014,72,HHS Region 6,Season peak week,52
+2014,20,2013/2014,72,HHS Region 6,Season peak percentage,9.9
+2014,20,2013/2014,72,HHS Region 6,1 wk ahead,2.2
+2014,20,2013/2014,72,HHS Region 6,2 wk ahead,2.2
+2014,20,2013/2014,72,HHS Region 6,3 wk ahead,2
+2014,20,2013/2014,72,HHS Region 6,4 wk ahead,1.7
+2014,20,2013/2014,72,HHS Region 7,Season onset,51
+2014,20,2013/2014,72,HHS Region 7,Season peak week,52
+2014,20,2013/2014,72,HHS Region 7,Season peak percentage,4.5
+2014,20,2013/2014,72,HHS Region 7,1 wk ahead,0.5
+2014,20,2013/2014,72,HHS Region 7,2 wk ahead,0.5
+2014,20,2013/2014,72,HHS Region 7,3 wk ahead,0.3
+2014,20,2013/2014,72,HHS Region 7,4 wk ahead,0.2
+2014,20,2013/2014,72,HHS Region 8,Season onset,49
+2014,20,2013/2014,72,HHS Region 8,Season peak week,52
+2014,20,2013/2014,72,HHS Region 8,Season peak percentage,3.7
+2014,20,2013/2014,72,HHS Region 8,1 wk ahead,0.6
+2014,20,2013/2014,72,HHS Region 8,2 wk ahead,0.6
+2014,20,2013/2014,72,HHS Region 8,3 wk ahead,0.4
+2014,20,2013/2014,72,HHS Region 8,4 wk ahead,0.6
+2014,20,2013/2014,72,HHS Region 9,Season onset,51
+2014,20,2013/2014,72,HHS Region 9,Season peak week,1
+2014,20,2013/2014,72,HHS Region 9,Season peak week,4
+2014,20,2013/2014,72,HHS Region 9,Season peak percentage,4.6
+2014,20,2013/2014,72,HHS Region 9,1 wk ahead,1.9
+2014,20,2013/2014,72,HHS Region 9,2 wk ahead,1.8
+2014,20,2013/2014,72,HHS Region 9,3 wk ahead,1.7
+2014,20,2013/2014,72,HHS Region 9,4 wk ahead,1.7
+2014,20,2013/2014,72,HHS Region 10,Season onset,51
+2014,20,2013/2014,72,HHS Region 10,Season peak week,1
+2014,20,2013/2014,72,HHS Region 10,Season peak percentage,4
+2014,20,2013/2014,72,HHS Region 10,1 wk ahead,0.6
+2014,20,2013/2014,72,HHS Region 10,2 wk ahead,0.4
+2014,20,2013/2014,72,HHS Region 10,3 wk ahead,0.4
+2014,20,2013/2014,72,HHS Region 10,4 wk ahead,0.4
+2014,40,2014/2015,40,US National,Season onset,47
+2014,40,2014/2015,40,US National,Season peak week,52
+2014,40,2014/2015,40,US National,Season peak percentage,6
+2014,40,2014/2015,40,US National,1 wk ahead,1.3
+2014,40,2014/2015,40,US National,2 wk ahead,1.4
+2014,40,2014/2015,40,US National,3 wk ahead,1.4
+2014,40,2014/2015,40,US National,4 wk ahead,1.4
+2014,40,2014/2015,40,HHS Region 1,Season onset,50
+2014,40,2014/2015,40,HHS Region 1,Season peak week,3
+2014,40,2014/2015,40,HHS Region 1,Season peak percentage,3.9
+2014,40,2014/2015,40,HHS Region 1,1 wk ahead,0.9
+2014,40,2014/2015,40,HHS Region 1,2 wk ahead,0.9
+2014,40,2014/2015,40,HHS Region 1,3 wk ahead,0.8
+2014,40,2014/2015,40,HHS Region 1,4 wk ahead,1
+2014,40,2014/2015,40,HHS Region 2,Season onset,45
+2014,40,2014/2015,40,HHS Region 2,Season peak week,52
+2014,40,2014/2015,40,HHS Region 2,Season peak week,4
+2014,40,2014/2015,40,HHS Region 2,Season peak week,5
+2014,40,2014/2015,40,HHS Region 2,Season peak percentage,5.2
+2014,40,2014/2015,40,HHS Region 2,1 wk ahead,1.9
+2014,40,2014/2015,40,HHS Region 2,2 wk ahead,2.3
+2014,40,2014/2015,40,HHS Region 2,3 wk ahead,2.3
+2014,40,2014/2015,40,HHS Region 2,4 wk ahead,1.9
+2014,40,2014/2015,40,HHS Region 3,Season onset,48
+2014,40,2014/2015,40,HHS Region 3,Season peak week,52
+2014,40,2014/2015,40,HHS Region 3,Season peak percentage,7.2
+2014,40,2014/2015,40,HHS Region 3,1 wk ahead,1.3
+2014,40,2014/2015,40,HHS Region 3,2 wk ahead,1.3
+2014,40,2014/2015,40,HHS Region 3,3 wk ahead,1.3
+2014,40,2014/2015,40,HHS Region 3,4 wk ahead,1.3
+2014,40,2014/2015,40,HHS Region 4,Season onset,47
+2014,40,2014/2015,40,HHS Region 4,Season peak week,52
+2014,40,2014/2015,40,HHS Region 4,Season peak percentage,7.5
+2014,40,2014/2015,40,HHS Region 4,1 wk ahead,1.1
+2014,40,2014/2015,40,HHS Region 4,2 wk ahead,1.1
+2014,40,2014/2015,40,HHS Region 4,3 wk ahead,1.3
+2014,40,2014/2015,40,HHS Region 4,4 wk ahead,1.3
+2014,40,2014/2015,40,HHS Region 5,Season onset,48
+2014,40,2014/2015,40,HHS Region 5,Season peak week,52
+2014,40,2014/2015,40,HHS Region 5,Season peak percentage,6.6
+2014,40,2014/2015,40,HHS Region 5,1 wk ahead,0.8
+2014,40,2014/2015,40,HHS Region 5,2 wk ahead,0.9
+2014,40,2014/2015,40,HHS Region 5,3 wk ahead,1
+2014,40,2014/2015,40,HHS Region 5,4 wk ahead,1
+2014,40,2014/2015,40,HHS Region 6,Season onset,47
+2014,40,2014/2015,40,HHS Region 6,Season peak week,51
+2014,40,2014/2015,40,HHS Region 6,Season peak percentage,11.1
+2014,40,2014/2015,40,HHS Region 6,1 wk ahead,2
+2014,40,2014/2015,40,HHS Region 6,2 wk ahead,2.1
+2014,40,2014/2015,40,HHS Region 6,3 wk ahead,2.2
+2014,40,2014/2015,40,HHS Region 6,4 wk ahead,2.3
+2014,40,2014/2015,40,HHS Region 7,Season onset,48
+2014,40,2014/2015,40,HHS Region 7,Season peak week,52
+2014,40,2014/2015,40,HHS Region 7,Season peak percentage,6.4
+2014,40,2014/2015,40,HHS Region 7,1 wk ahead,0.9
+2014,40,2014/2015,40,HHS Region 7,2 wk ahead,1
+2014,40,2014/2015,40,HHS Region 7,3 wk ahead,0.9
+2014,40,2014/2015,40,HHS Region 7,4 wk ahead,0.7
+2014,40,2014/2015,40,HHS Region 8,Season onset,49
+2014,40,2014/2015,40,HHS Region 8,Season peak week,53
+2014,40,2014/2015,40,HHS Region 8,Season peak percentage,4.4
+2014,40,2014/2015,40,HHS Region 8,1 wk ahead,0.7
+2014,40,2014/2015,40,HHS Region 8,2 wk ahead,0.7
+2014,40,2014/2015,40,HHS Region 8,3 wk ahead,0.8
+2014,40,2014/2015,40,HHS Region 8,4 wk ahead,0.8
+2014,40,2014/2015,40,HHS Region 9,Season onset,51
+2014,40,2014/2015,40,HHS Region 9,Season peak week,3
+2014,40,2014/2015,40,HHS Region 9,Season peak week,4
+2014,40,2014/2015,40,HHS Region 9,Season peak percentage,5
+2014,40,2014/2015,40,HHS Region 9,1 wk ahead,1.8
+2014,40,2014/2015,40,HHS Region 9,2 wk ahead,1.7
+2014,40,2014/2015,40,HHS Region 9,3 wk ahead,1.7
+2014,40,2014/2015,40,HHS Region 9,4 wk ahead,1.7
+2014,40,2014/2015,40,HHS Region 10,Season onset,48
+2014,40,2014/2015,40,HHS Region 10,Season peak week,2
+2014,40,2014/2015,40,HHS Region 10,Season peak percentage,3.6
+2014,40,2014/2015,40,HHS Region 10,1 wk ahead,1.1
+2014,40,2014/2015,40,HHS Region 10,2 wk ahead,0.8
+2014,40,2014/2015,40,HHS Region 10,3 wk ahead,0.7
+2014,40,2014/2015,40,HHS Region 10,4 wk ahead,0.9
+2014,41,2014/2015,41,US National,Season onset,47
+2014,41,2014/2015,41,US National,Season peak week,52
+2014,41,2014/2015,41,US National,Season peak percentage,6
+2014,41,2014/2015,41,US National,1 wk ahead,1.4
+2014,41,2014/2015,41,US National,2 wk ahead,1.4
+2014,41,2014/2015,41,US National,3 wk ahead,1.4
+2014,41,2014/2015,41,US National,4 wk ahead,1.7
+2014,41,2014/2015,41,HHS Region 1,Season onset,50
+2014,41,2014/2015,41,HHS Region 1,Season peak week,3
+2014,41,2014/2015,41,HHS Region 1,Season peak percentage,3.9
+2014,41,2014/2015,41,HHS Region 1,1 wk ahead,0.9
+2014,41,2014/2015,41,HHS Region 1,2 wk ahead,0.8
+2014,41,2014/2015,41,HHS Region 1,3 wk ahead,1
+2014,41,2014/2015,41,HHS Region 1,4 wk ahead,1.2
+2014,41,2014/2015,41,HHS Region 2,Season onset,45
+2014,41,2014/2015,41,HHS Region 2,Season peak week,52
+2014,41,2014/2015,41,HHS Region 2,Season peak week,4
+2014,41,2014/2015,41,HHS Region 2,Season peak week,5
+2014,41,2014/2015,41,HHS Region 2,Season peak percentage,5.2
+2014,41,2014/2015,41,HHS Region 2,1 wk ahead,2.3
+2014,41,2014/2015,41,HHS Region 2,2 wk ahead,2.3
+2014,41,2014/2015,41,HHS Region 2,3 wk ahead,1.9
+2014,41,2014/2015,41,HHS Region 2,4 wk ahead,2.5
+2014,41,2014/2015,41,HHS Region 3,Season onset,48
+2014,41,2014/2015,41,HHS Region 3,Season peak week,52
+2014,41,2014/2015,41,HHS Region 3,Season peak percentage,7.2
+2014,41,2014/2015,41,HHS Region 3,1 wk ahead,1.3
+2014,41,2014/2015,41,HHS Region 3,2 wk ahead,1.3
+2014,41,2014/2015,41,HHS Region 3,3 wk ahead,1.3
+2014,41,2014/2015,41,HHS Region 3,4 wk ahead,1.5
+2014,41,2014/2015,41,HHS Region 4,Season onset,47
+2014,41,2014/2015,41,HHS Region 4,Season peak week,52
+2014,41,2014/2015,41,HHS Region 4,Season peak percentage,7.5
+2014,41,2014/2015,41,HHS Region 4,1 wk ahead,1.1
+2014,41,2014/2015,41,HHS Region 4,2 wk ahead,1.3
+2014,41,2014/2015,41,HHS Region 4,3 wk ahead,1.3
+2014,41,2014/2015,41,HHS Region 4,4 wk ahead,1.5
+2014,41,2014/2015,41,HHS Region 5,Season onset,48
+2014,41,2014/2015,41,HHS Region 5,Season peak week,52
+2014,41,2014/2015,41,HHS Region 5,Season peak percentage,6.6
+2014,41,2014/2015,41,HHS Region 5,1 wk ahead,0.9
+2014,41,2014/2015,41,HHS Region 5,2 wk ahead,1
+2014,41,2014/2015,41,HHS Region 5,3 wk ahead,1
+2014,41,2014/2015,41,HHS Region 5,4 wk ahead,1.2
+2014,41,2014/2015,41,HHS Region 6,Season onset,47
+2014,41,2014/2015,41,HHS Region 6,Season peak week,51
+2014,41,2014/2015,41,HHS Region 6,Season peak percentage,11.1
+2014,41,2014/2015,41,HHS Region 6,1 wk ahead,2.1
+2014,41,2014/2015,41,HHS Region 6,2 wk ahead,2.2
+2014,41,2014/2015,41,HHS Region 6,3 wk ahead,2.3
+2014,41,2014/2015,41,HHS Region 6,4 wk ahead,2.4
+2014,41,2014/2015,41,HHS Region 7,Season onset,48
+2014,41,2014/2015,41,HHS Region 7,Season peak week,52
+2014,41,2014/2015,41,HHS Region 7,Season peak percentage,6.4
+2014,41,2014/2015,41,HHS Region 7,1 wk ahead,1
+2014,41,2014/2015,41,HHS Region 7,2 wk ahead,0.9
+2014,41,2014/2015,41,HHS Region 7,3 wk ahead,0.7
+2014,41,2014/2015,41,HHS Region 7,4 wk ahead,0.8
+2014,41,2014/2015,41,HHS Region 8,Season onset,49
+2014,41,2014/2015,41,HHS Region 8,Season peak week,53
+2014,41,2014/2015,41,HHS Region 8,Season peak percentage,4.4
+2014,41,2014/2015,41,HHS Region 8,1 wk ahead,0.7
+2014,41,2014/2015,41,HHS Region 8,2 wk ahead,0.8
+2014,41,2014/2015,41,HHS Region 8,3 wk ahead,0.8
+2014,41,2014/2015,41,HHS Region 8,4 wk ahead,0.8
+2014,41,2014/2015,41,HHS Region 9,Season onset,51
+2014,41,2014/2015,41,HHS Region 9,Season peak week,3
+2014,41,2014/2015,41,HHS Region 9,Season peak week,4
+2014,41,2014/2015,41,HHS Region 9,Season peak percentage,5
+2014,41,2014/2015,41,HHS Region 9,1 wk ahead,1.7
+2014,41,2014/2015,41,HHS Region 9,2 wk ahead,1.7
+2014,41,2014/2015,41,HHS Region 9,3 wk ahead,1.7
+2014,41,2014/2015,41,HHS Region 9,4 wk ahead,2.1
+2014,41,2014/2015,41,HHS Region 10,Season onset,48
+2014,41,2014/2015,41,HHS Region 10,Season peak week,2
+2014,41,2014/2015,41,HHS Region 10,Season peak percentage,3.6
+2014,41,2014/2015,41,HHS Region 10,1 wk ahead,0.8
+2014,41,2014/2015,41,HHS Region 10,2 wk ahead,0.7
+2014,41,2014/2015,41,HHS Region 10,3 wk ahead,0.9
+2014,41,2014/2015,41,HHS Region 10,4 wk ahead,0.9
+2014,42,2014/2015,42,US National,Season onset,47
+2014,42,2014/2015,42,US National,Season peak week,52
+2014,42,2014/2015,42,US National,Season peak percentage,6
+2014,42,2014/2015,42,US National,1 wk ahead,1.4
+2014,42,2014/2015,42,US National,2 wk ahead,1.4
+2014,42,2014/2015,42,US National,3 wk ahead,1.7
+2014,42,2014/2015,42,US National,4 wk ahead,1.6
+2014,42,2014/2015,42,HHS Region 1,Season onset,50
+2014,42,2014/2015,42,HHS Region 1,Season peak week,3
+2014,42,2014/2015,42,HHS Region 1,Season peak percentage,3.9
+2014,42,2014/2015,42,HHS Region 1,1 wk ahead,0.8
+2014,42,2014/2015,42,HHS Region 1,2 wk ahead,1
+2014,42,2014/2015,42,HHS Region 1,3 wk ahead,1.2
+2014,42,2014/2015,42,HHS Region 1,4 wk ahead,1.1
+2014,42,2014/2015,42,HHS Region 2,Season onset,45
+2014,42,2014/2015,42,HHS Region 2,Season peak week,52
+2014,42,2014/2015,42,HHS Region 2,Season peak week,4
+2014,42,2014/2015,42,HHS Region 2,Season peak week,5
+2014,42,2014/2015,42,HHS Region 2,Season peak percentage,5.2
+2014,42,2014/2015,42,HHS Region 2,1 wk ahead,2.3
+2014,42,2014/2015,42,HHS Region 2,2 wk ahead,1.9
+2014,42,2014/2015,42,HHS Region 2,3 wk ahead,2.5
+2014,42,2014/2015,42,HHS Region 2,4 wk ahead,2.3
+2014,42,2014/2015,42,HHS Region 3,Season onset,48
+2014,42,2014/2015,42,HHS Region 3,Season peak week,52
+2014,42,2014/2015,42,HHS Region 3,Season peak percentage,7.2
+2014,42,2014/2015,42,HHS Region 3,1 wk ahead,1.3
+2014,42,2014/2015,42,HHS Region 3,2 wk ahead,1.3
+2014,42,2014/2015,42,HHS Region 3,3 wk ahead,1.5
+2014,42,2014/2015,42,HHS Region 3,4 wk ahead,1.3
+2014,42,2014/2015,42,HHS Region 4,Season onset,47
+2014,42,2014/2015,42,HHS Region 4,Season peak week,52
+2014,42,2014/2015,42,HHS Region 4,Season peak percentage,7.5
+2014,42,2014/2015,42,HHS Region 4,1 wk ahead,1.3
+2014,42,2014/2015,42,HHS Region 4,2 wk ahead,1.3
+2014,42,2014/2015,42,HHS Region 4,3 wk ahead,1.5
+2014,42,2014/2015,42,HHS Region 4,4 wk ahead,1.7
+2014,42,2014/2015,42,HHS Region 5,Season onset,48
+2014,42,2014/2015,42,HHS Region 5,Season peak week,52
+2014,42,2014/2015,42,HHS Region 5,Season peak percentage,6.6
+2014,42,2014/2015,42,HHS Region 5,1 wk ahead,1
+2014,42,2014/2015,42,HHS Region 5,2 wk ahead,1
+2014,42,2014/2015,42,HHS Region 5,3 wk ahead,1.2
+2014,42,2014/2015,42,HHS Region 5,4 wk ahead,1.2
+2014,42,2014/2015,42,HHS Region 6,Season onset,47
+2014,42,2014/2015,42,HHS Region 6,Season peak week,51
+2014,42,2014/2015,42,HHS Region 6,Season peak percentage,11.1
+2014,42,2014/2015,42,HHS Region 6,1 wk ahead,2.2
+2014,42,2014/2015,42,HHS Region 6,2 wk ahead,2.3
+2014,42,2014/2015,42,HHS Region 6,3 wk ahead,2.4
+2014,42,2014/2015,42,HHS Region 6,4 wk ahead,2.3
+2014,42,2014/2015,42,HHS Region 7,Season onset,48
+2014,42,2014/2015,42,HHS Region 7,Season peak week,52
+2014,42,2014/2015,42,HHS Region 7,Season peak percentage,6.4
+2014,42,2014/2015,42,HHS Region 7,1 wk ahead,0.9
+2014,42,2014/2015,42,HHS Region 7,2 wk ahead,0.7
+2014,42,2014/2015,42,HHS Region 7,3 wk ahead,0.8
+2014,42,2014/2015,42,HHS Region 7,4 wk ahead,1.1
+2014,42,2014/2015,42,HHS Region 8,Season onset,49
+2014,42,2014/2015,42,HHS Region 8,Season peak week,53
+2014,42,2014/2015,42,HHS Region 8,Season peak percentage,4.4
+2014,42,2014/2015,42,HHS Region 8,1 wk ahead,0.8
+2014,42,2014/2015,42,HHS Region 8,2 wk ahead,0.8
+2014,42,2014/2015,42,HHS Region 8,3 wk ahead,0.8
+2014,42,2014/2015,42,HHS Region 8,4 wk ahead,0.8
+2014,42,2014/2015,42,HHS Region 9,Season onset,51
+2014,42,2014/2015,42,HHS Region 9,Season peak week,3
+2014,42,2014/2015,42,HHS Region 9,Season peak week,4
+2014,42,2014/2015,42,HHS Region 9,Season peak percentage,5
+2014,42,2014/2015,42,HHS Region 9,1 wk ahead,1.7
+2014,42,2014/2015,42,HHS Region 9,2 wk ahead,1.7
+2014,42,2014/2015,42,HHS Region 9,3 wk ahead,2.1
+2014,42,2014/2015,42,HHS Region 9,4 wk ahead,2
+2014,42,2014/2015,42,HHS Region 10,Season onset,48
+2014,42,2014/2015,42,HHS Region 10,Season peak week,2
+2014,42,2014/2015,42,HHS Region 10,Season peak percentage,3.6
+2014,42,2014/2015,42,HHS Region 10,1 wk ahead,0.7
+2014,42,2014/2015,42,HHS Region 10,2 wk ahead,0.9
+2014,42,2014/2015,42,HHS Region 10,3 wk ahead,0.9
+2014,42,2014/2015,42,HHS Region 10,4 wk ahead,0.9
+2014,43,2014/2015,43,US National,Season onset,47
+2014,43,2014/2015,43,US National,Season peak week,52
+2014,43,2014/2015,43,US National,Season peak percentage,6
+2014,43,2014/2015,43,US National,1 wk ahead,1.4
+2014,43,2014/2015,43,US National,2 wk ahead,1.7
+2014,43,2014/2015,43,US National,3 wk ahead,1.6
+2014,43,2014/2015,43,US National,4 wk ahead,2.1
+2014,43,2014/2015,43,HHS Region 1,Season onset,50
+2014,43,2014/2015,43,HHS Region 1,Season peak week,3
+2014,43,2014/2015,43,HHS Region 1,Season peak percentage,3.9
+2014,43,2014/2015,43,HHS Region 1,1 wk ahead,1
+2014,43,2014/2015,43,HHS Region 1,2 wk ahead,1.2
+2014,43,2014/2015,43,HHS Region 1,3 wk ahead,1.1
+2014,43,2014/2015,43,HHS Region 1,4 wk ahead,1
+2014,43,2014/2015,43,HHS Region 2,Season onset,45
+2014,43,2014/2015,43,HHS Region 2,Season peak week,52
+2014,43,2014/2015,43,HHS Region 2,Season peak week,4
+2014,43,2014/2015,43,HHS Region 2,Season peak week,5
+2014,43,2014/2015,43,HHS Region 2,Season peak percentage,5.2
+2014,43,2014/2015,43,HHS Region 2,1 wk ahead,1.9
+2014,43,2014/2015,43,HHS Region 2,2 wk ahead,2.5
+2014,43,2014/2015,43,HHS Region 2,3 wk ahead,2.3
+2014,43,2014/2015,43,HHS Region 2,4 wk ahead,2.8
+2014,43,2014/2015,43,HHS Region 3,Season onset,48
+2014,43,2014/2015,43,HHS Region 3,Season peak week,52
+2014,43,2014/2015,43,HHS Region 3,Season peak percentage,7.2
+2014,43,2014/2015,43,HHS Region 3,1 wk ahead,1.3
+2014,43,2014/2015,43,HHS Region 3,2 wk ahead,1.5
+2014,43,2014/2015,43,HHS Region 3,3 wk ahead,1.3
+2014,43,2014/2015,43,HHS Region 3,4 wk ahead,1.7
+2014,43,2014/2015,43,HHS Region 4,Season onset,47
+2014,43,2014/2015,43,HHS Region 4,Season peak week,52
+2014,43,2014/2015,43,HHS Region 4,Season peak percentage,7.5
+2014,43,2014/2015,43,HHS Region 4,1 wk ahead,1.3
+2014,43,2014/2015,43,HHS Region 4,2 wk ahead,1.5
+2014,43,2014/2015,43,HHS Region 4,3 wk ahead,1.7
+2014,43,2014/2015,43,HHS Region 4,4 wk ahead,2.2
+2014,43,2014/2015,43,HHS Region 5,Season onset,48
+2014,43,2014/2015,43,HHS Region 5,Season peak week,52
+2014,43,2014/2015,43,HHS Region 5,Season peak percentage,6.6
+2014,43,2014/2015,43,HHS Region 5,1 wk ahead,1
+2014,43,2014/2015,43,HHS Region 5,2 wk ahead,1.2
+2014,43,2014/2015,43,HHS Region 5,3 wk ahead,1.2
+2014,43,2014/2015,43,HHS Region 5,4 wk ahead,1.5
+2014,43,2014/2015,43,HHS Region 6,Season onset,47
+2014,43,2014/2015,43,HHS Region 6,Season peak week,51
+2014,43,2014/2015,43,HHS Region 6,Season peak percentage,11.1
+2014,43,2014/2015,43,HHS Region 6,1 wk ahead,2.3
+2014,43,2014/2015,43,HHS Region 6,2 wk ahead,2.4
+2014,43,2014/2015,43,HHS Region 6,3 wk ahead,2.3
+2014,43,2014/2015,43,HHS Region 6,4 wk ahead,3.9
+2014,43,2014/2015,43,HHS Region 7,Season onset,48
+2014,43,2014/2015,43,HHS Region 7,Season peak week,52
+2014,43,2014/2015,43,HHS Region 7,Season peak percentage,6.4
+2014,43,2014/2015,43,HHS Region 7,1 wk ahead,0.7
+2014,43,2014/2015,43,HHS Region 7,2 wk ahead,0.8
+2014,43,2014/2015,43,HHS Region 7,3 wk ahead,1.1
+2014,43,2014/2015,43,HHS Region 7,4 wk ahead,1
+2014,43,2014/2015,43,HHS Region 8,Season onset,49
+2014,43,2014/2015,43,HHS Region 8,Season peak week,53
+2014,43,2014/2015,43,HHS Region 8,Season peak percentage,4.4
+2014,43,2014/2015,43,HHS Region 8,1 wk ahead,0.8
+2014,43,2014/2015,43,HHS Region 8,2 wk ahead,0.8
+2014,43,2014/2015,43,HHS Region 8,3 wk ahead,0.8
+2014,43,2014/2015,43,HHS Region 8,4 wk ahead,0.7
+2014,43,2014/2015,43,HHS Region 9,Season onset,51
+2014,43,2014/2015,43,HHS Region 9,Season peak week,3
+2014,43,2014/2015,43,HHS Region 9,Season peak week,4
+2014,43,2014/2015,43,HHS Region 9,Season peak percentage,5
+2014,43,2014/2015,43,HHS Region 9,1 wk ahead,1.7
+2014,43,2014/2015,43,HHS Region 9,2 wk ahead,2.1
+2014,43,2014/2015,43,HHS Region 9,3 wk ahead,2
+2014,43,2014/2015,43,HHS Region 9,4 wk ahead,2.2
+2014,43,2014/2015,43,HHS Region 10,Season onset,48
+2014,43,2014/2015,43,HHS Region 10,Season peak week,2
+2014,43,2014/2015,43,HHS Region 10,Season peak percentage,3.6
+2014,43,2014/2015,43,HHS Region 10,1 wk ahead,0.9
+2014,43,2014/2015,43,HHS Region 10,2 wk ahead,0.9
+2014,43,2014/2015,43,HHS Region 10,3 wk ahead,0.9
+2014,43,2014/2015,43,HHS Region 10,4 wk ahead,1
+2014,44,2014/2015,44,US National,Season onset,47
+2014,44,2014/2015,44,US National,Season peak week,52
+2014,44,2014/2015,44,US National,Season peak percentage,6
+2014,44,2014/2015,44,US National,1 wk ahead,1.7
+2014,44,2014/2015,44,US National,2 wk ahead,1.6
+2014,44,2014/2015,44,US National,3 wk ahead,2.1
+2014,44,2014/2015,44,US National,4 wk ahead,2.6
+2014,44,2014/2015,44,HHS Region 1,Season onset,50
+2014,44,2014/2015,44,HHS Region 1,Season peak week,3
+2014,44,2014/2015,44,HHS Region 1,Season peak percentage,3.9
+2014,44,2014/2015,44,HHS Region 1,1 wk ahead,1.2
+2014,44,2014/2015,44,HHS Region 1,2 wk ahead,1.1
+2014,44,2014/2015,44,HHS Region 1,3 wk ahead,1
+2014,44,2014/2015,44,HHS Region 1,4 wk ahead,1.1
+2014,44,2014/2015,44,HHS Region 2,Season onset,45
+2014,44,2014/2015,44,HHS Region 2,Season peak week,52
+2014,44,2014/2015,44,HHS Region 2,Season peak week,4
+2014,44,2014/2015,44,HHS Region 2,Season peak week,5
+2014,44,2014/2015,44,HHS Region 2,Season peak percentage,5.2
+2014,44,2014/2015,44,HHS Region 2,1 wk ahead,2.5
+2014,44,2014/2015,44,HHS Region 2,2 wk ahead,2.3
+2014,44,2014/2015,44,HHS Region 2,3 wk ahead,2.8
+2014,44,2014/2015,44,HHS Region 2,4 wk ahead,2.9
+2014,44,2014/2015,44,HHS Region 3,Season onset,48
+2014,44,2014/2015,44,HHS Region 3,Season peak week,52
+2014,44,2014/2015,44,HHS Region 3,Season peak percentage,7.2
+2014,44,2014/2015,44,HHS Region 3,1 wk ahead,1.5
+2014,44,2014/2015,44,HHS Region 3,2 wk ahead,1.3
+2014,44,2014/2015,44,HHS Region 3,3 wk ahead,1.7
+2014,44,2014/2015,44,HHS Region 3,4 wk ahead,2.2
+2014,44,2014/2015,44,HHS Region 4,Season onset,47
+2014,44,2014/2015,44,HHS Region 4,Season peak week,52
+2014,44,2014/2015,44,HHS Region 4,Season peak percentage,7.5
+2014,44,2014/2015,44,HHS Region 4,1 wk ahead,1.5
+2014,44,2014/2015,44,HHS Region 4,2 wk ahead,1.7
+2014,44,2014/2015,44,HHS Region 4,3 wk ahead,2.2
+2014,44,2014/2015,44,HHS Region 4,4 wk ahead,3.1
+2014,44,2014/2015,44,HHS Region 5,Season onset,48
+2014,44,2014/2015,44,HHS Region 5,Season peak week,52
+2014,44,2014/2015,44,HHS Region 5,Season peak percentage,6.6
+2014,44,2014/2015,44,HHS Region 5,1 wk ahead,1.2
+2014,44,2014/2015,44,HHS Region 5,2 wk ahead,1.2
+2014,44,2014/2015,44,HHS Region 5,3 wk ahead,1.5
+2014,44,2014/2015,44,HHS Region 5,4 wk ahead,1.9
+2014,44,2014/2015,44,HHS Region 6,Season onset,47
+2014,44,2014/2015,44,HHS Region 6,Season peak week,51
+2014,44,2014/2015,44,HHS Region 6,Season peak percentage,11.1
+2014,44,2014/2015,44,HHS Region 6,1 wk ahead,2.4
+2014,44,2014/2015,44,HHS Region 6,2 wk ahead,2.3
+2014,44,2014/2015,44,HHS Region 6,3 wk ahead,3.9
+2014,44,2014/2015,44,HHS Region 6,4 wk ahead,4.7
+2014,44,2014/2015,44,HHS Region 7,Season onset,48
+2014,44,2014/2015,44,HHS Region 7,Season peak week,52
+2014,44,2014/2015,44,HHS Region 7,Season peak percentage,6.4
+2014,44,2014/2015,44,HHS Region 7,1 wk ahead,0.8
+2014,44,2014/2015,44,HHS Region 7,2 wk ahead,1.1
+2014,44,2014/2015,44,HHS Region 7,3 wk ahead,1
+2014,44,2014/2015,44,HHS Region 7,4 wk ahead,1.8
+2014,44,2014/2015,44,HHS Region 8,Season onset,49
+2014,44,2014/2015,44,HHS Region 8,Season peak week,53
+2014,44,2014/2015,44,HHS Region 8,Season peak percentage,4.4
+2014,44,2014/2015,44,HHS Region 8,1 wk ahead,0.8
+2014,44,2014/2015,44,HHS Region 8,2 wk ahead,0.8
+2014,44,2014/2015,44,HHS Region 8,3 wk ahead,0.7
+2014,44,2014/2015,44,HHS Region 8,4 wk ahead,1
+2014,44,2014/2015,44,HHS Region 9,Season onset,51
+2014,44,2014/2015,44,HHS Region 9,Season peak week,3
+2014,44,2014/2015,44,HHS Region 9,Season peak week,4
+2014,44,2014/2015,44,HHS Region 9,Season peak percentage,5
+2014,44,2014/2015,44,HHS Region 9,1 wk ahead,2.1
+2014,44,2014/2015,44,HHS Region 9,2 wk ahead,2
+2014,44,2014/2015,44,HHS Region 9,3 wk ahead,2.2
+2014,44,2014/2015,44,HHS Region 9,4 wk ahead,2.5
+2014,44,2014/2015,44,HHS Region 10,Season onset,48
+2014,44,2014/2015,44,HHS Region 10,Season peak week,2
+2014,44,2014/2015,44,HHS Region 10,Season peak percentage,3.6
+2014,44,2014/2015,44,HHS Region 10,1 wk ahead,0.9
+2014,44,2014/2015,44,HHS Region 10,2 wk ahead,0.9
+2014,44,2014/2015,44,HHS Region 10,3 wk ahead,1
+2014,44,2014/2015,44,HHS Region 10,4 wk ahead,1.1
+2014,45,2014/2015,45,US National,Season onset,47
+2014,45,2014/2015,45,US National,Season peak week,52
+2014,45,2014/2015,45,US National,Season peak percentage,6
+2014,45,2014/2015,45,US National,1 wk ahead,1.6
+2014,45,2014/2015,45,US National,2 wk ahead,2.1
+2014,45,2014/2015,45,US National,3 wk ahead,2.6
+2014,45,2014/2015,45,US National,4 wk ahead,2.6
+2014,45,2014/2015,45,HHS Region 1,Season onset,50
+2014,45,2014/2015,45,HHS Region 1,Season peak week,3
+2014,45,2014/2015,45,HHS Region 1,Season peak percentage,3.9
+2014,45,2014/2015,45,HHS Region 1,1 wk ahead,1.1
+2014,45,2014/2015,45,HHS Region 1,2 wk ahead,1
+2014,45,2014/2015,45,HHS Region 1,3 wk ahead,1.1
+2014,45,2014/2015,45,HHS Region 1,4 wk ahead,1.1
+2014,45,2014/2015,45,HHS Region 2,Season onset,45
+2014,45,2014/2015,45,HHS Region 2,Season peak week,52
+2014,45,2014/2015,45,HHS Region 2,Season peak week,4
+2014,45,2014/2015,45,HHS Region 2,Season peak week,5
+2014,45,2014/2015,45,HHS Region 2,Season peak percentage,5.2
+2014,45,2014/2015,45,HHS Region 2,1 wk ahead,2.3
+2014,45,2014/2015,45,HHS Region 2,2 wk ahead,2.8
+2014,45,2014/2015,45,HHS Region 2,3 wk ahead,2.9
+2014,45,2014/2015,45,HHS Region 2,4 wk ahead,2.4
+2014,45,2014/2015,45,HHS Region 3,Season onset,48
+2014,45,2014/2015,45,HHS Region 3,Season peak week,52
+2014,45,2014/2015,45,HHS Region 3,Season peak percentage,7.2
+2014,45,2014/2015,45,HHS Region 3,1 wk ahead,1.3
+2014,45,2014/2015,45,HHS Region 3,2 wk ahead,1.7
+2014,45,2014/2015,45,HHS Region 3,3 wk ahead,2.2
+2014,45,2014/2015,45,HHS Region 3,4 wk ahead,2.1
+2014,45,2014/2015,45,HHS Region 4,Season onset,47
+2014,45,2014/2015,45,HHS Region 4,Season peak week,52
+2014,45,2014/2015,45,HHS Region 4,Season peak percentage,7.5
+2014,45,2014/2015,45,HHS Region 4,1 wk ahead,1.7
+2014,45,2014/2015,45,HHS Region 4,2 wk ahead,2.2
+2014,45,2014/2015,45,HHS Region 4,3 wk ahead,3.1
+2014,45,2014/2015,45,HHS Region 4,4 wk ahead,2.9
+2014,45,2014/2015,45,HHS Region 5,Season onset,48
+2014,45,2014/2015,45,HHS Region 5,Season peak week,52
+2014,45,2014/2015,45,HHS Region 5,Season peak percentage,6.6
+2014,45,2014/2015,45,HHS Region 5,1 wk ahead,1.2
+2014,45,2014/2015,45,HHS Region 5,2 wk ahead,1.5
+2014,45,2014/2015,45,HHS Region 5,3 wk ahead,1.9
+2014,45,2014/2015,45,HHS Region 5,4 wk ahead,2.4
+2014,45,2014/2015,45,HHS Region 6,Season onset,47
+2014,45,2014/2015,45,HHS Region 6,Season peak week,51
+2014,45,2014/2015,45,HHS Region 6,Season peak percentage,11.1
+2014,45,2014/2015,45,HHS Region 6,1 wk ahead,2.3
+2014,45,2014/2015,45,HHS Region 6,2 wk ahead,3.9
+2014,45,2014/2015,45,HHS Region 6,3 wk ahead,4.7
+2014,45,2014/2015,45,HHS Region 6,4 wk ahead,4.8
+2014,45,2014/2015,45,HHS Region 7,Season onset,48
+2014,45,2014/2015,45,HHS Region 7,Season peak week,52
+2014,45,2014/2015,45,HHS Region 7,Season peak percentage,6.4
+2014,45,2014/2015,45,HHS Region 7,1 wk ahead,1.1
+2014,45,2014/2015,45,HHS Region 7,2 wk ahead,1
+2014,45,2014/2015,45,HHS Region 7,3 wk ahead,1.8
+2014,45,2014/2015,45,HHS Region 7,4 wk ahead,1.8
+2014,45,2014/2015,45,HHS Region 8,Season onset,49
+2014,45,2014/2015,45,HHS Region 8,Season peak week,53
+2014,45,2014/2015,45,HHS Region 8,Season peak percentage,4.4
+2014,45,2014/2015,45,HHS Region 8,1 wk ahead,0.8
+2014,45,2014/2015,45,HHS Region 8,2 wk ahead,0.7
+2014,45,2014/2015,45,HHS Region 8,3 wk ahead,1
+2014,45,2014/2015,45,HHS Region 8,4 wk ahead,1.3
+2014,45,2014/2015,45,HHS Region 9,Season onset,51
+2014,45,2014/2015,45,HHS Region 9,Season peak week,3
+2014,45,2014/2015,45,HHS Region 9,Season peak week,4
+2014,45,2014/2015,45,HHS Region 9,Season peak percentage,5
+2014,45,2014/2015,45,HHS Region 9,1 wk ahead,2
+2014,45,2014/2015,45,HHS Region 9,2 wk ahead,2.2
+2014,45,2014/2015,45,HHS Region 9,3 wk ahead,2.5
+2014,45,2014/2015,45,HHS Region 9,4 wk ahead,2.2
+2014,45,2014/2015,45,HHS Region 10,Season onset,48
+2014,45,2014/2015,45,HHS Region 10,Season peak week,2
+2014,45,2014/2015,45,HHS Region 10,Season peak percentage,3.6
+2014,45,2014/2015,45,HHS Region 10,1 wk ahead,0.9
+2014,45,2014/2015,45,HHS Region 10,2 wk ahead,1
+2014,45,2014/2015,45,HHS Region 10,3 wk ahead,1.1
+2014,45,2014/2015,45,HHS Region 10,4 wk ahead,1.3
+2014,46,2014/2015,46,US National,Season onset,47
+2014,46,2014/2015,46,US National,Season peak week,52
+2014,46,2014/2015,46,US National,Season peak percentage,6
+2014,46,2014/2015,46,US National,1 wk ahead,2.1
+2014,46,2014/2015,46,US National,2 wk ahead,2.6
+2014,46,2014/2015,46,US National,3 wk ahead,2.6
+2014,46,2014/2015,46,US National,4 wk ahead,3.7
+2014,46,2014/2015,46,HHS Region 1,Season onset,50
+2014,46,2014/2015,46,HHS Region 1,Season peak week,3
+2014,46,2014/2015,46,HHS Region 1,Season peak percentage,3.9
+2014,46,2014/2015,46,HHS Region 1,1 wk ahead,1
+2014,46,2014/2015,46,HHS Region 1,2 wk ahead,1.1
+2014,46,2014/2015,46,HHS Region 1,3 wk ahead,1.1
+2014,46,2014/2015,46,HHS Region 1,4 wk ahead,1.2
+2014,46,2014/2015,46,HHS Region 2,Season onset,45
+2014,46,2014/2015,46,HHS Region 2,Season peak week,52
+2014,46,2014/2015,46,HHS Region 2,Season peak week,4
+2014,46,2014/2015,46,HHS Region 2,Season peak week,5
+2014,46,2014/2015,46,HHS Region 2,Season peak percentage,5.2
+2014,46,2014/2015,46,HHS Region 2,1 wk ahead,2.8
+2014,46,2014/2015,46,HHS Region 2,2 wk ahead,2.9
+2014,46,2014/2015,46,HHS Region 2,3 wk ahead,2.4
+2014,46,2014/2015,46,HHS Region 2,4 wk ahead,2.9
+2014,46,2014/2015,46,HHS Region 3,Season onset,48
+2014,46,2014/2015,46,HHS Region 3,Season peak week,52
+2014,46,2014/2015,46,HHS Region 3,Season peak percentage,7.2
+2014,46,2014/2015,46,HHS Region 3,1 wk ahead,1.7
+2014,46,2014/2015,46,HHS Region 3,2 wk ahead,2.2
+2014,46,2014/2015,46,HHS Region 3,3 wk ahead,2.1
+2014,46,2014/2015,46,HHS Region 3,4 wk ahead,2.9
+2014,46,2014/2015,46,HHS Region 4,Season onset,47
+2014,46,2014/2015,46,HHS Region 4,Season peak week,52
+2014,46,2014/2015,46,HHS Region 4,Season peak percentage,7.5
+2014,46,2014/2015,46,HHS Region 4,1 wk ahead,2.2
+2014,46,2014/2015,46,HHS Region 4,2 wk ahead,3.1
+2014,46,2014/2015,46,HHS Region 4,3 wk ahead,2.9
+2014,46,2014/2015,46,HHS Region 4,4 wk ahead,3.8
+2014,46,2014/2015,46,HHS Region 5,Season onset,48
+2014,46,2014/2015,46,HHS Region 5,Season peak week,52
+2014,46,2014/2015,46,HHS Region 5,Season peak percentage,6.6
+2014,46,2014/2015,46,HHS Region 5,1 wk ahead,1.5
+2014,46,2014/2015,46,HHS Region 5,2 wk ahead,1.9
+2014,46,2014/2015,46,HHS Region 5,3 wk ahead,2.4
+2014,46,2014/2015,46,HHS Region 5,4 wk ahead,3.9
+2014,46,2014/2015,46,HHS Region 6,Season onset,47
+2014,46,2014/2015,46,HHS Region 6,Season peak week,51
+2014,46,2014/2015,46,HHS Region 6,Season peak percentage,11.1
+2014,46,2014/2015,46,HHS Region 6,1 wk ahead,3.9
+2014,46,2014/2015,46,HHS Region 6,2 wk ahead,4.7
+2014,46,2014/2015,46,HHS Region 6,3 wk ahead,4.8
+2014,46,2014/2015,46,HHS Region 6,4 wk ahead,8.1
+2014,46,2014/2015,46,HHS Region 7,Season onset,48
+2014,46,2014/2015,46,HHS Region 7,Season peak week,52
+2014,46,2014/2015,46,HHS Region 7,Season peak percentage,6.4
+2014,46,2014/2015,46,HHS Region 7,1 wk ahead,1
+2014,46,2014/2015,46,HHS Region 7,2 wk ahead,1.8
+2014,46,2014/2015,46,HHS Region 7,3 wk ahead,1.8
+2014,46,2014/2015,46,HHS Region 7,4 wk ahead,3.7
+2014,46,2014/2015,46,HHS Region 8,Season onset,49
+2014,46,2014/2015,46,HHS Region 8,Season peak week,53
+2014,46,2014/2015,46,HHS Region 8,Season peak percentage,4.4
+2014,46,2014/2015,46,HHS Region 8,1 wk ahead,0.7
+2014,46,2014/2015,46,HHS Region 8,2 wk ahead,1
+2014,46,2014/2015,46,HHS Region 8,3 wk ahead,1.3
+2014,46,2014/2015,46,HHS Region 8,4 wk ahead,1.8
+2014,46,2014/2015,46,HHS Region 9,Season onset,51
+2014,46,2014/2015,46,HHS Region 9,Season peak week,3
+2014,46,2014/2015,46,HHS Region 9,Season peak week,4
+2014,46,2014/2015,46,HHS Region 9,Season peak percentage,5
+2014,46,2014/2015,46,HHS Region 9,1 wk ahead,2.2
+2014,46,2014/2015,46,HHS Region 9,2 wk ahead,2.5
+2014,46,2014/2015,46,HHS Region 9,3 wk ahead,2.2
+2014,46,2014/2015,46,HHS Region 9,4 wk ahead,2.4
+2014,46,2014/2015,46,HHS Region 10,Season onset,48
+2014,46,2014/2015,46,HHS Region 10,Season peak week,2
+2014,46,2014/2015,46,HHS Region 10,Season peak percentage,3.6
+2014,46,2014/2015,46,HHS Region 10,1 wk ahead,1
+2014,46,2014/2015,46,HHS Region 10,2 wk ahead,1.1
+2014,46,2014/2015,46,HHS Region 10,3 wk ahead,1.3
+2014,46,2014/2015,46,HHS Region 10,4 wk ahead,1.5
+2014,47,2014/2015,47,US National,Season onset,47
+2014,47,2014/2015,47,US National,Season peak week,52
+2014,47,2014/2015,47,US National,Season peak percentage,6
+2014,47,2014/2015,47,US National,1 wk ahead,2.6
+2014,47,2014/2015,47,US National,2 wk ahead,2.6
+2014,47,2014/2015,47,US National,3 wk ahead,3.7
+2014,47,2014/2015,47,US National,4 wk ahead,5
+2014,47,2014/2015,47,HHS Region 1,Season onset,50
+2014,47,2014/2015,47,HHS Region 1,Season peak week,3
+2014,47,2014/2015,47,HHS Region 1,Season peak percentage,3.9
+2014,47,2014/2015,47,HHS Region 1,1 wk ahead,1.1
+2014,47,2014/2015,47,HHS Region 1,2 wk ahead,1.1
+2014,47,2014/2015,47,HHS Region 1,3 wk ahead,1.2
+2014,47,2014/2015,47,HHS Region 1,4 wk ahead,1.3
+2014,47,2014/2015,47,HHS Region 2,Season onset,45
+2014,47,2014/2015,47,HHS Region 2,Season peak week,52
+2014,47,2014/2015,47,HHS Region 2,Season peak week,4
+2014,47,2014/2015,47,HHS Region 2,Season peak week,5
+2014,47,2014/2015,47,HHS Region 2,Season peak percentage,5.2
+2014,47,2014/2015,47,HHS Region 2,1 wk ahead,2.9
+2014,47,2014/2015,47,HHS Region 2,2 wk ahead,2.4
+2014,47,2014/2015,47,HHS Region 2,3 wk ahead,2.9
+2014,47,2014/2015,47,HHS Region 2,4 wk ahead,3.6
+2014,47,2014/2015,47,HHS Region 3,Season onset,48
+2014,47,2014/2015,47,HHS Region 3,Season peak week,52
+2014,47,2014/2015,47,HHS Region 3,Season peak percentage,7.2
+2014,47,2014/2015,47,HHS Region 3,1 wk ahead,2.2
+2014,47,2014/2015,47,HHS Region 3,2 wk ahead,2.1
+2014,47,2014/2015,47,HHS Region 3,3 wk ahead,2.9
+2014,47,2014/2015,47,HHS Region 3,4 wk ahead,4.5
+2014,47,2014/2015,47,HHS Region 4,Season onset,47
+2014,47,2014/2015,47,HHS Region 4,Season peak week,52
+2014,47,2014/2015,47,HHS Region 4,Season peak percentage,7.5
+2014,47,2014/2015,47,HHS Region 4,1 wk ahead,3.1
+2014,47,2014/2015,47,HHS Region 4,2 wk ahead,2.9
+2014,47,2014/2015,47,HHS Region 4,3 wk ahead,3.8
+2014,47,2014/2015,47,HHS Region 4,4 wk ahead,5.7
+2014,47,2014/2015,47,HHS Region 5,Season onset,48
+2014,47,2014/2015,47,HHS Region 5,Season peak week,52
+2014,47,2014/2015,47,HHS Region 5,Season peak percentage,6.6
+2014,47,2014/2015,47,HHS Region 5,1 wk ahead,1.9
+2014,47,2014/2015,47,HHS Region 5,2 wk ahead,2.4
+2014,47,2014/2015,47,HHS Region 5,3 wk ahead,3.9
+2014,47,2014/2015,47,HHS Region 5,4 wk ahead,4.9
+2014,47,2014/2015,47,HHS Region 6,Season onset,47
+2014,47,2014/2015,47,HHS Region 6,Season peak week,51
+2014,47,2014/2015,47,HHS Region 6,Season peak percentage,11.1
+2014,47,2014/2015,47,HHS Region 6,1 wk ahead,4.7
+2014,47,2014/2015,47,HHS Region 6,2 wk ahead,4.8
+2014,47,2014/2015,47,HHS Region 6,3 wk ahead,8.1
+2014,47,2014/2015,47,HHS Region 6,4 wk ahead,11.1
+2014,47,2014/2015,47,HHS Region 7,Season onset,48
+2014,47,2014/2015,47,HHS Region 7,Season peak week,52
+2014,47,2014/2015,47,HHS Region 7,Season peak percentage,6.4
+2014,47,2014/2015,47,HHS Region 7,1 wk ahead,1.8
+2014,47,2014/2015,47,HHS Region 7,2 wk ahead,1.8
+2014,47,2014/2015,47,HHS Region 7,3 wk ahead,3.7
+2014,47,2014/2015,47,HHS Region 7,4 wk ahead,4.9
+2014,47,2014/2015,47,HHS Region 8,Season onset,49
+2014,47,2014/2015,47,HHS Region 8,Season peak week,53
+2014,47,2014/2015,47,HHS Region 8,Season peak percentage,4.4
+2014,47,2014/2015,47,HHS Region 8,1 wk ahead,1
+2014,47,2014/2015,47,HHS Region 8,2 wk ahead,1.3
+2014,47,2014/2015,47,HHS Region 8,3 wk ahead,1.8
+2014,47,2014/2015,47,HHS Region 8,4 wk ahead,2.4
+2014,47,2014/2015,47,HHS Region 9,Season onset,51
+2014,47,2014/2015,47,HHS Region 9,Season peak week,3
+2014,47,2014/2015,47,HHS Region 9,Season peak week,4
+2014,47,2014/2015,47,HHS Region 9,Season peak percentage,5
+2014,47,2014/2015,47,HHS Region 9,1 wk ahead,2.5
+2014,47,2014/2015,47,HHS Region 9,2 wk ahead,2.2
+2014,47,2014/2015,47,HHS Region 9,3 wk ahead,2.4
+2014,47,2014/2015,47,HHS Region 9,4 wk ahead,2.8
+2014,47,2014/2015,47,HHS Region 10,Season onset,48
+2014,47,2014/2015,47,HHS Region 10,Season peak week,2
+2014,47,2014/2015,47,HHS Region 10,Season peak percentage,3.6
+2014,47,2014/2015,47,HHS Region 10,1 wk ahead,1.1
+2014,47,2014/2015,47,HHS Region 10,2 wk ahead,1.3
+2014,47,2014/2015,47,HHS Region 10,3 wk ahead,1.5
+2014,47,2014/2015,47,HHS Region 10,4 wk ahead,2
+2014,48,2014/2015,48,US National,Season onset,47
+2014,48,2014/2015,48,US National,Season peak week,52
+2014,48,2014/2015,48,US National,Season peak percentage,6
+2014,48,2014/2015,48,US National,1 wk ahead,2.6
+2014,48,2014/2015,48,US National,2 wk ahead,3.7
+2014,48,2014/2015,48,US National,3 wk ahead,5
+2014,48,2014/2015,48,US National,4 wk ahead,6
+2014,48,2014/2015,48,HHS Region 1,Season onset,50
+2014,48,2014/2015,48,HHS Region 1,Season peak week,3
+2014,48,2014/2015,48,HHS Region 1,Season peak percentage,3.9
+2014,48,2014/2015,48,HHS Region 1,1 wk ahead,1.1
+2014,48,2014/2015,48,HHS Region 1,2 wk ahead,1.2
+2014,48,2014/2015,48,HHS Region 1,3 wk ahead,1.3
+2014,48,2014/2015,48,HHS Region 1,4 wk ahead,2
+2014,48,2014/2015,48,HHS Region 2,Season onset,45
+2014,48,2014/2015,48,HHS Region 2,Season peak week,52
+2014,48,2014/2015,48,HHS Region 2,Season peak week,4
+2014,48,2014/2015,48,HHS Region 2,Season peak week,5
+2014,48,2014/2015,48,HHS Region 2,Season peak percentage,5.2
+2014,48,2014/2015,48,HHS Region 2,1 wk ahead,2.4
+2014,48,2014/2015,48,HHS Region 2,2 wk ahead,2.9
+2014,48,2014/2015,48,HHS Region 2,3 wk ahead,3.6
+2014,48,2014/2015,48,HHS Region 2,4 wk ahead,5.2
+2014,48,2014/2015,48,HHS Region 3,Season onset,48
+2014,48,2014/2015,48,HHS Region 3,Season peak week,52
+2014,48,2014/2015,48,HHS Region 3,Season peak percentage,7.2
+2014,48,2014/2015,48,HHS Region 3,1 wk ahead,2.1
+2014,48,2014/2015,48,HHS Region 3,2 wk ahead,2.9
+2014,48,2014/2015,48,HHS Region 3,3 wk ahead,4.5
+2014,48,2014/2015,48,HHS Region 3,4 wk ahead,7.2
+2014,48,2014/2015,48,HHS Region 4,Season onset,47
+2014,48,2014/2015,48,HHS Region 4,Season peak week,52
+2014,48,2014/2015,48,HHS Region 4,Season peak percentage,7.5
+2014,48,2014/2015,48,HHS Region 4,1 wk ahead,2.9
+2014,48,2014/2015,48,HHS Region 4,2 wk ahead,3.8
+2014,48,2014/2015,48,HHS Region 4,3 wk ahead,5.7
+2014,48,2014/2015,48,HHS Region 4,4 wk ahead,7.5
+2014,48,2014/2015,48,HHS Region 5,Season onset,48
+2014,48,2014/2015,48,HHS Region 5,Season peak week,52
+2014,48,2014/2015,48,HHS Region 5,Season peak percentage,6.6
+2014,48,2014/2015,48,HHS Region 5,1 wk ahead,2.4
+2014,48,2014/2015,48,HHS Region 5,2 wk ahead,3.9
+2014,48,2014/2015,48,HHS Region 5,3 wk ahead,4.9
+2014,48,2014/2015,48,HHS Region 5,4 wk ahead,6.6
+2014,48,2014/2015,48,HHS Region 6,Season onset,47
+2014,48,2014/2015,48,HHS Region 6,Season peak week,51
+2014,48,2014/2015,48,HHS Region 6,Season peak percentage,11.1
+2014,48,2014/2015,48,HHS Region 6,1 wk ahead,4.8
+2014,48,2014/2015,48,HHS Region 6,2 wk ahead,8.1
+2014,48,2014/2015,48,HHS Region 6,3 wk ahead,11.1
+2014,48,2014/2015,48,HHS Region 6,4 wk ahead,7.8
+2014,48,2014/2015,48,HHS Region 7,Season onset,48
+2014,48,2014/2015,48,HHS Region 7,Season peak week,52
+2014,48,2014/2015,48,HHS Region 7,Season peak percentage,6.4
+2014,48,2014/2015,48,HHS Region 7,1 wk ahead,1.8
+2014,48,2014/2015,48,HHS Region 7,2 wk ahead,3.7
+2014,48,2014/2015,48,HHS Region 7,3 wk ahead,4.9
+2014,48,2014/2015,48,HHS Region 7,4 wk ahead,6.4
+2014,48,2014/2015,48,HHS Region 8,Season onset,49
+2014,48,2014/2015,48,HHS Region 8,Season peak week,53
+2014,48,2014/2015,48,HHS Region 8,Season peak percentage,4.4
+2014,48,2014/2015,48,HHS Region 8,1 wk ahead,1.3
+2014,48,2014/2015,48,HHS Region 8,2 wk ahead,1.8
+2014,48,2014/2015,48,HHS Region 8,3 wk ahead,2.4
+2014,48,2014/2015,48,HHS Region 8,4 wk ahead,3.8
+2014,48,2014/2015,48,HHS Region 9,Season onset,51
+2014,48,2014/2015,48,HHS Region 9,Season peak week,3
+2014,48,2014/2015,48,HHS Region 9,Season peak week,4
+2014,48,2014/2015,48,HHS Region 9,Season peak percentage,5
+2014,48,2014/2015,48,HHS Region 9,1 wk ahead,2.2
+2014,48,2014/2015,48,HHS Region 9,2 wk ahead,2.4
+2014,48,2014/2015,48,HHS Region 9,3 wk ahead,2.8
+2014,48,2014/2015,48,HHS Region 9,4 wk ahead,4.3
+2014,48,2014/2015,48,HHS Region 10,Season onset,48
+2014,48,2014/2015,48,HHS Region 10,Season peak week,2
+2014,48,2014/2015,48,HHS Region 10,Season peak percentage,3.6
+2014,48,2014/2015,48,HHS Region 10,1 wk ahead,1.3
+2014,48,2014/2015,48,HHS Region 10,2 wk ahead,1.5
+2014,48,2014/2015,48,HHS Region 10,3 wk ahead,2
+2014,48,2014/2015,48,HHS Region 10,4 wk ahead,2.6
+2014,49,2014/2015,49,US National,Season onset,47
+2014,49,2014/2015,49,US National,Season peak week,52
+2014,49,2014/2015,49,US National,Season peak percentage,6
+2014,49,2014/2015,49,US National,1 wk ahead,3.7
+2014,49,2014/2015,49,US National,2 wk ahead,5
+2014,49,2014/2015,49,US National,3 wk ahead,6
+2014,49,2014/2015,49,US National,4 wk ahead,5.5
+2014,49,2014/2015,49,HHS Region 1,Season onset,50
+2014,49,2014/2015,49,HHS Region 1,Season peak week,3
+2014,49,2014/2015,49,HHS Region 1,Season peak percentage,3.9
+2014,49,2014/2015,49,HHS Region 1,1 wk ahead,1.2
+2014,49,2014/2015,49,HHS Region 1,2 wk ahead,1.3
+2014,49,2014/2015,49,HHS Region 1,3 wk ahead,2
+2014,49,2014/2015,49,HHS Region 1,4 wk ahead,1.9
+2014,49,2014/2015,49,HHS Region 2,Season onset,45
+2014,49,2014/2015,49,HHS Region 2,Season peak week,52
+2014,49,2014/2015,49,HHS Region 2,Season peak week,4
+2014,49,2014/2015,49,HHS Region 2,Season peak week,5
+2014,49,2014/2015,49,HHS Region 2,Season peak percentage,5.2
+2014,49,2014/2015,49,HHS Region 2,1 wk ahead,2.9
+2014,49,2014/2015,49,HHS Region 2,2 wk ahead,3.6
+2014,49,2014/2015,49,HHS Region 2,3 wk ahead,5.2
+2014,49,2014/2015,49,HHS Region 2,4 wk ahead,4.5
+2014,49,2014/2015,49,HHS Region 3,Season onset,48
+2014,49,2014/2015,49,HHS Region 3,Season peak week,52
+2014,49,2014/2015,49,HHS Region 3,Season peak percentage,7.2
+2014,49,2014/2015,49,HHS Region 3,1 wk ahead,2.9
+2014,49,2014/2015,49,HHS Region 3,2 wk ahead,4.5
+2014,49,2014/2015,49,HHS Region 3,3 wk ahead,7.2
+2014,49,2014/2015,49,HHS Region 3,4 wk ahead,6.9
+2014,49,2014/2015,49,HHS Region 4,Season onset,47
+2014,49,2014/2015,49,HHS Region 4,Season peak week,52
+2014,49,2014/2015,49,HHS Region 4,Season peak percentage,7.5
+2014,49,2014/2015,49,HHS Region 4,1 wk ahead,3.8
+2014,49,2014/2015,49,HHS Region 4,2 wk ahead,5.7
+2014,49,2014/2015,49,HHS Region 4,3 wk ahead,7.5
+2014,49,2014/2015,49,HHS Region 4,4 wk ahead,5.2
+2014,49,2014/2015,49,HHS Region 5,Season onset,48
+2014,49,2014/2015,49,HHS Region 5,Season peak week,52
+2014,49,2014/2015,49,HHS Region 5,Season peak percentage,6.6
+2014,49,2014/2015,49,HHS Region 5,1 wk ahead,3.9
+2014,49,2014/2015,49,HHS Region 5,2 wk ahead,4.9
+2014,49,2014/2015,49,HHS Region 5,3 wk ahead,6.6
+2014,49,2014/2015,49,HHS Region 5,4 wk ahead,4.8
+2014,49,2014/2015,49,HHS Region 6,Season onset,47
+2014,49,2014/2015,49,HHS Region 6,Season peak week,51
+2014,49,2014/2015,49,HHS Region 6,Season peak percentage,11.1
+2014,49,2014/2015,49,HHS Region 6,1 wk ahead,8.1
+2014,49,2014/2015,49,HHS Region 6,2 wk ahead,11.1
+2014,49,2014/2015,49,HHS Region 6,3 wk ahead,7.8
+2014,49,2014/2015,49,HHS Region 6,4 wk ahead,10
+2014,49,2014/2015,49,HHS Region 7,Season onset,48
+2014,49,2014/2015,49,HHS Region 7,Season peak week,52
+2014,49,2014/2015,49,HHS Region 7,Season peak percentage,6.4
+2014,49,2014/2015,49,HHS Region 7,1 wk ahead,3.7
+2014,49,2014/2015,49,HHS Region 7,2 wk ahead,4.9
+2014,49,2014/2015,49,HHS Region 7,3 wk ahead,6.4
+2014,49,2014/2015,49,HHS Region 7,4 wk ahead,5.8
+2014,49,2014/2015,49,HHS Region 8,Season onset,49
+2014,49,2014/2015,49,HHS Region 8,Season peak week,53
+2014,49,2014/2015,49,HHS Region 8,Season peak percentage,4.4
+2014,49,2014/2015,49,HHS Region 8,1 wk ahead,1.8
+2014,49,2014/2015,49,HHS Region 8,2 wk ahead,2.4
+2014,49,2014/2015,49,HHS Region 8,3 wk ahead,3.8
+2014,49,2014/2015,49,HHS Region 8,4 wk ahead,4.4
+2014,49,2014/2015,49,HHS Region 9,Season onset,51
+2014,49,2014/2015,49,HHS Region 9,Season peak week,3
+2014,49,2014/2015,49,HHS Region 9,Season peak week,4
+2014,49,2014/2015,49,HHS Region 9,Season peak percentage,5
+2014,49,2014/2015,49,HHS Region 9,1 wk ahead,2.4
+2014,49,2014/2015,49,HHS Region 9,2 wk ahead,2.8
+2014,49,2014/2015,49,HHS Region 9,3 wk ahead,4.3
+2014,49,2014/2015,49,HHS Region 9,4 wk ahead,4.7
+2014,49,2014/2015,49,HHS Region 10,Season onset,48
+2014,49,2014/2015,49,HHS Region 10,Season peak week,2
+2014,49,2014/2015,49,HHS Region 10,Season peak percentage,3.6
+2014,49,2014/2015,49,HHS Region 10,1 wk ahead,1.5
+2014,49,2014/2015,49,HHS Region 10,2 wk ahead,2
+2014,49,2014/2015,49,HHS Region 10,3 wk ahead,2.6
+2014,49,2014/2015,49,HHS Region 10,4 wk ahead,3.2
+2014,50,2014/2015,50,US National,Season onset,47
+2014,50,2014/2015,50,US National,Season peak week,52
+2014,50,2014/2015,50,US National,Season peak percentage,6
+2014,50,2014/2015,50,US National,1 wk ahead,5
+2014,50,2014/2015,50,US National,2 wk ahead,6
+2014,50,2014/2015,50,US National,3 wk ahead,5.5
+2014,50,2014/2015,50,US National,4 wk ahead,4.2
+2014,50,2014/2015,50,HHS Region 1,Season onset,50
+2014,50,2014/2015,50,HHS Region 1,Season peak week,3
+2014,50,2014/2015,50,HHS Region 1,Season peak percentage,3.9
+2014,50,2014/2015,50,HHS Region 1,1 wk ahead,1.3
+2014,50,2014/2015,50,HHS Region 1,2 wk ahead,2
+2014,50,2014/2015,50,HHS Region 1,3 wk ahead,1.9
+2014,50,2014/2015,50,HHS Region 1,4 wk ahead,1.9
+2014,50,2014/2015,50,HHS Region 2,Season onset,45
+2014,50,2014/2015,50,HHS Region 2,Season peak week,52
+2014,50,2014/2015,50,HHS Region 2,Season peak week,4
+2014,50,2014/2015,50,HHS Region 2,Season peak week,5
+2014,50,2014/2015,50,HHS Region 2,Season peak percentage,5.2
+2014,50,2014/2015,50,HHS Region 2,1 wk ahead,3.6
+2014,50,2014/2015,50,HHS Region 2,2 wk ahead,5.2
+2014,50,2014/2015,50,HHS Region 2,3 wk ahead,4.5
+2014,50,2014/2015,50,HHS Region 2,4 wk ahead,4
+2014,50,2014/2015,50,HHS Region 3,Season onset,48
+2014,50,2014/2015,50,HHS Region 3,Season peak week,52
+2014,50,2014/2015,50,HHS Region 3,Season peak percentage,7.2
+2014,50,2014/2015,50,HHS Region 3,1 wk ahead,4.5
+2014,50,2014/2015,50,HHS Region 3,2 wk ahead,7.2
+2014,50,2014/2015,50,HHS Region 3,3 wk ahead,6.9
+2014,50,2014/2015,50,HHS Region 3,4 wk ahead,4.8
+2014,50,2014/2015,50,HHS Region 4,Season onset,47
+2014,50,2014/2015,50,HHS Region 4,Season peak week,52
+2014,50,2014/2015,50,HHS Region 4,Season peak percentage,7.5
+2014,50,2014/2015,50,HHS Region 4,1 wk ahead,5.7
+2014,50,2014/2015,50,HHS Region 4,2 wk ahead,7.5
+2014,50,2014/2015,50,HHS Region 4,3 wk ahead,5.2
+2014,50,2014/2015,50,HHS Region 4,4 wk ahead,3.4
+2014,50,2014/2015,50,HHS Region 5,Season onset,48
+2014,50,2014/2015,50,HHS Region 5,Season peak week,52
+2014,50,2014/2015,50,HHS Region 5,Season peak percentage,6.6
+2014,50,2014/2015,50,HHS Region 5,1 wk ahead,4.9
+2014,50,2014/2015,50,HHS Region 5,2 wk ahead,6.6
+2014,50,2014/2015,50,HHS Region 5,3 wk ahead,4.8
+2014,50,2014/2015,50,HHS Region 5,4 wk ahead,3.2
+2014,50,2014/2015,50,HHS Region 6,Season onset,47
+2014,50,2014/2015,50,HHS Region 6,Season peak week,51
+2014,50,2014/2015,50,HHS Region 6,Season peak percentage,11.1
+2014,50,2014/2015,50,HHS Region 6,1 wk ahead,11.1
+2014,50,2014/2015,50,HHS Region 6,2 wk ahead,7.8
+2014,50,2014/2015,50,HHS Region 6,3 wk ahead,10
+2014,50,2014/2015,50,HHS Region 6,4 wk ahead,8.3
+2014,50,2014/2015,50,HHS Region 7,Season onset,48
+2014,50,2014/2015,50,HHS Region 7,Season peak week,52
+2014,50,2014/2015,50,HHS Region 7,Season peak percentage,6.4
+2014,50,2014/2015,50,HHS Region 7,1 wk ahead,4.9
+2014,50,2014/2015,50,HHS Region 7,2 wk ahead,6.4
+2014,50,2014/2015,50,HHS Region 7,3 wk ahead,5.8
+2014,50,2014/2015,50,HHS Region 7,4 wk ahead,4.5
+2014,50,2014/2015,50,HHS Region 8,Season onset,49
+2014,50,2014/2015,50,HHS Region 8,Season peak week,53
+2014,50,2014/2015,50,HHS Region 8,Season peak percentage,4.4
+2014,50,2014/2015,50,HHS Region 8,1 wk ahead,2.4
+2014,50,2014/2015,50,HHS Region 8,2 wk ahead,3.8
+2014,50,2014/2015,50,HHS Region 8,3 wk ahead,4.4
+2014,50,2014/2015,50,HHS Region 8,4 wk ahead,3.4
+2014,50,2014/2015,50,HHS Region 9,Season onset,51
+2014,50,2014/2015,50,HHS Region 9,Season peak week,3
+2014,50,2014/2015,50,HHS Region 9,Season peak week,4
+2014,50,2014/2015,50,HHS Region 9,Season peak percentage,5
+2014,50,2014/2015,50,HHS Region 9,1 wk ahead,2.8
+2014,50,2014/2015,50,HHS Region 9,2 wk ahead,4.3
+2014,50,2014/2015,50,HHS Region 9,3 wk ahead,4.7
+2014,50,2014/2015,50,HHS Region 9,4 wk ahead,4
+2014,50,2014/2015,50,HHS Region 10,Season onset,48
+2014,50,2014/2015,50,HHS Region 10,Season peak week,2
+2014,50,2014/2015,50,HHS Region 10,Season peak percentage,3.6
+2014,50,2014/2015,50,HHS Region 10,1 wk ahead,2
+2014,50,2014/2015,50,HHS Region 10,2 wk ahead,2.6
+2014,50,2014/2015,50,HHS Region 10,3 wk ahead,3.2
+2014,50,2014/2015,50,HHS Region 10,4 wk ahead,3.1
+2014,51,2014/2015,51,US National,Season onset,47
+2014,51,2014/2015,51,US National,Season peak week,52
+2014,51,2014/2015,51,US National,Season peak percentage,6
+2014,51,2014/2015,51,US National,1 wk ahead,6
+2014,51,2014/2015,51,US National,2 wk ahead,5.5
+2014,51,2014/2015,51,US National,3 wk ahead,4.2
+2014,51,2014/2015,51,US National,4 wk ahead,4.3
+2014,51,2014/2015,51,HHS Region 1,Season onset,50
+2014,51,2014/2015,51,HHS Region 1,Season peak week,3
+2014,51,2014/2015,51,HHS Region 1,Season peak percentage,3.9
+2014,51,2014/2015,51,HHS Region 1,1 wk ahead,2
+2014,51,2014/2015,51,HHS Region 1,2 wk ahead,1.9
+2014,51,2014/2015,51,HHS Region 1,3 wk ahead,1.9
+2014,51,2014/2015,51,HHS Region 1,4 wk ahead,2.6
+2014,51,2014/2015,51,HHS Region 2,Season onset,45
+2014,51,2014/2015,51,HHS Region 2,Season peak week,52
+2014,51,2014/2015,51,HHS Region 2,Season peak week,4
+2014,51,2014/2015,51,HHS Region 2,Season peak week,5
+2014,51,2014/2015,51,HHS Region 2,Season peak percentage,5.2
+2014,51,2014/2015,51,HHS Region 2,1 wk ahead,5.2
+2014,51,2014/2015,51,HHS Region 2,2 wk ahead,4.5
+2014,51,2014/2015,51,HHS Region 2,3 wk ahead,4
+2014,51,2014/2015,51,HHS Region 2,4 wk ahead,4.6
+2014,51,2014/2015,51,HHS Region 3,Season onset,48
+2014,51,2014/2015,51,HHS Region 3,Season peak week,52
+2014,51,2014/2015,51,HHS Region 3,Season peak percentage,7.2
+2014,51,2014/2015,51,HHS Region 3,1 wk ahead,7.2
+2014,51,2014/2015,51,HHS Region 3,2 wk ahead,6.9
+2014,51,2014/2015,51,HHS Region 3,3 wk ahead,4.8
+2014,51,2014/2015,51,HHS Region 3,4 wk ahead,4.1
+2014,51,2014/2015,51,HHS Region 4,Season onset,47
+2014,51,2014/2015,51,HHS Region 4,Season peak week,52
+2014,51,2014/2015,51,HHS Region 4,Season peak percentage,7.5
+2014,51,2014/2015,51,HHS Region 4,1 wk ahead,7.5
+2014,51,2014/2015,51,HHS Region 4,2 wk ahead,5.2
+2014,51,2014/2015,51,HHS Region 4,3 wk ahead,3.4
+2014,51,2014/2015,51,HHS Region 4,4 wk ahead,3
+2014,51,2014/2015,51,HHS Region 5,Season onset,48
+2014,51,2014/2015,51,HHS Region 5,Season peak week,52
+2014,51,2014/2015,51,HHS Region 5,Season peak percentage,6.6
+2014,51,2014/2015,51,HHS Region 5,1 wk ahead,6.6
+2014,51,2014/2015,51,HHS Region 5,2 wk ahead,4.8
+2014,51,2014/2015,51,HHS Region 5,3 wk ahead,3.2
+2014,51,2014/2015,51,HHS Region 5,4 wk ahead,2.6
+2014,51,2014/2015,51,HHS Region 6,Season onset,47
+2014,51,2014/2015,51,HHS Region 6,Season peak week,51
+2014,51,2014/2015,51,HHS Region 6,Season peak percentage,11.1
+2014,51,2014/2015,51,HHS Region 6,1 wk ahead,7.8
+2014,51,2014/2015,51,HHS Region 6,2 wk ahead,10
+2014,51,2014/2015,51,HHS Region 6,3 wk ahead,8.3
+2014,51,2014/2015,51,HHS Region 6,4 wk ahead,9.4
+2014,51,2014/2015,51,HHS Region 7,Season onset,48
+2014,51,2014/2015,51,HHS Region 7,Season peak week,52
+2014,51,2014/2015,51,HHS Region 7,Season peak percentage,6.4
+2014,51,2014/2015,51,HHS Region 7,1 wk ahead,6.4
+2014,51,2014/2015,51,HHS Region 7,2 wk ahead,5.8
+2014,51,2014/2015,51,HHS Region 7,3 wk ahead,4.5
+2014,51,2014/2015,51,HHS Region 7,4 wk ahead,3.6
+2014,51,2014/2015,51,HHS Region 8,Season onset,49
+2014,51,2014/2015,51,HHS Region 8,Season peak week,53
+2014,51,2014/2015,51,HHS Region 8,Season peak percentage,4.4
+2014,51,2014/2015,51,HHS Region 8,1 wk ahead,3.8
+2014,51,2014/2015,51,HHS Region 8,2 wk ahead,4.4
+2014,51,2014/2015,51,HHS Region 8,3 wk ahead,3.4
+2014,51,2014/2015,51,HHS Region 8,4 wk ahead,3.3
+2014,51,2014/2015,51,HHS Region 9,Season onset,51
+2014,51,2014/2015,51,HHS Region 9,Season peak week,3
+2014,51,2014/2015,51,HHS Region 9,Season peak week,4
+2014,51,2014/2015,51,HHS Region 9,Season peak percentage,5
+2014,51,2014/2015,51,HHS Region 9,1 wk ahead,4.3
+2014,51,2014/2015,51,HHS Region 9,2 wk ahead,4.7
+2014,51,2014/2015,51,HHS Region 9,3 wk ahead,4
+2014,51,2014/2015,51,HHS Region 9,4 wk ahead,4.4
+2014,51,2014/2015,51,HHS Region 10,Season onset,48
+2014,51,2014/2015,51,HHS Region 10,Season peak week,2
+2014,51,2014/2015,51,HHS Region 10,Season peak percentage,3.6
+2014,51,2014/2015,51,HHS Region 10,1 wk ahead,2.6
+2014,51,2014/2015,51,HHS Region 10,2 wk ahead,3.2
+2014,51,2014/2015,51,HHS Region 10,3 wk ahead,3.1
+2014,51,2014/2015,51,HHS Region 10,4 wk ahead,3.6
+2014,52,2014/2015,52,US National,Season onset,47
+2014,52,2014/2015,52,US National,Season peak week,52
+2014,52,2014/2015,52,US National,Season peak percentage,6
+2014,52,2014/2015,52,US National,1 wk ahead,5.5
+2014,52,2014/2015,52,US National,2 wk ahead,4.2
+2014,52,2014/2015,52,US National,3 wk ahead,4.3
+2014,52,2014/2015,52,US National,4 wk ahead,4.3
+2014,52,2014/2015,52,HHS Region 1,Season onset,50
+2014,52,2014/2015,52,HHS Region 1,Season peak week,3
+2014,52,2014/2015,52,HHS Region 1,Season peak percentage,3.9
+2014,52,2014/2015,52,HHS Region 1,1 wk ahead,1.9
+2014,52,2014/2015,52,HHS Region 1,2 wk ahead,1.9
+2014,52,2014/2015,52,HHS Region 1,3 wk ahead,2.6
+2014,52,2014/2015,52,HHS Region 1,4 wk ahead,3.9
+2014,52,2014/2015,52,HHS Region 2,Season onset,45
+2014,52,2014/2015,52,HHS Region 2,Season peak week,52
+2014,52,2014/2015,52,HHS Region 2,Season peak week,4
+2014,52,2014/2015,52,HHS Region 2,Season peak week,5
+2014,52,2014/2015,52,HHS Region 2,Season peak percentage,5.2
+2014,52,2014/2015,52,HHS Region 2,1 wk ahead,4.5
+2014,52,2014/2015,52,HHS Region 2,2 wk ahead,4
+2014,52,2014/2015,52,HHS Region 2,3 wk ahead,4.6
+2014,52,2014/2015,52,HHS Region 2,4 wk ahead,5
+2014,52,2014/2015,52,HHS Region 3,Season onset,48
+2014,52,2014/2015,52,HHS Region 3,Season peak week,52
+2014,52,2014/2015,52,HHS Region 3,Season peak percentage,7.2
+2014,52,2014/2015,52,HHS Region 3,1 wk ahead,6.9
+2014,52,2014/2015,52,HHS Region 3,2 wk ahead,4.8
+2014,52,2014/2015,52,HHS Region 3,3 wk ahead,4.1
+2014,52,2014/2015,52,HHS Region 3,4 wk ahead,4.5
+2014,52,2014/2015,52,HHS Region 4,Season onset,47
+2014,52,2014/2015,52,HHS Region 4,Season peak week,52
+2014,52,2014/2015,52,HHS Region 4,Season peak percentage,7.5
+2014,52,2014/2015,52,HHS Region 4,1 wk ahead,5.2
+2014,52,2014/2015,52,HHS Region 4,2 wk ahead,3.4
+2014,52,2014/2015,52,HHS Region 4,3 wk ahead,3
+2014,52,2014/2015,52,HHS Region 4,4 wk ahead,3.1
+2014,52,2014/2015,52,HHS Region 5,Season onset,48
+2014,52,2014/2015,52,HHS Region 5,Season peak week,52
+2014,52,2014/2015,52,HHS Region 5,Season peak percentage,6.6
+2014,52,2014/2015,52,HHS Region 5,1 wk ahead,4.8
+2014,52,2014/2015,52,HHS Region 5,2 wk ahead,3.2
+2014,52,2014/2015,52,HHS Region 5,3 wk ahead,2.6
+2014,52,2014/2015,52,HHS Region 5,4 wk ahead,2.3
+2014,52,2014/2015,52,HHS Region 6,Season onset,47
+2014,52,2014/2015,52,HHS Region 6,Season peak week,51
+2014,52,2014/2015,52,HHS Region 6,Season peak percentage,11.1
+2014,52,2014/2015,52,HHS Region 6,1 wk ahead,10
+2014,52,2014/2015,52,HHS Region 6,2 wk ahead,8.3
+2014,52,2014/2015,52,HHS Region 6,3 wk ahead,9.4
+2014,52,2014/2015,52,HHS Region 6,4 wk ahead,7.7
+2014,52,2014/2015,52,HHS Region 7,Season onset,48
+2014,52,2014/2015,52,HHS Region 7,Season peak week,52
+2014,52,2014/2015,52,HHS Region 7,Season peak percentage,6.4
+2014,52,2014/2015,52,HHS Region 7,1 wk ahead,5.8
+2014,52,2014/2015,52,HHS Region 7,2 wk ahead,4.5
+2014,52,2014/2015,52,HHS Region 7,3 wk ahead,3.6
+2014,52,2014/2015,52,HHS Region 7,4 wk ahead,4.2
+2014,52,2014/2015,52,HHS Region 8,Season onset,49
+2014,52,2014/2015,52,HHS Region 8,Season peak week,53
+2014,52,2014/2015,52,HHS Region 8,Season peak percentage,4.4
+2014,52,2014/2015,52,HHS Region 8,1 wk ahead,4.4
+2014,52,2014/2015,52,HHS Region 8,2 wk ahead,3.4
+2014,52,2014/2015,52,HHS Region 8,3 wk ahead,3.3
+2014,52,2014/2015,52,HHS Region 8,4 wk ahead,3.2
+2014,52,2014/2015,52,HHS Region 9,Season onset,51
+2014,52,2014/2015,52,HHS Region 9,Season peak week,3
+2014,52,2014/2015,52,HHS Region 9,Season peak week,4
+2014,52,2014/2015,52,HHS Region 9,Season peak percentage,5
+2014,52,2014/2015,52,HHS Region 9,1 wk ahead,4.7
+2014,52,2014/2015,52,HHS Region 9,2 wk ahead,4
+2014,52,2014/2015,52,HHS Region 9,3 wk ahead,4.4
+2014,52,2014/2015,52,HHS Region 9,4 wk ahead,5
+2014,52,2014/2015,52,HHS Region 10,Season onset,48
+2014,52,2014/2015,52,HHS Region 10,Season peak week,2
+2014,52,2014/2015,52,HHS Region 10,Season peak percentage,3.6
+2014,52,2014/2015,52,HHS Region 10,1 wk ahead,3.2
+2014,52,2014/2015,52,HHS Region 10,2 wk ahead,3.1
+2014,52,2014/2015,52,HHS Region 10,3 wk ahead,3.6
+2014,52,2014/2015,52,HHS Region 10,4 wk ahead,3.4
+2014,53,2014/2015,53,US National,Season onset,47
+2014,53,2014/2015,53,US National,Season peak week,52
+2014,53,2014/2015,53,US National,Season peak percentage,6
+2014,53,2014/2015,53,US National,1 wk ahead,4.2
+2014,53,2014/2015,53,US National,2 wk ahead,4.3
+2014,53,2014/2015,53,US National,3 wk ahead,4.3
+2014,53,2014/2015,53,US National,4 wk ahead,4
+2014,53,2014/2015,53,HHS Region 1,Season onset,50
+2014,53,2014/2015,53,HHS Region 1,Season peak week,3
+2014,53,2014/2015,53,HHS Region 1,Season peak percentage,3.9
+2014,53,2014/2015,53,HHS Region 1,1 wk ahead,1.9
+2014,53,2014/2015,53,HHS Region 1,2 wk ahead,2.6
+2014,53,2014/2015,53,HHS Region 1,3 wk ahead,3.9
+2014,53,2014/2015,53,HHS Region 1,4 wk ahead,3.6
+2014,53,2014/2015,53,HHS Region 2,Season onset,45
+2014,53,2014/2015,53,HHS Region 2,Season peak week,52
+2014,53,2014/2015,53,HHS Region 2,Season peak week,4
+2014,53,2014/2015,53,HHS Region 2,Season peak week,5
+2014,53,2014/2015,53,HHS Region 2,Season peak percentage,5.2
+2014,53,2014/2015,53,HHS Region 2,1 wk ahead,4
+2014,53,2014/2015,53,HHS Region 2,2 wk ahead,4.6
+2014,53,2014/2015,53,HHS Region 2,3 wk ahead,5
+2014,53,2014/2015,53,HHS Region 2,4 wk ahead,5.2
+2014,53,2014/2015,53,HHS Region 3,Season onset,48
+2014,53,2014/2015,53,HHS Region 3,Season peak week,52
+2014,53,2014/2015,53,HHS Region 3,Season peak percentage,7.2
+2014,53,2014/2015,53,HHS Region 3,1 wk ahead,4.8
+2014,53,2014/2015,53,HHS Region 3,2 wk ahead,4.1
+2014,53,2014/2015,53,HHS Region 3,3 wk ahead,4.5
+2014,53,2014/2015,53,HHS Region 3,4 wk ahead,4.2
+2014,53,2014/2015,53,HHS Region 4,Season onset,47
+2014,53,2014/2015,53,HHS Region 4,Season peak week,52
+2014,53,2014/2015,53,HHS Region 4,Season peak percentage,7.5
+2014,53,2014/2015,53,HHS Region 4,1 wk ahead,3.4
+2014,53,2014/2015,53,HHS Region 4,2 wk ahead,3
+2014,53,2014/2015,53,HHS Region 4,3 wk ahead,3.1
+2014,53,2014/2015,53,HHS Region 4,4 wk ahead,2.8
+2014,53,2014/2015,53,HHS Region 5,Season onset,48
+2014,53,2014/2015,53,HHS Region 5,Season peak week,52
+2014,53,2014/2015,53,HHS Region 5,Season peak percentage,6.6
+2014,53,2014/2015,53,HHS Region 5,1 wk ahead,3.2
+2014,53,2014/2015,53,HHS Region 5,2 wk ahead,2.6
+2014,53,2014/2015,53,HHS Region 5,3 wk ahead,2.3
+2014,53,2014/2015,53,HHS Region 5,4 wk ahead,1.9
+2014,53,2014/2015,53,HHS Region 6,Season onset,47
+2014,53,2014/2015,53,HHS Region 6,Season peak week,51
+2014,53,2014/2015,53,HHS Region 6,Season peak percentage,11.1
+2014,53,2014/2015,53,HHS Region 6,1 wk ahead,8.3
+2014,53,2014/2015,53,HHS Region 6,2 wk ahead,9.4
+2014,53,2014/2015,53,HHS Region 6,3 wk ahead,7.7
+2014,53,2014/2015,53,HHS Region 6,4 wk ahead,6.7
+2014,53,2014/2015,53,HHS Region 7,Season onset,48
+2014,53,2014/2015,53,HHS Region 7,Season peak week,52
+2014,53,2014/2015,53,HHS Region 7,Season peak percentage,6.4
+2014,53,2014/2015,53,HHS Region 7,1 wk ahead,4.5
+2014,53,2014/2015,53,HHS Region 7,2 wk ahead,3.6
+2014,53,2014/2015,53,HHS Region 7,3 wk ahead,4.2
+2014,53,2014/2015,53,HHS Region 7,4 wk ahead,4.2
+2014,53,2014/2015,53,HHS Region 8,Season onset,49
+2014,53,2014/2015,53,HHS Region 8,Season peak week,53
+2014,53,2014/2015,53,HHS Region 8,Season peak percentage,4.4
+2014,53,2014/2015,53,HHS Region 8,1 wk ahead,3.4
+2014,53,2014/2015,53,HHS Region 8,2 wk ahead,3.3
+2014,53,2014/2015,53,HHS Region 8,3 wk ahead,3.2
+2014,53,2014/2015,53,HHS Region 8,4 wk ahead,3
+2014,53,2014/2015,53,HHS Region 9,Season onset,51
+2014,53,2014/2015,53,HHS Region 9,Season peak week,3
+2014,53,2014/2015,53,HHS Region 9,Season peak week,4
+2014,53,2014/2015,53,HHS Region 9,Season peak percentage,5
+2014,53,2014/2015,53,HHS Region 9,1 wk ahead,4
+2014,53,2014/2015,53,HHS Region 9,2 wk ahead,4.4
+2014,53,2014/2015,53,HHS Region 9,3 wk ahead,5
+2014,53,2014/2015,53,HHS Region 9,4 wk ahead,5
+2014,53,2014/2015,53,HHS Region 10,Season onset,48
+2014,53,2014/2015,53,HHS Region 10,Season peak week,2
+2014,53,2014/2015,53,HHS Region 10,Season peak percentage,3.6
+2014,53,2014/2015,53,HHS Region 10,1 wk ahead,3.1
+2014,53,2014/2015,53,HHS Region 10,2 wk ahead,3.6
+2014,53,2014/2015,53,HHS Region 10,3 wk ahead,3.4
+2014,53,2014/2015,53,HHS Region 10,4 wk ahead,2.8
+2015,1,2014/2015,54,US National,Season onset,47
+2015,1,2014/2015,54,US National,Season peak week,52
+2015,1,2014/2015,54,US National,Season peak percentage,6
+2015,1,2014/2015,54,US National,1 wk ahead,4.3
+2015,1,2014/2015,54,US National,2 wk ahead,4.3
+2015,1,2014/2015,54,US National,3 wk ahead,4
+2015,1,2014/2015,54,US National,4 wk ahead,3.6
+2015,1,2014/2015,54,HHS Region 1,Season onset,50
+2015,1,2014/2015,54,HHS Region 1,Season peak week,3
+2015,1,2014/2015,54,HHS Region 1,Season peak percentage,3.9
+2015,1,2014/2015,54,HHS Region 1,1 wk ahead,2.6
+2015,1,2014/2015,54,HHS Region 1,2 wk ahead,3.9
+2015,1,2014/2015,54,HHS Region 1,3 wk ahead,3.6
+2015,1,2014/2015,54,HHS Region 1,4 wk ahead,3.6
+2015,1,2014/2015,54,HHS Region 2,Season onset,45
+2015,1,2014/2015,54,HHS Region 2,Season peak week,52
+2015,1,2014/2015,54,HHS Region 2,Season peak week,4
+2015,1,2014/2015,54,HHS Region 2,Season peak week,5
+2015,1,2014/2015,54,HHS Region 2,Season peak percentage,5.2
+2015,1,2014/2015,54,HHS Region 2,1 wk ahead,4.6
+2015,1,2014/2015,54,HHS Region 2,2 wk ahead,5
+2015,1,2014/2015,54,HHS Region 2,3 wk ahead,5.2
+2015,1,2014/2015,54,HHS Region 2,4 wk ahead,5.2
+2015,1,2014/2015,54,HHS Region 3,Season onset,48
+2015,1,2014/2015,54,HHS Region 3,Season peak week,52
+2015,1,2014/2015,54,HHS Region 3,Season peak percentage,7.2
+2015,1,2014/2015,54,HHS Region 3,1 wk ahead,4.1
+2015,1,2014/2015,54,HHS Region 3,2 wk ahead,4.5
+2015,1,2014/2015,54,HHS Region 3,3 wk ahead,4.2
+2015,1,2014/2015,54,HHS Region 3,4 wk ahead,3.5
+2015,1,2014/2015,54,HHS Region 4,Season onset,47
+2015,1,2014/2015,54,HHS Region 4,Season peak week,52
+2015,1,2014/2015,54,HHS Region 4,Season peak percentage,7.5
+2015,1,2014/2015,54,HHS Region 4,1 wk ahead,3
+2015,1,2014/2015,54,HHS Region 4,2 wk ahead,3.1
+2015,1,2014/2015,54,HHS Region 4,3 wk ahead,2.8
+2015,1,2014/2015,54,HHS Region 4,4 wk ahead,2.6
+2015,1,2014/2015,54,HHS Region 5,Season onset,48
+2015,1,2014/2015,54,HHS Region 5,Season peak week,52
+2015,1,2014/2015,54,HHS Region 5,Season peak percentage,6.6
+2015,1,2014/2015,54,HHS Region 5,1 wk ahead,2.6
+2015,1,2014/2015,54,HHS Region 5,2 wk ahead,2.3
+2015,1,2014/2015,54,HHS Region 5,3 wk ahead,1.9
+2015,1,2014/2015,54,HHS Region 5,4 wk ahead,1.9
+2015,1,2014/2015,54,HHS Region 6,Season onset,47
+2015,1,2014/2015,54,HHS Region 6,Season peak week,51
+2015,1,2014/2015,54,HHS Region 6,Season peak percentage,11.1
+2015,1,2014/2015,54,HHS Region 6,1 wk ahead,9.4
+2015,1,2014/2015,54,HHS Region 6,2 wk ahead,7.7
+2015,1,2014/2015,54,HHS Region 6,3 wk ahead,6.7
+2015,1,2014/2015,54,HHS Region 6,4 wk ahead,6.3
+2015,1,2014/2015,54,HHS Region 7,Season onset,48
+2015,1,2014/2015,54,HHS Region 7,Season peak week,52
+2015,1,2014/2015,54,HHS Region 7,Season peak percentage,6.4
+2015,1,2014/2015,54,HHS Region 7,1 wk ahead,3.6
+2015,1,2014/2015,54,HHS Region 7,2 wk ahead,4.2
+2015,1,2014/2015,54,HHS Region 7,3 wk ahead,4.2
+2015,1,2014/2015,54,HHS Region 7,4 wk ahead,3.2
+2015,1,2014/2015,54,HHS Region 8,Season onset,49
+2015,1,2014/2015,54,HHS Region 8,Season peak week,53
+2015,1,2014/2015,54,HHS Region 8,Season peak percentage,4.4
+2015,1,2014/2015,54,HHS Region 8,1 wk ahead,3.3
+2015,1,2014/2015,54,HHS Region 8,2 wk ahead,3.2
+2015,1,2014/2015,54,HHS Region 8,3 wk ahead,3
+2015,1,2014/2015,54,HHS Region 8,4 wk ahead,2.8
+2015,1,2014/2015,54,HHS Region 9,Season onset,51
+2015,1,2014/2015,54,HHS Region 9,Season peak week,3
+2015,1,2014/2015,54,HHS Region 9,Season peak week,4
+2015,1,2014/2015,54,HHS Region 9,Season peak percentage,5
+2015,1,2014/2015,54,HHS Region 9,1 wk ahead,4.4
+2015,1,2014/2015,54,HHS Region 9,2 wk ahead,5
+2015,1,2014/2015,54,HHS Region 9,3 wk ahead,5
+2015,1,2014/2015,54,HHS Region 9,4 wk ahead,4.4
+2015,1,2014/2015,54,HHS Region 10,Season onset,48
+2015,1,2014/2015,54,HHS Region 10,Season peak week,2
+2015,1,2014/2015,54,HHS Region 10,Season peak percentage,3.6
+2015,1,2014/2015,54,HHS Region 10,1 wk ahead,3.6
+2015,1,2014/2015,54,HHS Region 10,2 wk ahead,3.4
+2015,1,2014/2015,54,HHS Region 10,3 wk ahead,2.8
+2015,1,2014/2015,54,HHS Region 10,4 wk ahead,2.2
+2015,2,2014/2015,55,US National,Season onset,47
+2015,2,2014/2015,55,US National,Season peak week,52
+2015,2,2014/2015,55,US National,Season peak percentage,6
+2015,2,2014/2015,55,US National,1 wk ahead,4.3
+2015,2,2014/2015,55,US National,2 wk ahead,4
+2015,2,2014/2015,55,US National,3 wk ahead,3.6
+2015,2,2014/2015,55,US National,4 wk ahead,3.3
+2015,2,2014/2015,55,HHS Region 1,Season onset,50
+2015,2,2014/2015,55,HHS Region 1,Season peak week,3
+2015,2,2014/2015,55,HHS Region 1,Season peak percentage,3.9
+2015,2,2014/2015,55,HHS Region 1,1 wk ahead,3.9
+2015,2,2014/2015,55,HHS Region 1,2 wk ahead,3.6
+2015,2,2014/2015,55,HHS Region 1,3 wk ahead,3.6
+2015,2,2014/2015,55,HHS Region 1,4 wk ahead,3.3
+2015,2,2014/2015,55,HHS Region 2,Season onset,45
+2015,2,2014/2015,55,HHS Region 2,Season peak week,52
+2015,2,2014/2015,55,HHS Region 2,Season peak week,4
+2015,2,2014/2015,55,HHS Region 2,Season peak week,5
+2015,2,2014/2015,55,HHS Region 2,Season peak percentage,5.2
+2015,2,2014/2015,55,HHS Region 2,1 wk ahead,5
+2015,2,2014/2015,55,HHS Region 2,2 wk ahead,5.2
+2015,2,2014/2015,55,HHS Region 2,3 wk ahead,5.2
+2015,2,2014/2015,55,HHS Region 2,4 wk ahead,4.9
+2015,2,2014/2015,55,HHS Region 3,Season onset,48
+2015,2,2014/2015,55,HHS Region 3,Season peak week,52
+2015,2,2014/2015,55,HHS Region 3,Season peak percentage,7.2
+2015,2,2014/2015,55,HHS Region 3,1 wk ahead,4.5
+2015,2,2014/2015,55,HHS Region 3,2 wk ahead,4.2
+2015,2,2014/2015,55,HHS Region 3,3 wk ahead,3.5
+2015,2,2014/2015,55,HHS Region 3,4 wk ahead,2.6
+2015,2,2014/2015,55,HHS Region 4,Season onset,47
+2015,2,2014/2015,55,HHS Region 4,Season peak week,52
+2015,2,2014/2015,55,HHS Region 4,Season peak percentage,7.5
+2015,2,2014/2015,55,HHS Region 4,1 wk ahead,3.1
+2015,2,2014/2015,55,HHS Region 4,2 wk ahead,2.8
+2015,2,2014/2015,55,HHS Region 4,3 wk ahead,2.6
+2015,2,2014/2015,55,HHS Region 4,4 wk ahead,2.4
+2015,2,2014/2015,55,HHS Region 5,Season onset,48
+2015,2,2014/2015,55,HHS Region 5,Season peak week,52
+2015,2,2014/2015,55,HHS Region 5,Season peak percentage,6.6
+2015,2,2014/2015,55,HHS Region 5,1 wk ahead,2.3
+2015,2,2014/2015,55,HHS Region 5,2 wk ahead,1.9
+2015,2,2014/2015,55,HHS Region 5,3 wk ahead,1.9
+2015,2,2014/2015,55,HHS Region 5,4 wk ahead,1.9
+2015,2,2014/2015,55,HHS Region 6,Season onset,47
+2015,2,2014/2015,55,HHS Region 6,Season peak week,51
+2015,2,2014/2015,55,HHS Region 6,Season peak percentage,11.1
+2015,2,2014/2015,55,HHS Region 6,1 wk ahead,7.7
+2015,2,2014/2015,55,HHS Region 6,2 wk ahead,6.7
+2015,2,2014/2015,55,HHS Region 6,3 wk ahead,6.3
+2015,2,2014/2015,55,HHS Region 6,4 wk ahead,5.9
+2015,2,2014/2015,55,HHS Region 7,Season onset,48
+2015,2,2014/2015,55,HHS Region 7,Season peak week,52
+2015,2,2014/2015,55,HHS Region 7,Season peak percentage,6.4
+2015,2,2014/2015,55,HHS Region 7,1 wk ahead,4.2
+2015,2,2014/2015,55,HHS Region 7,2 wk ahead,4.2
+2015,2,2014/2015,55,HHS Region 7,3 wk ahead,3.2
+2015,2,2014/2015,55,HHS Region 7,4 wk ahead,2.7
+2015,2,2014/2015,55,HHS Region 8,Season onset,49
+2015,2,2014/2015,55,HHS Region 8,Season peak week,53
+2015,2,2014/2015,55,HHS Region 8,Season peak percentage,4.4
+2015,2,2014/2015,55,HHS Region 8,1 wk ahead,3.2
+2015,2,2014/2015,55,HHS Region 8,2 wk ahead,3
+2015,2,2014/2015,55,HHS Region 8,3 wk ahead,2.8
+2015,2,2014/2015,55,HHS Region 8,4 wk ahead,2.1
+2015,2,2014/2015,55,HHS Region 9,Season onset,51
+2015,2,2014/2015,55,HHS Region 9,Season peak week,3
+2015,2,2014/2015,55,HHS Region 9,Season peak week,4
+2015,2,2014/2015,55,HHS Region 9,Season peak percentage,5
+2015,2,2014/2015,55,HHS Region 9,1 wk ahead,5
+2015,2,2014/2015,55,HHS Region 9,2 wk ahead,5
+2015,2,2014/2015,55,HHS Region 9,3 wk ahead,4.4
+2015,2,2014/2015,55,HHS Region 9,4 wk ahead,3.9
+2015,2,2014/2015,55,HHS Region 10,Season onset,48
+2015,2,2014/2015,55,HHS Region 10,Season peak week,2
+2015,2,2014/2015,55,HHS Region 10,Season peak percentage,3.6
+2015,2,2014/2015,55,HHS Region 10,1 wk ahead,3.4
+2015,2,2014/2015,55,HHS Region 10,2 wk ahead,2.8
+2015,2,2014/2015,55,HHS Region 10,3 wk ahead,2.2
+2015,2,2014/2015,55,HHS Region 10,4 wk ahead,1.8
+2015,3,2014/2015,56,US National,Season onset,47
+2015,3,2014/2015,56,US National,Season peak week,52
+2015,3,2014/2015,56,US National,Season peak percentage,6
+2015,3,2014/2015,56,US National,1 wk ahead,4
+2015,3,2014/2015,56,US National,2 wk ahead,3.6
+2015,3,2014/2015,56,US National,3 wk ahead,3.3
+2015,3,2014/2015,56,US National,4 wk ahead,3
+2015,3,2014/2015,56,HHS Region 1,Season onset,50
+2015,3,2014/2015,56,HHS Region 1,Season peak week,3
+2015,3,2014/2015,56,HHS Region 1,Season peak percentage,3.9
+2015,3,2014/2015,56,HHS Region 1,1 wk ahead,3.6
+2015,3,2014/2015,56,HHS Region 1,2 wk ahead,3.6
+2015,3,2014/2015,56,HHS Region 1,3 wk ahead,3.3
+2015,3,2014/2015,56,HHS Region 1,4 wk ahead,2.9
+2015,3,2014/2015,56,HHS Region 2,Season onset,45
+2015,3,2014/2015,56,HHS Region 2,Season peak week,52
+2015,3,2014/2015,56,HHS Region 2,Season peak week,4
+2015,3,2014/2015,56,HHS Region 2,Season peak week,5
+2015,3,2014/2015,56,HHS Region 2,Season peak percentage,5.2
+2015,3,2014/2015,56,HHS Region 2,1 wk ahead,5.2
+2015,3,2014/2015,56,HHS Region 2,2 wk ahead,5.2
+2015,3,2014/2015,56,HHS Region 2,3 wk ahead,4.9
+2015,3,2014/2015,56,HHS Region 2,4 wk ahead,3.7
+2015,3,2014/2015,56,HHS Region 3,Season onset,48
+2015,3,2014/2015,56,HHS Region 3,Season peak week,52
+2015,3,2014/2015,56,HHS Region 3,Season peak percentage,7.2
+2015,3,2014/2015,56,HHS Region 3,1 wk ahead,4.2
+2015,3,2014/2015,56,HHS Region 3,2 wk ahead,3.5
+2015,3,2014/2015,56,HHS Region 3,3 wk ahead,2.6
+2015,3,2014/2015,56,HHS Region 3,4 wk ahead,2.5
+2015,3,2014/2015,56,HHS Region 4,Season onset,47
+2015,3,2014/2015,56,HHS Region 4,Season peak week,52
+2015,3,2014/2015,56,HHS Region 4,Season peak percentage,7.5
+2015,3,2014/2015,56,HHS Region 4,1 wk ahead,2.8
+2015,3,2014/2015,56,HHS Region 4,2 wk ahead,2.6
+2015,3,2014/2015,56,HHS Region 4,3 wk ahead,2.4
+2015,3,2014/2015,56,HHS Region 4,4 wk ahead,2.6
+2015,3,2014/2015,56,HHS Region 5,Season onset,48
+2015,3,2014/2015,56,HHS Region 5,Season peak week,52
+2015,3,2014/2015,56,HHS Region 5,Season peak percentage,6.6
+2015,3,2014/2015,56,HHS Region 5,1 wk ahead,1.9
+2015,3,2014/2015,56,HHS Region 5,2 wk ahead,1.9
+2015,3,2014/2015,56,HHS Region 5,3 wk ahead,1.9
+2015,3,2014/2015,56,HHS Region 5,4 wk ahead,1.8
+2015,3,2014/2015,56,HHS Region 6,Season onset,47
+2015,3,2014/2015,56,HHS Region 6,Season peak week,51
+2015,3,2014/2015,56,HHS Region 6,Season peak percentage,11.1
+2015,3,2014/2015,56,HHS Region 6,1 wk ahead,6.7
+2015,3,2014/2015,56,HHS Region 6,2 wk ahead,6.3
+2015,3,2014/2015,56,HHS Region 6,3 wk ahead,5.9
+2015,3,2014/2015,56,HHS Region 6,4 wk ahead,5.4
+2015,3,2014/2015,56,HHS Region 7,Season onset,48
+2015,3,2014/2015,56,HHS Region 7,Season peak week,52
+2015,3,2014/2015,56,HHS Region 7,Season peak percentage,6.4
+2015,3,2014/2015,56,HHS Region 7,1 wk ahead,4.2
+2015,3,2014/2015,56,HHS Region 7,2 wk ahead,3.2
+2015,3,2014/2015,56,HHS Region 7,3 wk ahead,2.7
+2015,3,2014/2015,56,HHS Region 7,4 wk ahead,2.4
+2015,3,2014/2015,56,HHS Region 8,Season onset,49
+2015,3,2014/2015,56,HHS Region 8,Season peak week,53
+2015,3,2014/2015,56,HHS Region 8,Season peak percentage,4.4
+2015,3,2014/2015,56,HHS Region 8,1 wk ahead,3
+2015,3,2014/2015,56,HHS Region 8,2 wk ahead,2.8
+2015,3,2014/2015,56,HHS Region 8,3 wk ahead,2.1
+2015,3,2014/2015,56,HHS Region 8,4 wk ahead,2
+2015,3,2014/2015,56,HHS Region 9,Season onset,51
+2015,3,2014/2015,56,HHS Region 9,Season peak week,3
+2015,3,2014/2015,56,HHS Region 9,Season peak week,4
+2015,3,2014/2015,56,HHS Region 9,Season peak percentage,5
+2015,3,2014/2015,56,HHS Region 9,1 wk ahead,5
+2015,3,2014/2015,56,HHS Region 9,2 wk ahead,4.4
+2015,3,2014/2015,56,HHS Region 9,3 wk ahead,3.9
+2015,3,2014/2015,56,HHS Region 9,4 wk ahead,3.4
+2015,3,2014/2015,56,HHS Region 10,Season onset,48
+2015,3,2014/2015,56,HHS Region 10,Season peak week,2
+2015,3,2014/2015,56,HHS Region 10,Season peak percentage,3.6
+2015,3,2014/2015,56,HHS Region 10,1 wk ahead,2.8
+2015,3,2014/2015,56,HHS Region 10,2 wk ahead,2.2
+2015,3,2014/2015,56,HHS Region 10,3 wk ahead,1.8
+2015,3,2014/2015,56,HHS Region 10,4 wk ahead,1.2
+2015,4,2014/2015,57,US National,Season onset,47
+2015,4,2014/2015,57,US National,Season peak week,52
+2015,4,2014/2015,57,US National,Season peak percentage,6
+2015,4,2014/2015,57,US National,1 wk ahead,3.6
+2015,4,2014/2015,57,US National,2 wk ahead,3.3
+2015,4,2014/2015,57,US National,3 wk ahead,3
+2015,4,2014/2015,57,US National,4 wk ahead,2.6
+2015,4,2014/2015,57,HHS Region 1,Season onset,50
+2015,4,2014/2015,57,HHS Region 1,Season peak week,3
+2015,4,2014/2015,57,HHS Region 1,Season peak percentage,3.9
+2015,4,2014/2015,57,HHS Region 1,1 wk ahead,3.6
+2015,4,2014/2015,57,HHS Region 1,2 wk ahead,3.3
+2015,4,2014/2015,57,HHS Region 1,3 wk ahead,2.9
+2015,4,2014/2015,57,HHS Region 1,4 wk ahead,1.9
+2015,4,2014/2015,57,HHS Region 2,Season onset,45
+2015,4,2014/2015,57,HHS Region 2,Season peak week,52
+2015,4,2014/2015,57,HHS Region 2,Season peak week,4
+2015,4,2014/2015,57,HHS Region 2,Season peak week,5
+2015,4,2014/2015,57,HHS Region 2,Season peak percentage,5.2
+2015,4,2014/2015,57,HHS Region 2,1 wk ahead,5.2
+2015,4,2014/2015,57,HHS Region 2,2 wk ahead,4.9
+2015,4,2014/2015,57,HHS Region 2,3 wk ahead,3.7
+2015,4,2014/2015,57,HHS Region 2,4 wk ahead,3.4
+2015,4,2014/2015,57,HHS Region 3,Season onset,48
+2015,4,2014/2015,57,HHS Region 3,Season peak week,52
+2015,4,2014/2015,57,HHS Region 3,Season peak percentage,7.2
+2015,4,2014/2015,57,HHS Region 3,1 wk ahead,3.5
+2015,4,2014/2015,57,HHS Region 3,2 wk ahead,2.6
+2015,4,2014/2015,57,HHS Region 3,3 wk ahead,2.5
+2015,4,2014/2015,57,HHS Region 3,4 wk ahead,1.8
+2015,4,2014/2015,57,HHS Region 4,Season onset,47
+2015,4,2014/2015,57,HHS Region 4,Season peak week,52
+2015,4,2014/2015,57,HHS Region 4,Season peak percentage,7.5
+2015,4,2014/2015,57,HHS Region 4,1 wk ahead,2.6
+2015,4,2014/2015,57,HHS Region 4,2 wk ahead,2.4
+2015,4,2014/2015,57,HHS Region 4,3 wk ahead,2.6
+2015,4,2014/2015,57,HHS Region 4,4 wk ahead,2.3
+2015,4,2014/2015,57,HHS Region 5,Season onset,48
+2015,4,2014/2015,57,HHS Region 5,Season peak week,52
+2015,4,2014/2015,57,HHS Region 5,Season peak percentage,6.6
+2015,4,2014/2015,57,HHS Region 5,1 wk ahead,1.9
+2015,4,2014/2015,57,HHS Region 5,2 wk ahead,1.9
+2015,4,2014/2015,57,HHS Region 5,3 wk ahead,1.8
+2015,4,2014/2015,57,HHS Region 5,4 wk ahead,1.6
+2015,4,2014/2015,57,HHS Region 6,Season onset,47
+2015,4,2014/2015,57,HHS Region 6,Season peak week,51
+2015,4,2014/2015,57,HHS Region 6,Season peak percentage,11.1
+2015,4,2014/2015,57,HHS Region 6,1 wk ahead,6.3
+2015,4,2014/2015,57,HHS Region 6,2 wk ahead,5.9
+2015,4,2014/2015,57,HHS Region 6,3 wk ahead,5.4
+2015,4,2014/2015,57,HHS Region 6,4 wk ahead,4.7
+2015,4,2014/2015,57,HHS Region 7,Season onset,48
+2015,4,2014/2015,57,HHS Region 7,Season peak week,52
+2015,4,2014/2015,57,HHS Region 7,Season peak percentage,6.4
+2015,4,2014/2015,57,HHS Region 7,1 wk ahead,3.2
+2015,4,2014/2015,57,HHS Region 7,2 wk ahead,2.7
+2015,4,2014/2015,57,HHS Region 7,3 wk ahead,2.4
+2015,4,2014/2015,57,HHS Region 7,4 wk ahead,2.4
+2015,4,2014/2015,57,HHS Region 8,Season onset,49
+2015,4,2014/2015,57,HHS Region 8,Season peak week,53
+2015,4,2014/2015,57,HHS Region 8,Season peak percentage,4.4
+2015,4,2014/2015,57,HHS Region 8,1 wk ahead,2.8
+2015,4,2014/2015,57,HHS Region 8,2 wk ahead,2.1
+2015,4,2014/2015,57,HHS Region 8,3 wk ahead,2
+2015,4,2014/2015,57,HHS Region 8,4 wk ahead,1.5
+2015,4,2014/2015,57,HHS Region 9,Season onset,51
+2015,4,2014/2015,57,HHS Region 9,Season peak week,3
+2015,4,2014/2015,57,HHS Region 9,Season peak week,4
+2015,4,2014/2015,57,HHS Region 9,Season peak percentage,5
+2015,4,2014/2015,57,HHS Region 9,1 wk ahead,4.4
+2015,4,2014/2015,57,HHS Region 9,2 wk ahead,3.9
+2015,4,2014/2015,57,HHS Region 9,3 wk ahead,3.4
+2015,4,2014/2015,57,HHS Region 9,4 wk ahead,3.1
+2015,4,2014/2015,57,HHS Region 10,Season onset,48
+2015,4,2014/2015,57,HHS Region 10,Season peak week,2
+2015,4,2014/2015,57,HHS Region 10,Season peak percentage,3.6
+2015,4,2014/2015,57,HHS Region 10,1 wk ahead,2.2
+2015,4,2014/2015,57,HHS Region 10,2 wk ahead,1.8
+2015,4,2014/2015,57,HHS Region 10,3 wk ahead,1.2
+2015,4,2014/2015,57,HHS Region 10,4 wk ahead,1.1
+2015,5,2014/2015,58,US National,Season onset,47
+2015,5,2014/2015,58,US National,Season peak week,52
+2015,5,2014/2015,58,US National,Season peak percentage,6
+2015,5,2014/2015,58,US National,1 wk ahead,3.3
+2015,5,2014/2015,58,US National,2 wk ahead,3
+2015,5,2014/2015,58,US National,3 wk ahead,2.6
+2015,5,2014/2015,58,US National,4 wk ahead,2.5
+2015,5,2014/2015,58,HHS Region 1,Season onset,50
+2015,5,2014/2015,58,HHS Region 1,Season peak week,3
+2015,5,2014/2015,58,HHS Region 1,Season peak percentage,3.9
+2015,5,2014/2015,58,HHS Region 1,1 wk ahead,3.3
+2015,5,2014/2015,58,HHS Region 1,2 wk ahead,2.9
+2015,5,2014/2015,58,HHS Region 1,3 wk ahead,1.9
+2015,5,2014/2015,58,HHS Region 1,4 wk ahead,1.8
+2015,5,2014/2015,58,HHS Region 2,Season onset,45
+2015,5,2014/2015,58,HHS Region 2,Season peak week,52
+2015,5,2014/2015,58,HHS Region 2,Season peak week,4
+2015,5,2014/2015,58,HHS Region 2,Season peak week,5
+2015,5,2014/2015,58,HHS Region 2,Season peak percentage,5.2
+2015,5,2014/2015,58,HHS Region 2,1 wk ahead,4.9
+2015,5,2014/2015,58,HHS Region 2,2 wk ahead,3.7
+2015,5,2014/2015,58,HHS Region 2,3 wk ahead,3.4
+2015,5,2014/2015,58,HHS Region 2,4 wk ahead,2.8
+2015,5,2014/2015,58,HHS Region 3,Season onset,48
+2015,5,2014/2015,58,HHS Region 3,Season peak week,52
+2015,5,2014/2015,58,HHS Region 3,Season peak percentage,7.2
+2015,5,2014/2015,58,HHS Region 3,1 wk ahead,2.6
+2015,5,2014/2015,58,HHS Region 3,2 wk ahead,2.5
+2015,5,2014/2015,58,HHS Region 3,3 wk ahead,1.8
+2015,5,2014/2015,58,HHS Region 3,4 wk ahead,2.1
+2015,5,2014/2015,58,HHS Region 4,Season onset,47
+2015,5,2014/2015,58,HHS Region 4,Season peak week,52
+2015,5,2014/2015,58,HHS Region 4,Season peak percentage,7.5
+2015,5,2014/2015,58,HHS Region 4,1 wk ahead,2.4
+2015,5,2014/2015,58,HHS Region 4,2 wk ahead,2.6
+2015,5,2014/2015,58,HHS Region 4,3 wk ahead,2.3
+2015,5,2014/2015,58,HHS Region 4,4 wk ahead,2.3
+2015,5,2014/2015,58,HHS Region 5,Season onset,48
+2015,5,2014/2015,58,HHS Region 5,Season peak week,52
+2015,5,2014/2015,58,HHS Region 5,Season peak percentage,6.6
+2015,5,2014/2015,58,HHS Region 5,1 wk ahead,1.9
+2015,5,2014/2015,58,HHS Region 5,2 wk ahead,1.8
+2015,5,2014/2015,58,HHS Region 5,3 wk ahead,1.6
+2015,5,2014/2015,58,HHS Region 5,4 wk ahead,1.8
+2015,5,2014/2015,58,HHS Region 6,Season onset,47
+2015,5,2014/2015,58,HHS Region 6,Season peak week,51
+2015,5,2014/2015,58,HHS Region 6,Season peak percentage,11.1
+2015,5,2014/2015,58,HHS Region 6,1 wk ahead,5.9
+2015,5,2014/2015,58,HHS Region 6,2 wk ahead,5.4
+2015,5,2014/2015,58,HHS Region 6,3 wk ahead,4.7
+2015,5,2014/2015,58,HHS Region 6,4 wk ahead,4.6
+2015,5,2014/2015,58,HHS Region 7,Season onset,48
+2015,5,2014/2015,58,HHS Region 7,Season peak week,52
+2015,5,2014/2015,58,HHS Region 7,Season peak percentage,6.4
+2015,5,2014/2015,58,HHS Region 7,1 wk ahead,2.7
+2015,5,2014/2015,58,HHS Region 7,2 wk ahead,2.4
+2015,5,2014/2015,58,HHS Region 7,3 wk ahead,2.4
+2015,5,2014/2015,58,HHS Region 7,4 wk ahead,2.3
+2015,5,2014/2015,58,HHS Region 8,Season onset,49
+2015,5,2014/2015,58,HHS Region 8,Season peak week,53
+2015,5,2014/2015,58,HHS Region 8,Season peak percentage,4.4
+2015,5,2014/2015,58,HHS Region 8,1 wk ahead,2.1
+2015,5,2014/2015,58,HHS Region 8,2 wk ahead,2
+2015,5,2014/2015,58,HHS Region 8,3 wk ahead,1.5
+2015,5,2014/2015,58,HHS Region 8,4 wk ahead,1.5
+2015,5,2014/2015,58,HHS Region 9,Season onset,51
+2015,5,2014/2015,58,HHS Region 9,Season peak week,3
+2015,5,2014/2015,58,HHS Region 9,Season peak week,4
+2015,5,2014/2015,58,HHS Region 9,Season peak percentage,5
+2015,5,2014/2015,58,HHS Region 9,1 wk ahead,3.9
+2015,5,2014/2015,58,HHS Region 9,2 wk ahead,3.4
+2015,5,2014/2015,58,HHS Region 9,3 wk ahead,3.1
+2015,5,2014/2015,58,HHS Region 9,4 wk ahead,2.9
+2015,5,2014/2015,58,HHS Region 10,Season onset,48
+2015,5,2014/2015,58,HHS Region 10,Season peak week,2
+2015,5,2014/2015,58,HHS Region 10,Season peak percentage,3.6
+2015,5,2014/2015,58,HHS Region 10,1 wk ahead,1.8
+2015,5,2014/2015,58,HHS Region 10,2 wk ahead,1.2
+2015,5,2014/2015,58,HHS Region 10,3 wk ahead,1.1
+2015,5,2014/2015,58,HHS Region 10,4 wk ahead,1.1
+2015,6,2014/2015,59,US National,Season onset,47
+2015,6,2014/2015,59,US National,Season peak week,52
+2015,6,2014/2015,59,US National,Season peak percentage,6
+2015,6,2014/2015,59,US National,1 wk ahead,3
+2015,6,2014/2015,59,US National,2 wk ahead,2.6
+2015,6,2014/2015,59,US National,3 wk ahead,2.5
+2015,6,2014/2015,59,US National,4 wk ahead,2.4
+2015,6,2014/2015,59,HHS Region 1,Season onset,50
+2015,6,2014/2015,59,HHS Region 1,Season peak week,3
+2015,6,2014/2015,59,HHS Region 1,Season peak percentage,3.9
+2015,6,2014/2015,59,HHS Region 1,1 wk ahead,2.9
+2015,6,2014/2015,59,HHS Region 1,2 wk ahead,1.9
+2015,6,2014/2015,59,HHS Region 1,3 wk ahead,1.8
+2015,6,2014/2015,59,HHS Region 1,4 wk ahead,1.7
+2015,6,2014/2015,59,HHS Region 2,Season onset,45
+2015,6,2014/2015,59,HHS Region 2,Season peak week,52
+2015,6,2014/2015,59,HHS Region 2,Season peak week,4
+2015,6,2014/2015,59,HHS Region 2,Season peak week,5
+2015,6,2014/2015,59,HHS Region 2,Season peak percentage,5.2
+2015,6,2014/2015,59,HHS Region 2,1 wk ahead,3.7
+2015,6,2014/2015,59,HHS Region 2,2 wk ahead,3.4
+2015,6,2014/2015,59,HHS Region 2,3 wk ahead,2.8
+2015,6,2014/2015,59,HHS Region 2,4 wk ahead,2.5
+2015,6,2014/2015,59,HHS Region 3,Season onset,48
+2015,6,2014/2015,59,HHS Region 3,Season peak week,52
+2015,6,2014/2015,59,HHS Region 3,Season peak percentage,7.2
+2015,6,2014/2015,59,HHS Region 3,1 wk ahead,2.5
+2015,6,2014/2015,59,HHS Region 3,2 wk ahead,1.8
+2015,6,2014/2015,59,HHS Region 3,3 wk ahead,2.1
+2015,6,2014/2015,59,HHS Region 3,4 wk ahead,1.7
+2015,6,2014/2015,59,HHS Region 4,Season onset,47
+2015,6,2014/2015,59,HHS Region 4,Season peak week,52
+2015,6,2014/2015,59,HHS Region 4,Season peak percentage,7.5
+2015,6,2014/2015,59,HHS Region 4,1 wk ahead,2.6
+2015,6,2014/2015,59,HHS Region 4,2 wk ahead,2.3
+2015,6,2014/2015,59,HHS Region 4,3 wk ahead,2.3
+2015,6,2014/2015,59,HHS Region 4,4 wk ahead,1.9
+2015,6,2014/2015,59,HHS Region 5,Season onset,48
+2015,6,2014/2015,59,HHS Region 5,Season peak week,52
+2015,6,2014/2015,59,HHS Region 5,Season peak percentage,6.6
+2015,6,2014/2015,59,HHS Region 5,1 wk ahead,1.8
+2015,6,2014/2015,59,HHS Region 5,2 wk ahead,1.6
+2015,6,2014/2015,59,HHS Region 5,3 wk ahead,1.8
+2015,6,2014/2015,59,HHS Region 5,4 wk ahead,1.8
+2015,6,2014/2015,59,HHS Region 6,Season onset,47
+2015,6,2014/2015,59,HHS Region 6,Season peak week,51
+2015,6,2014/2015,59,HHS Region 6,Season peak percentage,11.1
+2015,6,2014/2015,59,HHS Region 6,1 wk ahead,5.4
+2015,6,2014/2015,59,HHS Region 6,2 wk ahead,4.7
+2015,6,2014/2015,59,HHS Region 6,3 wk ahead,4.6
+2015,6,2014/2015,59,HHS Region 6,4 wk ahead,4.7
+2015,6,2014/2015,59,HHS Region 7,Season onset,48
+2015,6,2014/2015,59,HHS Region 7,Season peak week,52
+2015,6,2014/2015,59,HHS Region 7,Season peak percentage,6.4
+2015,6,2014/2015,59,HHS Region 7,1 wk ahead,2.4
+2015,6,2014/2015,59,HHS Region 7,2 wk ahead,2.4
+2015,6,2014/2015,59,HHS Region 7,3 wk ahead,2.3
+2015,6,2014/2015,59,HHS Region 7,4 wk ahead,2.4
+2015,6,2014/2015,59,HHS Region 8,Season onset,49
+2015,6,2014/2015,59,HHS Region 8,Season peak week,53
+2015,6,2014/2015,59,HHS Region 8,Season peak percentage,4.4
+2015,6,2014/2015,59,HHS Region 8,1 wk ahead,2
+2015,6,2014/2015,59,HHS Region 8,2 wk ahead,1.5
+2015,6,2014/2015,59,HHS Region 8,3 wk ahead,1.5
+2015,6,2014/2015,59,HHS Region 8,4 wk ahead,1.5
+2015,6,2014/2015,59,HHS Region 9,Season onset,51
+2015,6,2014/2015,59,HHS Region 9,Season peak week,3
+2015,6,2014/2015,59,HHS Region 9,Season peak week,4
+2015,6,2014/2015,59,HHS Region 9,Season peak percentage,5
+2015,6,2014/2015,59,HHS Region 9,1 wk ahead,3.4
+2015,6,2014/2015,59,HHS Region 9,2 wk ahead,3.1
+2015,6,2014/2015,59,HHS Region 9,3 wk ahead,2.9
+2015,6,2014/2015,59,HHS Region 9,4 wk ahead,3
+2015,6,2014/2015,59,HHS Region 10,Season onset,48
+2015,6,2014/2015,59,HHS Region 10,Season peak week,2
+2015,6,2014/2015,59,HHS Region 10,Season peak percentage,3.6
+2015,6,2014/2015,59,HHS Region 10,1 wk ahead,1.2
+2015,6,2014/2015,59,HHS Region 10,2 wk ahead,1.1
+2015,6,2014/2015,59,HHS Region 10,3 wk ahead,1.1
+2015,6,2014/2015,59,HHS Region 10,4 wk ahead,1.2
+2015,7,2014/2015,60,US National,Season onset,47
+2015,7,2014/2015,60,US National,Season peak week,52
+2015,7,2014/2015,60,US National,Season peak percentage,6
+2015,7,2014/2015,60,US National,1 wk ahead,2.6
+2015,7,2014/2015,60,US National,2 wk ahead,2.5
+2015,7,2014/2015,60,US National,3 wk ahead,2.4
+2015,7,2014/2015,60,US National,4 wk ahead,2.2
+2015,7,2014/2015,60,HHS Region 1,Season onset,50
+2015,7,2014/2015,60,HHS Region 1,Season peak week,3
+2015,7,2014/2015,60,HHS Region 1,Season peak percentage,3.9
+2015,7,2014/2015,60,HHS Region 1,1 wk ahead,1.9
+2015,7,2014/2015,60,HHS Region 1,2 wk ahead,1.8
+2015,7,2014/2015,60,HHS Region 1,3 wk ahead,1.7
+2015,7,2014/2015,60,HHS Region 1,4 wk ahead,1.5
+2015,7,2014/2015,60,HHS Region 2,Season onset,45
+2015,7,2014/2015,60,HHS Region 2,Season peak week,52
+2015,7,2014/2015,60,HHS Region 2,Season peak week,4
+2015,7,2014/2015,60,HHS Region 2,Season peak week,5
+2015,7,2014/2015,60,HHS Region 2,Season peak percentage,5.2
+2015,7,2014/2015,60,HHS Region 2,1 wk ahead,3.4
+2015,7,2014/2015,60,HHS Region 2,2 wk ahead,2.8
+2015,7,2014/2015,60,HHS Region 2,3 wk ahead,2.5
+2015,7,2014/2015,60,HHS Region 2,4 wk ahead,2.8
+2015,7,2014/2015,60,HHS Region 3,Season onset,48
+2015,7,2014/2015,60,HHS Region 3,Season peak week,52
+2015,7,2014/2015,60,HHS Region 3,Season peak percentage,7.2
+2015,7,2014/2015,60,HHS Region 3,1 wk ahead,1.8
+2015,7,2014/2015,60,HHS Region 3,2 wk ahead,2.1
+2015,7,2014/2015,60,HHS Region 3,3 wk ahead,1.7
+2015,7,2014/2015,60,HHS Region 3,4 wk ahead,1.6
+2015,7,2014/2015,60,HHS Region 4,Season onset,47
+2015,7,2014/2015,60,HHS Region 4,Season peak week,52
+2015,7,2014/2015,60,HHS Region 4,Season peak percentage,7.5
+2015,7,2014/2015,60,HHS Region 4,1 wk ahead,2.3
+2015,7,2014/2015,60,HHS Region 4,2 wk ahead,2.3
+2015,7,2014/2015,60,HHS Region 4,3 wk ahead,1.9
+2015,7,2014/2015,60,HHS Region 4,4 wk ahead,1.4
+2015,7,2014/2015,60,HHS Region 5,Season onset,48
+2015,7,2014/2015,60,HHS Region 5,Season peak week,52
+2015,7,2014/2015,60,HHS Region 5,Season peak percentage,6.6
+2015,7,2014/2015,60,HHS Region 5,1 wk ahead,1.6
+2015,7,2014/2015,60,HHS Region 5,2 wk ahead,1.8
+2015,7,2014/2015,60,HHS Region 5,3 wk ahead,1.8
+2015,7,2014/2015,60,HHS Region 5,4 wk ahead,1.9
+2015,7,2014/2015,60,HHS Region 6,Season onset,47
+2015,7,2014/2015,60,HHS Region 6,Season peak week,51
+2015,7,2014/2015,60,HHS Region 6,Season peak percentage,11.1
+2015,7,2014/2015,60,HHS Region 6,1 wk ahead,4.7
+2015,7,2014/2015,60,HHS Region 6,2 wk ahead,4.6
+2015,7,2014/2015,60,HHS Region 6,3 wk ahead,4.7
+2015,7,2014/2015,60,HHS Region 6,4 wk ahead,4
+2015,7,2014/2015,60,HHS Region 7,Season onset,48
+2015,7,2014/2015,60,HHS Region 7,Season peak week,52
+2015,7,2014/2015,60,HHS Region 7,Season peak percentage,6.4
+2015,7,2014/2015,60,HHS Region 7,1 wk ahead,2.4
+2015,7,2014/2015,60,HHS Region 7,2 wk ahead,2.3
+2015,7,2014/2015,60,HHS Region 7,3 wk ahead,2.4
+2015,7,2014/2015,60,HHS Region 7,4 wk ahead,2.1
+2015,7,2014/2015,60,HHS Region 8,Season onset,49
+2015,7,2014/2015,60,HHS Region 8,Season peak week,53
+2015,7,2014/2015,60,HHS Region 8,Season peak percentage,4.4
+2015,7,2014/2015,60,HHS Region 8,1 wk ahead,1.5
+2015,7,2014/2015,60,HHS Region 8,2 wk ahead,1.5
+2015,7,2014/2015,60,HHS Region 8,3 wk ahead,1.5
+2015,7,2014/2015,60,HHS Region 8,4 wk ahead,1.5
+2015,7,2014/2015,60,HHS Region 9,Season onset,51
+2015,7,2014/2015,60,HHS Region 9,Season peak week,3
+2015,7,2014/2015,60,HHS Region 9,Season peak week,4
+2015,7,2014/2015,60,HHS Region 9,Season peak percentage,5
+2015,7,2014/2015,60,HHS Region 9,1 wk ahead,3.1
+2015,7,2014/2015,60,HHS Region 9,2 wk ahead,2.9
+2015,7,2014/2015,60,HHS Region 9,3 wk ahead,3
+2015,7,2014/2015,60,HHS Region 9,4 wk ahead,2.7
+2015,7,2014/2015,60,HHS Region 10,Season onset,48
+2015,7,2014/2015,60,HHS Region 10,Season peak week,2
+2015,7,2014/2015,60,HHS Region 10,Season peak percentage,3.6
+2015,7,2014/2015,60,HHS Region 10,1 wk ahead,1.1
+2015,7,2014/2015,60,HHS Region 10,2 wk ahead,1.1
+2015,7,2014/2015,60,HHS Region 10,3 wk ahead,1.2
+2015,7,2014/2015,60,HHS Region 10,4 wk ahead,1.2
+2015,8,2014/2015,61,US National,Season onset,47
+2015,8,2014/2015,61,US National,Season peak week,52
+2015,8,2014/2015,61,US National,Season peak percentage,6
+2015,8,2014/2015,61,US National,1 wk ahead,2.5
+2015,8,2014/2015,61,US National,2 wk ahead,2.4
+2015,8,2014/2015,61,US National,3 wk ahead,2.2
+2015,8,2014/2015,61,US National,4 wk ahead,2.1
+2015,8,2014/2015,61,HHS Region 1,Season onset,50
+2015,8,2014/2015,61,HHS Region 1,Season peak week,3
+2015,8,2014/2015,61,HHS Region 1,Season peak percentage,3.9
+2015,8,2014/2015,61,HHS Region 1,1 wk ahead,1.8
+2015,8,2014/2015,61,HHS Region 1,2 wk ahead,1.7
+2015,8,2014/2015,61,HHS Region 1,3 wk ahead,1.5
+2015,8,2014/2015,61,HHS Region 1,4 wk ahead,1.5
+2015,8,2014/2015,61,HHS Region 2,Season onset,45
+2015,8,2014/2015,61,HHS Region 2,Season peak week,52
+2015,8,2014/2015,61,HHS Region 2,Season peak week,4
+2015,8,2014/2015,61,HHS Region 2,Season peak week,5
+2015,8,2014/2015,61,HHS Region 2,Season peak percentage,5.2
+2015,8,2014/2015,61,HHS Region 2,1 wk ahead,2.8
+2015,8,2014/2015,61,HHS Region 2,2 wk ahead,2.5
+2015,8,2014/2015,61,HHS Region 2,3 wk ahead,2.8
+2015,8,2014/2015,61,HHS Region 2,4 wk ahead,2.6
+2015,8,2014/2015,61,HHS Region 3,Season onset,48
+2015,8,2014/2015,61,HHS Region 3,Season peak week,52
+2015,8,2014/2015,61,HHS Region 3,Season peak percentage,7.2
+2015,8,2014/2015,61,HHS Region 3,1 wk ahead,2.1
+2015,8,2014/2015,61,HHS Region 3,2 wk ahead,1.7
+2015,8,2014/2015,61,HHS Region 3,3 wk ahead,1.6
+2015,8,2014/2015,61,HHS Region 3,4 wk ahead,1.8
+2015,8,2014/2015,61,HHS Region 4,Season onset,47
+2015,8,2014/2015,61,HHS Region 4,Season peak week,52
+2015,8,2014/2015,61,HHS Region 4,Season peak percentage,7.5
+2015,8,2014/2015,61,HHS Region 4,1 wk ahead,2.3
+2015,8,2014/2015,61,HHS Region 4,2 wk ahead,1.9
+2015,8,2014/2015,61,HHS Region 4,3 wk ahead,1.4
+2015,8,2014/2015,61,HHS Region 4,4 wk ahead,1.4
+2015,8,2014/2015,61,HHS Region 5,Season onset,48
+2015,8,2014/2015,61,HHS Region 5,Season peak week,52
+2015,8,2014/2015,61,HHS Region 5,Season peak percentage,6.6
+2015,8,2014/2015,61,HHS Region 5,1 wk ahead,1.8
+2015,8,2014/2015,61,HHS Region 5,2 wk ahead,1.8
+2015,8,2014/2015,61,HHS Region 5,3 wk ahead,1.9
+2015,8,2014/2015,61,HHS Region 5,4 wk ahead,2
+2015,8,2014/2015,61,HHS Region 6,Season onset,47
+2015,8,2014/2015,61,HHS Region 6,Season peak week,51
+2015,8,2014/2015,61,HHS Region 6,Season peak percentage,11.1
+2015,8,2014/2015,61,HHS Region 6,1 wk ahead,4.6
+2015,8,2014/2015,61,HHS Region 6,2 wk ahead,4.7
+2015,8,2014/2015,61,HHS Region 6,3 wk ahead,4
+2015,8,2014/2015,61,HHS Region 6,4 wk ahead,3.6
+2015,8,2014/2015,61,HHS Region 7,Season onset,48
+2015,8,2014/2015,61,HHS Region 7,Season peak week,52
+2015,8,2014/2015,61,HHS Region 7,Season peak percentage,6.4
+2015,8,2014/2015,61,HHS Region 7,1 wk ahead,2.3
+2015,8,2014/2015,61,HHS Region 7,2 wk ahead,2.4
+2015,8,2014/2015,61,HHS Region 7,3 wk ahead,2.1
+2015,8,2014/2015,61,HHS Region 7,4 wk ahead,1.9
+2015,8,2014/2015,61,HHS Region 8,Season onset,49
+2015,8,2014/2015,61,HHS Region 8,Season peak week,53
+2015,8,2014/2015,61,HHS Region 8,Season peak percentage,4.4
+2015,8,2014/2015,61,HHS Region 8,1 wk ahead,1.5
+2015,8,2014/2015,61,HHS Region 8,2 wk ahead,1.5
+2015,8,2014/2015,61,HHS Region 8,3 wk ahead,1.5
+2015,8,2014/2015,61,HHS Region 8,4 wk ahead,1.2
+2015,8,2014/2015,61,HHS Region 9,Season onset,51
+2015,8,2014/2015,61,HHS Region 9,Season peak week,3
+2015,8,2014/2015,61,HHS Region 9,Season peak week,4
+2015,8,2014/2015,61,HHS Region 9,Season peak percentage,5
+2015,8,2014/2015,61,HHS Region 9,1 wk ahead,2.9
+2015,8,2014/2015,61,HHS Region 9,2 wk ahead,3
+2015,8,2014/2015,61,HHS Region 9,3 wk ahead,2.7
+2015,8,2014/2015,61,HHS Region 9,4 wk ahead,2.5
+2015,8,2014/2015,61,HHS Region 10,Season onset,48
+2015,8,2014/2015,61,HHS Region 10,Season peak week,2
+2015,8,2014/2015,61,HHS Region 10,Season peak percentage,3.6
+2015,8,2014/2015,61,HHS Region 10,1 wk ahead,1.1
+2015,8,2014/2015,61,HHS Region 10,2 wk ahead,1.2
+2015,8,2014/2015,61,HHS Region 10,3 wk ahead,1.2
+2015,8,2014/2015,61,HHS Region 10,4 wk ahead,0.9
+2015,9,2014/2015,62,US National,Season onset,47
+2015,9,2014/2015,62,US National,Season peak week,52
+2015,9,2014/2015,62,US National,Season peak percentage,6
+2015,9,2014/2015,62,US National,1 wk ahead,2.4
+2015,9,2014/2015,62,US National,2 wk ahead,2.2
+2015,9,2014/2015,62,US National,3 wk ahead,2.1
+2015,9,2014/2015,62,US National,4 wk ahead,2
+2015,9,2014/2015,62,HHS Region 1,Season onset,50
+2015,9,2014/2015,62,HHS Region 1,Season peak week,3
+2015,9,2014/2015,62,HHS Region 1,Season peak percentage,3.9
+2015,9,2014/2015,62,HHS Region 1,1 wk ahead,1.7
+2015,9,2014/2015,62,HHS Region 1,2 wk ahead,1.5
+2015,9,2014/2015,62,HHS Region 1,3 wk ahead,1.5
+2015,9,2014/2015,62,HHS Region 1,4 wk ahead,1.6
+2015,9,2014/2015,62,HHS Region 2,Season onset,45
+2015,9,2014/2015,62,HHS Region 2,Season peak week,52
+2015,9,2014/2015,62,HHS Region 2,Season peak week,4
+2015,9,2014/2015,62,HHS Region 2,Season peak week,5
+2015,9,2014/2015,62,HHS Region 2,Season peak percentage,5.2
+2015,9,2014/2015,62,HHS Region 2,1 wk ahead,2.5
+2015,9,2014/2015,62,HHS Region 2,2 wk ahead,2.8
+2015,9,2014/2015,62,HHS Region 2,3 wk ahead,2.6
+2015,9,2014/2015,62,HHS Region 2,4 wk ahead,2.5
+2015,9,2014/2015,62,HHS Region 3,Season onset,48
+2015,9,2014/2015,62,HHS Region 3,Season peak week,52
+2015,9,2014/2015,62,HHS Region 3,Season peak percentage,7.2
+2015,9,2014/2015,62,HHS Region 3,1 wk ahead,1.7
+2015,9,2014/2015,62,HHS Region 3,2 wk ahead,1.6
+2015,9,2014/2015,62,HHS Region 3,3 wk ahead,1.8
+2015,9,2014/2015,62,HHS Region 3,4 wk ahead,1.7
+2015,9,2014/2015,62,HHS Region 4,Season onset,47
+2015,9,2014/2015,62,HHS Region 4,Season peak week,52
+2015,9,2014/2015,62,HHS Region 4,Season peak percentage,7.5
+2015,9,2014/2015,62,HHS Region 4,1 wk ahead,1.9
+2015,9,2014/2015,62,HHS Region 4,2 wk ahead,1.4
+2015,9,2014/2015,62,HHS Region 4,3 wk ahead,1.4
+2015,9,2014/2015,62,HHS Region 4,4 wk ahead,1.3
+2015,9,2014/2015,62,HHS Region 5,Season onset,48
+2015,9,2014/2015,62,HHS Region 5,Season peak week,52
+2015,9,2014/2015,62,HHS Region 5,Season peak percentage,6.6
+2015,9,2014/2015,62,HHS Region 5,1 wk ahead,1.8
+2015,9,2014/2015,62,HHS Region 5,2 wk ahead,1.9
+2015,9,2014/2015,62,HHS Region 5,3 wk ahead,2
+2015,9,2014/2015,62,HHS Region 5,4 wk ahead,1.8
+2015,9,2014/2015,62,HHS Region 6,Season onset,47
+2015,9,2014/2015,62,HHS Region 6,Season peak week,51
+2015,9,2014/2015,62,HHS Region 6,Season peak percentage,11.1
+2015,9,2014/2015,62,HHS Region 6,1 wk ahead,4.7
+2015,9,2014/2015,62,HHS Region 6,2 wk ahead,4
+2015,9,2014/2015,62,HHS Region 6,3 wk ahead,3.6
+2015,9,2014/2015,62,HHS Region 6,4 wk ahead,3.3
+2015,9,2014/2015,62,HHS Region 7,Season onset,48
+2015,9,2014/2015,62,HHS Region 7,Season peak week,52
+2015,9,2014/2015,62,HHS Region 7,Season peak percentage,6.4
+2015,9,2014/2015,62,HHS Region 7,1 wk ahead,2.4
+2015,9,2014/2015,62,HHS Region 7,2 wk ahead,2.1
+2015,9,2014/2015,62,HHS Region 7,3 wk ahead,1.9
+2015,9,2014/2015,62,HHS Region 7,4 wk ahead,1.8
+2015,9,2014/2015,62,HHS Region 8,Season onset,49
+2015,9,2014/2015,62,HHS Region 8,Season peak week,53
+2015,9,2014/2015,62,HHS Region 8,Season peak percentage,4.4
+2015,9,2014/2015,62,HHS Region 8,1 wk ahead,1.5
+2015,9,2014/2015,62,HHS Region 8,2 wk ahead,1.5
+2015,9,2014/2015,62,HHS Region 8,3 wk ahead,1.2
+2015,9,2014/2015,62,HHS Region 8,4 wk ahead,1.2
+2015,9,2014/2015,62,HHS Region 9,Season onset,51
+2015,9,2014/2015,62,HHS Region 9,Season peak week,3
+2015,9,2014/2015,62,HHS Region 9,Season peak week,4
+2015,9,2014/2015,62,HHS Region 9,Season peak percentage,5
+2015,9,2014/2015,62,HHS Region 9,1 wk ahead,3
+2015,9,2014/2015,62,HHS Region 9,2 wk ahead,2.7
+2015,9,2014/2015,62,HHS Region 9,3 wk ahead,2.5
+2015,9,2014/2015,62,HHS Region 9,4 wk ahead,2.5
+2015,9,2014/2015,62,HHS Region 10,Season onset,48
+2015,9,2014/2015,62,HHS Region 10,Season peak week,2
+2015,9,2014/2015,62,HHS Region 10,Season peak percentage,3.6
+2015,9,2014/2015,62,HHS Region 10,1 wk ahead,1.2
+2015,9,2014/2015,62,HHS Region 10,2 wk ahead,1.2
+2015,9,2014/2015,62,HHS Region 10,3 wk ahead,0.9
+2015,9,2014/2015,62,HHS Region 10,4 wk ahead,1
+2015,10,2014/2015,63,US National,Season onset,47
+2015,10,2014/2015,63,US National,Season peak week,52
+2015,10,2014/2015,63,US National,Season peak percentage,6
+2015,10,2014/2015,63,US National,1 wk ahead,2.2
+2015,10,2014/2015,63,US National,2 wk ahead,2.1
+2015,10,2014/2015,63,US National,3 wk ahead,2
+2015,10,2014/2015,63,US National,4 wk ahead,1.8
+2015,10,2014/2015,63,HHS Region 1,Season onset,50
+2015,10,2014/2015,63,HHS Region 1,Season peak week,3
+2015,10,2014/2015,63,HHS Region 1,Season peak percentage,3.9
+2015,10,2014/2015,63,HHS Region 1,1 wk ahead,1.5
+2015,10,2014/2015,63,HHS Region 1,2 wk ahead,1.5
+2015,10,2014/2015,63,HHS Region 1,3 wk ahead,1.6
+2015,10,2014/2015,63,HHS Region 1,4 wk ahead,1.4
+2015,10,2014/2015,63,HHS Region 2,Season onset,45
+2015,10,2014/2015,63,HHS Region 2,Season peak week,52
+2015,10,2014/2015,63,HHS Region 2,Season peak week,4
+2015,10,2014/2015,63,HHS Region 2,Season peak week,5
+2015,10,2014/2015,63,HHS Region 2,Season peak percentage,5.2
+2015,10,2014/2015,63,HHS Region 2,1 wk ahead,2.8
+2015,10,2014/2015,63,HHS Region 2,2 wk ahead,2.6
+2015,10,2014/2015,63,HHS Region 2,3 wk ahead,2.5
+2015,10,2014/2015,63,HHS Region 2,4 wk ahead,2.3
+2015,10,2014/2015,63,HHS Region 3,Season onset,48
+2015,10,2014/2015,63,HHS Region 3,Season peak week,52
+2015,10,2014/2015,63,HHS Region 3,Season peak percentage,7.2
+2015,10,2014/2015,63,HHS Region 3,1 wk ahead,1.6
+2015,10,2014/2015,63,HHS Region 3,2 wk ahead,1.8
+2015,10,2014/2015,63,HHS Region 3,3 wk ahead,1.7
+2015,10,2014/2015,63,HHS Region 3,4 wk ahead,1.7
+2015,10,2014/2015,63,HHS Region 4,Season onset,47
+2015,10,2014/2015,63,HHS Region 4,Season peak week,52
+2015,10,2014/2015,63,HHS Region 4,Season peak percentage,7.5
+2015,10,2014/2015,63,HHS Region 4,1 wk ahead,1.4
+2015,10,2014/2015,63,HHS Region 4,2 wk ahead,1.4
+2015,10,2014/2015,63,HHS Region 4,3 wk ahead,1.3
+2015,10,2014/2015,63,HHS Region 4,4 wk ahead,1.1
+2015,10,2014/2015,63,HHS Region 5,Season onset,48
+2015,10,2014/2015,63,HHS Region 5,Season peak week,52
+2015,10,2014/2015,63,HHS Region 5,Season peak percentage,6.6
+2015,10,2014/2015,63,HHS Region 5,1 wk ahead,1.9
+2015,10,2014/2015,63,HHS Region 5,2 wk ahead,2
+2015,10,2014/2015,63,HHS Region 5,3 wk ahead,1.8
+2015,10,2014/2015,63,HHS Region 5,4 wk ahead,1.7
+2015,10,2014/2015,63,HHS Region 6,Season onset,47
+2015,10,2014/2015,63,HHS Region 6,Season peak week,51
+2015,10,2014/2015,63,HHS Region 6,Season peak percentage,11.1
+2015,10,2014/2015,63,HHS Region 6,1 wk ahead,4
+2015,10,2014/2015,63,HHS Region 6,2 wk ahead,3.6
+2015,10,2014/2015,63,HHS Region 6,3 wk ahead,3.3
+2015,10,2014/2015,63,HHS Region 6,4 wk ahead,2.8
+2015,10,2014/2015,63,HHS Region 7,Season onset,48
+2015,10,2014/2015,63,HHS Region 7,Season peak week,52
+2015,10,2014/2015,63,HHS Region 7,Season peak percentage,6.4
+2015,10,2014/2015,63,HHS Region 7,1 wk ahead,2.1
+2015,10,2014/2015,63,HHS Region 7,2 wk ahead,1.9
+2015,10,2014/2015,63,HHS Region 7,3 wk ahead,1.8
+2015,10,2014/2015,63,HHS Region 7,4 wk ahead,1.4
+2015,10,2014/2015,63,HHS Region 8,Season onset,49
+2015,10,2014/2015,63,HHS Region 8,Season peak week,53
+2015,10,2014/2015,63,HHS Region 8,Season peak percentage,4.4
+2015,10,2014/2015,63,HHS Region 8,1 wk ahead,1.5
+2015,10,2014/2015,63,HHS Region 8,2 wk ahead,1.2
+2015,10,2014/2015,63,HHS Region 8,3 wk ahead,1.2
+2015,10,2014/2015,63,HHS Region 8,4 wk ahead,1
+2015,10,2014/2015,63,HHS Region 9,Season onset,51
+2015,10,2014/2015,63,HHS Region 9,Season peak week,3
+2015,10,2014/2015,63,HHS Region 9,Season peak week,4
+2015,10,2014/2015,63,HHS Region 9,Season peak percentage,5
+2015,10,2014/2015,63,HHS Region 9,1 wk ahead,2.7
+2015,10,2014/2015,63,HHS Region 9,2 wk ahead,2.5
+2015,10,2014/2015,63,HHS Region 9,3 wk ahead,2.5
+2015,10,2014/2015,63,HHS Region 9,4 wk ahead,2.3
+2015,10,2014/2015,63,HHS Region 10,Season onset,48
+2015,10,2014/2015,63,HHS Region 10,Season peak week,2
+2015,10,2014/2015,63,HHS Region 10,Season peak percentage,3.6
+2015,10,2014/2015,63,HHS Region 10,1 wk ahead,1.2
+2015,10,2014/2015,63,HHS Region 10,2 wk ahead,0.9
+2015,10,2014/2015,63,HHS Region 10,3 wk ahead,1
+2015,10,2014/2015,63,HHS Region 10,4 wk ahead,0.7
+2015,11,2014/2015,64,US National,Season onset,47
+2015,11,2014/2015,64,US National,Season peak week,52
+2015,11,2014/2015,64,US National,Season peak percentage,6
+2015,11,2014/2015,64,US National,1 wk ahead,2.1
+2015,11,2014/2015,64,US National,2 wk ahead,2
+2015,11,2014/2015,64,US National,3 wk ahead,1.8
+2015,11,2014/2015,64,US National,4 wk ahead,1.6
+2015,11,2014/2015,64,HHS Region 1,Season onset,50
+2015,11,2014/2015,64,HHS Region 1,Season peak week,3
+2015,11,2014/2015,64,HHS Region 1,Season peak percentage,3.9
+2015,11,2014/2015,64,HHS Region 1,1 wk ahead,1.5
+2015,11,2014/2015,64,HHS Region 1,2 wk ahead,1.6
+2015,11,2014/2015,64,HHS Region 1,3 wk ahead,1.4
+2015,11,2014/2015,64,HHS Region 1,4 wk ahead,1.3
+2015,11,2014/2015,64,HHS Region 2,Season onset,45
+2015,11,2014/2015,64,HHS Region 2,Season peak week,52
+2015,11,2014/2015,64,HHS Region 2,Season peak week,4
+2015,11,2014/2015,64,HHS Region 2,Season peak week,5
+2015,11,2014/2015,64,HHS Region 2,Season peak percentage,5.2
+2015,11,2014/2015,64,HHS Region 2,1 wk ahead,2.6
+2015,11,2014/2015,64,HHS Region 2,2 wk ahead,2.5
+2015,11,2014/2015,64,HHS Region 2,3 wk ahead,2.3
+2015,11,2014/2015,64,HHS Region 2,4 wk ahead,1.9
+2015,11,2014/2015,64,HHS Region 3,Season onset,48
+2015,11,2014/2015,64,HHS Region 3,Season peak week,52
+2015,11,2014/2015,64,HHS Region 3,Season peak percentage,7.2
+2015,11,2014/2015,64,HHS Region 3,1 wk ahead,1.8
+2015,11,2014/2015,64,HHS Region 3,2 wk ahead,1.7
+2015,11,2014/2015,64,HHS Region 3,3 wk ahead,1.7
+2015,11,2014/2015,64,HHS Region 3,4 wk ahead,1.5
+2015,11,2014/2015,64,HHS Region 4,Season onset,47
+2015,11,2014/2015,64,HHS Region 4,Season peak week,52
+2015,11,2014/2015,64,HHS Region 4,Season peak percentage,7.5
+2015,11,2014/2015,64,HHS Region 4,1 wk ahead,1.4
+2015,11,2014/2015,64,HHS Region 4,2 wk ahead,1.3
+2015,11,2014/2015,64,HHS Region 4,3 wk ahead,1.1
+2015,11,2014/2015,64,HHS Region 4,4 wk ahead,0.9
+2015,11,2014/2015,64,HHS Region 5,Season onset,48
+2015,11,2014/2015,64,HHS Region 5,Season peak week,52
+2015,11,2014/2015,64,HHS Region 5,Season peak percentage,6.6
+2015,11,2014/2015,64,HHS Region 5,1 wk ahead,2
+2015,11,2014/2015,64,HHS Region 5,2 wk ahead,1.8
+2015,11,2014/2015,64,HHS Region 5,3 wk ahead,1.7
+2015,11,2014/2015,64,HHS Region 5,4 wk ahead,1.4
+2015,11,2014/2015,64,HHS Region 6,Season onset,47
+2015,11,2014/2015,64,HHS Region 6,Season peak week,51
+2015,11,2014/2015,64,HHS Region 6,Season peak percentage,11.1
+2015,11,2014/2015,64,HHS Region 6,1 wk ahead,3.6
+2015,11,2014/2015,64,HHS Region 6,2 wk ahead,3.3
+2015,11,2014/2015,64,HHS Region 6,3 wk ahead,2.8
+2015,11,2014/2015,64,HHS Region 6,4 wk ahead,2.7
+2015,11,2014/2015,64,HHS Region 7,Season onset,48
+2015,11,2014/2015,64,HHS Region 7,Season peak week,52
+2015,11,2014/2015,64,HHS Region 7,Season peak percentage,6.4
+2015,11,2014/2015,64,HHS Region 7,1 wk ahead,1.9
+2015,11,2014/2015,64,HHS Region 7,2 wk ahead,1.8
+2015,11,2014/2015,64,HHS Region 7,3 wk ahead,1.4
+2015,11,2014/2015,64,HHS Region 7,4 wk ahead,1.1
+2015,11,2014/2015,64,HHS Region 8,Season onset,49
+2015,11,2014/2015,64,HHS Region 8,Season peak week,53
+2015,11,2014/2015,64,HHS Region 8,Season peak percentage,4.4
+2015,11,2014/2015,64,HHS Region 8,1 wk ahead,1.2
+2015,11,2014/2015,64,HHS Region 8,2 wk ahead,1.2
+2015,11,2014/2015,64,HHS Region 8,3 wk ahead,1
+2015,11,2014/2015,64,HHS Region 8,4 wk ahead,1
+2015,11,2014/2015,64,HHS Region 9,Season onset,51
+2015,11,2014/2015,64,HHS Region 9,Season peak week,3
+2015,11,2014/2015,64,HHS Region 9,Season peak week,4
+2015,11,2014/2015,64,HHS Region 9,Season peak percentage,5
+2015,11,2014/2015,64,HHS Region 9,1 wk ahead,2.5
+2015,11,2014/2015,64,HHS Region 9,2 wk ahead,2.5
+2015,11,2014/2015,64,HHS Region 9,3 wk ahead,2.3
+2015,11,2014/2015,64,HHS Region 9,4 wk ahead,2
+2015,11,2014/2015,64,HHS Region 10,Season onset,48
+2015,11,2014/2015,64,HHS Region 10,Season peak week,2
+2015,11,2014/2015,64,HHS Region 10,Season peak percentage,3.6
+2015,11,2014/2015,64,HHS Region 10,1 wk ahead,0.9
+2015,11,2014/2015,64,HHS Region 10,2 wk ahead,1
+2015,11,2014/2015,64,HHS Region 10,3 wk ahead,0.7
+2015,11,2014/2015,64,HHS Region 10,4 wk ahead,0.8
+2015,12,2014/2015,65,US National,Season onset,47
+2015,12,2014/2015,65,US National,Season peak week,52
+2015,12,2014/2015,65,US National,Season peak percentage,6
+2015,12,2014/2015,65,US National,1 wk ahead,2
+2015,12,2014/2015,65,US National,2 wk ahead,1.8
+2015,12,2014/2015,65,US National,3 wk ahead,1.6
+2015,12,2014/2015,65,US National,4 wk ahead,1.4
+2015,12,2014/2015,65,HHS Region 1,Season onset,50
+2015,12,2014/2015,65,HHS Region 1,Season peak week,3
+2015,12,2014/2015,65,HHS Region 1,Season peak percentage,3.9
+2015,12,2014/2015,65,HHS Region 1,1 wk ahead,1.6
+2015,12,2014/2015,65,HHS Region 1,2 wk ahead,1.4
+2015,12,2014/2015,65,HHS Region 1,3 wk ahead,1.3
+2015,12,2014/2015,65,HHS Region 1,4 wk ahead,1.3
+2015,12,2014/2015,65,HHS Region 2,Season onset,45
+2015,12,2014/2015,65,HHS Region 2,Season peak week,52
+2015,12,2014/2015,65,HHS Region 2,Season peak week,4
+2015,12,2014/2015,65,HHS Region 2,Season peak week,5
+2015,12,2014/2015,65,HHS Region 2,Season peak percentage,5.2
+2015,12,2014/2015,65,HHS Region 2,1 wk ahead,2.5
+2015,12,2014/2015,65,HHS Region 2,2 wk ahead,2.3
+2015,12,2014/2015,65,HHS Region 2,3 wk ahead,1.9
+2015,12,2014/2015,65,HHS Region 2,4 wk ahead,1.9
+2015,12,2014/2015,65,HHS Region 3,Season onset,48
+2015,12,2014/2015,65,HHS Region 3,Season peak week,52
+2015,12,2014/2015,65,HHS Region 3,Season peak percentage,7.2
+2015,12,2014/2015,65,HHS Region 3,1 wk ahead,1.7
+2015,12,2014/2015,65,HHS Region 3,2 wk ahead,1.7
+2015,12,2014/2015,65,HHS Region 3,3 wk ahead,1.5
+2015,12,2014/2015,65,HHS Region 3,4 wk ahead,1.3
+2015,12,2014/2015,65,HHS Region 4,Season onset,47
+2015,12,2014/2015,65,HHS Region 4,Season peak week,52
+2015,12,2014/2015,65,HHS Region 4,Season peak percentage,7.5
+2015,12,2014/2015,65,HHS Region 4,1 wk ahead,1.3
+2015,12,2014/2015,65,HHS Region 4,2 wk ahead,1.1
+2015,12,2014/2015,65,HHS Region 4,3 wk ahead,0.9
+2015,12,2014/2015,65,HHS Region 4,4 wk ahead,0.9
+2015,12,2014/2015,65,HHS Region 5,Season onset,48
+2015,12,2014/2015,65,HHS Region 5,Season peak week,52
+2015,12,2014/2015,65,HHS Region 5,Season peak percentage,6.6
+2015,12,2014/2015,65,HHS Region 5,1 wk ahead,1.8
+2015,12,2014/2015,65,HHS Region 5,2 wk ahead,1.7
+2015,12,2014/2015,65,HHS Region 5,3 wk ahead,1.4
+2015,12,2014/2015,65,HHS Region 5,4 wk ahead,1.2
+2015,12,2014/2015,65,HHS Region 6,Season onset,47
+2015,12,2014/2015,65,HHS Region 6,Season peak week,51
+2015,12,2014/2015,65,HHS Region 6,Season peak percentage,11.1
+2015,12,2014/2015,65,HHS Region 6,1 wk ahead,3.3
+2015,12,2014/2015,65,HHS Region 6,2 wk ahead,2.8
+2015,12,2014/2015,65,HHS Region 6,3 wk ahead,2.7
+2015,12,2014/2015,65,HHS Region 6,4 wk ahead,1.8
+2015,12,2014/2015,65,HHS Region 7,Season onset,48
+2015,12,2014/2015,65,HHS Region 7,Season peak week,52
+2015,12,2014/2015,65,HHS Region 7,Season peak percentage,6.4
+2015,12,2014/2015,65,HHS Region 7,1 wk ahead,1.8
+2015,12,2014/2015,65,HHS Region 7,2 wk ahead,1.4
+2015,12,2014/2015,65,HHS Region 7,3 wk ahead,1.1
+2015,12,2014/2015,65,HHS Region 7,4 wk ahead,1.1
+2015,12,2014/2015,65,HHS Region 8,Season onset,49
+2015,12,2014/2015,65,HHS Region 8,Season peak week,53
+2015,12,2014/2015,65,HHS Region 8,Season peak percentage,4.4
+2015,12,2014/2015,65,HHS Region 8,1 wk ahead,1.2
+2015,12,2014/2015,65,HHS Region 8,2 wk ahead,1
+2015,12,2014/2015,65,HHS Region 8,3 wk ahead,1
+2015,12,2014/2015,65,HHS Region 8,4 wk ahead,0.9
+2015,12,2014/2015,65,HHS Region 9,Season onset,51
+2015,12,2014/2015,65,HHS Region 9,Season peak week,3
+2015,12,2014/2015,65,HHS Region 9,Season peak week,4
+2015,12,2014/2015,65,HHS Region 9,Season peak percentage,5
+2015,12,2014/2015,65,HHS Region 9,1 wk ahead,2.5
+2015,12,2014/2015,65,HHS Region 9,2 wk ahead,2.3
+2015,12,2014/2015,65,HHS Region 9,3 wk ahead,2
+2015,12,2014/2015,65,HHS Region 9,4 wk ahead,2
+2015,12,2014/2015,65,HHS Region 10,Season onset,48
+2015,12,2014/2015,65,HHS Region 10,Season peak week,2
+2015,12,2014/2015,65,HHS Region 10,Season peak percentage,3.6
+2015,12,2014/2015,65,HHS Region 10,1 wk ahead,1
+2015,12,2014/2015,65,HHS Region 10,2 wk ahead,0.7
+2015,12,2014/2015,65,HHS Region 10,3 wk ahead,0.8
+2015,12,2014/2015,65,HHS Region 10,4 wk ahead,0.9
+2015,13,2014/2015,66,US National,Season onset,47
+2015,13,2014/2015,66,US National,Season peak week,52
+2015,13,2014/2015,66,US National,Season peak percentage,6
+2015,13,2014/2015,66,US National,1 wk ahead,1.8
+2015,13,2014/2015,66,US National,2 wk ahead,1.6
+2015,13,2014/2015,66,US National,3 wk ahead,1.4
+2015,13,2014/2015,66,US National,4 wk ahead,1.5
+2015,13,2014/2015,66,HHS Region 1,Season onset,50
+2015,13,2014/2015,66,HHS Region 1,Season peak week,3
+2015,13,2014/2015,66,HHS Region 1,Season peak percentage,3.9
+2015,13,2014/2015,66,HHS Region 1,1 wk ahead,1.4
+2015,13,2014/2015,66,HHS Region 1,2 wk ahead,1.3
+2015,13,2014/2015,66,HHS Region 1,3 wk ahead,1.3
+2015,13,2014/2015,66,HHS Region 1,4 wk ahead,1
+2015,13,2014/2015,66,HHS Region 2,Season onset,45
+2015,13,2014/2015,66,HHS Region 2,Season peak week,52
+2015,13,2014/2015,66,HHS Region 2,Season peak week,4
+2015,13,2014/2015,66,HHS Region 2,Season peak week,5
+2015,13,2014/2015,66,HHS Region 2,Season peak percentage,5.2
+2015,13,2014/2015,66,HHS Region 2,1 wk ahead,2.3
+2015,13,2014/2015,66,HHS Region 2,2 wk ahead,1.9
+2015,13,2014/2015,66,HHS Region 2,3 wk ahead,1.9
+2015,13,2014/2015,66,HHS Region 2,4 wk ahead,1.8
+2015,13,2014/2015,66,HHS Region 3,Season onset,48
+2015,13,2014/2015,66,HHS Region 3,Season peak week,52
+2015,13,2014/2015,66,HHS Region 3,Season peak percentage,7.2
+2015,13,2014/2015,66,HHS Region 3,1 wk ahead,1.7
+2015,13,2014/2015,66,HHS Region 3,2 wk ahead,1.5
+2015,13,2014/2015,66,HHS Region 3,3 wk ahead,1.3
+2015,13,2014/2015,66,HHS Region 3,4 wk ahead,1.5
+2015,13,2014/2015,66,HHS Region 4,Season onset,47
+2015,13,2014/2015,66,HHS Region 4,Season peak week,52
+2015,13,2014/2015,66,HHS Region 4,Season peak percentage,7.5
+2015,13,2014/2015,66,HHS Region 4,1 wk ahead,1.1
+2015,13,2014/2015,66,HHS Region 4,2 wk ahead,0.9
+2015,13,2014/2015,66,HHS Region 4,3 wk ahead,0.9
+2015,13,2014/2015,66,HHS Region 4,4 wk ahead,1
+2015,13,2014/2015,66,HHS Region 5,Season onset,48
+2015,13,2014/2015,66,HHS Region 5,Season peak week,52
+2015,13,2014/2015,66,HHS Region 5,Season peak percentage,6.6
+2015,13,2014/2015,66,HHS Region 5,1 wk ahead,1.7
+2015,13,2014/2015,66,HHS Region 5,2 wk ahead,1.4
+2015,13,2014/2015,66,HHS Region 5,3 wk ahead,1.2
+2015,13,2014/2015,66,HHS Region 5,4 wk ahead,1.2
+2015,13,2014/2015,66,HHS Region 6,Season onset,47
+2015,13,2014/2015,66,HHS Region 6,Season peak week,51
+2015,13,2014/2015,66,HHS Region 6,Season peak percentage,11.1
+2015,13,2014/2015,66,HHS Region 6,1 wk ahead,2.8
+2015,13,2014/2015,66,HHS Region 6,2 wk ahead,2.7
+2015,13,2014/2015,66,HHS Region 6,3 wk ahead,1.8
+2015,13,2014/2015,66,HHS Region 6,4 wk ahead,2.5
+2015,13,2014/2015,66,HHS Region 7,Season onset,48
+2015,13,2014/2015,66,HHS Region 7,Season peak week,52
+2015,13,2014/2015,66,HHS Region 7,Season peak percentage,6.4
+2015,13,2014/2015,66,HHS Region 7,1 wk ahead,1.4
+2015,13,2014/2015,66,HHS Region 7,2 wk ahead,1.1
+2015,13,2014/2015,66,HHS Region 7,3 wk ahead,1.1
+2015,13,2014/2015,66,HHS Region 7,4 wk ahead,1.1
+2015,13,2014/2015,66,HHS Region 8,Season onset,49
+2015,13,2014/2015,66,HHS Region 8,Season peak week,53
+2015,13,2014/2015,66,HHS Region 8,Season peak percentage,4.4
+2015,13,2014/2015,66,HHS Region 8,1 wk ahead,1
+2015,13,2014/2015,66,HHS Region 8,2 wk ahead,1
+2015,13,2014/2015,66,HHS Region 8,3 wk ahead,0.9
+2015,13,2014/2015,66,HHS Region 8,4 wk ahead,0.8
+2015,13,2014/2015,66,HHS Region 9,Season onset,51
+2015,13,2014/2015,66,HHS Region 9,Season peak week,3
+2015,13,2014/2015,66,HHS Region 9,Season peak week,4
+2015,13,2014/2015,66,HHS Region 9,Season peak percentage,5
+2015,13,2014/2015,66,HHS Region 9,1 wk ahead,2.3
+2015,13,2014/2015,66,HHS Region 9,2 wk ahead,2
+2015,13,2014/2015,66,HHS Region 9,3 wk ahead,2
+2015,13,2014/2015,66,HHS Region 9,4 wk ahead,2
+2015,13,2014/2015,66,HHS Region 10,Season onset,48
+2015,13,2014/2015,66,HHS Region 10,Season peak week,2
+2015,13,2014/2015,66,HHS Region 10,Season peak percentage,3.6
+2015,13,2014/2015,66,HHS Region 10,1 wk ahead,0.7
+2015,13,2014/2015,66,HHS Region 10,2 wk ahead,0.8
+2015,13,2014/2015,66,HHS Region 10,3 wk ahead,0.9
+2015,13,2014/2015,66,HHS Region 10,4 wk ahead,0.8
+2015,14,2014/2015,67,US National,Season onset,47
+2015,14,2014/2015,67,US National,Season peak week,52
+2015,14,2014/2015,67,US National,Season peak percentage,6
+2015,14,2014/2015,67,US National,1 wk ahead,1.6
+2015,14,2014/2015,67,US National,2 wk ahead,1.4
+2015,14,2014/2015,67,US National,3 wk ahead,1.5
+2015,14,2014/2015,67,US National,4 wk ahead,1.4
+2015,14,2014/2015,67,HHS Region 1,Season onset,50
+2015,14,2014/2015,67,HHS Region 1,Season peak week,3
+2015,14,2014/2015,67,HHS Region 1,Season peak percentage,3.9
+2015,14,2014/2015,67,HHS Region 1,1 wk ahead,1.3
+2015,14,2014/2015,67,HHS Region 1,2 wk ahead,1.3
+2015,14,2014/2015,67,HHS Region 1,3 wk ahead,1
+2015,14,2014/2015,67,HHS Region 1,4 wk ahead,1
+2015,14,2014/2015,67,HHS Region 2,Season onset,45
+2015,14,2014/2015,67,HHS Region 2,Season peak week,52
+2015,14,2014/2015,67,HHS Region 2,Season peak week,4
+2015,14,2014/2015,67,HHS Region 2,Season peak week,5
+2015,14,2014/2015,67,HHS Region 2,Season peak percentage,5.2
+2015,14,2014/2015,67,HHS Region 2,1 wk ahead,1.9
+2015,14,2014/2015,67,HHS Region 2,2 wk ahead,1.9
+2015,14,2014/2015,67,HHS Region 2,3 wk ahead,1.8
+2015,14,2014/2015,67,HHS Region 2,4 wk ahead,1.9
+2015,14,2014/2015,67,HHS Region 3,Season onset,48
+2015,14,2014/2015,67,HHS Region 3,Season peak week,52
+2015,14,2014/2015,67,HHS Region 3,Season peak percentage,7.2
+2015,14,2014/2015,67,HHS Region 3,1 wk ahead,1.5
+2015,14,2014/2015,67,HHS Region 3,2 wk ahead,1.3
+2015,14,2014/2015,67,HHS Region 3,3 wk ahead,1.5
+2015,14,2014/2015,67,HHS Region 3,4 wk ahead,1.3
+2015,14,2014/2015,67,HHS Region 4,Season onset,47
+2015,14,2014/2015,67,HHS Region 4,Season peak week,52
+2015,14,2014/2015,67,HHS Region 4,Season peak percentage,7.5
+2015,14,2014/2015,67,HHS Region 4,1 wk ahead,0.9
+2015,14,2014/2015,67,HHS Region 4,2 wk ahead,0.9
+2015,14,2014/2015,67,HHS Region 4,3 wk ahead,1
+2015,14,2014/2015,67,HHS Region 4,4 wk ahead,0.9
+2015,14,2014/2015,67,HHS Region 5,Season onset,48
+2015,14,2014/2015,67,HHS Region 5,Season peak week,52
+2015,14,2014/2015,67,HHS Region 5,Season peak percentage,6.6
+2015,14,2014/2015,67,HHS Region 5,1 wk ahead,1.4
+2015,14,2014/2015,67,HHS Region 5,2 wk ahead,1.2
+2015,14,2014/2015,67,HHS Region 5,3 wk ahead,1.2
+2015,14,2014/2015,67,HHS Region 5,4 wk ahead,1
+2015,14,2014/2015,67,HHS Region 6,Season onset,47
+2015,14,2014/2015,67,HHS Region 6,Season peak week,51
+2015,14,2014/2015,67,HHS Region 6,Season peak percentage,11.1
+2015,14,2014/2015,67,HHS Region 6,1 wk ahead,2.7
+2015,14,2014/2015,67,HHS Region 6,2 wk ahead,1.8
+2015,14,2014/2015,67,HHS Region 6,3 wk ahead,2.5
+2015,14,2014/2015,67,HHS Region 6,4 wk ahead,2.4
+2015,14,2014/2015,67,HHS Region 7,Season onset,48
+2015,14,2014/2015,67,HHS Region 7,Season peak week,52
+2015,14,2014/2015,67,HHS Region 7,Season peak percentage,6.4
+2015,14,2014/2015,67,HHS Region 7,1 wk ahead,1.1
+2015,14,2014/2015,67,HHS Region 7,2 wk ahead,1.1
+2015,14,2014/2015,67,HHS Region 7,3 wk ahead,1.1
+2015,14,2014/2015,67,HHS Region 7,4 wk ahead,0.8
+2015,14,2014/2015,67,HHS Region 8,Season onset,49
+2015,14,2014/2015,67,HHS Region 8,Season peak week,53
+2015,14,2014/2015,67,HHS Region 8,Season peak percentage,4.4
+2015,14,2014/2015,67,HHS Region 8,1 wk ahead,1
+2015,14,2014/2015,67,HHS Region 8,2 wk ahead,0.9
+2015,14,2014/2015,67,HHS Region 8,3 wk ahead,0.8
+2015,14,2014/2015,67,HHS Region 8,4 wk ahead,0.9
+2015,14,2014/2015,67,HHS Region 9,Season onset,51
+2015,14,2014/2015,67,HHS Region 9,Season peak week,3
+2015,14,2014/2015,67,HHS Region 9,Season peak week,4
+2015,14,2014/2015,67,HHS Region 9,Season peak percentage,5
+2015,14,2014/2015,67,HHS Region 9,1 wk ahead,2
+2015,14,2014/2015,67,HHS Region 9,2 wk ahead,2
+2015,14,2014/2015,67,HHS Region 9,3 wk ahead,2
+2015,14,2014/2015,67,HHS Region 9,4 wk ahead,2.1
+2015,14,2014/2015,67,HHS Region 10,Season onset,48
+2015,14,2014/2015,67,HHS Region 10,Season peak week,2
+2015,14,2014/2015,67,HHS Region 10,Season peak percentage,3.6
+2015,14,2014/2015,67,HHS Region 10,1 wk ahead,0.8
+2015,14,2014/2015,67,HHS Region 10,2 wk ahead,0.9
+2015,14,2014/2015,67,HHS Region 10,3 wk ahead,0.8
+2015,14,2014/2015,67,HHS Region 10,4 wk ahead,0.5
+2015,15,2014/2015,68,US National,Season onset,47
+2015,15,2014/2015,68,US National,Season peak week,52
+2015,15,2014/2015,68,US National,Season peak percentage,6
+2015,15,2014/2015,68,US National,1 wk ahead,1.4
+2015,15,2014/2015,68,US National,2 wk ahead,1.5
+2015,15,2014/2015,68,US National,3 wk ahead,1.4
+2015,15,2014/2015,68,US National,4 wk ahead,1.4
+2015,15,2014/2015,68,HHS Region 1,Season onset,50
+2015,15,2014/2015,68,HHS Region 1,Season peak week,3
+2015,15,2014/2015,68,HHS Region 1,Season peak percentage,3.9
+2015,15,2014/2015,68,HHS Region 1,1 wk ahead,1.3
+2015,15,2014/2015,68,HHS Region 1,2 wk ahead,1
+2015,15,2014/2015,68,HHS Region 1,3 wk ahead,1
+2015,15,2014/2015,68,HHS Region 1,4 wk ahead,0.8
+2015,15,2014/2015,68,HHS Region 2,Season onset,45
+2015,15,2014/2015,68,HHS Region 2,Season peak week,52
+2015,15,2014/2015,68,HHS Region 2,Season peak week,4
+2015,15,2014/2015,68,HHS Region 2,Season peak week,5
+2015,15,2014/2015,68,HHS Region 2,Season peak percentage,5.2
+2015,15,2014/2015,68,HHS Region 2,1 wk ahead,1.9
+2015,15,2014/2015,68,HHS Region 2,2 wk ahead,1.8
+2015,15,2014/2015,68,HHS Region 2,3 wk ahead,1.9
+2015,15,2014/2015,68,HHS Region 2,4 wk ahead,1.8
+2015,15,2014/2015,68,HHS Region 3,Season onset,48
+2015,15,2014/2015,68,HHS Region 3,Season peak week,52
+2015,15,2014/2015,68,HHS Region 3,Season peak percentage,7.2
+2015,15,2014/2015,68,HHS Region 3,1 wk ahead,1.3
+2015,15,2014/2015,68,HHS Region 3,2 wk ahead,1.5
+2015,15,2014/2015,68,HHS Region 3,3 wk ahead,1.3
+2015,15,2014/2015,68,HHS Region 3,4 wk ahead,1.2
+2015,15,2014/2015,68,HHS Region 4,Season onset,47
+2015,15,2014/2015,68,HHS Region 4,Season peak week,52
+2015,15,2014/2015,68,HHS Region 4,Season peak percentage,7.5
+2015,15,2014/2015,68,HHS Region 4,1 wk ahead,0.9
+2015,15,2014/2015,68,HHS Region 4,2 wk ahead,1
+2015,15,2014/2015,68,HHS Region 4,3 wk ahead,0.9
+2015,15,2014/2015,68,HHS Region 4,4 wk ahead,1
+2015,15,2014/2015,68,HHS Region 5,Season onset,48
+2015,15,2014/2015,68,HHS Region 5,Season peak week,52
+2015,15,2014/2015,68,HHS Region 5,Season peak percentage,6.6
+2015,15,2014/2015,68,HHS Region 5,1 wk ahead,1.2
+2015,15,2014/2015,68,HHS Region 5,2 wk ahead,1.2
+2015,15,2014/2015,68,HHS Region 5,3 wk ahead,1
+2015,15,2014/2015,68,HHS Region 5,4 wk ahead,1
+2015,15,2014/2015,68,HHS Region 6,Season onset,47
+2015,15,2014/2015,68,HHS Region 6,Season peak week,51
+2015,15,2014/2015,68,HHS Region 6,Season peak percentage,11.1
+2015,15,2014/2015,68,HHS Region 6,1 wk ahead,1.8
+2015,15,2014/2015,68,HHS Region 6,2 wk ahead,2.5
+2015,15,2014/2015,68,HHS Region 6,3 wk ahead,2.4
+2015,15,2014/2015,68,HHS Region 6,4 wk ahead,2.3
+2015,15,2014/2015,68,HHS Region 7,Season onset,48
+2015,15,2014/2015,68,HHS Region 7,Season peak week,52
+2015,15,2014/2015,68,HHS Region 7,Season peak percentage,6.4
+2015,15,2014/2015,68,HHS Region 7,1 wk ahead,1.1
+2015,15,2014/2015,68,HHS Region 7,2 wk ahead,1.1
+2015,15,2014/2015,68,HHS Region 7,3 wk ahead,0.8
+2015,15,2014/2015,68,HHS Region 7,4 wk ahead,0.8
+2015,15,2014/2015,68,HHS Region 8,Season onset,49
+2015,15,2014/2015,68,HHS Region 8,Season peak week,53
+2015,15,2014/2015,68,HHS Region 8,Season peak percentage,4.4
+2015,15,2014/2015,68,HHS Region 8,1 wk ahead,0.9
+2015,15,2014/2015,68,HHS Region 8,2 wk ahead,0.8
+2015,15,2014/2015,68,HHS Region 8,3 wk ahead,0.9
+2015,15,2014/2015,68,HHS Region 8,4 wk ahead,0.7
+2015,15,2014/2015,68,HHS Region 9,Season onset,51
+2015,15,2014/2015,68,HHS Region 9,Season peak week,3
+2015,15,2014/2015,68,HHS Region 9,Season peak week,4
+2015,15,2014/2015,68,HHS Region 9,Season peak percentage,5
+2015,15,2014/2015,68,HHS Region 9,1 wk ahead,2
+2015,15,2014/2015,68,HHS Region 9,2 wk ahead,2
+2015,15,2014/2015,68,HHS Region 9,3 wk ahead,2.1
+2015,15,2014/2015,68,HHS Region 9,4 wk ahead,2.1
+2015,15,2014/2015,68,HHS Region 10,Season onset,48
+2015,15,2014/2015,68,HHS Region 10,Season peak week,2
+2015,15,2014/2015,68,HHS Region 10,Season peak percentage,3.6
+2015,15,2014/2015,68,HHS Region 10,1 wk ahead,0.9
+2015,15,2014/2015,68,HHS Region 10,2 wk ahead,0.8
+2015,15,2014/2015,68,HHS Region 10,3 wk ahead,0.5
+2015,15,2014/2015,68,HHS Region 10,4 wk ahead,0.7
+2015,16,2014/2015,69,US National,Season onset,47
+2015,16,2014/2015,69,US National,Season peak week,52
+2015,16,2014/2015,69,US National,Season peak percentage,6
+2015,16,2014/2015,69,US National,1 wk ahead,1.5
+2015,16,2014/2015,69,US National,2 wk ahead,1.4
+2015,16,2014/2015,69,US National,3 wk ahead,1.4
+2015,16,2014/2015,69,US National,4 wk ahead,1.3
+2015,16,2014/2015,69,HHS Region 1,Season onset,50
+2015,16,2014/2015,69,HHS Region 1,Season peak week,3
+2015,16,2014/2015,69,HHS Region 1,Season peak percentage,3.9
+2015,16,2014/2015,69,HHS Region 1,1 wk ahead,1
+2015,16,2014/2015,69,HHS Region 1,2 wk ahead,1
+2015,16,2014/2015,69,HHS Region 1,3 wk ahead,0.8
+2015,16,2014/2015,69,HHS Region 1,4 wk ahead,0.8
+2015,16,2014/2015,69,HHS Region 2,Season onset,45
+2015,16,2014/2015,69,HHS Region 2,Season peak week,52
+2015,16,2014/2015,69,HHS Region 2,Season peak week,4
+2015,16,2014/2015,69,HHS Region 2,Season peak week,5
+2015,16,2014/2015,69,HHS Region 2,Season peak percentage,5.2
+2015,16,2014/2015,69,HHS Region 2,1 wk ahead,1.8
+2015,16,2014/2015,69,HHS Region 2,2 wk ahead,1.9
+2015,16,2014/2015,69,HHS Region 2,3 wk ahead,1.8
+2015,16,2014/2015,69,HHS Region 2,4 wk ahead,1.6
+2015,16,2014/2015,69,HHS Region 3,Season onset,48
+2015,16,2014/2015,69,HHS Region 3,Season peak week,52
+2015,16,2014/2015,69,HHS Region 3,Season peak percentage,7.2
+2015,16,2014/2015,69,HHS Region 3,1 wk ahead,1.5
+2015,16,2014/2015,69,HHS Region 3,2 wk ahead,1.3
+2015,16,2014/2015,69,HHS Region 3,3 wk ahead,1.2
+2015,16,2014/2015,69,HHS Region 3,4 wk ahead,1.2
+2015,16,2014/2015,69,HHS Region 4,Season onset,47
+2015,16,2014/2015,69,HHS Region 4,Season peak week,52
+2015,16,2014/2015,69,HHS Region 4,Season peak percentage,7.5
+2015,16,2014/2015,69,HHS Region 4,1 wk ahead,1
+2015,16,2014/2015,69,HHS Region 4,2 wk ahead,0.9
+2015,16,2014/2015,69,HHS Region 4,3 wk ahead,1
+2015,16,2014/2015,69,HHS Region 4,4 wk ahead,0.9
+2015,16,2014/2015,69,HHS Region 5,Season onset,48
+2015,16,2014/2015,69,HHS Region 5,Season peak week,52
+2015,16,2014/2015,69,HHS Region 5,Season peak percentage,6.6
+2015,16,2014/2015,69,HHS Region 5,1 wk ahead,1.2
+2015,16,2014/2015,69,HHS Region 5,2 wk ahead,1
+2015,16,2014/2015,69,HHS Region 5,3 wk ahead,1
+2015,16,2014/2015,69,HHS Region 5,4 wk ahead,0.8
+2015,16,2014/2015,69,HHS Region 6,Season onset,47
+2015,16,2014/2015,69,HHS Region 6,Season peak week,51
+2015,16,2014/2015,69,HHS Region 6,Season peak percentage,11.1
+2015,16,2014/2015,69,HHS Region 6,1 wk ahead,2.5
+2015,16,2014/2015,69,HHS Region 6,2 wk ahead,2.4
+2015,16,2014/2015,69,HHS Region 6,3 wk ahead,2.3
+2015,16,2014/2015,69,HHS Region 6,4 wk ahead,2.2
+2015,16,2014/2015,69,HHS Region 7,Season onset,48
+2015,16,2014/2015,69,HHS Region 7,Season peak week,52
+2015,16,2014/2015,69,HHS Region 7,Season peak percentage,6.4
+2015,16,2014/2015,69,HHS Region 7,1 wk ahead,1.1
+2015,16,2014/2015,69,HHS Region 7,2 wk ahead,0.8
+2015,16,2014/2015,69,HHS Region 7,3 wk ahead,0.8
+2015,16,2014/2015,69,HHS Region 7,4 wk ahead,0.6
+2015,16,2014/2015,69,HHS Region 8,Season onset,49
+2015,16,2014/2015,69,HHS Region 8,Season peak week,53
+2015,16,2014/2015,69,HHS Region 8,Season peak percentage,4.4
+2015,16,2014/2015,69,HHS Region 8,1 wk ahead,0.8
+2015,16,2014/2015,69,HHS Region 8,2 wk ahead,0.9
+2015,16,2014/2015,69,HHS Region 8,3 wk ahead,0.7
+2015,16,2014/2015,69,HHS Region 8,4 wk ahead,0.6
+2015,16,2014/2015,69,HHS Region 9,Season onset,51
+2015,16,2014/2015,69,HHS Region 9,Season peak week,3
+2015,16,2014/2015,69,HHS Region 9,Season peak week,4
+2015,16,2014/2015,69,HHS Region 9,Season peak percentage,5
+2015,16,2014/2015,69,HHS Region 9,1 wk ahead,2
+2015,16,2014/2015,69,HHS Region 9,2 wk ahead,2.1
+2015,16,2014/2015,69,HHS Region 9,3 wk ahead,2.1
+2015,16,2014/2015,69,HHS Region 9,4 wk ahead,2
+2015,16,2014/2015,69,HHS Region 10,Season onset,48
+2015,16,2014/2015,69,HHS Region 10,Season peak week,2
+2015,16,2014/2015,69,HHS Region 10,Season peak percentage,3.6
+2015,16,2014/2015,69,HHS Region 10,1 wk ahead,0.8
+2015,16,2014/2015,69,HHS Region 10,2 wk ahead,0.5
+2015,16,2014/2015,69,HHS Region 10,3 wk ahead,0.7
+2015,16,2014/2015,69,HHS Region 10,4 wk ahead,0.6
+2015,17,2014/2015,70,US National,Season onset,47
+2015,17,2014/2015,70,US National,Season peak week,52
+2015,17,2014/2015,70,US National,Season peak percentage,6
+2015,17,2014/2015,70,US National,1 wk ahead,1.4
+2015,17,2014/2015,70,US National,2 wk ahead,1.4
+2015,17,2014/2015,70,US National,3 wk ahead,1.3
+2015,17,2014/2015,70,US National,4 wk ahead,1.3
+2015,17,2014/2015,70,HHS Region 1,Season onset,50
+2015,17,2014/2015,70,HHS Region 1,Season peak week,3
+2015,17,2014/2015,70,HHS Region 1,Season peak percentage,3.9
+2015,17,2014/2015,70,HHS Region 1,1 wk ahead,1
+2015,17,2014/2015,70,HHS Region 1,2 wk ahead,0.8
+2015,17,2014/2015,70,HHS Region 1,3 wk ahead,0.8
+2015,17,2014/2015,70,HHS Region 1,4 wk ahead,0.8
+2015,17,2014/2015,70,HHS Region 2,Season onset,45
+2015,17,2014/2015,70,HHS Region 2,Season peak week,52
+2015,17,2014/2015,70,HHS Region 2,Season peak week,4
+2015,17,2014/2015,70,HHS Region 2,Season peak week,5
+2015,17,2014/2015,70,HHS Region 2,Season peak percentage,5.2
+2015,17,2014/2015,70,HHS Region 2,1 wk ahead,1.9
+2015,17,2014/2015,70,HHS Region 2,2 wk ahead,1.8
+2015,17,2014/2015,70,HHS Region 2,3 wk ahead,1.6
+2015,17,2014/2015,70,HHS Region 2,4 wk ahead,1.8
+2015,17,2014/2015,70,HHS Region 3,Season onset,48
+2015,17,2014/2015,70,HHS Region 3,Season peak week,52
+2015,17,2014/2015,70,HHS Region 3,Season peak percentage,7.2
+2015,17,2014/2015,70,HHS Region 3,1 wk ahead,1.3
+2015,17,2014/2015,70,HHS Region 3,2 wk ahead,1.2
+2015,17,2014/2015,70,HHS Region 3,3 wk ahead,1.2
+2015,17,2014/2015,70,HHS Region 3,4 wk ahead,1.6
+2015,17,2014/2015,70,HHS Region 4,Season onset,47
+2015,17,2014/2015,70,HHS Region 4,Season peak week,52
+2015,17,2014/2015,70,HHS Region 4,Season peak percentage,7.5
+2015,17,2014/2015,70,HHS Region 4,1 wk ahead,0.9
+2015,17,2014/2015,70,HHS Region 4,2 wk ahead,1
+2015,17,2014/2015,70,HHS Region 4,3 wk ahead,0.9
+2015,17,2014/2015,70,HHS Region 4,4 wk ahead,0.7
+2015,17,2014/2015,70,HHS Region 5,Season onset,48
+2015,17,2014/2015,70,HHS Region 5,Season peak week,52
+2015,17,2014/2015,70,HHS Region 5,Season peak percentage,6.6
+2015,17,2014/2015,70,HHS Region 5,1 wk ahead,1
+2015,17,2014/2015,70,HHS Region 5,2 wk ahead,1
+2015,17,2014/2015,70,HHS Region 5,3 wk ahead,0.8
+2015,17,2014/2015,70,HHS Region 5,4 wk ahead,0.7
+2015,17,2014/2015,70,HHS Region 6,Season onset,47
+2015,17,2014/2015,70,HHS Region 6,Season peak week,51
+2015,17,2014/2015,70,HHS Region 6,Season peak percentage,11.1
+2015,17,2014/2015,70,HHS Region 6,1 wk ahead,2.4
+2015,17,2014/2015,70,HHS Region 6,2 wk ahead,2.3
+2015,17,2014/2015,70,HHS Region 6,3 wk ahead,2.2
+2015,17,2014/2015,70,HHS Region 6,4 wk ahead,2.3
+2015,17,2014/2015,70,HHS Region 7,Season onset,48
+2015,17,2014/2015,70,HHS Region 7,Season peak week,52
+2015,17,2014/2015,70,HHS Region 7,Season peak percentage,6.4
+2015,17,2014/2015,70,HHS Region 7,1 wk ahead,0.8
+2015,17,2014/2015,70,HHS Region 7,2 wk ahead,0.8
+2015,17,2014/2015,70,HHS Region 7,3 wk ahead,0.6
+2015,17,2014/2015,70,HHS Region 7,4 wk ahead,0.3
+2015,17,2014/2015,70,HHS Region 8,Season onset,49
+2015,17,2014/2015,70,HHS Region 8,Season peak week,53
+2015,17,2014/2015,70,HHS Region 8,Season peak percentage,4.4
+2015,17,2014/2015,70,HHS Region 8,1 wk ahead,0.9
+2015,17,2014/2015,70,HHS Region 8,2 wk ahead,0.7
+2015,17,2014/2015,70,HHS Region 8,3 wk ahead,0.6
+2015,17,2014/2015,70,HHS Region 8,4 wk ahead,0.6
+2015,17,2014/2015,70,HHS Region 9,Season onset,51
+2015,17,2014/2015,70,HHS Region 9,Season peak week,3
+2015,17,2014/2015,70,HHS Region 9,Season peak week,4
+2015,17,2014/2015,70,HHS Region 9,Season peak percentage,5
+2015,17,2014/2015,70,HHS Region 9,1 wk ahead,2.1
+2015,17,2014/2015,70,HHS Region 9,2 wk ahead,2.1
+2015,17,2014/2015,70,HHS Region 9,3 wk ahead,2
+2015,17,2014/2015,70,HHS Region 9,4 wk ahead,1.9
+2015,17,2014/2015,70,HHS Region 10,Season onset,48
+2015,17,2014/2015,70,HHS Region 10,Season peak week,2
+2015,17,2014/2015,70,HHS Region 10,Season peak percentage,3.6
+2015,17,2014/2015,70,HHS Region 10,1 wk ahead,0.5
+2015,17,2014/2015,70,HHS Region 10,2 wk ahead,0.7
+2015,17,2014/2015,70,HHS Region 10,3 wk ahead,0.6
+2015,17,2014/2015,70,HHS Region 10,4 wk ahead,0.6
+2015,18,2014/2015,71,US National,Season onset,47
+2015,18,2014/2015,71,US National,Season peak week,52
+2015,18,2014/2015,71,US National,Season peak percentage,6
+2015,18,2014/2015,71,US National,1 wk ahead,1.4
+2015,18,2014/2015,71,US National,2 wk ahead,1.3
+2015,18,2014/2015,71,US National,3 wk ahead,1.3
+2015,18,2014/2015,71,US National,4 wk ahead,1.2
+2015,18,2014/2015,71,HHS Region 1,Season onset,50
+2015,18,2014/2015,71,HHS Region 1,Season peak week,3
+2015,18,2014/2015,71,HHS Region 1,Season peak percentage,3.9
+2015,18,2014/2015,71,HHS Region 1,1 wk ahead,0.8
+2015,18,2014/2015,71,HHS Region 1,2 wk ahead,0.8
+2015,18,2014/2015,71,HHS Region 1,3 wk ahead,0.8
+2015,18,2014/2015,71,HHS Region 1,4 wk ahead,0.7
+2015,18,2014/2015,71,HHS Region 2,Season onset,45
+2015,18,2014/2015,71,HHS Region 2,Season peak week,52
+2015,18,2014/2015,71,HHS Region 2,Season peak week,4
+2015,18,2014/2015,71,HHS Region 2,Season peak week,5
+2015,18,2014/2015,71,HHS Region 2,Season peak percentage,5.2
+2015,18,2014/2015,71,HHS Region 2,1 wk ahead,1.8
+2015,18,2014/2015,71,HHS Region 2,2 wk ahead,1.6
+2015,18,2014/2015,71,HHS Region 2,3 wk ahead,1.8
+2015,18,2014/2015,71,HHS Region 2,4 wk ahead,1.6
+2015,18,2014/2015,71,HHS Region 3,Season onset,48
+2015,18,2014/2015,71,HHS Region 3,Season peak week,52
+2015,18,2014/2015,71,HHS Region 3,Season peak percentage,7.2
+2015,18,2014/2015,71,HHS Region 3,1 wk ahead,1.2
+2015,18,2014/2015,71,HHS Region 3,2 wk ahead,1.2
+2015,18,2014/2015,71,HHS Region 3,3 wk ahead,1.6
+2015,18,2014/2015,71,HHS Region 3,4 wk ahead,1.2
+2015,18,2014/2015,71,HHS Region 4,Season onset,47
+2015,18,2014/2015,71,HHS Region 4,Season peak week,52
+2015,18,2014/2015,71,HHS Region 4,Season peak percentage,7.5
+2015,18,2014/2015,71,HHS Region 4,1 wk ahead,1
+2015,18,2014/2015,71,HHS Region 4,2 wk ahead,0.9
+2015,18,2014/2015,71,HHS Region 4,3 wk ahead,0.7
+2015,18,2014/2015,71,HHS Region 4,4 wk ahead,0.7
+2015,18,2014/2015,71,HHS Region 5,Season onset,48
+2015,18,2014/2015,71,HHS Region 5,Season peak week,52
+2015,18,2014/2015,71,HHS Region 5,Season peak percentage,6.6
+2015,18,2014/2015,71,HHS Region 5,1 wk ahead,1
+2015,18,2014/2015,71,HHS Region 5,2 wk ahead,0.8
+2015,18,2014/2015,71,HHS Region 5,3 wk ahead,0.7
+2015,18,2014/2015,71,HHS Region 5,4 wk ahead,0.7
+2015,18,2014/2015,71,HHS Region 6,Season onset,47
+2015,18,2014/2015,71,HHS Region 6,Season peak week,51
+2015,18,2014/2015,71,HHS Region 6,Season peak percentage,11.1
+2015,18,2014/2015,71,HHS Region 6,1 wk ahead,2.3
+2015,18,2014/2015,71,HHS Region 6,2 wk ahead,2.2
+2015,18,2014/2015,71,HHS Region 6,3 wk ahead,2.3
+2015,18,2014/2015,71,HHS Region 6,4 wk ahead,2.6
+2015,18,2014/2015,71,HHS Region 7,Season onset,48
+2015,18,2014/2015,71,HHS Region 7,Season peak week,52
+2015,18,2014/2015,71,HHS Region 7,Season peak percentage,6.4
+2015,18,2014/2015,71,HHS Region 7,1 wk ahead,0.8
+2015,18,2014/2015,71,HHS Region 7,2 wk ahead,0.6
+2015,18,2014/2015,71,HHS Region 7,3 wk ahead,0.3
+2015,18,2014/2015,71,HHS Region 7,4 wk ahead,0.3
+2015,18,2014/2015,71,HHS Region 8,Season onset,49
+2015,18,2014/2015,71,HHS Region 8,Season peak week,53
+2015,18,2014/2015,71,HHS Region 8,Season peak percentage,4.4
+2015,18,2014/2015,71,HHS Region 8,1 wk ahead,0.7
+2015,18,2014/2015,71,HHS Region 8,2 wk ahead,0.6
+2015,18,2014/2015,71,HHS Region 8,3 wk ahead,0.6
+2015,18,2014/2015,71,HHS Region 8,4 wk ahead,0.5
+2015,18,2014/2015,71,HHS Region 9,Season onset,51
+2015,18,2014/2015,71,HHS Region 9,Season peak week,3
+2015,18,2014/2015,71,HHS Region 9,Season peak week,4
+2015,18,2014/2015,71,HHS Region 9,Season peak percentage,5
+2015,18,2014/2015,71,HHS Region 9,1 wk ahead,2.1
+2015,18,2014/2015,71,HHS Region 9,2 wk ahead,2
+2015,18,2014/2015,71,HHS Region 9,3 wk ahead,1.9
+2015,18,2014/2015,71,HHS Region 9,4 wk ahead,2
+2015,18,2014/2015,71,HHS Region 10,Season onset,48
+2015,18,2014/2015,71,HHS Region 10,Season peak week,2
+2015,18,2014/2015,71,HHS Region 10,Season peak percentage,3.6
+2015,18,2014/2015,71,HHS Region 10,1 wk ahead,0.7
+2015,18,2014/2015,71,HHS Region 10,2 wk ahead,0.6
+2015,18,2014/2015,71,HHS Region 10,3 wk ahead,0.6
+2015,18,2014/2015,71,HHS Region 10,4 wk ahead,0.6
+2015,19,2014/2015,72,US National,Season onset,47
+2015,19,2014/2015,72,US National,Season peak week,52
+2015,19,2014/2015,72,US National,Season peak percentage,6
+2015,19,2014/2015,72,US National,1 wk ahead,1.3
+2015,19,2014/2015,72,US National,2 wk ahead,1.3
+2015,19,2014/2015,72,US National,3 wk ahead,1.2
+2015,19,2014/2015,72,US National,4 wk ahead,1.1
+2015,19,2014/2015,72,HHS Region 1,Season onset,50
+2015,19,2014/2015,72,HHS Region 1,Season peak week,3
+2015,19,2014/2015,72,HHS Region 1,Season peak percentage,3.9
+2015,19,2014/2015,72,HHS Region 1,1 wk ahead,0.8
+2015,19,2014/2015,72,HHS Region 1,2 wk ahead,0.8
+2015,19,2014/2015,72,HHS Region 1,3 wk ahead,0.7
+2015,19,2014/2015,72,HHS Region 1,4 wk ahead,0.7
+2015,19,2014/2015,72,HHS Region 2,Season onset,45
+2015,19,2014/2015,72,HHS Region 2,Season peak week,52
+2015,19,2014/2015,72,HHS Region 2,Season peak week,4
+2015,19,2014/2015,72,HHS Region 2,Season peak week,5
+2015,19,2014/2015,72,HHS Region 2,Season peak percentage,5.2
+2015,19,2014/2015,72,HHS Region 2,1 wk ahead,1.6
+2015,19,2014/2015,72,HHS Region 2,2 wk ahead,1.8
+2015,19,2014/2015,72,HHS Region 2,3 wk ahead,1.6
+2015,19,2014/2015,72,HHS Region 2,4 wk ahead,1.6
+2015,19,2014/2015,72,HHS Region 3,Season onset,48
+2015,19,2014/2015,72,HHS Region 3,Season peak week,52
+2015,19,2014/2015,72,HHS Region 3,Season peak percentage,7.2
+2015,19,2014/2015,72,HHS Region 3,1 wk ahead,1.2
+2015,19,2014/2015,72,HHS Region 3,2 wk ahead,1.6
+2015,19,2014/2015,72,HHS Region 3,3 wk ahead,1.2
+2015,19,2014/2015,72,HHS Region 3,4 wk ahead,1.3
+2015,19,2014/2015,72,HHS Region 4,Season onset,47
+2015,19,2014/2015,72,HHS Region 4,Season peak week,52
+2015,19,2014/2015,72,HHS Region 4,Season peak percentage,7.5
+2015,19,2014/2015,72,HHS Region 4,1 wk ahead,0.9
+2015,19,2014/2015,72,HHS Region 4,2 wk ahead,0.7
+2015,19,2014/2015,72,HHS Region 4,3 wk ahead,0.7
+2015,19,2014/2015,72,HHS Region 4,4 wk ahead,0.7
+2015,19,2014/2015,72,HHS Region 5,Season onset,48
+2015,19,2014/2015,72,HHS Region 5,Season peak week,52
+2015,19,2014/2015,72,HHS Region 5,Season peak percentage,6.6
+2015,19,2014/2015,72,HHS Region 5,1 wk ahead,0.8
+2015,19,2014/2015,72,HHS Region 5,2 wk ahead,0.7
+2015,19,2014/2015,72,HHS Region 5,3 wk ahead,0.7
+2015,19,2014/2015,72,HHS Region 5,4 wk ahead,0.6
+2015,19,2014/2015,72,HHS Region 6,Season onset,47
+2015,19,2014/2015,72,HHS Region 6,Season peak week,51
+2015,19,2014/2015,72,HHS Region 6,Season peak percentage,11.1
+2015,19,2014/2015,72,HHS Region 6,1 wk ahead,2.2
+2015,19,2014/2015,72,HHS Region 6,2 wk ahead,2.3
+2015,19,2014/2015,72,HHS Region 6,3 wk ahead,2.6
+2015,19,2014/2015,72,HHS Region 6,4 wk ahead,1.9
+2015,19,2014/2015,72,HHS Region 7,Season onset,48
+2015,19,2014/2015,72,HHS Region 7,Season peak week,52
+2015,19,2014/2015,72,HHS Region 7,Season peak percentage,6.4
+2015,19,2014/2015,72,HHS Region 7,1 wk ahead,0.6
+2015,19,2014/2015,72,HHS Region 7,2 wk ahead,0.3
+2015,19,2014/2015,72,HHS Region 7,3 wk ahead,0.3
+2015,19,2014/2015,72,HHS Region 7,4 wk ahead,0.2
+2015,19,2014/2015,72,HHS Region 8,Season onset,49
+2015,19,2014/2015,72,HHS Region 8,Season peak week,53
+2015,19,2014/2015,72,HHS Region 8,Season peak percentage,4.4
+2015,19,2014/2015,72,HHS Region 8,1 wk ahead,0.6
+2015,19,2014/2015,72,HHS Region 8,2 wk ahead,0.6
+2015,19,2014/2015,72,HHS Region 8,3 wk ahead,0.5
+2015,19,2014/2015,72,HHS Region 8,4 wk ahead,0.5
+2015,19,2014/2015,72,HHS Region 9,Season onset,51
+2015,19,2014/2015,72,HHS Region 9,Season peak week,3
+2015,19,2014/2015,72,HHS Region 9,Season peak week,4
+2015,19,2014/2015,72,HHS Region 9,Season peak percentage,5
+2015,19,2014/2015,72,HHS Region 9,1 wk ahead,2
+2015,19,2014/2015,72,HHS Region 9,2 wk ahead,1.9
+2015,19,2014/2015,72,HHS Region 9,3 wk ahead,2
+2015,19,2014/2015,72,HHS Region 9,4 wk ahead,1.7
+2015,19,2014/2015,72,HHS Region 10,Season onset,48
+2015,19,2014/2015,72,HHS Region 10,Season peak week,2
+2015,19,2014/2015,72,HHS Region 10,Season peak percentage,3.6
+2015,19,2014/2015,72,HHS Region 10,1 wk ahead,0.6
+2015,19,2014/2015,72,HHS Region 10,2 wk ahead,0.6
+2015,19,2014/2015,72,HHS Region 10,3 wk ahead,0.6
+2015,19,2014/2015,72,HHS Region 10,4 wk ahead,0.5
+2015,20,2014/2015,73,US National,Season onset,47
+2015,20,2014/2015,73,US National,Season peak week,52
+2015,20,2014/2015,73,US National,Season peak percentage,6
+2015,20,2014/2015,73,US National,1 wk ahead,1.3
+2015,20,2014/2015,73,US National,2 wk ahead,1.2
+2015,20,2014/2015,73,US National,3 wk ahead,1.1
+2015,20,2014/2015,73,US National,4 wk ahead,1
+2015,20,2014/2015,73,HHS Region 1,Season onset,50
+2015,20,2014/2015,73,HHS Region 1,Season peak week,3
+2015,20,2014/2015,73,HHS Region 1,Season peak percentage,3.9
+2015,20,2014/2015,73,HHS Region 1,1 wk ahead,0.8
+2015,20,2014/2015,73,HHS Region 1,2 wk ahead,0.7
+2015,20,2014/2015,73,HHS Region 1,3 wk ahead,0.7
+2015,20,2014/2015,73,HHS Region 1,4 wk ahead,0.5
+2015,20,2014/2015,73,HHS Region 2,Season onset,45
+2015,20,2014/2015,73,HHS Region 2,Season peak week,52
+2015,20,2014/2015,73,HHS Region 2,Season peak week,4
+2015,20,2014/2015,73,HHS Region 2,Season peak week,5
+2015,20,2014/2015,73,HHS Region 2,Season peak percentage,5.2
+2015,20,2014/2015,73,HHS Region 2,1 wk ahead,1.8
+2015,20,2014/2015,73,HHS Region 2,2 wk ahead,1.6
+2015,20,2014/2015,73,HHS Region 2,3 wk ahead,1.6
+2015,20,2014/2015,73,HHS Region 2,4 wk ahead,1.2
+2015,20,2014/2015,73,HHS Region 3,Season onset,48
+2015,20,2014/2015,73,HHS Region 3,Season peak week,52
+2015,20,2014/2015,73,HHS Region 3,Season peak percentage,7.2
+2015,20,2014/2015,73,HHS Region 3,1 wk ahead,1.6
+2015,20,2014/2015,73,HHS Region 3,2 wk ahead,1.2
+2015,20,2014/2015,73,HHS Region 3,3 wk ahead,1.3
+2015,20,2014/2015,73,HHS Region 3,4 wk ahead,1.2
+2015,20,2014/2015,73,HHS Region 4,Season onset,47
+2015,20,2014/2015,73,HHS Region 4,Season peak week,52
+2015,20,2014/2015,73,HHS Region 4,Season peak percentage,7.5
+2015,20,2014/2015,73,HHS Region 4,1 wk ahead,0.7
+2015,20,2014/2015,73,HHS Region 4,2 wk ahead,0.7
+2015,20,2014/2015,73,HHS Region 4,3 wk ahead,0.7
+2015,20,2014/2015,73,HHS Region 4,4 wk ahead,0.7
+2015,20,2014/2015,73,HHS Region 5,Season onset,48
+2015,20,2014/2015,73,HHS Region 5,Season peak week,52
+2015,20,2014/2015,73,HHS Region 5,Season peak percentage,6.6
+2015,20,2014/2015,73,HHS Region 5,1 wk ahead,0.7
+2015,20,2014/2015,73,HHS Region 5,2 wk ahead,0.7
+2015,20,2014/2015,73,HHS Region 5,3 wk ahead,0.6
+2015,20,2014/2015,73,HHS Region 5,4 wk ahead,0.5
+2015,20,2014/2015,73,HHS Region 6,Season onset,47
+2015,20,2014/2015,73,HHS Region 6,Season peak week,51
+2015,20,2014/2015,73,HHS Region 6,Season peak percentage,11.1
+2015,20,2014/2015,73,HHS Region 6,1 wk ahead,2.3
+2015,20,2014/2015,73,HHS Region 6,2 wk ahead,2.6
+2015,20,2014/2015,73,HHS Region 6,3 wk ahead,1.9
+2015,20,2014/2015,73,HHS Region 6,4 wk ahead,1.9
+2015,20,2014/2015,73,HHS Region 7,Season onset,48
+2015,20,2014/2015,73,HHS Region 7,Season peak week,52
+2015,20,2014/2015,73,HHS Region 7,Season peak percentage,6.4
+2015,20,2014/2015,73,HHS Region 7,1 wk ahead,0.3
+2015,20,2014/2015,73,HHS Region 7,2 wk ahead,0.3
+2015,20,2014/2015,73,HHS Region 7,3 wk ahead,0.2
+2015,20,2014/2015,73,HHS Region 7,4 wk ahead,0.2
+2015,20,2014/2015,73,HHS Region 8,Season onset,49
+2015,20,2014/2015,73,HHS Region 8,Season peak week,53
+2015,20,2014/2015,73,HHS Region 8,Season peak percentage,4.4
+2015,20,2014/2015,73,HHS Region 8,1 wk ahead,0.6
+2015,20,2014/2015,73,HHS Region 8,2 wk ahead,0.5
+2015,20,2014/2015,73,HHS Region 8,3 wk ahead,0.5
+2015,20,2014/2015,73,HHS Region 8,4 wk ahead,0.4
+2015,20,2014/2015,73,HHS Region 9,Season onset,51
+2015,20,2014/2015,73,HHS Region 9,Season peak week,3
+2015,20,2014/2015,73,HHS Region 9,Season peak week,4
+2015,20,2014/2015,73,HHS Region 9,Season peak percentage,5
+2015,20,2014/2015,73,HHS Region 9,1 wk ahead,1.9
+2015,20,2014/2015,73,HHS Region 9,2 wk ahead,2
+2015,20,2014/2015,73,HHS Region 9,3 wk ahead,1.7
+2015,20,2014/2015,73,HHS Region 9,4 wk ahead,1.6
+2015,20,2014/2015,73,HHS Region 10,Season onset,48
+2015,20,2014/2015,73,HHS Region 10,Season peak week,2
+2015,20,2014/2015,73,HHS Region 10,Season peak percentage,3.6
+2015,20,2014/2015,73,HHS Region 10,1 wk ahead,0.6
+2015,20,2014/2015,73,HHS Region 10,2 wk ahead,0.6
+2015,20,2014/2015,73,HHS Region 10,3 wk ahead,0.5
+2015,20,2014/2015,73,HHS Region 10,4 wk ahead,0.4
+2015,40,2015/2016,40,US National,Season onset,3
+2015,40,2015/2016,40,US National,Season peak week,10
+2015,40,2015/2016,40,US National,Season peak percentage,3.6
+2015,40,2015/2016,40,US National,1 wk ahead,1.3
+2015,40,2015/2016,40,US National,2 wk ahead,1.4
+2015,40,2015/2016,40,US National,3 wk ahead,1.4
+2015,40,2015/2016,40,US National,4 wk ahead,1.4
+2015,40,2015/2016,40,HHS Region 1,Season onset,51
+2015,40,2015/2016,40,HHS Region 1,Season peak week,10
+2015,40,2015/2016,40,HHS Region 1,Season peak percentage,2.5
+2015,40,2015/2016,40,HHS Region 1,1 wk ahead,0.6
+2015,40,2015/2016,40,HHS Region 1,2 wk ahead,0.7
+2015,40,2015/2016,40,HHS Region 1,3 wk ahead,0.8
+2015,40,2015/2016,40,HHS Region 1,4 wk ahead,0.9
+2015,40,2015/2016,40,HHS Region 2,Season onset,4
+2015,40,2015/2016,40,HHS Region 2,Season peak week,11
+2015,40,2015/2016,40,HHS Region 2,Season peak percentage,4.1
+2015,40,2015/2016,40,HHS Region 2,1 wk ahead,0.9
+2015,40,2015/2016,40,HHS Region 2,2 wk ahead,1.2
+2015,40,2015/2016,40,HHS Region 2,3 wk ahead,1.1
+2015,40,2015/2016,40,HHS Region 2,4 wk ahead,1.2
+2015,40,2015/2016,40,HHS Region 3,Season onset,47
+2015,40,2015/2016,40,HHS Region 3,Season peak week,10
+2015,40,2015/2016,40,HHS Region 3,Season peak percentage,4
+2015,40,2015/2016,40,HHS Region 3,1 wk ahead,1.3
+2015,40,2015/2016,40,HHS Region 3,2 wk ahead,1.5
+2015,40,2015/2016,40,HHS Region 3,3 wk ahead,1.4
+2015,40,2015/2016,40,HHS Region 3,4 wk ahead,1.5
+2015,40,2015/2016,40,HHS Region 4,Season onset,3
+2015,40,2015/2016,40,HHS Region 4,Season peak week,10
+2015,40,2015/2016,40,HHS Region 4,Season peak percentage,3.6
+2015,40,2015/2016,40,HHS Region 4,1 wk ahead,1.1
+2015,40,2015/2016,40,HHS Region 4,2 wk ahead,1
+2015,40,2015/2016,40,HHS Region 4,3 wk ahead,1.1
+2015,40,2015/2016,40,HHS Region 4,4 wk ahead,1.1
+2015,40,2015/2016,40,HHS Region 5,Season onset,7
+2015,40,2015/2016,40,HHS Region 5,Season peak week,10
+2015,40,2015/2016,40,HHS Region 5,Season peak percentage,3.4
+2015,40,2015/2016,40,HHS Region 5,1 wk ahead,1.2
+2015,40,2015/2016,40,HHS Region 5,2 wk ahead,1.1
+2015,40,2015/2016,40,HHS Region 5,3 wk ahead,1
+2015,40,2015/2016,40,HHS Region 5,4 wk ahead,1.2
+2015,40,2015/2016,40,HHS Region 6,Season onset,47
+2015,40,2015/2016,40,HHS Region 6,Season peak week,7
+2015,40,2015/2016,40,HHS Region 6,Season peak percentage,5.3
+2015,40,2015/2016,40,HHS Region 6,1 wk ahead,2.8
+2015,40,2015/2016,40,HHS Region 6,2 wk ahead,3
+2015,40,2015/2016,40,HHS Region 6,3 wk ahead,3.1
+2015,40,2015/2016,40,HHS Region 6,4 wk ahead,2.9
+2015,40,2015/2016,40,HHS Region 7,Season onset,7
+2015,40,2015/2016,40,HHS Region 7,Season peak week,10
+2015,40,2015/2016,40,HHS Region 7,Season peak percentage,2.5
+2015,40,2015/2016,40,HHS Region 7,1 wk ahead,0.9
+2015,40,2015/2016,40,HHS Region 7,2 wk ahead,1.1
+2015,40,2015/2016,40,HHS Region 7,3 wk ahead,0.9
+2015,40,2015/2016,40,HHS Region 7,4 wk ahead,1.2
+2015,40,2015/2016,40,HHS Region 8,Season onset,5
+2015,40,2015/2016,40,HHS Region 8,Season peak week,8
+2015,40,2015/2016,40,HHS Region 8,Season peak week,11
+2015,40,2015/2016,40,HHS Region 8,Season peak percentage,2.2
+2015,40,2015/2016,40,HHS Region 8,1 wk ahead,0.7
+2015,40,2015/2016,40,HHS Region 8,2 wk ahead,0.7
+2015,40,2015/2016,40,HHS Region 8,3 wk ahead,0.6
+2015,40,2015/2016,40,HHS Region 8,4 wk ahead,0.7
+2015,40,2015/2016,40,HHS Region 9,Season onset,3
+2015,40,2015/2016,40,HHS Region 9,Season peak week,7
+2015,40,2015/2016,40,HHS Region 9,Season peak percentage,4.4
+2015,40,2015/2016,40,HHS Region 9,1 wk ahead,1.5
+2015,40,2015/2016,40,HHS Region 9,2 wk ahead,1.4
+2015,40,2015/2016,40,HHS Region 9,3 wk ahead,1.6
+2015,40,2015/2016,40,HHS Region 9,4 wk ahead,1.8
+2015,40,2015/2016,40,HHS Region 10,Season onset,2
+2015,40,2015/2016,40,HHS Region 10,Season peak week,7
+2015,40,2015/2016,40,HHS Region 10,Season peak percentage,2.4
+2015,40,2015/2016,40,HHS Region 10,1 wk ahead,0.8
+2015,40,2015/2016,40,HHS Region 10,2 wk ahead,0.6
+2015,40,2015/2016,40,HHS Region 10,3 wk ahead,0.9
+2015,40,2015/2016,40,HHS Region 10,4 wk ahead,0.5
+2015,41,2015/2016,41,US National,Season onset,3
+2015,41,2015/2016,41,US National,Season peak week,10
+2015,41,2015/2016,41,US National,Season peak percentage,3.6
+2015,41,2015/2016,41,US National,1 wk ahead,1.4
+2015,41,2015/2016,41,US National,2 wk ahead,1.4
+2015,41,2015/2016,41,US National,3 wk ahead,1.4
+2015,41,2015/2016,41,US National,4 wk ahead,1.5
+2015,41,2015/2016,41,HHS Region 1,Season onset,51
+2015,41,2015/2016,41,HHS Region 1,Season peak week,10
+2015,41,2015/2016,41,HHS Region 1,Season peak percentage,2.5
+2015,41,2015/2016,41,HHS Region 1,1 wk ahead,0.7
+2015,41,2015/2016,41,HHS Region 1,2 wk ahead,0.8
+2015,41,2015/2016,41,HHS Region 1,3 wk ahead,0.9
+2015,41,2015/2016,41,HHS Region 1,4 wk ahead,0.8
+2015,41,2015/2016,41,HHS Region 2,Season onset,4
+2015,41,2015/2016,41,HHS Region 2,Season peak week,11
+2015,41,2015/2016,41,HHS Region 2,Season peak percentage,4.1
+2015,41,2015/2016,41,HHS Region 2,1 wk ahead,1.2
+2015,41,2015/2016,41,HHS Region 2,2 wk ahead,1.1
+2015,41,2015/2016,41,HHS Region 2,3 wk ahead,1.2
+2015,41,2015/2016,41,HHS Region 2,4 wk ahead,1.1
+2015,41,2015/2016,41,HHS Region 3,Season onset,47
+2015,41,2015/2016,41,HHS Region 3,Season peak week,10
+2015,41,2015/2016,41,HHS Region 3,Season peak percentage,4
+2015,41,2015/2016,41,HHS Region 3,1 wk ahead,1.5
+2015,41,2015/2016,41,HHS Region 3,2 wk ahead,1.4
+2015,41,2015/2016,41,HHS Region 3,3 wk ahead,1.5
+2015,41,2015/2016,41,HHS Region 3,4 wk ahead,1.6
+2015,41,2015/2016,41,HHS Region 4,Season onset,3
+2015,41,2015/2016,41,HHS Region 4,Season peak week,10
+2015,41,2015/2016,41,HHS Region 4,Season peak percentage,3.6
+2015,41,2015/2016,41,HHS Region 4,1 wk ahead,1
+2015,41,2015/2016,41,HHS Region 4,2 wk ahead,1.1
+2015,41,2015/2016,41,HHS Region 4,3 wk ahead,1.1
+2015,41,2015/2016,41,HHS Region 4,4 wk ahead,1.2
+2015,41,2015/2016,41,HHS Region 5,Season onset,7
+2015,41,2015/2016,41,HHS Region 5,Season peak week,10
+2015,41,2015/2016,41,HHS Region 5,Season peak percentage,3.4
+2015,41,2015/2016,41,HHS Region 5,1 wk ahead,1.1
+2015,41,2015/2016,41,HHS Region 5,2 wk ahead,1
+2015,41,2015/2016,41,HHS Region 5,3 wk ahead,1.2
+2015,41,2015/2016,41,HHS Region 5,4 wk ahead,1.3
+2015,41,2015/2016,41,HHS Region 6,Season onset,47
+2015,41,2015/2016,41,HHS Region 6,Season peak week,7
+2015,41,2015/2016,41,HHS Region 6,Season peak percentage,5.3
+2015,41,2015/2016,41,HHS Region 6,1 wk ahead,3
+2015,41,2015/2016,41,HHS Region 6,2 wk ahead,3.1
+2015,41,2015/2016,41,HHS Region 6,3 wk ahead,2.9
+2015,41,2015/2016,41,HHS Region 6,4 wk ahead,3.3
+2015,41,2015/2016,41,HHS Region 7,Season onset,7
+2015,41,2015/2016,41,HHS Region 7,Season peak week,10
+2015,41,2015/2016,41,HHS Region 7,Season peak percentage,2.5
+2015,41,2015/2016,41,HHS Region 7,1 wk ahead,1.1
+2015,41,2015/2016,41,HHS Region 7,2 wk ahead,0.9
+2015,41,2015/2016,41,HHS Region 7,3 wk ahead,1.2
+2015,41,2015/2016,41,HHS Region 7,4 wk ahead,1.2
+2015,41,2015/2016,41,HHS Region 8,Season onset,5
+2015,41,2015/2016,41,HHS Region 8,Season peak week,8
+2015,41,2015/2016,41,HHS Region 8,Season peak week,11
+2015,41,2015/2016,41,HHS Region 8,Season peak percentage,2.2
+2015,41,2015/2016,41,HHS Region 8,1 wk ahead,0.7
+2015,41,2015/2016,41,HHS Region 8,2 wk ahead,0.6
+2015,41,2015/2016,41,HHS Region 8,3 wk ahead,0.7
+2015,41,2015/2016,41,HHS Region 8,4 wk ahead,0.7
+2015,41,2015/2016,41,HHS Region 9,Season onset,3
+2015,41,2015/2016,41,HHS Region 9,Season peak week,7
+2015,41,2015/2016,41,HHS Region 9,Season peak percentage,4.4
+2015,41,2015/2016,41,HHS Region 9,1 wk ahead,1.4
+2015,41,2015/2016,41,HHS Region 9,2 wk ahead,1.6
+2015,41,2015/2016,41,HHS Region 9,3 wk ahead,1.8
+2015,41,2015/2016,41,HHS Region 9,4 wk ahead,1.7
+2015,41,2015/2016,41,HHS Region 10,Season onset,2
+2015,41,2015/2016,41,HHS Region 10,Season peak week,7
+2015,41,2015/2016,41,HHS Region 10,Season peak percentage,2.4
+2015,41,2015/2016,41,HHS Region 10,1 wk ahead,0.6
+2015,41,2015/2016,41,HHS Region 10,2 wk ahead,0.9
+2015,41,2015/2016,41,HHS Region 10,3 wk ahead,0.5
+2015,41,2015/2016,41,HHS Region 10,4 wk ahead,0.9
+2015,42,2015/2016,42,US National,Season onset,3
+2015,42,2015/2016,42,US National,Season peak week,10
+2015,42,2015/2016,42,US National,Season peak percentage,3.6
+2015,42,2015/2016,42,US National,1 wk ahead,1.4
+2015,42,2015/2016,42,US National,2 wk ahead,1.4
+2015,42,2015/2016,42,US National,3 wk ahead,1.5
+2015,42,2015/2016,42,US National,4 wk ahead,1.6
+2015,42,2015/2016,42,HHS Region 1,Season onset,51
+2015,42,2015/2016,42,HHS Region 1,Season peak week,10
+2015,42,2015/2016,42,HHS Region 1,Season peak percentage,2.5
+2015,42,2015/2016,42,HHS Region 1,1 wk ahead,0.8
+2015,42,2015/2016,42,HHS Region 1,2 wk ahead,0.9
+2015,42,2015/2016,42,HHS Region 1,3 wk ahead,0.8
+2015,42,2015/2016,42,HHS Region 1,4 wk ahead,0.7
+2015,42,2015/2016,42,HHS Region 2,Season onset,4
+2015,42,2015/2016,42,HHS Region 2,Season peak week,11
+2015,42,2015/2016,42,HHS Region 2,Season peak percentage,4.1
+2015,42,2015/2016,42,HHS Region 2,1 wk ahead,1.1
+2015,42,2015/2016,42,HHS Region 2,2 wk ahead,1.2
+2015,42,2015/2016,42,HHS Region 2,3 wk ahead,1.1
+2015,42,2015/2016,42,HHS Region 2,4 wk ahead,1.4
+2015,42,2015/2016,42,HHS Region 3,Season onset,47
+2015,42,2015/2016,42,HHS Region 3,Season peak week,10
+2015,42,2015/2016,42,HHS Region 3,Season peak percentage,4
+2015,42,2015/2016,42,HHS Region 3,1 wk ahead,1.4
+2015,42,2015/2016,42,HHS Region 3,2 wk ahead,1.5
+2015,42,2015/2016,42,HHS Region 3,3 wk ahead,1.6
+2015,42,2015/2016,42,HHS Region 3,4 wk ahead,1.7
+2015,42,2015/2016,42,HHS Region 4,Season onset,3
+2015,42,2015/2016,42,HHS Region 4,Season peak week,10
+2015,42,2015/2016,42,HHS Region 4,Season peak percentage,3.6
+2015,42,2015/2016,42,HHS Region 4,1 wk ahead,1.1
+2015,42,2015/2016,42,HHS Region 4,2 wk ahead,1.1
+2015,42,2015/2016,42,HHS Region 4,3 wk ahead,1.2
+2015,42,2015/2016,42,HHS Region 4,4 wk ahead,1.3
+2015,42,2015/2016,42,HHS Region 5,Season onset,7
+2015,42,2015/2016,42,HHS Region 5,Season peak week,10
+2015,42,2015/2016,42,HHS Region 5,Season peak percentage,3.4
+2015,42,2015/2016,42,HHS Region 5,1 wk ahead,1
+2015,42,2015/2016,42,HHS Region 5,2 wk ahead,1.2
+2015,42,2015/2016,42,HHS Region 5,3 wk ahead,1.3
+2015,42,2015/2016,42,HHS Region 5,4 wk ahead,1.2
+2015,42,2015/2016,42,HHS Region 6,Season onset,47
+2015,42,2015/2016,42,HHS Region 6,Season peak week,7
+2015,42,2015/2016,42,HHS Region 6,Season peak percentage,5.3
+2015,42,2015/2016,42,HHS Region 6,1 wk ahead,3.1
+2015,42,2015/2016,42,HHS Region 6,2 wk ahead,2.9
+2015,42,2015/2016,42,HHS Region 6,3 wk ahead,3.3
+2015,42,2015/2016,42,HHS Region 6,4 wk ahead,3.2
+2015,42,2015/2016,42,HHS Region 7,Season onset,7
+2015,42,2015/2016,42,HHS Region 7,Season peak week,10
+2015,42,2015/2016,42,HHS Region 7,Season peak percentage,2.5
+2015,42,2015/2016,42,HHS Region 7,1 wk ahead,0.9
+2015,42,2015/2016,42,HHS Region 7,2 wk ahead,1.2
+2015,42,2015/2016,42,HHS Region 7,3 wk ahead,1.2
+2015,42,2015/2016,42,HHS Region 7,4 wk ahead,1.1
+2015,42,2015/2016,42,HHS Region 8,Season onset,5
+2015,42,2015/2016,42,HHS Region 8,Season peak week,8
+2015,42,2015/2016,42,HHS Region 8,Season peak week,11
+2015,42,2015/2016,42,HHS Region 8,Season peak percentage,2.2
+2015,42,2015/2016,42,HHS Region 8,1 wk ahead,0.6
+2015,42,2015/2016,42,HHS Region 8,2 wk ahead,0.7
+2015,42,2015/2016,42,HHS Region 8,3 wk ahead,0.7
+2015,42,2015/2016,42,HHS Region 8,4 wk ahead,0.8
+2015,42,2015/2016,42,HHS Region 9,Season onset,3
+2015,42,2015/2016,42,HHS Region 9,Season peak week,7
+2015,42,2015/2016,42,HHS Region 9,Season peak percentage,4.4
+2015,42,2015/2016,42,HHS Region 9,1 wk ahead,1.6
+2015,42,2015/2016,42,HHS Region 9,2 wk ahead,1.8
+2015,42,2015/2016,42,HHS Region 9,3 wk ahead,1.7
+2015,42,2015/2016,42,HHS Region 9,4 wk ahead,2
+2015,42,2015/2016,42,HHS Region 10,Season onset,2
+2015,42,2015/2016,42,HHS Region 10,Season peak week,7
+2015,42,2015/2016,42,HHS Region 10,Season peak percentage,2.4
+2015,42,2015/2016,42,HHS Region 10,1 wk ahead,0.9
+2015,42,2015/2016,42,HHS Region 10,2 wk ahead,0.5
+2015,42,2015/2016,42,HHS Region 10,3 wk ahead,0.9
+2015,42,2015/2016,42,HHS Region 10,4 wk ahead,0.7
+2015,43,2015/2016,43,US National,Season onset,3
+2015,43,2015/2016,43,US National,Season peak week,10
+2015,43,2015/2016,43,US National,Season peak percentage,3.6
+2015,43,2015/2016,43,US National,1 wk ahead,1.4
+2015,43,2015/2016,43,US National,2 wk ahead,1.5
+2015,43,2015/2016,43,US National,3 wk ahead,1.6
+2015,43,2015/2016,43,US National,4 wk ahead,1.9
+2015,43,2015/2016,43,HHS Region 1,Season onset,51
+2015,43,2015/2016,43,HHS Region 1,Season peak week,10
+2015,43,2015/2016,43,HHS Region 1,Season peak percentage,2.5
+2015,43,2015/2016,43,HHS Region 1,1 wk ahead,0.9
+2015,43,2015/2016,43,HHS Region 1,2 wk ahead,0.8
+2015,43,2015/2016,43,HHS Region 1,3 wk ahead,0.7
+2015,43,2015/2016,43,HHS Region 1,4 wk ahead,1
+2015,43,2015/2016,43,HHS Region 2,Season onset,4
+2015,43,2015/2016,43,HHS Region 2,Season peak week,11
+2015,43,2015/2016,43,HHS Region 2,Season peak percentage,4.1
+2015,43,2015/2016,43,HHS Region 2,1 wk ahead,1.2
+2015,43,2015/2016,43,HHS Region 2,2 wk ahead,1.1
+2015,43,2015/2016,43,HHS Region 2,3 wk ahead,1.4
+2015,43,2015/2016,43,HHS Region 2,4 wk ahead,1.4
+2015,43,2015/2016,43,HHS Region 3,Season onset,47
+2015,43,2015/2016,43,HHS Region 3,Season peak week,10
+2015,43,2015/2016,43,HHS Region 3,Season peak percentage,4
+2015,43,2015/2016,43,HHS Region 3,1 wk ahead,1.5
+2015,43,2015/2016,43,HHS Region 3,2 wk ahead,1.6
+2015,43,2015/2016,43,HHS Region 3,3 wk ahead,1.7
+2015,43,2015/2016,43,HHS Region 3,4 wk ahead,2.2
+2015,43,2015/2016,43,HHS Region 4,Season onset,3
+2015,43,2015/2016,43,HHS Region 4,Season peak week,10
+2015,43,2015/2016,43,HHS Region 4,Season peak percentage,3.6
+2015,43,2015/2016,43,HHS Region 4,1 wk ahead,1.1
+2015,43,2015/2016,43,HHS Region 4,2 wk ahead,1.2
+2015,43,2015/2016,43,HHS Region 4,3 wk ahead,1.3
+2015,43,2015/2016,43,HHS Region 4,4 wk ahead,1.7
+2015,43,2015/2016,43,HHS Region 5,Season onset,7
+2015,43,2015/2016,43,HHS Region 5,Season peak week,10
+2015,43,2015/2016,43,HHS Region 5,Season peak percentage,3.4
+2015,43,2015/2016,43,HHS Region 5,1 wk ahead,1.2
+2015,43,2015/2016,43,HHS Region 5,2 wk ahead,1.3
+2015,43,2015/2016,43,HHS Region 5,3 wk ahead,1.2
+2015,43,2015/2016,43,HHS Region 5,4 wk ahead,1.4
+2015,43,2015/2016,43,HHS Region 6,Season onset,47
+2015,43,2015/2016,43,HHS Region 6,Season peak week,7
+2015,43,2015/2016,43,HHS Region 6,Season peak percentage,5.3
+2015,43,2015/2016,43,HHS Region 6,1 wk ahead,2.9
+2015,43,2015/2016,43,HHS Region 6,2 wk ahead,3.3
+2015,43,2015/2016,43,HHS Region 6,3 wk ahead,3.2
+2015,43,2015/2016,43,HHS Region 6,4 wk ahead,4
+2015,43,2015/2016,43,HHS Region 7,Season onset,7
+2015,43,2015/2016,43,HHS Region 7,Season peak week,10
+2015,43,2015/2016,43,HHS Region 7,Season peak percentage,2.5
+2015,43,2015/2016,43,HHS Region 7,1 wk ahead,1.2
+2015,43,2015/2016,43,HHS Region 7,2 wk ahead,1.2
+2015,43,2015/2016,43,HHS Region 7,3 wk ahead,1.1
+2015,43,2015/2016,43,HHS Region 7,4 wk ahead,1.3
+2015,43,2015/2016,43,HHS Region 8,Season onset,5
+2015,43,2015/2016,43,HHS Region 8,Season peak week,8
+2015,43,2015/2016,43,HHS Region 8,Season peak week,11
+2015,43,2015/2016,43,HHS Region 8,Season peak percentage,2.2
+2015,43,2015/2016,43,HHS Region 8,1 wk ahead,0.7
+2015,43,2015/2016,43,HHS Region 8,2 wk ahead,0.7
+2015,43,2015/2016,43,HHS Region 8,3 wk ahead,0.8
+2015,43,2015/2016,43,HHS Region 8,4 wk ahead,1
+2015,43,2015/2016,43,HHS Region 9,Season onset,3
+2015,43,2015/2016,43,HHS Region 9,Season peak week,7
+2015,43,2015/2016,43,HHS Region 9,Season peak percentage,4.4
+2015,43,2015/2016,43,HHS Region 9,1 wk ahead,1.8
+2015,43,2015/2016,43,HHS Region 9,2 wk ahead,1.7
+2015,43,2015/2016,43,HHS Region 9,3 wk ahead,2
+2015,43,2015/2016,43,HHS Region 9,4 wk ahead,2.2
+2015,43,2015/2016,43,HHS Region 10,Season onset,2
+2015,43,2015/2016,43,HHS Region 10,Season peak week,7
+2015,43,2015/2016,43,HHS Region 10,Season peak percentage,2.4
+2015,43,2015/2016,43,HHS Region 10,1 wk ahead,0.5
+2015,43,2015/2016,43,HHS Region 10,2 wk ahead,0.9
+2015,43,2015/2016,43,HHS Region 10,3 wk ahead,0.7
+2015,43,2015/2016,43,HHS Region 10,4 wk ahead,0.8
+2015,44,2015/2016,44,US National,Season onset,3
+2015,44,2015/2016,44,US National,Season peak week,10
+2015,44,2015/2016,44,US National,Season peak percentage,3.6
+2015,44,2015/2016,44,US National,1 wk ahead,1.5
+2015,44,2015/2016,44,US National,2 wk ahead,1.6
+2015,44,2015/2016,44,US National,3 wk ahead,1.9
+2015,44,2015/2016,44,US National,4 wk ahead,1.7
+2015,44,2015/2016,44,HHS Region 1,Season onset,51
+2015,44,2015/2016,44,HHS Region 1,Season peak week,10
+2015,44,2015/2016,44,HHS Region 1,Season peak percentage,2.5
+2015,44,2015/2016,44,HHS Region 1,1 wk ahead,0.8
+2015,44,2015/2016,44,HHS Region 1,2 wk ahead,0.7
+2015,44,2015/2016,44,HHS Region 1,3 wk ahead,1
+2015,44,2015/2016,44,HHS Region 1,4 wk ahead,0.8
+2015,44,2015/2016,44,HHS Region 2,Season onset,4
+2015,44,2015/2016,44,HHS Region 2,Season peak week,11
+2015,44,2015/2016,44,HHS Region 2,Season peak percentage,4.1
+2015,44,2015/2016,44,HHS Region 2,1 wk ahead,1.1
+2015,44,2015/2016,44,HHS Region 2,2 wk ahead,1.4
+2015,44,2015/2016,44,HHS Region 2,3 wk ahead,1.4
+2015,44,2015/2016,44,HHS Region 2,4 wk ahead,1.6
+2015,44,2015/2016,44,HHS Region 3,Season onset,47
+2015,44,2015/2016,44,HHS Region 3,Season peak week,10
+2015,44,2015/2016,44,HHS Region 3,Season peak percentage,4
+2015,44,2015/2016,44,HHS Region 3,1 wk ahead,1.6
+2015,44,2015/2016,44,HHS Region 3,2 wk ahead,1.7
+2015,44,2015/2016,44,HHS Region 3,3 wk ahead,2.2
+2015,44,2015/2016,44,HHS Region 3,4 wk ahead,1.8
+2015,44,2015/2016,44,HHS Region 4,Season onset,3
+2015,44,2015/2016,44,HHS Region 4,Season peak week,10
+2015,44,2015/2016,44,HHS Region 4,Season peak percentage,3.6
+2015,44,2015/2016,44,HHS Region 4,1 wk ahead,1.2
+2015,44,2015/2016,44,HHS Region 4,2 wk ahead,1.3
+2015,44,2015/2016,44,HHS Region 4,3 wk ahead,1.7
+2015,44,2015/2016,44,HHS Region 4,4 wk ahead,1.4
+2015,44,2015/2016,44,HHS Region 5,Season onset,7
+2015,44,2015/2016,44,HHS Region 5,Season peak week,10
+2015,44,2015/2016,44,HHS Region 5,Season peak percentage,3.4
+2015,44,2015/2016,44,HHS Region 5,1 wk ahead,1.3
+2015,44,2015/2016,44,HHS Region 5,2 wk ahead,1.2
+2015,44,2015/2016,44,HHS Region 5,3 wk ahead,1.4
+2015,44,2015/2016,44,HHS Region 5,4 wk ahead,1.1
+2015,44,2015/2016,44,HHS Region 6,Season onset,47
+2015,44,2015/2016,44,HHS Region 6,Season peak week,7
+2015,44,2015/2016,44,HHS Region 6,Season peak percentage,5.3
+2015,44,2015/2016,44,HHS Region 6,1 wk ahead,3.3
+2015,44,2015/2016,44,HHS Region 6,2 wk ahead,3.2
+2015,44,2015/2016,44,HHS Region 6,3 wk ahead,4
+2015,44,2015/2016,44,HHS Region 6,4 wk ahead,3.6
+2015,44,2015/2016,44,HHS Region 7,Season onset,7
+2015,44,2015/2016,44,HHS Region 7,Season peak week,10
+2015,44,2015/2016,44,HHS Region 7,Season peak percentage,2.5
+2015,44,2015/2016,44,HHS Region 7,1 wk ahead,1.2
+2015,44,2015/2016,44,HHS Region 7,2 wk ahead,1.1
+2015,44,2015/2016,44,HHS Region 7,3 wk ahead,1.3
+2015,44,2015/2016,44,HHS Region 7,4 wk ahead,1
+2015,44,2015/2016,44,HHS Region 8,Season onset,5
+2015,44,2015/2016,44,HHS Region 8,Season peak week,8
+2015,44,2015/2016,44,HHS Region 8,Season peak week,11
+2015,44,2015/2016,44,HHS Region 8,Season peak percentage,2.2
+2015,44,2015/2016,44,HHS Region 8,1 wk ahead,0.7
+2015,44,2015/2016,44,HHS Region 8,2 wk ahead,0.8
+2015,44,2015/2016,44,HHS Region 8,3 wk ahead,1
+2015,44,2015/2016,44,HHS Region 8,4 wk ahead,0.7
+2015,44,2015/2016,44,HHS Region 9,Season onset,3
+2015,44,2015/2016,44,HHS Region 9,Season peak week,7
+2015,44,2015/2016,44,HHS Region 9,Season peak percentage,4.4
+2015,44,2015/2016,44,HHS Region 9,1 wk ahead,1.7
+2015,44,2015/2016,44,HHS Region 9,2 wk ahead,2
+2015,44,2015/2016,44,HHS Region 9,3 wk ahead,2.2
+2015,44,2015/2016,44,HHS Region 9,4 wk ahead,2
+2015,44,2015/2016,44,HHS Region 10,Season onset,2
+2015,44,2015/2016,44,HHS Region 10,Season peak week,7
+2015,44,2015/2016,44,HHS Region 10,Season peak percentage,2.4
+2015,44,2015/2016,44,HHS Region 10,1 wk ahead,0.9
+2015,44,2015/2016,44,HHS Region 10,2 wk ahead,0.7
+2015,44,2015/2016,44,HHS Region 10,3 wk ahead,0.8
+2015,44,2015/2016,44,HHS Region 10,4 wk ahead,0.8
+2015,45,2015/2016,45,US National,Season onset,3
+2015,45,2015/2016,45,US National,Season peak week,10
+2015,45,2015/2016,45,US National,Season peak percentage,3.6
+2015,45,2015/2016,45,US National,1 wk ahead,1.6
+2015,45,2015/2016,45,US National,2 wk ahead,1.9
+2015,45,2015/2016,45,US National,3 wk ahead,1.7
+2015,45,2015/2016,45,US National,4 wk ahead,1.8
+2015,45,2015/2016,45,HHS Region 1,Season onset,51
+2015,45,2015/2016,45,HHS Region 1,Season peak week,10
+2015,45,2015/2016,45,HHS Region 1,Season peak percentage,2.5
+2015,45,2015/2016,45,HHS Region 1,1 wk ahead,0.7
+2015,45,2015/2016,45,HHS Region 1,2 wk ahead,1
+2015,45,2015/2016,45,HHS Region 1,3 wk ahead,0.8
+2015,45,2015/2016,45,HHS Region 1,4 wk ahead,1
+2015,45,2015/2016,45,HHS Region 2,Season onset,4
+2015,45,2015/2016,45,HHS Region 2,Season peak week,11
+2015,45,2015/2016,45,HHS Region 2,Season peak percentage,4.1
+2015,45,2015/2016,45,HHS Region 2,1 wk ahead,1.4
+2015,45,2015/2016,45,HHS Region 2,2 wk ahead,1.4
+2015,45,2015/2016,45,HHS Region 2,3 wk ahead,1.6
+2015,45,2015/2016,45,HHS Region 2,4 wk ahead,1.9
+2015,45,2015/2016,45,HHS Region 3,Season onset,47
+2015,45,2015/2016,45,HHS Region 3,Season peak week,10
+2015,45,2015/2016,45,HHS Region 3,Season peak percentage,4
+2015,45,2015/2016,45,HHS Region 3,1 wk ahead,1.7
+2015,45,2015/2016,45,HHS Region 3,2 wk ahead,2.2
+2015,45,2015/2016,45,HHS Region 3,3 wk ahead,1.8
+2015,45,2015/2016,45,HHS Region 3,4 wk ahead,2
+2015,45,2015/2016,45,HHS Region 4,Season onset,3
+2015,45,2015/2016,45,HHS Region 4,Season peak week,10
+2015,45,2015/2016,45,HHS Region 4,Season peak percentage,3.6
+2015,45,2015/2016,45,HHS Region 4,1 wk ahead,1.3
+2015,45,2015/2016,45,HHS Region 4,2 wk ahead,1.7
+2015,45,2015/2016,45,HHS Region 4,3 wk ahead,1.4
+2015,45,2015/2016,45,HHS Region 4,4 wk ahead,1.4
+2015,45,2015/2016,45,HHS Region 5,Season onset,7
+2015,45,2015/2016,45,HHS Region 5,Season peak week,10
+2015,45,2015/2016,45,HHS Region 5,Season peak percentage,3.4
+2015,45,2015/2016,45,HHS Region 5,1 wk ahead,1.2
+2015,45,2015/2016,45,HHS Region 5,2 wk ahead,1.4
+2015,45,2015/2016,45,HHS Region 5,3 wk ahead,1.1
+2015,45,2015/2016,45,HHS Region 5,4 wk ahead,1.4
+2015,45,2015/2016,45,HHS Region 6,Season onset,47
+2015,45,2015/2016,45,HHS Region 6,Season peak week,7
+2015,45,2015/2016,45,HHS Region 6,Season peak percentage,5.3
+2015,45,2015/2016,45,HHS Region 6,1 wk ahead,3.2
+2015,45,2015/2016,45,HHS Region 6,2 wk ahead,4
+2015,45,2015/2016,45,HHS Region 6,3 wk ahead,3.6
+2015,45,2015/2016,45,HHS Region 6,4 wk ahead,3.7
+2015,45,2015/2016,45,HHS Region 7,Season onset,7
+2015,45,2015/2016,45,HHS Region 7,Season peak week,10
+2015,45,2015/2016,45,HHS Region 7,Season peak percentage,2.5
+2015,45,2015/2016,45,HHS Region 7,1 wk ahead,1.1
+2015,45,2015/2016,45,HHS Region 7,2 wk ahead,1.3
+2015,45,2015/2016,45,HHS Region 7,3 wk ahead,1
+2015,45,2015/2016,45,HHS Region 7,4 wk ahead,0.9
+2015,45,2015/2016,45,HHS Region 8,Season onset,5
+2015,45,2015/2016,45,HHS Region 8,Season peak week,8
+2015,45,2015/2016,45,HHS Region 8,Season peak week,11
+2015,45,2015/2016,45,HHS Region 8,Season peak percentage,2.2
+2015,45,2015/2016,45,HHS Region 8,1 wk ahead,0.8
+2015,45,2015/2016,45,HHS Region 8,2 wk ahead,1
+2015,45,2015/2016,45,HHS Region 8,3 wk ahead,0.7
+2015,45,2015/2016,45,HHS Region 8,4 wk ahead,0.9
+2015,45,2015/2016,45,HHS Region 9,Season onset,3
+2015,45,2015/2016,45,HHS Region 9,Season peak week,7
+2015,45,2015/2016,45,HHS Region 9,Season peak percentage,4.4
+2015,45,2015/2016,45,HHS Region 9,1 wk ahead,2
+2015,45,2015/2016,45,HHS Region 9,2 wk ahead,2.2
+2015,45,2015/2016,45,HHS Region 9,3 wk ahead,2
+2015,45,2015/2016,45,HHS Region 9,4 wk ahead,2
+2015,45,2015/2016,45,HHS Region 10,Season onset,2
+2015,45,2015/2016,45,HHS Region 10,Season peak week,7
+2015,45,2015/2016,45,HHS Region 10,Season peak percentage,2.4
+2015,45,2015/2016,45,HHS Region 10,1 wk ahead,0.7
+2015,45,2015/2016,45,HHS Region 10,2 wk ahead,0.8
+2015,45,2015/2016,45,HHS Region 10,3 wk ahead,0.8
+2015,45,2015/2016,45,HHS Region 10,4 wk ahead,0.6
+2015,46,2015/2016,46,US National,Season onset,3
+2015,46,2015/2016,46,US National,Season peak week,10
+2015,46,2015/2016,46,US National,Season peak percentage,3.6
+2015,46,2015/2016,46,US National,1 wk ahead,1.9
+2015,46,2015/2016,46,US National,2 wk ahead,1.7
+2015,46,2015/2016,46,US National,3 wk ahead,1.8
+2015,46,2015/2016,46,US National,4 wk ahead,1.9
+2015,46,2015/2016,46,HHS Region 1,Season onset,51
+2015,46,2015/2016,46,HHS Region 1,Season peak week,10
+2015,46,2015/2016,46,HHS Region 1,Season peak percentage,2.5
+2015,46,2015/2016,46,HHS Region 1,1 wk ahead,1
+2015,46,2015/2016,46,HHS Region 1,2 wk ahead,0.8
+2015,46,2015/2016,46,HHS Region 1,3 wk ahead,1
+2015,46,2015/2016,46,HHS Region 1,4 wk ahead,1
+2015,46,2015/2016,46,HHS Region 2,Season onset,4
+2015,46,2015/2016,46,HHS Region 2,Season peak week,11
+2015,46,2015/2016,46,HHS Region 2,Season peak percentage,4.1
+2015,46,2015/2016,46,HHS Region 2,1 wk ahead,1.4
+2015,46,2015/2016,46,HHS Region 2,2 wk ahead,1.6
+2015,46,2015/2016,46,HHS Region 2,3 wk ahead,1.9
+2015,46,2015/2016,46,HHS Region 2,4 wk ahead,1.7
+2015,46,2015/2016,46,HHS Region 3,Season onset,47
+2015,46,2015/2016,46,HHS Region 3,Season peak week,10
+2015,46,2015/2016,46,HHS Region 3,Season peak percentage,4
+2015,46,2015/2016,46,HHS Region 3,1 wk ahead,2.2
+2015,46,2015/2016,46,HHS Region 3,2 wk ahead,1.8
+2015,46,2015/2016,46,HHS Region 3,3 wk ahead,2
+2015,46,2015/2016,46,HHS Region 3,4 wk ahead,2.3
+2015,46,2015/2016,46,HHS Region 4,Season onset,3
+2015,46,2015/2016,46,HHS Region 4,Season peak week,10
+2015,46,2015/2016,46,HHS Region 4,Season peak percentage,3.6
+2015,46,2015/2016,46,HHS Region 4,1 wk ahead,1.7
+2015,46,2015/2016,46,HHS Region 4,2 wk ahead,1.4
+2015,46,2015/2016,46,HHS Region 4,3 wk ahead,1.4
+2015,46,2015/2016,46,HHS Region 4,4 wk ahead,1.5
+2015,46,2015/2016,46,HHS Region 5,Season onset,7
+2015,46,2015/2016,46,HHS Region 5,Season peak week,10
+2015,46,2015/2016,46,HHS Region 5,Season peak percentage,3.4
+2015,46,2015/2016,46,HHS Region 5,1 wk ahead,1.4
+2015,46,2015/2016,46,HHS Region 5,2 wk ahead,1.1
+2015,46,2015/2016,46,HHS Region 5,3 wk ahead,1.4
+2015,46,2015/2016,46,HHS Region 5,4 wk ahead,1.4
+2015,46,2015/2016,46,HHS Region 6,Season onset,47
+2015,46,2015/2016,46,HHS Region 6,Season peak week,7
+2015,46,2015/2016,46,HHS Region 6,Season peak percentage,5.3
+2015,46,2015/2016,46,HHS Region 6,1 wk ahead,4
+2015,46,2015/2016,46,HHS Region 6,2 wk ahead,3.6
+2015,46,2015/2016,46,HHS Region 6,3 wk ahead,3.7
+2015,46,2015/2016,46,HHS Region 6,4 wk ahead,3.8
+2015,46,2015/2016,46,HHS Region 7,Season onset,7
+2015,46,2015/2016,46,HHS Region 7,Season peak week,10
+2015,46,2015/2016,46,HHS Region 7,Season peak percentage,2.5
+2015,46,2015/2016,46,HHS Region 7,1 wk ahead,1.3
+2015,46,2015/2016,46,HHS Region 7,2 wk ahead,1
+2015,46,2015/2016,46,HHS Region 7,3 wk ahead,0.9
+2015,46,2015/2016,46,HHS Region 7,4 wk ahead,1.2
+2015,46,2015/2016,46,HHS Region 8,Season onset,5
+2015,46,2015/2016,46,HHS Region 8,Season peak week,8
+2015,46,2015/2016,46,HHS Region 8,Season peak week,11
+2015,46,2015/2016,46,HHS Region 8,Season peak percentage,2.2
+2015,46,2015/2016,46,HHS Region 8,1 wk ahead,1
+2015,46,2015/2016,46,HHS Region 8,2 wk ahead,0.7
+2015,46,2015/2016,46,HHS Region 8,3 wk ahead,0.9
+2015,46,2015/2016,46,HHS Region 8,4 wk ahead,0.9
+2015,46,2015/2016,46,HHS Region 9,Season onset,3
+2015,46,2015/2016,46,HHS Region 9,Season peak week,7
+2015,46,2015/2016,46,HHS Region 9,Season peak percentage,4.4
+2015,46,2015/2016,46,HHS Region 9,1 wk ahead,2.2
+2015,46,2015/2016,46,HHS Region 9,2 wk ahead,2
+2015,46,2015/2016,46,HHS Region 9,3 wk ahead,2
+2015,46,2015/2016,46,HHS Region 9,4 wk ahead,2.1
+2015,46,2015/2016,46,HHS Region 10,Season onset,2
+2015,46,2015/2016,46,HHS Region 10,Season peak week,7
+2015,46,2015/2016,46,HHS Region 10,Season peak percentage,2.4
+2015,46,2015/2016,46,HHS Region 10,1 wk ahead,0.8
+2015,46,2015/2016,46,HHS Region 10,2 wk ahead,0.8
+2015,46,2015/2016,46,HHS Region 10,3 wk ahead,0.6
+2015,46,2015/2016,46,HHS Region 10,4 wk ahead,0.7
+2015,47,2015/2016,47,US National,Season onset,3
+2015,47,2015/2016,47,US National,Season peak week,10
+2015,47,2015/2016,47,US National,Season peak percentage,3.6
+2015,47,2015/2016,47,US National,1 wk ahead,1.7
+2015,47,2015/2016,47,US National,2 wk ahead,1.8
+2015,47,2015/2016,47,US National,3 wk ahead,1.9
+2015,47,2015/2016,47,US National,4 wk ahead,2.3
+2015,47,2015/2016,47,HHS Region 1,Season onset,51
+2015,47,2015/2016,47,HHS Region 1,Season peak week,10
+2015,47,2015/2016,47,HHS Region 1,Season peak percentage,2.5
+2015,47,2015/2016,47,HHS Region 1,1 wk ahead,0.8
+2015,47,2015/2016,47,HHS Region 1,2 wk ahead,1
+2015,47,2015/2016,47,HHS Region 1,3 wk ahead,1
+2015,47,2015/2016,47,HHS Region 1,4 wk ahead,1.4
+2015,47,2015/2016,47,HHS Region 2,Season onset,4
+2015,47,2015/2016,47,HHS Region 2,Season peak week,11
+2015,47,2015/2016,47,HHS Region 2,Season peak percentage,4.1
+2015,47,2015/2016,47,HHS Region 2,1 wk ahead,1.6
+2015,47,2015/2016,47,HHS Region 2,2 wk ahead,1.9
+2015,47,2015/2016,47,HHS Region 2,3 wk ahead,1.7
+2015,47,2015/2016,47,HHS Region 2,4 wk ahead,2.3
+2015,47,2015/2016,47,HHS Region 3,Season onset,47
+2015,47,2015/2016,47,HHS Region 3,Season peak week,10
+2015,47,2015/2016,47,HHS Region 3,Season peak percentage,4
+2015,47,2015/2016,47,HHS Region 3,1 wk ahead,1.8
+2015,47,2015/2016,47,HHS Region 3,2 wk ahead,2
+2015,47,2015/2016,47,HHS Region 3,3 wk ahead,2.3
+2015,47,2015/2016,47,HHS Region 3,4 wk ahead,2.8
+2015,47,2015/2016,47,HHS Region 4,Season onset,3
+2015,47,2015/2016,47,HHS Region 4,Season peak week,10
+2015,47,2015/2016,47,HHS Region 4,Season peak percentage,3.6
+2015,47,2015/2016,47,HHS Region 4,1 wk ahead,1.4
+2015,47,2015/2016,47,HHS Region 4,2 wk ahead,1.4
+2015,47,2015/2016,47,HHS Region 4,3 wk ahead,1.5
+2015,47,2015/2016,47,HHS Region 4,4 wk ahead,1.9
+2015,47,2015/2016,47,HHS Region 5,Season onset,7
+2015,47,2015/2016,47,HHS Region 5,Season peak week,10
+2015,47,2015/2016,47,HHS Region 5,Season peak percentage,3.4
+2015,47,2015/2016,47,HHS Region 5,1 wk ahead,1.1
+2015,47,2015/2016,47,HHS Region 5,2 wk ahead,1.4
+2015,47,2015/2016,47,HHS Region 5,3 wk ahead,1.4
+2015,47,2015/2016,47,HHS Region 5,4 wk ahead,1.8
+2015,47,2015/2016,47,HHS Region 6,Season onset,47
+2015,47,2015/2016,47,HHS Region 6,Season peak week,7
+2015,47,2015/2016,47,HHS Region 6,Season peak percentage,5.3
+2015,47,2015/2016,47,HHS Region 6,1 wk ahead,3.6
+2015,47,2015/2016,47,HHS Region 6,2 wk ahead,3.7
+2015,47,2015/2016,47,HHS Region 6,3 wk ahead,3.8
+2015,47,2015/2016,47,HHS Region 6,4 wk ahead,4.3
+2015,47,2015/2016,47,HHS Region 7,Season onset,7
+2015,47,2015/2016,47,HHS Region 7,Season peak week,10
+2015,47,2015/2016,47,HHS Region 7,Season peak percentage,2.5
+2015,47,2015/2016,47,HHS Region 7,1 wk ahead,1
+2015,47,2015/2016,47,HHS Region 7,2 wk ahead,0.9
+2015,47,2015/2016,47,HHS Region 7,3 wk ahead,1.2
+2015,47,2015/2016,47,HHS Region 7,4 wk ahead,1.4
+2015,47,2015/2016,47,HHS Region 8,Season onset,5
+2015,47,2015/2016,47,HHS Region 8,Season peak week,8
+2015,47,2015/2016,47,HHS Region 8,Season peak week,11
+2015,47,2015/2016,47,HHS Region 8,Season peak percentage,2.2
+2015,47,2015/2016,47,HHS Region 8,1 wk ahead,0.7
+2015,47,2015/2016,47,HHS Region 8,2 wk ahead,0.9
+2015,47,2015/2016,47,HHS Region 8,3 wk ahead,0.9
+2015,47,2015/2016,47,HHS Region 8,4 wk ahead,1.2
+2015,47,2015/2016,47,HHS Region 9,Season onset,3
+2015,47,2015/2016,47,HHS Region 9,Season peak week,7
+2015,47,2015/2016,47,HHS Region 9,Season peak percentage,4.4
+2015,47,2015/2016,47,HHS Region 9,1 wk ahead,2
+2015,47,2015/2016,47,HHS Region 9,2 wk ahead,2
+2015,47,2015/2016,47,HHS Region 9,3 wk ahead,2.1
+2015,47,2015/2016,47,HHS Region 9,4 wk ahead,2.8
+2015,47,2015/2016,47,HHS Region 10,Season onset,2
+2015,47,2015/2016,47,HHS Region 10,Season peak week,7
+2015,47,2015/2016,47,HHS Region 10,Season peak percentage,2.4
+2015,47,2015/2016,47,HHS Region 10,1 wk ahead,0.8
+2015,47,2015/2016,47,HHS Region 10,2 wk ahead,0.6
+2015,47,2015/2016,47,HHS Region 10,3 wk ahead,0.7
+2015,47,2015/2016,47,HHS Region 10,4 wk ahead,0.7
+2015,48,2015/2016,48,US National,Season onset,3
+2015,48,2015/2016,48,US National,Season peak week,10
+2015,48,2015/2016,48,US National,Season peak percentage,3.6
+2015,48,2015/2016,48,US National,1 wk ahead,1.8
+2015,48,2015/2016,48,US National,2 wk ahead,1.9
+2015,48,2015/2016,48,US National,3 wk ahead,2.3
+2015,48,2015/2016,48,US National,4 wk ahead,2.4
+2015,48,2015/2016,48,HHS Region 1,Season onset,51
+2015,48,2015/2016,48,HHS Region 1,Season peak week,10
+2015,48,2015/2016,48,HHS Region 1,Season peak percentage,2.5
+2015,48,2015/2016,48,HHS Region 1,1 wk ahead,1
+2015,48,2015/2016,48,HHS Region 1,2 wk ahead,1
+2015,48,2015/2016,48,HHS Region 1,3 wk ahead,1.4
+2015,48,2015/2016,48,HHS Region 1,4 wk ahead,1.6
+2015,48,2015/2016,48,HHS Region 2,Season onset,4
+2015,48,2015/2016,48,HHS Region 2,Season peak week,11
+2015,48,2015/2016,48,HHS Region 2,Season peak percentage,4.1
+2015,48,2015/2016,48,HHS Region 2,1 wk ahead,1.9
+2015,48,2015/2016,48,HHS Region 2,2 wk ahead,1.7
+2015,48,2015/2016,48,HHS Region 2,3 wk ahead,2.3
+2015,48,2015/2016,48,HHS Region 2,4 wk ahead,2.3
+2015,48,2015/2016,48,HHS Region 3,Season onset,47
+2015,48,2015/2016,48,HHS Region 3,Season peak week,10
+2015,48,2015/2016,48,HHS Region 3,Season peak percentage,4
+2015,48,2015/2016,48,HHS Region 3,1 wk ahead,2
+2015,48,2015/2016,48,HHS Region 3,2 wk ahead,2.3
+2015,48,2015/2016,48,HHS Region 3,3 wk ahead,2.8
+2015,48,2015/2016,48,HHS Region 3,4 wk ahead,3
+2015,48,2015/2016,48,HHS Region 4,Season onset,3
+2015,48,2015/2016,48,HHS Region 4,Season peak week,10
+2015,48,2015/2016,48,HHS Region 4,Season peak percentage,3.6
+2015,48,2015/2016,48,HHS Region 4,1 wk ahead,1.4
+2015,48,2015/2016,48,HHS Region 4,2 wk ahead,1.5
+2015,48,2015/2016,48,HHS Region 4,3 wk ahead,1.9
+2015,48,2015/2016,48,HHS Region 4,4 wk ahead,1.8
+2015,48,2015/2016,48,HHS Region 5,Season onset,7
+2015,48,2015/2016,48,HHS Region 5,Season peak week,10
+2015,48,2015/2016,48,HHS Region 5,Season peak percentage,3.4
+2015,48,2015/2016,48,HHS Region 5,1 wk ahead,1.4
+2015,48,2015/2016,48,HHS Region 5,2 wk ahead,1.4
+2015,48,2015/2016,48,HHS Region 5,3 wk ahead,1.8
+2015,48,2015/2016,48,HHS Region 5,4 wk ahead,1.7
+2015,48,2015/2016,48,HHS Region 6,Season onset,47
+2015,48,2015/2016,48,HHS Region 6,Season peak week,7
+2015,48,2015/2016,48,HHS Region 6,Season peak percentage,5.3
+2015,48,2015/2016,48,HHS Region 6,1 wk ahead,3.7
+2015,48,2015/2016,48,HHS Region 6,2 wk ahead,3.8
+2015,48,2015/2016,48,HHS Region 6,3 wk ahead,4.3
+2015,48,2015/2016,48,HHS Region 6,4 wk ahead,4.6
+2015,48,2015/2016,48,HHS Region 7,Season onset,7
+2015,48,2015/2016,48,HHS Region 7,Season peak week,10
+2015,48,2015/2016,48,HHS Region 7,Season peak percentage,2.5
+2015,48,2015/2016,48,HHS Region 7,1 wk ahead,0.9
+2015,48,2015/2016,48,HHS Region 7,2 wk ahead,1.2
+2015,48,2015/2016,48,HHS Region 7,3 wk ahead,1.4
+2015,48,2015/2016,48,HHS Region 7,4 wk ahead,1.6
+2015,48,2015/2016,48,HHS Region 8,Season onset,5
+2015,48,2015/2016,48,HHS Region 8,Season peak week,8
+2015,48,2015/2016,48,HHS Region 8,Season peak week,11
+2015,48,2015/2016,48,HHS Region 8,Season peak percentage,2.2
+2015,48,2015/2016,48,HHS Region 8,1 wk ahead,0.9
+2015,48,2015/2016,48,HHS Region 8,2 wk ahead,0.9
+2015,48,2015/2016,48,HHS Region 8,3 wk ahead,1.2
+2015,48,2015/2016,48,HHS Region 8,4 wk ahead,1.5
+2015,48,2015/2016,48,HHS Region 9,Season onset,3
+2015,48,2015/2016,48,HHS Region 9,Season peak week,7
+2015,48,2015/2016,48,HHS Region 9,Season peak percentage,4.4
+2015,48,2015/2016,48,HHS Region 9,1 wk ahead,2
+2015,48,2015/2016,48,HHS Region 9,2 wk ahead,2.1
+2015,48,2015/2016,48,HHS Region 9,3 wk ahead,2.8
+2015,48,2015/2016,48,HHS Region 9,4 wk ahead,3
+2015,48,2015/2016,48,HHS Region 10,Season onset,2
+2015,48,2015/2016,48,HHS Region 10,Season peak week,7
+2015,48,2015/2016,48,HHS Region 10,Season peak percentage,2.4
+2015,48,2015/2016,48,HHS Region 10,1 wk ahead,0.6
+2015,48,2015/2016,48,HHS Region 10,2 wk ahead,0.7
+2015,48,2015/2016,48,HHS Region 10,3 wk ahead,0.7
+2015,48,2015/2016,48,HHS Region 10,4 wk ahead,0.8
+2015,49,2015/2016,49,US National,Season onset,3
+2015,49,2015/2016,49,US National,Season peak week,10
+2015,49,2015/2016,49,US National,Season peak percentage,3.6
+2015,49,2015/2016,49,US National,1 wk ahead,1.9
+2015,49,2015/2016,49,US National,2 wk ahead,2.3
+2015,49,2015/2016,49,US National,3 wk ahead,2.4
+2015,49,2015/2016,49,US National,4 wk ahead,2
+2015,49,2015/2016,49,HHS Region 1,Season onset,51
+2015,49,2015/2016,49,HHS Region 1,Season peak week,10
+2015,49,2015/2016,49,HHS Region 1,Season peak percentage,2.5
+2015,49,2015/2016,49,HHS Region 1,1 wk ahead,1
+2015,49,2015/2016,49,HHS Region 1,2 wk ahead,1.4
+2015,49,2015/2016,49,HHS Region 1,3 wk ahead,1.6
+2015,49,2015/2016,49,HHS Region 1,4 wk ahead,1.3
+2015,49,2015/2016,49,HHS Region 2,Season onset,4
+2015,49,2015/2016,49,HHS Region 2,Season peak week,11
+2015,49,2015/2016,49,HHS Region 2,Season peak percentage,4.1
+2015,49,2015/2016,49,HHS Region 2,1 wk ahead,1.7
+2015,49,2015/2016,49,HHS Region 2,2 wk ahead,2.3
+2015,49,2015/2016,49,HHS Region 2,3 wk ahead,2.3
+2015,49,2015/2016,49,HHS Region 2,4 wk ahead,1.8
+2015,49,2015/2016,49,HHS Region 3,Season onset,47
+2015,49,2015/2016,49,HHS Region 3,Season peak week,10
+2015,49,2015/2016,49,HHS Region 3,Season peak percentage,4
+2015,49,2015/2016,49,HHS Region 3,1 wk ahead,2.3
+2015,49,2015/2016,49,HHS Region 3,2 wk ahead,2.8
+2015,49,2015/2016,49,HHS Region 3,3 wk ahead,3
+2015,49,2015/2016,49,HHS Region 3,4 wk ahead,2.4
+2015,49,2015/2016,49,HHS Region 4,Season onset,3
+2015,49,2015/2016,49,HHS Region 4,Season peak week,10
+2015,49,2015/2016,49,HHS Region 4,Season peak percentage,3.6
+2015,49,2015/2016,49,HHS Region 4,1 wk ahead,1.5
+2015,49,2015/2016,49,HHS Region 4,2 wk ahead,1.9
+2015,49,2015/2016,49,HHS Region 4,3 wk ahead,1.8
+2015,49,2015/2016,49,HHS Region 4,4 wk ahead,1.4
+2015,49,2015/2016,49,HHS Region 5,Season onset,7
+2015,49,2015/2016,49,HHS Region 5,Season peak week,10
+2015,49,2015/2016,49,HHS Region 5,Season peak percentage,3.4
+2015,49,2015/2016,49,HHS Region 5,1 wk ahead,1.4
+2015,49,2015/2016,49,HHS Region 5,2 wk ahead,1.8
+2015,49,2015/2016,49,HHS Region 5,3 wk ahead,1.7
+2015,49,2015/2016,49,HHS Region 5,4 wk ahead,1.4
+2015,49,2015/2016,49,HHS Region 6,Season onset,47
+2015,49,2015/2016,49,HHS Region 6,Season peak week,7
+2015,49,2015/2016,49,HHS Region 6,Season peak percentage,5.3
+2015,49,2015/2016,49,HHS Region 6,1 wk ahead,3.8
+2015,49,2015/2016,49,HHS Region 6,2 wk ahead,4.3
+2015,49,2015/2016,49,HHS Region 6,3 wk ahead,4.6
+2015,49,2015/2016,49,HHS Region 6,4 wk ahead,3.8
+2015,49,2015/2016,49,HHS Region 7,Season onset,7
+2015,49,2015/2016,49,HHS Region 7,Season peak week,10
+2015,49,2015/2016,49,HHS Region 7,Season peak percentage,2.5
+2015,49,2015/2016,49,HHS Region 7,1 wk ahead,1.2
+2015,49,2015/2016,49,HHS Region 7,2 wk ahead,1.4
+2015,49,2015/2016,49,HHS Region 7,3 wk ahead,1.6
+2015,49,2015/2016,49,HHS Region 7,4 wk ahead,1.4
+2015,49,2015/2016,49,HHS Region 8,Season onset,5
+2015,49,2015/2016,49,HHS Region 8,Season peak week,8
+2015,49,2015/2016,49,HHS Region 8,Season peak week,11
+2015,49,2015/2016,49,HHS Region 8,Season peak percentage,2.2
+2015,49,2015/2016,49,HHS Region 8,1 wk ahead,0.9
+2015,49,2015/2016,49,HHS Region 8,2 wk ahead,1.2
+2015,49,2015/2016,49,HHS Region 8,3 wk ahead,1.5
+2015,49,2015/2016,49,HHS Region 8,4 wk ahead,1.1
+2015,49,2015/2016,49,HHS Region 9,Season onset,3
+2015,49,2015/2016,49,HHS Region 9,Season peak week,7
+2015,49,2015/2016,49,HHS Region 9,Season peak percentage,4.4
+2015,49,2015/2016,49,HHS Region 9,1 wk ahead,2.1
+2015,49,2015/2016,49,HHS Region 9,2 wk ahead,2.8
+2015,49,2015/2016,49,HHS Region 9,3 wk ahead,3
+2015,49,2015/2016,49,HHS Region 9,4 wk ahead,2.4
+2015,49,2015/2016,49,HHS Region 10,Season onset,2
+2015,49,2015/2016,49,HHS Region 10,Season peak week,7
+2015,49,2015/2016,49,HHS Region 10,Season peak percentage,2.4
+2015,49,2015/2016,49,HHS Region 10,1 wk ahead,0.7
+2015,49,2015/2016,49,HHS Region 10,2 wk ahead,0.7
+2015,49,2015/2016,49,HHS Region 10,3 wk ahead,0.8
+2015,49,2015/2016,49,HHS Region 10,4 wk ahead,0.9
+2015,50,2015/2016,50,US National,Season onset,3
+2015,50,2015/2016,50,US National,Season peak week,10
+2015,50,2015/2016,50,US National,Season peak percentage,3.6
+2015,50,2015/2016,50,US National,1 wk ahead,2.3
+2015,50,2015/2016,50,US National,2 wk ahead,2.4
+2015,50,2015/2016,50,US National,3 wk ahead,2
+2015,50,2015/2016,50,US National,4 wk ahead,2
+2015,50,2015/2016,50,HHS Region 1,Season onset,51
+2015,50,2015/2016,50,HHS Region 1,Season peak week,10
+2015,50,2015/2016,50,HHS Region 1,Season peak percentage,2.5
+2015,50,2015/2016,50,HHS Region 1,1 wk ahead,1.4
+2015,50,2015/2016,50,HHS Region 1,2 wk ahead,1.6
+2015,50,2015/2016,50,HHS Region 1,3 wk ahead,1.3
+2015,50,2015/2016,50,HHS Region 1,4 wk ahead,1.4
+2015,50,2015/2016,50,HHS Region 2,Season onset,4
+2015,50,2015/2016,50,HHS Region 2,Season peak week,11
+2015,50,2015/2016,50,HHS Region 2,Season peak percentage,4.1
+2015,50,2015/2016,50,HHS Region 2,1 wk ahead,2.3
+2015,50,2015/2016,50,HHS Region 2,2 wk ahead,2.3
+2015,50,2015/2016,50,HHS Region 2,3 wk ahead,1.8
+2015,50,2015/2016,50,HHS Region 2,4 wk ahead,2.4
+2015,50,2015/2016,50,HHS Region 3,Season onset,47
+2015,50,2015/2016,50,HHS Region 3,Season peak week,10
+2015,50,2015/2016,50,HHS Region 3,Season peak percentage,4
+2015,50,2015/2016,50,HHS Region 3,1 wk ahead,2.8
+2015,50,2015/2016,50,HHS Region 3,2 wk ahead,3
+2015,50,2015/2016,50,HHS Region 3,3 wk ahead,2.4
+2015,50,2015/2016,50,HHS Region 3,4 wk ahead,2.3
+2015,50,2015/2016,50,HHS Region 4,Season onset,3
+2015,50,2015/2016,50,HHS Region 4,Season peak week,10
+2015,50,2015/2016,50,HHS Region 4,Season peak percentage,3.6
+2015,50,2015/2016,50,HHS Region 4,1 wk ahead,1.9
+2015,50,2015/2016,50,HHS Region 4,2 wk ahead,1.8
+2015,50,2015/2016,50,HHS Region 4,3 wk ahead,1.4
+2015,50,2015/2016,50,HHS Region 4,4 wk ahead,1.5
+2015,50,2015/2016,50,HHS Region 5,Season onset,7
+2015,50,2015/2016,50,HHS Region 5,Season peak week,10
+2015,50,2015/2016,50,HHS Region 5,Season peak percentage,3.4
+2015,50,2015/2016,50,HHS Region 5,1 wk ahead,1.8
+2015,50,2015/2016,50,HHS Region 5,2 wk ahead,1.7
+2015,50,2015/2016,50,HHS Region 5,3 wk ahead,1.4
+2015,50,2015/2016,50,HHS Region 5,4 wk ahead,1.4
+2015,50,2015/2016,50,HHS Region 6,Season onset,47
+2015,50,2015/2016,50,HHS Region 6,Season peak week,7
+2015,50,2015/2016,50,HHS Region 6,Season peak percentage,5.3
+2015,50,2015/2016,50,HHS Region 6,1 wk ahead,4.3
+2015,50,2015/2016,50,HHS Region 6,2 wk ahead,4.6
+2015,50,2015/2016,50,HHS Region 6,3 wk ahead,3.8
+2015,50,2015/2016,50,HHS Region 6,4 wk ahead,3.5
+2015,50,2015/2016,50,HHS Region 7,Season onset,7
+2015,50,2015/2016,50,HHS Region 7,Season peak week,10
+2015,50,2015/2016,50,HHS Region 7,Season peak percentage,2.5
+2015,50,2015/2016,50,HHS Region 7,1 wk ahead,1.4
+2015,50,2015/2016,50,HHS Region 7,2 wk ahead,1.6
+2015,50,2015/2016,50,HHS Region 7,3 wk ahead,1.4
+2015,50,2015/2016,50,HHS Region 7,4 wk ahead,1.1
+2015,50,2015/2016,50,HHS Region 8,Season onset,5
+2015,50,2015/2016,50,HHS Region 8,Season peak week,8
+2015,50,2015/2016,50,HHS Region 8,Season peak week,11
+2015,50,2015/2016,50,HHS Region 8,Season peak percentage,2.2
+2015,50,2015/2016,50,HHS Region 8,1 wk ahead,1.2
+2015,50,2015/2016,50,HHS Region 8,2 wk ahead,1.5
+2015,50,2015/2016,50,HHS Region 8,3 wk ahead,1.1
+2015,50,2015/2016,50,HHS Region 8,4 wk ahead,1.2
+2015,50,2015/2016,50,HHS Region 9,Season onset,3
+2015,50,2015/2016,50,HHS Region 9,Season peak week,7
+2015,50,2015/2016,50,HHS Region 9,Season peak percentage,4.4
+2015,50,2015/2016,50,HHS Region 9,1 wk ahead,2.8
+2015,50,2015/2016,50,HHS Region 9,2 wk ahead,3
+2015,50,2015/2016,50,HHS Region 9,3 wk ahead,2.4
+2015,50,2015/2016,50,HHS Region 9,4 wk ahead,2.4
+2015,50,2015/2016,50,HHS Region 10,Season onset,2
+2015,50,2015/2016,50,HHS Region 10,Season peak week,7
+2015,50,2015/2016,50,HHS Region 10,Season peak percentage,2.4
+2015,50,2015/2016,50,HHS Region 10,1 wk ahead,0.7
+2015,50,2015/2016,50,HHS Region 10,2 wk ahead,0.8
+2015,50,2015/2016,50,HHS Region 10,3 wk ahead,0.9
+2015,50,2015/2016,50,HHS Region 10,4 wk ahead,1.1
+2015,51,2015/2016,51,US National,Season onset,3
+2015,51,2015/2016,51,US National,Season peak week,10
+2015,51,2015/2016,51,US National,Season peak percentage,3.6
+2015,51,2015/2016,51,US National,1 wk ahead,2.4
+2015,51,2015/2016,51,US National,2 wk ahead,2
+2015,51,2015/2016,51,US National,3 wk ahead,2
+2015,51,2015/2016,51,US National,4 wk ahead,2.1
+2015,51,2015/2016,51,HHS Region 1,Season onset,51
+2015,51,2015/2016,51,HHS Region 1,Season peak week,10
+2015,51,2015/2016,51,HHS Region 1,Season peak percentage,2.5
+2015,51,2015/2016,51,HHS Region 1,1 wk ahead,1.6
+2015,51,2015/2016,51,HHS Region 1,2 wk ahead,1.3
+2015,51,2015/2016,51,HHS Region 1,3 wk ahead,1.4
+2015,51,2015/2016,51,HHS Region 1,4 wk ahead,1.5
+2015,51,2015/2016,51,HHS Region 2,Season onset,4
+2015,51,2015/2016,51,HHS Region 2,Season peak week,11
+2015,51,2015/2016,51,HHS Region 2,Season peak percentage,4.1
+2015,51,2015/2016,51,HHS Region 2,1 wk ahead,2.3
+2015,51,2015/2016,51,HHS Region 2,2 wk ahead,1.8
+2015,51,2015/2016,51,HHS Region 2,3 wk ahead,2.4
+2015,51,2015/2016,51,HHS Region 2,4 wk ahead,2.2
+2015,51,2015/2016,51,HHS Region 3,Season onset,47
+2015,51,2015/2016,51,HHS Region 3,Season peak week,10
+2015,51,2015/2016,51,HHS Region 3,Season peak percentage,4
+2015,51,2015/2016,51,HHS Region 3,1 wk ahead,3
+2015,51,2015/2016,51,HHS Region 3,2 wk ahead,2.4
+2015,51,2015/2016,51,HHS Region 3,3 wk ahead,2.3
+2015,51,2015/2016,51,HHS Region 3,4 wk ahead,2.3
+2015,51,2015/2016,51,HHS Region 4,Season onset,3
+2015,51,2015/2016,51,HHS Region 4,Season peak week,10
+2015,51,2015/2016,51,HHS Region 4,Season peak percentage,3.6
+2015,51,2015/2016,51,HHS Region 4,1 wk ahead,1.8
+2015,51,2015/2016,51,HHS Region 4,2 wk ahead,1.4
+2015,51,2015/2016,51,HHS Region 4,3 wk ahead,1.5
+2015,51,2015/2016,51,HHS Region 4,4 wk ahead,1.8
+2015,51,2015/2016,51,HHS Region 5,Season onset,7
+2015,51,2015/2016,51,HHS Region 5,Season peak week,10
+2015,51,2015/2016,51,HHS Region 5,Season peak percentage,3.4
+2015,51,2015/2016,51,HHS Region 5,1 wk ahead,1.7
+2015,51,2015/2016,51,HHS Region 5,2 wk ahead,1.4
+2015,51,2015/2016,51,HHS Region 5,3 wk ahead,1.4
+2015,51,2015/2016,51,HHS Region 5,4 wk ahead,1.4
+2015,51,2015/2016,51,HHS Region 6,Season onset,47
+2015,51,2015/2016,51,HHS Region 6,Season peak week,7
+2015,51,2015/2016,51,HHS Region 6,Season peak percentage,5.3
+2015,51,2015/2016,51,HHS Region 6,1 wk ahead,4.6
+2015,51,2015/2016,51,HHS Region 6,2 wk ahead,3.8
+2015,51,2015/2016,51,HHS Region 6,3 wk ahead,3.5
+2015,51,2015/2016,51,HHS Region 6,4 wk ahead,3.8
+2015,51,2015/2016,51,HHS Region 7,Season onset,7
+2015,51,2015/2016,51,HHS Region 7,Season peak week,10
+2015,51,2015/2016,51,HHS Region 7,Season peak percentage,2.5
+2015,51,2015/2016,51,HHS Region 7,1 wk ahead,1.6
+2015,51,2015/2016,51,HHS Region 7,2 wk ahead,1.4
+2015,51,2015/2016,51,HHS Region 7,3 wk ahead,1.1
+2015,51,2015/2016,51,HHS Region 7,4 wk ahead,1.2
+2015,51,2015/2016,51,HHS Region 8,Season onset,5
+2015,51,2015/2016,51,HHS Region 8,Season peak week,8
+2015,51,2015/2016,51,HHS Region 8,Season peak week,11
+2015,51,2015/2016,51,HHS Region 8,Season peak percentage,2.2
+2015,51,2015/2016,51,HHS Region 8,1 wk ahead,1.5
+2015,51,2015/2016,51,HHS Region 8,2 wk ahead,1.1
+2015,51,2015/2016,51,HHS Region 8,3 wk ahead,1.2
+2015,51,2015/2016,51,HHS Region 8,4 wk ahead,1.2
+2015,51,2015/2016,51,HHS Region 9,Season onset,3
+2015,51,2015/2016,51,HHS Region 9,Season peak week,7
+2015,51,2015/2016,51,HHS Region 9,Season peak percentage,4.4
+2015,51,2015/2016,51,HHS Region 9,1 wk ahead,3
+2015,51,2015/2016,51,HHS Region 9,2 wk ahead,2.4
+2015,51,2015/2016,51,HHS Region 9,3 wk ahead,2.4
+2015,51,2015/2016,51,HHS Region 9,4 wk ahead,2.6
+2015,51,2015/2016,51,HHS Region 10,Season onset,2
+2015,51,2015/2016,51,HHS Region 10,Season peak week,7
+2015,51,2015/2016,51,HHS Region 10,Season peak percentage,2.4
+2015,51,2015/2016,51,HHS Region 10,1 wk ahead,0.8
+2015,51,2015/2016,51,HHS Region 10,2 wk ahead,0.9
+2015,51,2015/2016,51,HHS Region 10,3 wk ahead,1.1
+2015,51,2015/2016,51,HHS Region 10,4 wk ahead,1.4
+2015,52,2015/2016,52,US National,Season onset,3
+2015,52,2015/2016,52,US National,Season peak week,10
+2015,52,2015/2016,52,US National,Season peak percentage,3.6
+2015,52,2015/2016,52,US National,1 wk ahead,2
+2015,52,2015/2016,52,US National,2 wk ahead,2
+2015,52,2015/2016,52,US National,3 wk ahead,2.1
+2015,52,2015/2016,52,US National,4 wk ahead,2.2
+2015,52,2015/2016,52,HHS Region 1,Season onset,51
+2015,52,2015/2016,52,HHS Region 1,Season peak week,10
+2015,52,2015/2016,52,HHS Region 1,Season peak percentage,2.5
+2015,52,2015/2016,52,HHS Region 1,1 wk ahead,1.3
+2015,52,2015/2016,52,HHS Region 1,2 wk ahead,1.4
+2015,52,2015/2016,52,HHS Region 1,3 wk ahead,1.5
+2015,52,2015/2016,52,HHS Region 1,4 wk ahead,1.7
+2015,52,2015/2016,52,HHS Region 2,Season onset,4
+2015,52,2015/2016,52,HHS Region 2,Season peak week,11
+2015,52,2015/2016,52,HHS Region 2,Season peak percentage,4.1
+2015,52,2015/2016,52,HHS Region 2,1 wk ahead,1.8
+2015,52,2015/2016,52,HHS Region 2,2 wk ahead,2.4
+2015,52,2015/2016,52,HHS Region 2,3 wk ahead,2.2
+2015,52,2015/2016,52,HHS Region 2,4 wk ahead,2.3
+2015,52,2015/2016,52,HHS Region 3,Season onset,47
+2015,52,2015/2016,52,HHS Region 3,Season peak week,10
+2015,52,2015/2016,52,HHS Region 3,Season peak percentage,4
+2015,52,2015/2016,52,HHS Region 3,1 wk ahead,2.4
+2015,52,2015/2016,52,HHS Region 3,2 wk ahead,2.3
+2015,52,2015/2016,52,HHS Region 3,3 wk ahead,2.3
+2015,52,2015/2016,52,HHS Region 3,4 wk ahead,2.2
+2015,52,2015/2016,52,HHS Region 4,Season onset,3
+2015,52,2015/2016,52,HHS Region 4,Season peak week,10
+2015,52,2015/2016,52,HHS Region 4,Season peak percentage,3.6
+2015,52,2015/2016,52,HHS Region 4,1 wk ahead,1.4
+2015,52,2015/2016,52,HHS Region 4,2 wk ahead,1.5
+2015,52,2015/2016,52,HHS Region 4,3 wk ahead,1.8
+2015,52,2015/2016,52,HHS Region 4,4 wk ahead,1.9
+2015,52,2015/2016,52,HHS Region 5,Season onset,7
+2015,52,2015/2016,52,HHS Region 5,Season peak week,10
+2015,52,2015/2016,52,HHS Region 5,Season peak percentage,3.4
+2015,52,2015/2016,52,HHS Region 5,1 wk ahead,1.4
+2015,52,2015/2016,52,HHS Region 5,2 wk ahead,1.4
+2015,52,2015/2016,52,HHS Region 5,3 wk ahead,1.4
+2015,52,2015/2016,52,HHS Region 5,4 wk ahead,1.4
+2015,52,2015/2016,52,HHS Region 6,Season onset,47
+2015,52,2015/2016,52,HHS Region 6,Season peak week,7
+2015,52,2015/2016,52,HHS Region 6,Season peak percentage,5.3
+2015,52,2015/2016,52,HHS Region 6,1 wk ahead,3.8
+2015,52,2015/2016,52,HHS Region 6,2 wk ahead,3.5
+2015,52,2015/2016,52,HHS Region 6,3 wk ahead,3.8
+2015,52,2015/2016,52,HHS Region 6,4 wk ahead,4.2
+2015,52,2015/2016,52,HHS Region 7,Season onset,7
+2015,52,2015/2016,52,HHS Region 7,Season peak week,10
+2015,52,2015/2016,52,HHS Region 7,Season peak percentage,2.5
+2015,52,2015/2016,52,HHS Region 7,1 wk ahead,1.4
+2015,52,2015/2016,52,HHS Region 7,2 wk ahead,1.1
+2015,52,2015/2016,52,HHS Region 7,3 wk ahead,1.2
+2015,52,2015/2016,52,HHS Region 7,4 wk ahead,1.2
+2015,52,2015/2016,52,HHS Region 8,Season onset,5
+2015,52,2015/2016,52,HHS Region 8,Season peak week,8
+2015,52,2015/2016,52,HHS Region 8,Season peak week,11
+2015,52,2015/2016,52,HHS Region 8,Season peak percentage,2.2
+2015,52,2015/2016,52,HHS Region 8,1 wk ahead,1.1
+2015,52,2015/2016,52,HHS Region 8,2 wk ahead,1.2
+2015,52,2015/2016,52,HHS Region 8,3 wk ahead,1.2
+2015,52,2015/2016,52,HHS Region 8,4 wk ahead,1.3
+2015,52,2015/2016,52,HHS Region 9,Season onset,3
+2015,52,2015/2016,52,HHS Region 9,Season peak week,7
+2015,52,2015/2016,52,HHS Region 9,Season peak percentage,4.4
+2015,52,2015/2016,52,HHS Region 9,1 wk ahead,2.4
+2015,52,2015/2016,52,HHS Region 9,2 wk ahead,2.4
+2015,52,2015/2016,52,HHS Region 9,3 wk ahead,2.6
+2015,52,2015/2016,52,HHS Region 9,4 wk ahead,2.8
+2015,52,2015/2016,52,HHS Region 10,Season onset,2
+2015,52,2015/2016,52,HHS Region 10,Season peak week,7
+2015,52,2015/2016,52,HHS Region 10,Season peak percentage,2.4
+2015,52,2015/2016,52,HHS Region 10,1 wk ahead,0.9
+2015,52,2015/2016,52,HHS Region 10,2 wk ahead,1.1
+2015,52,2015/2016,52,HHS Region 10,3 wk ahead,1.4
+2015,52,2015/2016,52,HHS Region 10,4 wk ahead,1.4
+2016,1,2015/2016,53,US National,Season onset,3
+2016,1,2015/2016,53,US National,Season peak week,10
+2016,1,2015/2016,53,US National,Season peak percentage,3.6
+2016,1,2015/2016,53,US National,1 wk ahead,2
+2016,1,2015/2016,53,US National,2 wk ahead,2.1
+2016,1,2015/2016,53,US National,3 wk ahead,2.2
+2016,1,2015/2016,53,US National,4 wk ahead,2.4
+2016,1,2015/2016,53,HHS Region 1,Season onset,51
+2016,1,2015/2016,53,HHS Region 1,Season peak week,10
+2016,1,2015/2016,53,HHS Region 1,Season peak percentage,2.5
+2016,1,2015/2016,53,HHS Region 1,1 wk ahead,1.4
+2016,1,2015/2016,53,HHS Region 1,2 wk ahead,1.5
+2016,1,2015/2016,53,HHS Region 1,3 wk ahead,1.7
+2016,1,2015/2016,53,HHS Region 1,4 wk ahead,1.8
+2016,1,2015/2016,53,HHS Region 2,Season onset,4
+2016,1,2015/2016,53,HHS Region 2,Season peak week,11
+2016,1,2015/2016,53,HHS Region 2,Season peak percentage,4.1
+2016,1,2015/2016,53,HHS Region 2,1 wk ahead,2.4
+2016,1,2015/2016,53,HHS Region 2,2 wk ahead,2.2
+2016,1,2015/2016,53,HHS Region 2,3 wk ahead,2.3
+2016,1,2015/2016,53,HHS Region 2,4 wk ahead,2.5
+2016,1,2015/2016,53,HHS Region 3,Season onset,47
+2016,1,2015/2016,53,HHS Region 3,Season peak week,10
+2016,1,2015/2016,53,HHS Region 3,Season peak percentage,4
+2016,1,2015/2016,53,HHS Region 3,1 wk ahead,2.3
+2016,1,2015/2016,53,HHS Region 3,2 wk ahead,2.3
+2016,1,2015/2016,53,HHS Region 3,3 wk ahead,2.2
+2016,1,2015/2016,53,HHS Region 3,4 wk ahead,2
+2016,1,2015/2016,53,HHS Region 4,Season onset,3
+2016,1,2015/2016,53,HHS Region 4,Season peak week,10
+2016,1,2015/2016,53,HHS Region 4,Season peak percentage,3.6
+2016,1,2015/2016,53,HHS Region 4,1 wk ahead,1.5
+2016,1,2015/2016,53,HHS Region 4,2 wk ahead,1.8
+2016,1,2015/2016,53,HHS Region 4,3 wk ahead,1.9
+2016,1,2015/2016,53,HHS Region 4,4 wk ahead,2.1
+2016,1,2015/2016,53,HHS Region 5,Season onset,7
+2016,1,2015/2016,53,HHS Region 5,Season peak week,10
+2016,1,2015/2016,53,HHS Region 5,Season peak percentage,3.4
+2016,1,2015/2016,53,HHS Region 5,1 wk ahead,1.4
+2016,1,2015/2016,53,HHS Region 5,2 wk ahead,1.4
+2016,1,2015/2016,53,HHS Region 5,3 wk ahead,1.4
+2016,1,2015/2016,53,HHS Region 5,4 wk ahead,1.6
+2016,1,2015/2016,53,HHS Region 6,Season onset,47
+2016,1,2015/2016,53,HHS Region 6,Season peak week,7
+2016,1,2015/2016,53,HHS Region 6,Season peak percentage,5.3
+2016,1,2015/2016,53,HHS Region 6,1 wk ahead,3.5
+2016,1,2015/2016,53,HHS Region 6,2 wk ahead,3.8
+2016,1,2015/2016,53,HHS Region 6,3 wk ahead,4.2
+2016,1,2015/2016,53,HHS Region 6,4 wk ahead,4.2
+2016,1,2015/2016,53,HHS Region 7,Season onset,7
+2016,1,2015/2016,53,HHS Region 7,Season peak week,10
+2016,1,2015/2016,53,HHS Region 7,Season peak percentage,2.5
+2016,1,2015/2016,53,HHS Region 7,1 wk ahead,1.1
+2016,1,2015/2016,53,HHS Region 7,2 wk ahead,1.2
+2016,1,2015/2016,53,HHS Region 7,3 wk ahead,1.2
+2016,1,2015/2016,53,HHS Region 7,4 wk ahead,1.1
+2016,1,2015/2016,53,HHS Region 8,Season onset,5
+2016,1,2015/2016,53,HHS Region 8,Season peak week,8
+2016,1,2015/2016,53,HHS Region 8,Season peak week,11
+2016,1,2015/2016,53,HHS Region 8,Season peak percentage,2.2
+2016,1,2015/2016,53,HHS Region 8,1 wk ahead,1.2
+2016,1,2015/2016,53,HHS Region 8,2 wk ahead,1.2
+2016,1,2015/2016,53,HHS Region 8,3 wk ahead,1.3
+2016,1,2015/2016,53,HHS Region 8,4 wk ahead,1.6
+2016,1,2015/2016,53,HHS Region 9,Season onset,3
+2016,1,2015/2016,53,HHS Region 9,Season peak week,7
+2016,1,2015/2016,53,HHS Region 9,Season peak percentage,4.4
+2016,1,2015/2016,53,HHS Region 9,1 wk ahead,2.4
+2016,1,2015/2016,53,HHS Region 9,2 wk ahead,2.6
+2016,1,2015/2016,53,HHS Region 9,3 wk ahead,2.8
+2016,1,2015/2016,53,HHS Region 9,4 wk ahead,3.2
+2016,1,2015/2016,53,HHS Region 10,Season onset,2
+2016,1,2015/2016,53,HHS Region 10,Season peak week,7
+2016,1,2015/2016,53,HHS Region 10,Season peak percentage,2.4
+2016,1,2015/2016,53,HHS Region 10,1 wk ahead,1.1
+2016,1,2015/2016,53,HHS Region 10,2 wk ahead,1.4
+2016,1,2015/2016,53,HHS Region 10,3 wk ahead,1.4
+2016,1,2015/2016,53,HHS Region 10,4 wk ahead,1.7
+2016,2,2015/2016,54,US National,Season onset,3
+2016,2,2015/2016,54,US National,Season peak week,10
+2016,2,2015/2016,54,US National,Season peak percentage,3.6
+2016,2,2015/2016,54,US National,1 wk ahead,2.1
+2016,2,2015/2016,54,US National,2 wk ahead,2.2
+2016,2,2015/2016,54,US National,3 wk ahead,2.4
+2016,2,2015/2016,54,US National,4 wk ahead,2.8
+2016,2,2015/2016,54,HHS Region 1,Season onset,51
+2016,2,2015/2016,54,HHS Region 1,Season peak week,10
+2016,2,2015/2016,54,HHS Region 1,Season peak percentage,2.5
+2016,2,2015/2016,54,HHS Region 1,1 wk ahead,1.5
+2016,2,2015/2016,54,HHS Region 1,2 wk ahead,1.7
+2016,2,2015/2016,54,HHS Region 1,3 wk ahead,1.8
+2016,2,2015/2016,54,HHS Region 1,4 wk ahead,2
+2016,2,2015/2016,54,HHS Region 2,Season onset,4
+2016,2,2015/2016,54,HHS Region 2,Season peak week,11
+2016,2,2015/2016,54,HHS Region 2,Season peak percentage,4.1
+2016,2,2015/2016,54,HHS Region 2,1 wk ahead,2.2
+2016,2,2015/2016,54,HHS Region 2,2 wk ahead,2.3
+2016,2,2015/2016,54,HHS Region 2,3 wk ahead,2.5
+2016,2,2015/2016,54,HHS Region 2,4 wk ahead,3.2
+2016,2,2015/2016,54,HHS Region 3,Season onset,47
+2016,2,2015/2016,54,HHS Region 3,Season peak week,10
+2016,2,2015/2016,54,HHS Region 3,Season peak percentage,4
+2016,2,2015/2016,54,HHS Region 3,1 wk ahead,2.3
+2016,2,2015/2016,54,HHS Region 3,2 wk ahead,2.2
+2016,2,2015/2016,54,HHS Region 3,3 wk ahead,2
+2016,2,2015/2016,54,HHS Region 3,4 wk ahead,2.3
+2016,2,2015/2016,54,HHS Region 4,Season onset,3
+2016,2,2015/2016,54,HHS Region 4,Season peak week,10
+2016,2,2015/2016,54,HHS Region 4,Season peak percentage,3.6
+2016,2,2015/2016,54,HHS Region 4,1 wk ahead,1.8
+2016,2,2015/2016,54,HHS Region 4,2 wk ahead,1.9
+2016,2,2015/2016,54,HHS Region 4,3 wk ahead,2.1
+2016,2,2015/2016,54,HHS Region 4,4 wk ahead,2.3
+2016,2,2015/2016,54,HHS Region 5,Season onset,7
+2016,2,2015/2016,54,HHS Region 5,Season peak week,10
+2016,2,2015/2016,54,HHS Region 5,Season peak percentage,3.4
+2016,2,2015/2016,54,HHS Region 5,1 wk ahead,1.4
+2016,2,2015/2016,54,HHS Region 5,2 wk ahead,1.4
+2016,2,2015/2016,54,HHS Region 5,3 wk ahead,1.6
+2016,2,2015/2016,54,HHS Region 5,4 wk ahead,1.8
+2016,2,2015/2016,54,HHS Region 6,Season onset,47
+2016,2,2015/2016,54,HHS Region 6,Season peak week,7
+2016,2,2015/2016,54,HHS Region 6,Season peak percentage,5.3
+2016,2,2015/2016,54,HHS Region 6,1 wk ahead,3.8
+2016,2,2015/2016,54,HHS Region 6,2 wk ahead,4.2
+2016,2,2015/2016,54,HHS Region 6,3 wk ahead,4.2
+2016,2,2015/2016,54,HHS Region 6,4 wk ahead,4.8
+2016,2,2015/2016,54,HHS Region 7,Season onset,7
+2016,2,2015/2016,54,HHS Region 7,Season peak week,10
+2016,2,2015/2016,54,HHS Region 7,Season peak percentage,2.5
+2016,2,2015/2016,54,HHS Region 7,1 wk ahead,1.2
+2016,2,2015/2016,54,HHS Region 7,2 wk ahead,1.2
+2016,2,2015/2016,54,HHS Region 7,3 wk ahead,1.1
+2016,2,2015/2016,54,HHS Region 7,4 wk ahead,1.5
+2016,2,2015/2016,54,HHS Region 8,Season onset,5
+2016,2,2015/2016,54,HHS Region 8,Season peak week,8
+2016,2,2015/2016,54,HHS Region 8,Season peak week,11
+2016,2,2015/2016,54,HHS Region 8,Season peak percentage,2.2
+2016,2,2015/2016,54,HHS Region 8,1 wk ahead,1.2
+2016,2,2015/2016,54,HHS Region 8,2 wk ahead,1.3
+2016,2,2015/2016,54,HHS Region 8,3 wk ahead,1.6
+2016,2,2015/2016,54,HHS Region 8,4 wk ahead,1.8
+2016,2,2015/2016,54,HHS Region 9,Season onset,3
+2016,2,2015/2016,54,HHS Region 9,Season peak week,7
+2016,2,2015/2016,54,HHS Region 9,Season peak percentage,4.4
+2016,2,2015/2016,54,HHS Region 9,1 wk ahead,2.6
+2016,2,2015/2016,54,HHS Region 9,2 wk ahead,2.8
+2016,2,2015/2016,54,HHS Region 9,3 wk ahead,3.2
+2016,2,2015/2016,54,HHS Region 9,4 wk ahead,4
+2016,2,2015/2016,54,HHS Region 10,Season onset,2
+2016,2,2015/2016,54,HHS Region 10,Season peak week,7
+2016,2,2015/2016,54,HHS Region 10,Season peak percentage,2.4
+2016,2,2015/2016,54,HHS Region 10,1 wk ahead,1.4
+2016,2,2015/2016,54,HHS Region 10,2 wk ahead,1.4
+2016,2,2015/2016,54,HHS Region 10,3 wk ahead,1.7
+2016,2,2015/2016,54,HHS Region 10,4 wk ahead,1.7
+2016,3,2015/2016,55,US National,Season onset,3
+2016,3,2015/2016,55,US National,Season peak week,10
+2016,3,2015/2016,55,US National,Season peak percentage,3.6
+2016,3,2015/2016,55,US National,1 wk ahead,2.2
+2016,3,2015/2016,55,US National,2 wk ahead,2.4
+2016,3,2015/2016,55,US National,3 wk ahead,2.8
+2016,3,2015/2016,55,US National,4 wk ahead,3.1
+2016,3,2015/2016,55,HHS Region 1,Season onset,51
+2016,3,2015/2016,55,HHS Region 1,Season peak week,10
+2016,3,2015/2016,55,HHS Region 1,Season peak percentage,2.5
+2016,3,2015/2016,55,HHS Region 1,1 wk ahead,1.7
+2016,3,2015/2016,55,HHS Region 1,2 wk ahead,1.8
+2016,3,2015/2016,55,HHS Region 1,3 wk ahead,2
+2016,3,2015/2016,55,HHS Region 1,4 wk ahead,2
+2016,3,2015/2016,55,HHS Region 2,Season onset,4
+2016,3,2015/2016,55,HHS Region 2,Season peak week,11
+2016,3,2015/2016,55,HHS Region 2,Season peak percentage,4.1
+2016,3,2015/2016,55,HHS Region 2,1 wk ahead,2.3
+2016,3,2015/2016,55,HHS Region 2,2 wk ahead,2.5
+2016,3,2015/2016,55,HHS Region 2,3 wk ahead,3.2
+2016,3,2015/2016,55,HHS Region 2,4 wk ahead,2.8
+2016,3,2015/2016,55,HHS Region 3,Season onset,47
+2016,3,2015/2016,55,HHS Region 3,Season peak week,10
+2016,3,2015/2016,55,HHS Region 3,Season peak percentage,4
+2016,3,2015/2016,55,HHS Region 3,1 wk ahead,2.2
+2016,3,2015/2016,55,HHS Region 3,2 wk ahead,2
+2016,3,2015/2016,55,HHS Region 3,3 wk ahead,2.3
+2016,3,2015/2016,55,HHS Region 3,4 wk ahead,2.6
+2016,3,2015/2016,55,HHS Region 4,Season onset,3
+2016,3,2015/2016,55,HHS Region 4,Season peak week,10
+2016,3,2015/2016,55,HHS Region 4,Season peak percentage,3.6
+2016,3,2015/2016,55,HHS Region 4,1 wk ahead,1.9
+2016,3,2015/2016,55,HHS Region 4,2 wk ahead,2.1
+2016,3,2015/2016,55,HHS Region 4,3 wk ahead,2.3
+2016,3,2015/2016,55,HHS Region 4,4 wk ahead,2.9
+2016,3,2015/2016,55,HHS Region 5,Season onset,7
+2016,3,2015/2016,55,HHS Region 5,Season peak week,10
+2016,3,2015/2016,55,HHS Region 5,Season peak percentage,3.4
+2016,3,2015/2016,55,HHS Region 5,1 wk ahead,1.4
+2016,3,2015/2016,55,HHS Region 5,2 wk ahead,1.6
+2016,3,2015/2016,55,HHS Region 5,3 wk ahead,1.8
+2016,3,2015/2016,55,HHS Region 5,4 wk ahead,2.2
+2016,3,2015/2016,55,HHS Region 6,Season onset,47
+2016,3,2015/2016,55,HHS Region 6,Season peak week,7
+2016,3,2015/2016,55,HHS Region 6,Season peak percentage,5.3
+2016,3,2015/2016,55,HHS Region 6,1 wk ahead,4.2
+2016,3,2015/2016,55,HHS Region 6,2 wk ahead,4.2
+2016,3,2015/2016,55,HHS Region 6,3 wk ahead,4.8
+2016,3,2015/2016,55,HHS Region 6,4 wk ahead,5.3
+2016,3,2015/2016,55,HHS Region 7,Season onset,7
+2016,3,2015/2016,55,HHS Region 7,Season peak week,10
+2016,3,2015/2016,55,HHS Region 7,Season peak percentage,2.5
+2016,3,2015/2016,55,HHS Region 7,1 wk ahead,1.2
+2016,3,2015/2016,55,HHS Region 7,2 wk ahead,1.1
+2016,3,2015/2016,55,HHS Region 7,3 wk ahead,1.5
+2016,3,2015/2016,55,HHS Region 7,4 wk ahead,1.8
+2016,3,2015/2016,55,HHS Region 8,Season onset,5
+2016,3,2015/2016,55,HHS Region 8,Season peak week,8
+2016,3,2015/2016,55,HHS Region 8,Season peak week,11
+2016,3,2015/2016,55,HHS Region 8,Season peak percentage,2.2
+2016,3,2015/2016,55,HHS Region 8,1 wk ahead,1.3
+2016,3,2015/2016,55,HHS Region 8,2 wk ahead,1.6
+2016,3,2015/2016,55,HHS Region 8,3 wk ahead,1.8
+2016,3,2015/2016,55,HHS Region 8,4 wk ahead,2.1
+2016,3,2015/2016,55,HHS Region 9,Season onset,3
+2016,3,2015/2016,55,HHS Region 9,Season peak week,7
+2016,3,2015/2016,55,HHS Region 9,Season peak percentage,4.4
+2016,3,2015/2016,55,HHS Region 9,1 wk ahead,2.8
+2016,3,2015/2016,55,HHS Region 9,2 wk ahead,3.2
+2016,3,2015/2016,55,HHS Region 9,3 wk ahead,4
+2016,3,2015/2016,55,HHS Region 9,4 wk ahead,4.4
+2016,3,2015/2016,55,HHS Region 10,Season onset,2
+2016,3,2015/2016,55,HHS Region 10,Season peak week,7
+2016,3,2015/2016,55,HHS Region 10,Season peak percentage,2.4
+2016,3,2015/2016,55,HHS Region 10,1 wk ahead,1.4
+2016,3,2015/2016,55,HHS Region 10,2 wk ahead,1.7
+2016,3,2015/2016,55,HHS Region 10,3 wk ahead,1.7
+2016,3,2015/2016,55,HHS Region 10,4 wk ahead,2.4
+2016,4,2015/2016,56,US National,Season onset,3
+2016,4,2015/2016,56,US National,Season peak week,10
+2016,4,2015/2016,56,US National,Season peak percentage,3.6
+2016,4,2015/2016,56,US National,1 wk ahead,2.4
+2016,4,2015/2016,56,US National,2 wk ahead,2.8
+2016,4,2015/2016,56,US National,3 wk ahead,3.1
+2016,4,2015/2016,56,US National,4 wk ahead,3.2
+2016,4,2015/2016,56,HHS Region 1,Season onset,51
+2016,4,2015/2016,56,HHS Region 1,Season peak week,10
+2016,4,2015/2016,56,HHS Region 1,Season peak percentage,2.5
+2016,4,2015/2016,56,HHS Region 1,1 wk ahead,1.8
+2016,4,2015/2016,56,HHS Region 1,2 wk ahead,2
+2016,4,2015/2016,56,HHS Region 1,3 wk ahead,2
+2016,4,2015/2016,56,HHS Region 1,4 wk ahead,2
+2016,4,2015/2016,56,HHS Region 2,Season onset,4
+2016,4,2015/2016,56,HHS Region 2,Season peak week,11
+2016,4,2015/2016,56,HHS Region 2,Season peak percentage,4.1
+2016,4,2015/2016,56,HHS Region 2,1 wk ahead,2.5
+2016,4,2015/2016,56,HHS Region 2,2 wk ahead,3.2
+2016,4,2015/2016,56,HHS Region 2,3 wk ahead,2.8
+2016,4,2015/2016,56,HHS Region 2,4 wk ahead,3.2
+2016,4,2015/2016,56,HHS Region 3,Season onset,47
+2016,4,2015/2016,56,HHS Region 3,Season peak week,10
+2016,4,2015/2016,56,HHS Region 3,Season peak percentage,4
+2016,4,2015/2016,56,HHS Region 3,1 wk ahead,2
+2016,4,2015/2016,56,HHS Region 3,2 wk ahead,2.3
+2016,4,2015/2016,56,HHS Region 3,3 wk ahead,2.6
+2016,4,2015/2016,56,HHS Region 3,4 wk ahead,2.9
+2016,4,2015/2016,56,HHS Region 4,Season onset,3
+2016,4,2015/2016,56,HHS Region 4,Season peak week,10
+2016,4,2015/2016,56,HHS Region 4,Season peak percentage,3.6
+2016,4,2015/2016,56,HHS Region 4,1 wk ahead,2.1
+2016,4,2015/2016,56,HHS Region 4,2 wk ahead,2.3
+2016,4,2015/2016,56,HHS Region 4,3 wk ahead,2.9
+2016,4,2015/2016,56,HHS Region 4,4 wk ahead,3.4
+2016,4,2015/2016,56,HHS Region 5,Season onset,7
+2016,4,2015/2016,56,HHS Region 5,Season peak week,10
+2016,4,2015/2016,56,HHS Region 5,Season peak percentage,3.4
+2016,4,2015/2016,56,HHS Region 5,1 wk ahead,1.6
+2016,4,2015/2016,56,HHS Region 5,2 wk ahead,1.8
+2016,4,2015/2016,56,HHS Region 5,3 wk ahead,2.2
+2016,4,2015/2016,56,HHS Region 5,4 wk ahead,2.7
+2016,4,2015/2016,56,HHS Region 6,Season onset,47
+2016,4,2015/2016,56,HHS Region 6,Season peak week,7
+2016,4,2015/2016,56,HHS Region 6,Season peak percentage,5.3
+2016,4,2015/2016,56,HHS Region 6,1 wk ahead,4.2
+2016,4,2015/2016,56,HHS Region 6,2 wk ahead,4.8
+2016,4,2015/2016,56,HHS Region 6,3 wk ahead,5.3
+2016,4,2015/2016,56,HHS Region 6,4 wk ahead,4.2
+2016,4,2015/2016,56,HHS Region 7,Season onset,7
+2016,4,2015/2016,56,HHS Region 7,Season peak week,10
+2016,4,2015/2016,56,HHS Region 7,Season peak percentage,2.5
+2016,4,2015/2016,56,HHS Region 7,1 wk ahead,1.1
+2016,4,2015/2016,56,HHS Region 7,2 wk ahead,1.5
+2016,4,2015/2016,56,HHS Region 7,3 wk ahead,1.8
+2016,4,2015/2016,56,HHS Region 7,4 wk ahead,1.8
+2016,4,2015/2016,56,HHS Region 8,Season onset,5
+2016,4,2015/2016,56,HHS Region 8,Season peak week,8
+2016,4,2015/2016,56,HHS Region 8,Season peak week,11
+2016,4,2015/2016,56,HHS Region 8,Season peak percentage,2.2
+2016,4,2015/2016,56,HHS Region 8,1 wk ahead,1.6
+2016,4,2015/2016,56,HHS Region 8,2 wk ahead,1.8
+2016,4,2015/2016,56,HHS Region 8,3 wk ahead,2.1
+2016,4,2015/2016,56,HHS Region 8,4 wk ahead,2.2
+2016,4,2015/2016,56,HHS Region 9,Season onset,3
+2016,4,2015/2016,56,HHS Region 9,Season peak week,7
+2016,4,2015/2016,56,HHS Region 9,Season peak percentage,4.4
+2016,4,2015/2016,56,HHS Region 9,1 wk ahead,3.2
+2016,4,2015/2016,56,HHS Region 9,2 wk ahead,4
+2016,4,2015/2016,56,HHS Region 9,3 wk ahead,4.4
+2016,4,2015/2016,56,HHS Region 9,4 wk ahead,3.9
+2016,4,2015/2016,56,HHS Region 10,Season onset,2
+2016,4,2015/2016,56,HHS Region 10,Season peak week,7
+2016,4,2015/2016,56,HHS Region 10,Season peak percentage,2.4
+2016,4,2015/2016,56,HHS Region 10,1 wk ahead,1.7
+2016,4,2015/2016,56,HHS Region 10,2 wk ahead,1.7
+2016,4,2015/2016,56,HHS Region 10,3 wk ahead,2.4
+2016,4,2015/2016,56,HHS Region 10,4 wk ahead,2.1
+2016,5,2015/2016,57,US National,Season onset,3
+2016,5,2015/2016,57,US National,Season peak week,10
+2016,5,2015/2016,57,US National,Season peak percentage,3.6
+2016,5,2015/2016,57,US National,1 wk ahead,2.8
+2016,5,2015/2016,57,US National,2 wk ahead,3.1
+2016,5,2015/2016,57,US National,3 wk ahead,3.2
+2016,5,2015/2016,57,US National,4 wk ahead,3.3
+2016,5,2015/2016,57,HHS Region 1,Season onset,51
+2016,5,2015/2016,57,HHS Region 1,Season peak week,10
+2016,5,2015/2016,57,HHS Region 1,Season peak percentage,2.5
+2016,5,2015/2016,57,HHS Region 1,1 wk ahead,2
+2016,5,2015/2016,57,HHS Region 1,2 wk ahead,2
+2016,5,2015/2016,57,HHS Region 1,3 wk ahead,2
+2016,5,2015/2016,57,HHS Region 1,4 wk ahead,2
+2016,5,2015/2016,57,HHS Region 2,Season onset,4
+2016,5,2015/2016,57,HHS Region 2,Season peak week,11
+2016,5,2015/2016,57,HHS Region 2,Season peak percentage,4.1
+2016,5,2015/2016,57,HHS Region 2,1 wk ahead,3.2
+2016,5,2015/2016,57,HHS Region 2,2 wk ahead,2.8
+2016,5,2015/2016,57,HHS Region 2,3 wk ahead,3.2
+2016,5,2015/2016,57,HHS Region 2,4 wk ahead,3.7
+2016,5,2015/2016,57,HHS Region 3,Season onset,47
+2016,5,2015/2016,57,HHS Region 3,Season peak week,10
+2016,5,2015/2016,57,HHS Region 3,Season peak percentage,4
+2016,5,2015/2016,57,HHS Region 3,1 wk ahead,2.3
+2016,5,2015/2016,57,HHS Region 3,2 wk ahead,2.6
+2016,5,2015/2016,57,HHS Region 3,3 wk ahead,2.9
+2016,5,2015/2016,57,HHS Region 3,4 wk ahead,3.3
+2016,5,2015/2016,57,HHS Region 4,Season onset,3
+2016,5,2015/2016,57,HHS Region 4,Season peak week,10
+2016,5,2015/2016,57,HHS Region 4,Season peak percentage,3.6
+2016,5,2015/2016,57,HHS Region 4,1 wk ahead,2.3
+2016,5,2015/2016,57,HHS Region 4,2 wk ahead,2.9
+2016,5,2015/2016,57,HHS Region 4,3 wk ahead,3.4
+2016,5,2015/2016,57,HHS Region 4,4 wk ahead,3.3
+2016,5,2015/2016,57,HHS Region 5,Season onset,7
+2016,5,2015/2016,57,HHS Region 5,Season peak week,10
+2016,5,2015/2016,57,HHS Region 5,Season peak percentage,3.4
+2016,5,2015/2016,57,HHS Region 5,1 wk ahead,1.8
+2016,5,2015/2016,57,HHS Region 5,2 wk ahead,2.2
+2016,5,2015/2016,57,HHS Region 5,3 wk ahead,2.7
+2016,5,2015/2016,57,HHS Region 5,4 wk ahead,3
+2016,5,2015/2016,57,HHS Region 6,Season onset,47
+2016,5,2015/2016,57,HHS Region 6,Season peak week,7
+2016,5,2015/2016,57,HHS Region 6,Season peak percentage,5.3
+2016,5,2015/2016,57,HHS Region 6,1 wk ahead,4.8
+2016,5,2015/2016,57,HHS Region 6,2 wk ahead,5.3
+2016,5,2015/2016,57,HHS Region 6,3 wk ahead,4.2
+2016,5,2015/2016,57,HHS Region 6,4 wk ahead,4.5
+2016,5,2015/2016,57,HHS Region 7,Season onset,7
+2016,5,2015/2016,57,HHS Region 7,Season peak week,10
+2016,5,2015/2016,57,HHS Region 7,Season peak percentage,2.5
+2016,5,2015/2016,57,HHS Region 7,1 wk ahead,1.5
+2016,5,2015/2016,57,HHS Region 7,2 wk ahead,1.8
+2016,5,2015/2016,57,HHS Region 7,3 wk ahead,1.8
+2016,5,2015/2016,57,HHS Region 7,4 wk ahead,2.4
+2016,5,2015/2016,57,HHS Region 8,Season onset,5
+2016,5,2015/2016,57,HHS Region 8,Season peak week,8
+2016,5,2015/2016,57,HHS Region 8,Season peak week,11
+2016,5,2015/2016,57,HHS Region 8,Season peak percentage,2.2
+2016,5,2015/2016,57,HHS Region 8,1 wk ahead,1.8
+2016,5,2015/2016,57,HHS Region 8,2 wk ahead,2.1
+2016,5,2015/2016,57,HHS Region 8,3 wk ahead,2.2
+2016,5,2015/2016,57,HHS Region 8,4 wk ahead,2
+2016,5,2015/2016,57,HHS Region 9,Season onset,3
+2016,5,2015/2016,57,HHS Region 9,Season peak week,7
+2016,5,2015/2016,57,HHS Region 9,Season peak percentage,4.4
+2016,5,2015/2016,57,HHS Region 9,1 wk ahead,4
+2016,5,2015/2016,57,HHS Region 9,2 wk ahead,4.4
+2016,5,2015/2016,57,HHS Region 9,3 wk ahead,3.9
+2016,5,2015/2016,57,HHS Region 9,4 wk ahead,3.8
+2016,5,2015/2016,57,HHS Region 10,Season onset,2
+2016,5,2015/2016,57,HHS Region 10,Season peak week,7
+2016,5,2015/2016,57,HHS Region 10,Season peak percentage,2.4
+2016,5,2015/2016,57,HHS Region 10,1 wk ahead,1.7
+2016,5,2015/2016,57,HHS Region 10,2 wk ahead,2.4
+2016,5,2015/2016,57,HHS Region 10,3 wk ahead,2.1
+2016,5,2015/2016,57,HHS Region 10,4 wk ahead,2
+2016,6,2015/2016,58,US National,Season onset,3
+2016,6,2015/2016,58,US National,Season peak week,10
+2016,6,2015/2016,58,US National,Season peak percentage,3.6
+2016,6,2015/2016,58,US National,1 wk ahead,3.1
+2016,6,2015/2016,58,US National,2 wk ahead,3.2
+2016,6,2015/2016,58,US National,3 wk ahead,3.3
+2016,6,2015/2016,58,US National,4 wk ahead,3.6
+2016,6,2015/2016,58,HHS Region 1,Season onset,51
+2016,6,2015/2016,58,HHS Region 1,Season peak week,10
+2016,6,2015/2016,58,HHS Region 1,Season peak percentage,2.5
+2016,6,2015/2016,58,HHS Region 1,1 wk ahead,2
+2016,6,2015/2016,58,HHS Region 1,2 wk ahead,2
+2016,6,2015/2016,58,HHS Region 1,3 wk ahead,2
+2016,6,2015/2016,58,HHS Region 1,4 wk ahead,2.5
+2016,6,2015/2016,58,HHS Region 2,Season onset,4
+2016,6,2015/2016,58,HHS Region 2,Season peak week,11
+2016,6,2015/2016,58,HHS Region 2,Season peak percentage,4.1
+2016,6,2015/2016,58,HHS Region 2,1 wk ahead,2.8
+2016,6,2015/2016,58,HHS Region 2,2 wk ahead,3.2
+2016,6,2015/2016,58,HHS Region 2,3 wk ahead,3.7
+2016,6,2015/2016,58,HHS Region 2,4 wk ahead,4
+2016,6,2015/2016,58,HHS Region 3,Season onset,47
+2016,6,2015/2016,58,HHS Region 3,Season peak week,10
+2016,6,2015/2016,58,HHS Region 3,Season peak percentage,4
+2016,6,2015/2016,58,HHS Region 3,1 wk ahead,2.6
+2016,6,2015/2016,58,HHS Region 3,2 wk ahead,2.9
+2016,6,2015/2016,58,HHS Region 3,3 wk ahead,3.3
+2016,6,2015/2016,58,HHS Region 3,4 wk ahead,4
+2016,6,2015/2016,58,HHS Region 4,Season onset,3
+2016,6,2015/2016,58,HHS Region 4,Season peak week,10
+2016,6,2015/2016,58,HHS Region 4,Season peak percentage,3.6
+2016,6,2015/2016,58,HHS Region 4,1 wk ahead,2.9
+2016,6,2015/2016,58,HHS Region 4,2 wk ahead,3.4
+2016,6,2015/2016,58,HHS Region 4,3 wk ahead,3.3
+2016,6,2015/2016,58,HHS Region 4,4 wk ahead,3.6
+2016,6,2015/2016,58,HHS Region 5,Season onset,7
+2016,6,2015/2016,58,HHS Region 5,Season peak week,10
+2016,6,2015/2016,58,HHS Region 5,Season peak percentage,3.4
+2016,6,2015/2016,58,HHS Region 5,1 wk ahead,2.2
+2016,6,2015/2016,58,HHS Region 5,2 wk ahead,2.7
+2016,6,2015/2016,58,HHS Region 5,3 wk ahead,3
+2016,6,2015/2016,58,HHS Region 5,4 wk ahead,3.4
+2016,6,2015/2016,58,HHS Region 6,Season onset,47
+2016,6,2015/2016,58,HHS Region 6,Season peak week,7
+2016,6,2015/2016,58,HHS Region 6,Season peak percentage,5.3
+2016,6,2015/2016,58,HHS Region 6,1 wk ahead,5.3
+2016,6,2015/2016,58,HHS Region 6,2 wk ahead,4.2
+2016,6,2015/2016,58,HHS Region 6,3 wk ahead,4.5
+2016,6,2015/2016,58,HHS Region 6,4 wk ahead,4.1
+2016,6,2015/2016,58,HHS Region 7,Season onset,7
+2016,6,2015/2016,58,HHS Region 7,Season peak week,10
+2016,6,2015/2016,58,HHS Region 7,Season peak percentage,2.5
+2016,6,2015/2016,58,HHS Region 7,1 wk ahead,1.8
+2016,6,2015/2016,58,HHS Region 7,2 wk ahead,1.8
+2016,6,2015/2016,58,HHS Region 7,3 wk ahead,2.4
+2016,6,2015/2016,58,HHS Region 7,4 wk ahead,2.5
+2016,6,2015/2016,58,HHS Region 8,Season onset,5
+2016,6,2015/2016,58,HHS Region 8,Season peak week,8
+2016,6,2015/2016,58,HHS Region 8,Season peak week,11
+2016,6,2015/2016,58,HHS Region 8,Season peak percentage,2.2
+2016,6,2015/2016,58,HHS Region 8,1 wk ahead,2.1
+2016,6,2015/2016,58,HHS Region 8,2 wk ahead,2.2
+2016,6,2015/2016,58,HHS Region 8,3 wk ahead,2
+2016,6,2015/2016,58,HHS Region 8,4 wk ahead,2.1
+2016,6,2015/2016,58,HHS Region 9,Season onset,3
+2016,6,2015/2016,58,HHS Region 9,Season peak week,7
+2016,6,2015/2016,58,HHS Region 9,Season peak percentage,4.4
+2016,6,2015/2016,58,HHS Region 9,1 wk ahead,4.4
+2016,6,2015/2016,58,HHS Region 9,2 wk ahead,3.9
+2016,6,2015/2016,58,HHS Region 9,3 wk ahead,3.8
+2016,6,2015/2016,58,HHS Region 9,4 wk ahead,3.8
+2016,6,2015/2016,58,HHS Region 10,Season onset,2
+2016,6,2015/2016,58,HHS Region 10,Season peak week,7
+2016,6,2015/2016,58,HHS Region 10,Season peak percentage,2.4
+2016,6,2015/2016,58,HHS Region 10,1 wk ahead,2.4
+2016,6,2015/2016,58,HHS Region 10,2 wk ahead,2.1
+2016,6,2015/2016,58,HHS Region 10,3 wk ahead,2
+2016,6,2015/2016,58,HHS Region 10,4 wk ahead,2.2
+2016,7,2015/2016,59,US National,Season onset,3
+2016,7,2015/2016,59,US National,Season peak week,10
+2016,7,2015/2016,59,US National,Season peak percentage,3.6
+2016,7,2015/2016,59,US National,1 wk ahead,3.2
+2016,7,2015/2016,59,US National,2 wk ahead,3.3
+2016,7,2015/2016,59,US National,3 wk ahead,3.6
+2016,7,2015/2016,59,US National,4 wk ahead,3.1
+2016,7,2015/2016,59,HHS Region 1,Season onset,51
+2016,7,2015/2016,59,HHS Region 1,Season peak week,10
+2016,7,2015/2016,59,HHS Region 1,Season peak percentage,2.5
+2016,7,2015/2016,59,HHS Region 1,1 wk ahead,2
+2016,7,2015/2016,59,HHS Region 1,2 wk ahead,2
+2016,7,2015/2016,59,HHS Region 1,3 wk ahead,2.5
+2016,7,2015/2016,59,HHS Region 1,4 wk ahead,2.2
+2016,7,2015/2016,59,HHS Region 2,Season onset,4
+2016,7,2015/2016,59,HHS Region 2,Season peak week,11
+2016,7,2015/2016,59,HHS Region 2,Season peak percentage,4.1
+2016,7,2015/2016,59,HHS Region 2,1 wk ahead,3.2
+2016,7,2015/2016,59,HHS Region 2,2 wk ahead,3.7
+2016,7,2015/2016,59,HHS Region 2,3 wk ahead,4
+2016,7,2015/2016,59,HHS Region 2,4 wk ahead,4.1
+2016,7,2015/2016,59,HHS Region 3,Season onset,47
+2016,7,2015/2016,59,HHS Region 3,Season peak week,10
+2016,7,2015/2016,59,HHS Region 3,Season peak percentage,4
+2016,7,2015/2016,59,HHS Region 3,1 wk ahead,2.9
+2016,7,2015/2016,59,HHS Region 3,2 wk ahead,3.3
+2016,7,2015/2016,59,HHS Region 3,3 wk ahead,4
+2016,7,2015/2016,59,HHS Region 3,4 wk ahead,3.2
+2016,7,2015/2016,59,HHS Region 4,Season onset,3
+2016,7,2015/2016,59,HHS Region 4,Season peak week,10
+2016,7,2015/2016,59,HHS Region 4,Season peak percentage,3.6
+2016,7,2015/2016,59,HHS Region 4,1 wk ahead,3.4
+2016,7,2015/2016,59,HHS Region 4,2 wk ahead,3.3
+2016,7,2015/2016,59,HHS Region 4,3 wk ahead,3.6
+2016,7,2015/2016,59,HHS Region 4,4 wk ahead,2.9
+2016,7,2015/2016,59,HHS Region 5,Season onset,7
+2016,7,2015/2016,59,HHS Region 5,Season peak week,10
+2016,7,2015/2016,59,HHS Region 5,Season peak percentage,3.4
+2016,7,2015/2016,59,HHS Region 5,1 wk ahead,2.7
+2016,7,2015/2016,59,HHS Region 5,2 wk ahead,3
+2016,7,2015/2016,59,HHS Region 5,3 wk ahead,3.4
+2016,7,2015/2016,59,HHS Region 5,4 wk ahead,2.6
+2016,7,2015/2016,59,HHS Region 6,Season onset,47
+2016,7,2015/2016,59,HHS Region 6,Season peak week,7
+2016,7,2015/2016,59,HHS Region 6,Season peak percentage,5.3
+2016,7,2015/2016,59,HHS Region 6,1 wk ahead,4.2
+2016,7,2015/2016,59,HHS Region 6,2 wk ahead,4.5
+2016,7,2015/2016,59,HHS Region 6,3 wk ahead,4.1
+2016,7,2015/2016,59,HHS Region 6,4 wk ahead,3.7
+2016,7,2015/2016,59,HHS Region 7,Season onset,7
+2016,7,2015/2016,59,HHS Region 7,Season peak week,10
+2016,7,2015/2016,59,HHS Region 7,Season peak percentage,2.5
+2016,7,2015/2016,59,HHS Region 7,1 wk ahead,1.8
+2016,7,2015/2016,59,HHS Region 7,2 wk ahead,2.4
+2016,7,2015/2016,59,HHS Region 7,3 wk ahead,2.5
+2016,7,2015/2016,59,HHS Region 7,4 wk ahead,2
+2016,7,2015/2016,59,HHS Region 8,Season onset,5
+2016,7,2015/2016,59,HHS Region 8,Season peak week,8
+2016,7,2015/2016,59,HHS Region 8,Season peak week,11
+2016,7,2015/2016,59,HHS Region 8,Season peak percentage,2.2
+2016,7,2015/2016,59,HHS Region 8,1 wk ahead,2.2
+2016,7,2015/2016,59,HHS Region 8,2 wk ahead,2
+2016,7,2015/2016,59,HHS Region 8,3 wk ahead,2.1
+2016,7,2015/2016,59,HHS Region 8,4 wk ahead,2.2
+2016,7,2015/2016,59,HHS Region 9,Season onset,3
+2016,7,2015/2016,59,HHS Region 9,Season peak week,7
+2016,7,2015/2016,59,HHS Region 9,Season peak percentage,4.4
+2016,7,2015/2016,59,HHS Region 9,1 wk ahead,3.9
+2016,7,2015/2016,59,HHS Region 9,2 wk ahead,3.8
+2016,7,2015/2016,59,HHS Region 9,3 wk ahead,3.8
+2016,7,2015/2016,59,HHS Region 9,4 wk ahead,3.3
+2016,7,2015/2016,59,HHS Region 10,Season onset,2
+2016,7,2015/2016,59,HHS Region 10,Season peak week,7
+2016,7,2015/2016,59,HHS Region 10,Season peak percentage,2.4
+2016,7,2015/2016,59,HHS Region 10,1 wk ahead,2.1
+2016,7,2015/2016,59,HHS Region 10,2 wk ahead,2
+2016,7,2015/2016,59,HHS Region 10,3 wk ahead,2.2
+2016,7,2015/2016,59,HHS Region 10,4 wk ahead,2.2
+2016,8,2015/2016,60,US National,Season onset,3
+2016,8,2015/2016,60,US National,Season peak week,10
+2016,8,2015/2016,60,US National,Season peak percentage,3.6
+2016,8,2015/2016,60,US National,1 wk ahead,3.3
+2016,8,2015/2016,60,US National,2 wk ahead,3.6
+2016,8,2015/2016,60,US National,3 wk ahead,3.1
+2016,8,2015/2016,60,US National,4 wk ahead,2.8
+2016,8,2015/2016,60,HHS Region 1,Season onset,51
+2016,8,2015/2016,60,HHS Region 1,Season peak week,10
+2016,8,2015/2016,60,HHS Region 1,Season peak percentage,2.5
+2016,8,2015/2016,60,HHS Region 1,1 wk ahead,2
+2016,8,2015/2016,60,HHS Region 1,2 wk ahead,2.5
+2016,8,2015/2016,60,HHS Region 1,3 wk ahead,2.2
+2016,8,2015/2016,60,HHS Region 1,4 wk ahead,2
+2016,8,2015/2016,60,HHS Region 2,Season onset,4
+2016,8,2015/2016,60,HHS Region 2,Season peak week,11
+2016,8,2015/2016,60,HHS Region 2,Season peak percentage,4.1
+2016,8,2015/2016,60,HHS Region 2,1 wk ahead,3.7
+2016,8,2015/2016,60,HHS Region 2,2 wk ahead,4
+2016,8,2015/2016,60,HHS Region 2,3 wk ahead,4.1
+2016,8,2015/2016,60,HHS Region 2,4 wk ahead,3.3
+2016,8,2015/2016,60,HHS Region 3,Season onset,47
+2016,8,2015/2016,60,HHS Region 3,Season peak week,10
+2016,8,2015/2016,60,HHS Region 3,Season peak percentage,4
+2016,8,2015/2016,60,HHS Region 3,1 wk ahead,3.3
+2016,8,2015/2016,60,HHS Region 3,2 wk ahead,4
+2016,8,2015/2016,60,HHS Region 3,3 wk ahead,3.2
+2016,8,2015/2016,60,HHS Region 3,4 wk ahead,3
+2016,8,2015/2016,60,HHS Region 4,Season onset,3
+2016,8,2015/2016,60,HHS Region 4,Season peak week,10
+2016,8,2015/2016,60,HHS Region 4,Season peak percentage,3.6
+2016,8,2015/2016,60,HHS Region 4,1 wk ahead,3.3
+2016,8,2015/2016,60,HHS Region 4,2 wk ahead,3.6
+2016,8,2015/2016,60,HHS Region 4,3 wk ahead,2.9
+2016,8,2015/2016,60,HHS Region 4,4 wk ahead,2.8
+2016,8,2015/2016,60,HHS Region 5,Season onset,7
+2016,8,2015/2016,60,HHS Region 5,Season peak week,10
+2016,8,2015/2016,60,HHS Region 5,Season peak percentage,3.4
+2016,8,2015/2016,60,HHS Region 5,1 wk ahead,3
+2016,8,2015/2016,60,HHS Region 5,2 wk ahead,3.4
+2016,8,2015/2016,60,HHS Region 5,3 wk ahead,2.6
+2016,8,2015/2016,60,HHS Region 5,4 wk ahead,2.3
+2016,8,2015/2016,60,HHS Region 6,Season onset,47
+2016,8,2015/2016,60,HHS Region 6,Season peak week,7
+2016,8,2015/2016,60,HHS Region 6,Season peak percentage,5.3
+2016,8,2015/2016,60,HHS Region 6,1 wk ahead,4.5
+2016,8,2015/2016,60,HHS Region 6,2 wk ahead,4.1
+2016,8,2015/2016,60,HHS Region 6,3 wk ahead,3.7
+2016,8,2015/2016,60,HHS Region 6,4 wk ahead,3.4
+2016,8,2015/2016,60,HHS Region 7,Season onset,7
+2016,8,2015/2016,60,HHS Region 7,Season peak week,10
+2016,8,2015/2016,60,HHS Region 7,Season peak percentage,2.5
+2016,8,2015/2016,60,HHS Region 7,1 wk ahead,2.4
+2016,8,2015/2016,60,HHS Region 7,2 wk ahead,2.5
+2016,8,2015/2016,60,HHS Region 7,3 wk ahead,2
+2016,8,2015/2016,60,HHS Region 7,4 wk ahead,2.1
+2016,8,2015/2016,60,HHS Region 8,Season onset,5
+2016,8,2015/2016,60,HHS Region 8,Season peak week,8
+2016,8,2015/2016,60,HHS Region 8,Season peak week,11
+2016,8,2015/2016,60,HHS Region 8,Season peak percentage,2.2
+2016,8,2015/2016,60,HHS Region 8,1 wk ahead,2
+2016,8,2015/2016,60,HHS Region 8,2 wk ahead,2.1
+2016,8,2015/2016,60,HHS Region 8,3 wk ahead,2.2
+2016,8,2015/2016,60,HHS Region 8,4 wk ahead,1.9
+2016,8,2015/2016,60,HHS Region 9,Season onset,3
+2016,8,2015/2016,60,HHS Region 9,Season peak week,7
+2016,8,2015/2016,60,HHS Region 9,Season peak percentage,4.4
+2016,8,2015/2016,60,HHS Region 9,1 wk ahead,3.8
+2016,8,2015/2016,60,HHS Region 9,2 wk ahead,3.8
+2016,8,2015/2016,60,HHS Region 9,3 wk ahead,3.3
+2016,8,2015/2016,60,HHS Region 9,4 wk ahead,3
+2016,8,2015/2016,60,HHS Region 10,Season onset,2
+2016,8,2015/2016,60,HHS Region 10,Season peak week,7
+2016,8,2015/2016,60,HHS Region 10,Season peak percentage,2.4
+2016,8,2015/2016,60,HHS Region 10,1 wk ahead,2
+2016,8,2015/2016,60,HHS Region 10,2 wk ahead,2.2
+2016,8,2015/2016,60,HHS Region 10,3 wk ahead,2.2
+2016,8,2015/2016,60,HHS Region 10,4 wk ahead,1.7
+2016,9,2015/2016,61,US National,Season onset,3
+2016,9,2015/2016,61,US National,Season peak week,10
+2016,9,2015/2016,61,US National,Season peak percentage,3.6
+2016,9,2015/2016,61,US National,1 wk ahead,3.6
+2016,9,2015/2016,61,US National,2 wk ahead,3.1
+2016,9,2015/2016,61,US National,3 wk ahead,2.8
+2016,9,2015/2016,61,US National,4 wk ahead,2.4
+2016,9,2015/2016,61,HHS Region 1,Season onset,51
+2016,9,2015/2016,61,HHS Region 1,Season peak week,10
+2016,9,2015/2016,61,HHS Region 1,Season peak percentage,2.5
+2016,9,2015/2016,61,HHS Region 1,1 wk ahead,2.5
+2016,9,2015/2016,61,HHS Region 1,2 wk ahead,2.2
+2016,9,2015/2016,61,HHS Region 1,3 wk ahead,2
+2016,9,2015/2016,61,HHS Region 1,4 wk ahead,2
+2016,9,2015/2016,61,HHS Region 2,Season onset,4
+2016,9,2015/2016,61,HHS Region 2,Season peak week,11
+2016,9,2015/2016,61,HHS Region 2,Season peak percentage,4.1
+2016,9,2015/2016,61,HHS Region 2,1 wk ahead,4
+2016,9,2015/2016,61,HHS Region 2,2 wk ahead,4.1
+2016,9,2015/2016,61,HHS Region 2,3 wk ahead,3.3
+2016,9,2015/2016,61,HHS Region 2,4 wk ahead,2.3
+2016,9,2015/2016,61,HHS Region 3,Season onset,47
+2016,9,2015/2016,61,HHS Region 3,Season peak week,10
+2016,9,2015/2016,61,HHS Region 3,Season peak percentage,4
+2016,9,2015/2016,61,HHS Region 3,1 wk ahead,4
+2016,9,2015/2016,61,HHS Region 3,2 wk ahead,3.2
+2016,9,2015/2016,61,HHS Region 3,3 wk ahead,3
+2016,9,2015/2016,61,HHS Region 3,4 wk ahead,2.5
+2016,9,2015/2016,61,HHS Region 4,Season onset,3
+2016,9,2015/2016,61,HHS Region 4,Season peak week,10
+2016,9,2015/2016,61,HHS Region 4,Season peak percentage,3.6
+2016,9,2015/2016,61,HHS Region 4,1 wk ahead,3.6
+2016,9,2015/2016,61,HHS Region 4,2 wk ahead,2.9
+2016,9,2015/2016,61,HHS Region 4,3 wk ahead,2.8
+2016,9,2015/2016,61,HHS Region 4,4 wk ahead,2.6
+2016,9,2015/2016,61,HHS Region 5,Season onset,7
+2016,9,2015/2016,61,HHS Region 5,Season peak week,10
+2016,9,2015/2016,61,HHS Region 5,Season peak percentage,3.4
+2016,9,2015/2016,61,HHS Region 5,1 wk ahead,3.4
+2016,9,2015/2016,61,HHS Region 5,2 wk ahead,2.6
+2016,9,2015/2016,61,HHS Region 5,3 wk ahead,2.3
+2016,9,2015/2016,61,HHS Region 5,4 wk ahead,2
+2016,9,2015/2016,61,HHS Region 6,Season onset,47
+2016,9,2015/2016,61,HHS Region 6,Season peak week,7
+2016,9,2015/2016,61,HHS Region 6,Season peak percentage,5.3
+2016,9,2015/2016,61,HHS Region 6,1 wk ahead,4.1
+2016,9,2015/2016,61,HHS Region 6,2 wk ahead,3.7
+2016,9,2015/2016,61,HHS Region 6,3 wk ahead,3.4
+2016,9,2015/2016,61,HHS Region 6,4 wk ahead,3.1
+2016,9,2015/2016,61,HHS Region 7,Season onset,7
+2016,9,2015/2016,61,HHS Region 7,Season peak week,10
+2016,9,2015/2016,61,HHS Region 7,Season peak percentage,2.5
+2016,9,2015/2016,61,HHS Region 7,1 wk ahead,2.5
+2016,9,2015/2016,61,HHS Region 7,2 wk ahead,2
+2016,9,2015/2016,61,HHS Region 7,3 wk ahead,2.1
+2016,9,2015/2016,61,HHS Region 7,4 wk ahead,2.1
+2016,9,2015/2016,61,HHS Region 8,Season onset,5
+2016,9,2015/2016,61,HHS Region 8,Season peak week,8
+2016,9,2015/2016,61,HHS Region 8,Season peak week,11
+2016,9,2015/2016,61,HHS Region 8,Season peak percentage,2.2
+2016,9,2015/2016,61,HHS Region 8,1 wk ahead,2.1
+2016,9,2015/2016,61,HHS Region 8,2 wk ahead,2.2
+2016,9,2015/2016,61,HHS Region 8,3 wk ahead,1.9
+2016,9,2015/2016,61,HHS Region 8,4 wk ahead,1.8
+2016,9,2015/2016,61,HHS Region 9,Season onset,3
+2016,9,2015/2016,61,HHS Region 9,Season peak week,7
+2016,9,2015/2016,61,HHS Region 9,Season peak percentage,4.4
+2016,9,2015/2016,61,HHS Region 9,1 wk ahead,3.8
+2016,9,2015/2016,61,HHS Region 9,2 wk ahead,3.3
+2016,9,2015/2016,61,HHS Region 9,3 wk ahead,3
+2016,9,2015/2016,61,HHS Region 9,4 wk ahead,2.8
+2016,9,2015/2016,61,HHS Region 10,Season onset,2
+2016,9,2015/2016,61,HHS Region 10,Season peak week,7
+2016,9,2015/2016,61,HHS Region 10,Season peak percentage,2.4
+2016,9,2015/2016,61,HHS Region 10,1 wk ahead,2.2
+2016,9,2015/2016,61,HHS Region 10,2 wk ahead,2.2
+2016,9,2015/2016,61,HHS Region 10,3 wk ahead,1.7
+2016,9,2015/2016,61,HHS Region 10,4 wk ahead,1.8
+2016,10,2015/2016,62,US National,Season onset,3
+2016,10,2015/2016,62,US National,Season peak week,10
+2016,10,2015/2016,62,US National,Season peak percentage,3.6
+2016,10,2015/2016,62,US National,1 wk ahead,3.1
+2016,10,2015/2016,62,US National,2 wk ahead,2.8
+2016,10,2015/2016,62,US National,3 wk ahead,2.4
+2016,10,2015/2016,62,US National,4 wk ahead,2
+2016,10,2015/2016,62,HHS Region 1,Season onset,51
+2016,10,2015/2016,62,HHS Region 1,Season peak week,10
+2016,10,2015/2016,62,HHS Region 1,Season peak percentage,2.5
+2016,10,2015/2016,62,HHS Region 1,1 wk ahead,2.2
+2016,10,2015/2016,62,HHS Region 1,2 wk ahead,2
+2016,10,2015/2016,62,HHS Region 1,3 wk ahead,2
+2016,10,2015/2016,62,HHS Region 1,4 wk ahead,1.7
+2016,10,2015/2016,62,HHS Region 2,Season onset,4
+2016,10,2015/2016,62,HHS Region 2,Season peak week,11
+2016,10,2015/2016,62,HHS Region 2,Season peak percentage,4.1
+2016,10,2015/2016,62,HHS Region 2,1 wk ahead,4.1
+2016,10,2015/2016,62,HHS Region 2,2 wk ahead,3.3
+2016,10,2015/2016,62,HHS Region 2,3 wk ahead,2.3
+2016,10,2015/2016,62,HHS Region 2,4 wk ahead,2
+2016,10,2015/2016,62,HHS Region 3,Season onset,47
+2016,10,2015/2016,62,HHS Region 3,Season peak week,10
+2016,10,2015/2016,62,HHS Region 3,Season peak percentage,4
+2016,10,2015/2016,62,HHS Region 3,1 wk ahead,3.2
+2016,10,2015/2016,62,HHS Region 3,2 wk ahead,3
+2016,10,2015/2016,62,HHS Region 3,3 wk ahead,2.5
+2016,10,2015/2016,62,HHS Region 3,4 wk ahead,2.1
+2016,10,2015/2016,62,HHS Region 4,Season onset,3
+2016,10,2015/2016,62,HHS Region 4,Season peak week,10
+2016,10,2015/2016,62,HHS Region 4,Season peak percentage,3.6
+2016,10,2015/2016,62,HHS Region 4,1 wk ahead,2.9
+2016,10,2015/2016,62,HHS Region 4,2 wk ahead,2.8
+2016,10,2015/2016,62,HHS Region 4,3 wk ahead,2.6
+2016,10,2015/2016,62,HHS Region 4,4 wk ahead,2.1
+2016,10,2015/2016,62,HHS Region 5,Season onset,7
+2016,10,2015/2016,62,HHS Region 5,Season peak week,10
+2016,10,2015/2016,62,HHS Region 5,Season peak percentage,3.4
+2016,10,2015/2016,62,HHS Region 5,1 wk ahead,2.6
+2016,10,2015/2016,62,HHS Region 5,2 wk ahead,2.3
+2016,10,2015/2016,62,HHS Region 5,3 wk ahead,2
+2016,10,2015/2016,62,HHS Region 5,4 wk ahead,1.6
+2016,10,2015/2016,62,HHS Region 6,Season onset,47
+2016,10,2015/2016,62,HHS Region 6,Season peak week,7
+2016,10,2015/2016,62,HHS Region 6,Season peak percentage,5.3
+2016,10,2015/2016,62,HHS Region 6,1 wk ahead,3.7
+2016,10,2015/2016,62,HHS Region 6,2 wk ahead,3.4
+2016,10,2015/2016,62,HHS Region 6,3 wk ahead,3.1
+2016,10,2015/2016,62,HHS Region 6,4 wk ahead,2.6
+2016,10,2015/2016,62,HHS Region 7,Season onset,7
+2016,10,2015/2016,62,HHS Region 7,Season peak week,10
+2016,10,2015/2016,62,HHS Region 7,Season peak percentage,2.5
+2016,10,2015/2016,62,HHS Region 7,1 wk ahead,2
+2016,10,2015/2016,62,HHS Region 7,2 wk ahead,2.1
+2016,10,2015/2016,62,HHS Region 7,3 wk ahead,2.1
+2016,10,2015/2016,62,HHS Region 7,4 wk ahead,1.5
+2016,10,2015/2016,62,HHS Region 8,Season onset,5
+2016,10,2015/2016,62,HHS Region 8,Season peak week,8
+2016,10,2015/2016,62,HHS Region 8,Season peak week,11
+2016,10,2015/2016,62,HHS Region 8,Season peak percentage,2.2
+2016,10,2015/2016,62,HHS Region 8,1 wk ahead,2.2
+2016,10,2015/2016,62,HHS Region 8,2 wk ahead,1.9
+2016,10,2015/2016,62,HHS Region 8,3 wk ahead,1.8
+2016,10,2015/2016,62,HHS Region 8,4 wk ahead,1.6
+2016,10,2015/2016,62,HHS Region 9,Season onset,3
+2016,10,2015/2016,62,HHS Region 9,Season peak week,7
+2016,10,2015/2016,62,HHS Region 9,Season peak percentage,4.4
+2016,10,2015/2016,62,HHS Region 9,1 wk ahead,3.3
+2016,10,2015/2016,62,HHS Region 9,2 wk ahead,3
+2016,10,2015/2016,62,HHS Region 9,3 wk ahead,2.8
+2016,10,2015/2016,62,HHS Region 9,4 wk ahead,2.2
+2016,10,2015/2016,62,HHS Region 10,Season onset,2
+2016,10,2015/2016,62,HHS Region 10,Season peak week,7
+2016,10,2015/2016,62,HHS Region 10,Season peak percentage,2.4
+2016,10,2015/2016,62,HHS Region 10,1 wk ahead,2.2
+2016,10,2015/2016,62,HHS Region 10,2 wk ahead,1.7
+2016,10,2015/2016,62,HHS Region 10,3 wk ahead,1.8
+2016,10,2015/2016,62,HHS Region 10,4 wk ahead,1.7
+2016,11,2015/2016,63,US National,Season onset,3
+2016,11,2015/2016,63,US National,Season peak week,10
+2016,11,2015/2016,63,US National,Season peak percentage,3.6
+2016,11,2015/2016,63,US National,1 wk ahead,2.8
+2016,11,2015/2016,63,US National,2 wk ahead,2.4
+2016,11,2015/2016,63,US National,3 wk ahead,2
+2016,11,2015/2016,63,US National,4 wk ahead,2
+2016,11,2015/2016,63,HHS Region 1,Season onset,51
+2016,11,2015/2016,63,HHS Region 1,Season peak week,10
+2016,11,2015/2016,63,HHS Region 1,Season peak percentage,2.5
+2016,11,2015/2016,63,HHS Region 1,1 wk ahead,2
+2016,11,2015/2016,63,HHS Region 1,2 wk ahead,2
+2016,11,2015/2016,63,HHS Region 1,3 wk ahead,1.7
+2016,11,2015/2016,63,HHS Region 1,4 wk ahead,1.6
+2016,11,2015/2016,63,HHS Region 2,Season onset,4
+2016,11,2015/2016,63,HHS Region 2,Season peak week,11
+2016,11,2015/2016,63,HHS Region 2,Season peak percentage,4.1
+2016,11,2015/2016,63,HHS Region 2,1 wk ahead,3.3
+2016,11,2015/2016,63,HHS Region 2,2 wk ahead,2.3
+2016,11,2015/2016,63,HHS Region 2,3 wk ahead,2
+2016,11,2015/2016,63,HHS Region 2,4 wk ahead,2.2
+2016,11,2015/2016,63,HHS Region 3,Season onset,47
+2016,11,2015/2016,63,HHS Region 3,Season peak week,10
+2016,11,2015/2016,63,HHS Region 3,Season peak percentage,4
+2016,11,2015/2016,63,HHS Region 3,1 wk ahead,3
+2016,11,2015/2016,63,HHS Region 3,2 wk ahead,2.5
+2016,11,2015/2016,63,HHS Region 3,3 wk ahead,2.1
+2016,11,2015/2016,63,HHS Region 3,4 wk ahead,2.2
+2016,11,2015/2016,63,HHS Region 4,Season onset,3
+2016,11,2015/2016,63,HHS Region 4,Season peak week,10
+2016,11,2015/2016,63,HHS Region 4,Season peak percentage,3.6
+2016,11,2015/2016,63,HHS Region 4,1 wk ahead,2.8
+2016,11,2015/2016,63,HHS Region 4,2 wk ahead,2.6
+2016,11,2015/2016,63,HHS Region 4,3 wk ahead,2.1
+2016,11,2015/2016,63,HHS Region 4,4 wk ahead,2
+2016,11,2015/2016,63,HHS Region 5,Season onset,7
+2016,11,2015/2016,63,HHS Region 5,Season peak week,10
+2016,11,2015/2016,63,HHS Region 5,Season peak percentage,3.4
+2016,11,2015/2016,63,HHS Region 5,1 wk ahead,2.3
+2016,11,2015/2016,63,HHS Region 5,2 wk ahead,2
+2016,11,2015/2016,63,HHS Region 5,3 wk ahead,1.6
+2016,11,2015/2016,63,HHS Region 5,4 wk ahead,1.5
+2016,11,2015/2016,63,HHS Region 6,Season onset,47
+2016,11,2015/2016,63,HHS Region 6,Season peak week,7
+2016,11,2015/2016,63,HHS Region 6,Season peak percentage,5.3
+2016,11,2015/2016,63,HHS Region 6,1 wk ahead,3.4
+2016,11,2015/2016,63,HHS Region 6,2 wk ahead,3.1
+2016,11,2015/2016,63,HHS Region 6,3 wk ahead,2.6
+2016,11,2015/2016,63,HHS Region 6,4 wk ahead,3
+2016,11,2015/2016,63,HHS Region 7,Season onset,7
+2016,11,2015/2016,63,HHS Region 7,Season peak week,10
+2016,11,2015/2016,63,HHS Region 7,Season peak percentage,2.5
+2016,11,2015/2016,63,HHS Region 7,1 wk ahead,2.1
+2016,11,2015/2016,63,HHS Region 7,2 wk ahead,2.1
+2016,11,2015/2016,63,HHS Region 7,3 wk ahead,1.5
+2016,11,2015/2016,63,HHS Region 7,4 wk ahead,1.4
+2016,11,2015/2016,63,HHS Region 8,Season onset,5
+2016,11,2015/2016,63,HHS Region 8,Season peak week,8
+2016,11,2015/2016,63,HHS Region 8,Season peak week,11
+2016,11,2015/2016,63,HHS Region 8,Season peak percentage,2.2
+2016,11,2015/2016,63,HHS Region 8,1 wk ahead,1.9
+2016,11,2015/2016,63,HHS Region 8,2 wk ahead,1.8
+2016,11,2015/2016,63,HHS Region 8,3 wk ahead,1.6
+2016,11,2015/2016,63,HHS Region 8,4 wk ahead,1.3
+2016,11,2015/2016,63,HHS Region 9,Season onset,3
+2016,11,2015/2016,63,HHS Region 9,Season peak week,7
+2016,11,2015/2016,63,HHS Region 9,Season peak percentage,4.4
+2016,11,2015/2016,63,HHS Region 9,1 wk ahead,3
+2016,11,2015/2016,63,HHS Region 9,2 wk ahead,2.8
+2016,11,2015/2016,63,HHS Region 9,3 wk ahead,2.2
+2016,11,2015/2016,63,HHS Region 9,4 wk ahead,2
+2016,11,2015/2016,63,HHS Region 10,Season onset,2
+2016,11,2015/2016,63,HHS Region 10,Season peak week,7
+2016,11,2015/2016,63,HHS Region 10,Season peak percentage,2.4
+2016,11,2015/2016,63,HHS Region 10,1 wk ahead,1.7
+2016,11,2015/2016,63,HHS Region 10,2 wk ahead,1.8
+2016,11,2015/2016,63,HHS Region 10,3 wk ahead,1.7
+2016,11,2015/2016,63,HHS Region 10,4 wk ahead,1
+2016,12,2015/2016,64,US National,Season onset,3
+2016,12,2015/2016,64,US National,Season peak week,10
+2016,12,2015/2016,64,US National,Season peak percentage,3.6
+2016,12,2015/2016,64,US National,1 wk ahead,2.4
+2016,12,2015/2016,64,US National,2 wk ahead,2
+2016,12,2015/2016,64,US National,3 wk ahead,2
+2016,12,2015/2016,64,US National,4 wk ahead,1.9
+2016,12,2015/2016,64,HHS Region 1,Season onset,51
+2016,12,2015/2016,64,HHS Region 1,Season peak week,10
+2016,12,2015/2016,64,HHS Region 1,Season peak percentage,2.5
+2016,12,2015/2016,64,HHS Region 1,1 wk ahead,2
+2016,12,2015/2016,64,HHS Region 1,2 wk ahead,1.7
+2016,12,2015/2016,64,HHS Region 1,3 wk ahead,1.6
+2016,12,2015/2016,64,HHS Region 1,4 wk ahead,1.6
+2016,12,2015/2016,64,HHS Region 2,Season onset,4
+2016,12,2015/2016,64,HHS Region 2,Season peak week,11
+2016,12,2015/2016,64,HHS Region 2,Season peak percentage,4.1
+2016,12,2015/2016,64,HHS Region 2,1 wk ahead,2.3
+2016,12,2015/2016,64,HHS Region 2,2 wk ahead,2
+2016,12,2015/2016,64,HHS Region 2,3 wk ahead,2.2
+2016,12,2015/2016,64,HHS Region 2,4 wk ahead,2
+2016,12,2015/2016,64,HHS Region 3,Season onset,47
+2016,12,2015/2016,64,HHS Region 3,Season peak week,10
+2016,12,2015/2016,64,HHS Region 3,Season peak percentage,4
+2016,12,2015/2016,64,HHS Region 3,1 wk ahead,2.5
+2016,12,2015/2016,64,HHS Region 3,2 wk ahead,2.1
+2016,12,2015/2016,64,HHS Region 3,3 wk ahead,2.2
+2016,12,2015/2016,64,HHS Region 3,4 wk ahead,2.3
+2016,12,2015/2016,64,HHS Region 4,Season onset,3
+2016,12,2015/2016,64,HHS Region 4,Season peak week,10
+2016,12,2015/2016,64,HHS Region 4,Season peak percentage,3.6
+2016,12,2015/2016,64,HHS Region 4,1 wk ahead,2.6
+2016,12,2015/2016,64,HHS Region 4,2 wk ahead,2.1
+2016,12,2015/2016,64,HHS Region 4,3 wk ahead,2
+2016,12,2015/2016,64,HHS Region 4,4 wk ahead,2
+2016,12,2015/2016,64,HHS Region 5,Season onset,7
+2016,12,2015/2016,64,HHS Region 5,Season peak week,10
+2016,12,2015/2016,64,HHS Region 5,Season peak percentage,3.4
+2016,12,2015/2016,64,HHS Region 5,1 wk ahead,2
+2016,12,2015/2016,64,HHS Region 5,2 wk ahead,1.6
+2016,12,2015/2016,64,HHS Region 5,3 wk ahead,1.5
+2016,12,2015/2016,64,HHS Region 5,4 wk ahead,1.5
+2016,12,2015/2016,64,HHS Region 6,Season onset,47
+2016,12,2015/2016,64,HHS Region 6,Season peak week,7
+2016,12,2015/2016,64,HHS Region 6,Season peak percentage,5.3
+2016,12,2015/2016,64,HHS Region 6,1 wk ahead,3.1
+2016,12,2015/2016,64,HHS Region 6,2 wk ahead,2.6
+2016,12,2015/2016,64,HHS Region 6,3 wk ahead,3
+2016,12,2015/2016,64,HHS Region 6,4 wk ahead,3.1
+2016,12,2015/2016,64,HHS Region 7,Season onset,7
+2016,12,2015/2016,64,HHS Region 7,Season peak week,10
+2016,12,2015/2016,64,HHS Region 7,Season peak percentage,2.5
+2016,12,2015/2016,64,HHS Region 7,1 wk ahead,2.1
+2016,12,2015/2016,64,HHS Region 7,2 wk ahead,1.5
+2016,12,2015/2016,64,HHS Region 7,3 wk ahead,1.4
+2016,12,2015/2016,64,HHS Region 7,4 wk ahead,1.2
+2016,12,2015/2016,64,HHS Region 8,Season onset,5
+2016,12,2015/2016,64,HHS Region 8,Season peak week,8
+2016,12,2015/2016,64,HHS Region 8,Season peak week,11
+2016,12,2015/2016,64,HHS Region 8,Season peak percentage,2.2
+2016,12,2015/2016,64,HHS Region 8,1 wk ahead,1.8
+2016,12,2015/2016,64,HHS Region 8,2 wk ahead,1.6
+2016,12,2015/2016,64,HHS Region 8,3 wk ahead,1.3
+2016,12,2015/2016,64,HHS Region 8,4 wk ahead,1.1
+2016,12,2015/2016,64,HHS Region 9,Season onset,3
+2016,12,2015/2016,64,HHS Region 9,Season peak week,7
+2016,12,2015/2016,64,HHS Region 9,Season peak percentage,4.4
+2016,12,2015/2016,64,HHS Region 9,1 wk ahead,2.8
+2016,12,2015/2016,64,HHS Region 9,2 wk ahead,2.2
+2016,12,2015/2016,64,HHS Region 9,3 wk ahead,2
+2016,12,2015/2016,64,HHS Region 9,4 wk ahead,1.8
+2016,12,2015/2016,64,HHS Region 10,Season onset,2
+2016,12,2015/2016,64,HHS Region 10,Season peak week,7
+2016,12,2015/2016,64,HHS Region 10,Season peak percentage,2.4
+2016,12,2015/2016,64,HHS Region 10,1 wk ahead,1.8
+2016,12,2015/2016,64,HHS Region 10,2 wk ahead,1.7
+2016,12,2015/2016,64,HHS Region 10,3 wk ahead,1
+2016,12,2015/2016,64,HHS Region 10,4 wk ahead,0.8
+2016,13,2015/2016,65,US National,Season onset,3
+2016,13,2015/2016,65,US National,Season peak week,10
+2016,13,2015/2016,65,US National,Season peak percentage,3.6
+2016,13,2015/2016,65,US National,1 wk ahead,2
+2016,13,2015/2016,65,US National,2 wk ahead,2
+2016,13,2015/2016,65,US National,3 wk ahead,1.9
+2016,13,2015/2016,65,US National,4 wk ahead,1.7
+2016,13,2015/2016,65,HHS Region 1,Season onset,51
+2016,13,2015/2016,65,HHS Region 1,Season peak week,10
+2016,13,2015/2016,65,HHS Region 1,Season peak percentage,2.5
+2016,13,2015/2016,65,HHS Region 1,1 wk ahead,1.7
+2016,13,2015/2016,65,HHS Region 1,2 wk ahead,1.6
+2016,13,2015/2016,65,HHS Region 1,3 wk ahead,1.6
+2016,13,2015/2016,65,HHS Region 1,4 wk ahead,1.1
+2016,13,2015/2016,65,HHS Region 2,Season onset,4
+2016,13,2015/2016,65,HHS Region 2,Season peak week,11
+2016,13,2015/2016,65,HHS Region 2,Season peak percentage,4.1
+2016,13,2015/2016,65,HHS Region 2,1 wk ahead,2
+2016,13,2015/2016,65,HHS Region 2,2 wk ahead,2.2
+2016,13,2015/2016,65,HHS Region 2,3 wk ahead,2
+2016,13,2015/2016,65,HHS Region 2,4 wk ahead,1.7
+2016,13,2015/2016,65,HHS Region 3,Season onset,47
+2016,13,2015/2016,65,HHS Region 3,Season peak week,10
+2016,13,2015/2016,65,HHS Region 3,Season peak percentage,4
+2016,13,2015/2016,65,HHS Region 3,1 wk ahead,2.1
+2016,13,2015/2016,65,HHS Region 3,2 wk ahead,2.2
+2016,13,2015/2016,65,HHS Region 3,3 wk ahead,2.3
+2016,13,2015/2016,65,HHS Region 3,4 wk ahead,2.2
+2016,13,2015/2016,65,HHS Region 4,Season onset,3
+2016,13,2015/2016,65,HHS Region 4,Season peak week,10
+2016,13,2015/2016,65,HHS Region 4,Season peak percentage,3.6
+2016,13,2015/2016,65,HHS Region 4,1 wk ahead,2.1
+2016,13,2015/2016,65,HHS Region 4,2 wk ahead,2
+2016,13,2015/2016,65,HHS Region 4,3 wk ahead,2
+2016,13,2015/2016,65,HHS Region 4,4 wk ahead,1.8
+2016,13,2015/2016,65,HHS Region 5,Season onset,7
+2016,13,2015/2016,65,HHS Region 5,Season peak week,10
+2016,13,2015/2016,65,HHS Region 5,Season peak percentage,3.4
+2016,13,2015/2016,65,HHS Region 5,1 wk ahead,1.6
+2016,13,2015/2016,65,HHS Region 5,2 wk ahead,1.5
+2016,13,2015/2016,65,HHS Region 5,3 wk ahead,1.5
+2016,13,2015/2016,65,HHS Region 5,4 wk ahead,1.3
+2016,13,2015/2016,65,HHS Region 6,Season onset,47
+2016,13,2015/2016,65,HHS Region 6,Season peak week,7
+2016,13,2015/2016,65,HHS Region 6,Season peak percentage,5.3
+2016,13,2015/2016,65,HHS Region 6,1 wk ahead,2.6
+2016,13,2015/2016,65,HHS Region 6,2 wk ahead,3
+2016,13,2015/2016,65,HHS Region 6,3 wk ahead,3.1
+2016,13,2015/2016,65,HHS Region 6,4 wk ahead,2.6
+2016,13,2015/2016,65,HHS Region 7,Season onset,7
+2016,13,2015/2016,65,HHS Region 7,Season peak week,10
+2016,13,2015/2016,65,HHS Region 7,Season peak percentage,2.5
+2016,13,2015/2016,65,HHS Region 7,1 wk ahead,1.5
+2016,13,2015/2016,65,HHS Region 7,2 wk ahead,1.4
+2016,13,2015/2016,65,HHS Region 7,3 wk ahead,1.2
+2016,13,2015/2016,65,HHS Region 7,4 wk ahead,1
+2016,13,2015/2016,65,HHS Region 8,Season onset,5
+2016,13,2015/2016,65,HHS Region 8,Season peak week,8
+2016,13,2015/2016,65,HHS Region 8,Season peak week,11
+2016,13,2015/2016,65,HHS Region 8,Season peak percentage,2.2
+2016,13,2015/2016,65,HHS Region 8,1 wk ahead,1.6
+2016,13,2015/2016,65,HHS Region 8,2 wk ahead,1.3
+2016,13,2015/2016,65,HHS Region 8,3 wk ahead,1.1
+2016,13,2015/2016,65,HHS Region 8,4 wk ahead,1
+2016,13,2015/2016,65,HHS Region 9,Season onset,3
+2016,13,2015/2016,65,HHS Region 9,Season peak week,7
+2016,13,2015/2016,65,HHS Region 9,Season peak percentage,4.4
+2016,13,2015/2016,65,HHS Region 9,1 wk ahead,2.2
+2016,13,2015/2016,65,HHS Region 9,2 wk ahead,2
+2016,13,2015/2016,65,HHS Region 9,3 wk ahead,1.8
+2016,13,2015/2016,65,HHS Region 9,4 wk ahead,1.7
+2016,13,2015/2016,65,HHS Region 10,Season onset,2
+2016,13,2015/2016,65,HHS Region 10,Season peak week,7
+2016,13,2015/2016,65,HHS Region 10,Season peak percentage,2.4
+2016,13,2015/2016,65,HHS Region 10,1 wk ahead,1.7
+2016,13,2015/2016,65,HHS Region 10,2 wk ahead,1
+2016,13,2015/2016,65,HHS Region 10,3 wk ahead,0.8
+2016,13,2015/2016,65,HHS Region 10,4 wk ahead,0.7
+2016,14,2015/2016,66,US National,Season onset,3
+2016,14,2015/2016,66,US National,Season peak week,10
+2016,14,2015/2016,66,US National,Season peak percentage,3.6
+2016,14,2015/2016,66,US National,1 wk ahead,2
+2016,14,2015/2016,66,US National,2 wk ahead,1.9
+2016,14,2015/2016,66,US National,3 wk ahead,1.7
+2016,14,2015/2016,66,US National,4 wk ahead,1.6
+2016,14,2015/2016,66,HHS Region 1,Season onset,51
+2016,14,2015/2016,66,HHS Region 1,Season peak week,10
+2016,14,2015/2016,66,HHS Region 1,Season peak percentage,2.5
+2016,14,2015/2016,66,HHS Region 1,1 wk ahead,1.6
+2016,14,2015/2016,66,HHS Region 1,2 wk ahead,1.6
+2016,14,2015/2016,66,HHS Region 1,3 wk ahead,1.1
+2016,14,2015/2016,66,HHS Region 1,4 wk ahead,1.1
+2016,14,2015/2016,66,HHS Region 2,Season onset,4
+2016,14,2015/2016,66,HHS Region 2,Season peak week,11
+2016,14,2015/2016,66,HHS Region 2,Season peak percentage,4.1
+2016,14,2015/2016,66,HHS Region 2,1 wk ahead,2.2
+2016,14,2015/2016,66,HHS Region 2,2 wk ahead,2
+2016,14,2015/2016,66,HHS Region 2,3 wk ahead,1.7
+2016,14,2015/2016,66,HHS Region 2,4 wk ahead,1.5
+2016,14,2015/2016,66,HHS Region 3,Season onset,47
+2016,14,2015/2016,66,HHS Region 3,Season peak week,10
+2016,14,2015/2016,66,HHS Region 3,Season peak percentage,4
+2016,14,2015/2016,66,HHS Region 3,1 wk ahead,2.2
+2016,14,2015/2016,66,HHS Region 3,2 wk ahead,2.3
+2016,14,2015/2016,66,HHS Region 3,3 wk ahead,2.2
+2016,14,2015/2016,66,HHS Region 3,4 wk ahead,1.9
+2016,14,2015/2016,66,HHS Region 4,Season onset,3
+2016,14,2015/2016,66,HHS Region 4,Season peak week,10
+2016,14,2015/2016,66,HHS Region 4,Season peak percentage,3.6
+2016,14,2015/2016,66,HHS Region 4,1 wk ahead,2
+2016,14,2015/2016,66,HHS Region 4,2 wk ahead,2
+2016,14,2015/2016,66,HHS Region 4,3 wk ahead,1.8
+2016,14,2015/2016,66,HHS Region 4,4 wk ahead,1.7
+2016,14,2015/2016,66,HHS Region 5,Season onset,7
+2016,14,2015/2016,66,HHS Region 5,Season peak week,10
+2016,14,2015/2016,66,HHS Region 5,Season peak percentage,3.4
+2016,14,2015/2016,66,HHS Region 5,1 wk ahead,1.5
+2016,14,2015/2016,66,HHS Region 5,2 wk ahead,1.5
+2016,14,2015/2016,66,HHS Region 5,3 wk ahead,1.3
+2016,14,2015/2016,66,HHS Region 5,4 wk ahead,1
+2016,14,2015/2016,66,HHS Region 6,Season onset,47
+2016,14,2015/2016,66,HHS Region 6,Season peak week,7
+2016,14,2015/2016,66,HHS Region 6,Season peak percentage,5.3
+2016,14,2015/2016,66,HHS Region 6,1 wk ahead,3
+2016,14,2015/2016,66,HHS Region 6,2 wk ahead,3.1
+2016,14,2015/2016,66,HHS Region 6,3 wk ahead,2.6
+2016,14,2015/2016,66,HHS Region 6,4 wk ahead,2.5
+2016,14,2015/2016,66,HHS Region 7,Season onset,7
+2016,14,2015/2016,66,HHS Region 7,Season peak week,10
+2016,14,2015/2016,66,HHS Region 7,Season peak percentage,2.5
+2016,14,2015/2016,66,HHS Region 7,1 wk ahead,1.4
+2016,14,2015/2016,66,HHS Region 7,2 wk ahead,1.2
+2016,14,2015/2016,66,HHS Region 7,3 wk ahead,1
+2016,14,2015/2016,66,HHS Region 7,4 wk ahead,0.9
+2016,14,2015/2016,66,HHS Region 8,Season onset,5
+2016,14,2015/2016,66,HHS Region 8,Season peak week,8
+2016,14,2015/2016,66,HHS Region 8,Season peak week,11
+2016,14,2015/2016,66,HHS Region 8,Season peak percentage,2.2
+2016,14,2015/2016,66,HHS Region 8,1 wk ahead,1.3
+2016,14,2015/2016,66,HHS Region 8,2 wk ahead,1.1
+2016,14,2015/2016,66,HHS Region 8,3 wk ahead,1
+2016,14,2015/2016,66,HHS Region 8,4 wk ahead,1
+2016,14,2015/2016,66,HHS Region 9,Season onset,3
+2016,14,2015/2016,66,HHS Region 9,Season peak week,7
+2016,14,2015/2016,66,HHS Region 9,Season peak percentage,4.4
+2016,14,2015/2016,66,HHS Region 9,1 wk ahead,2
+2016,14,2015/2016,66,HHS Region 9,2 wk ahead,1.8
+2016,14,2015/2016,66,HHS Region 9,3 wk ahead,1.7
+2016,14,2015/2016,66,HHS Region 9,4 wk ahead,1.8
+2016,14,2015/2016,66,HHS Region 10,Season onset,2
+2016,14,2015/2016,66,HHS Region 10,Season peak week,7
+2016,14,2015/2016,66,HHS Region 10,Season peak percentage,2.4
+2016,14,2015/2016,66,HHS Region 10,1 wk ahead,1
+2016,14,2015/2016,66,HHS Region 10,2 wk ahead,0.8
+2016,14,2015/2016,66,HHS Region 10,3 wk ahead,0.7
+2016,14,2015/2016,66,HHS Region 10,4 wk ahead,0.9
+2016,15,2015/2016,67,US National,Season onset,3
+2016,15,2015/2016,67,US National,Season peak week,10
+2016,15,2015/2016,67,US National,Season peak percentage,3.6
+2016,15,2015/2016,67,US National,1 wk ahead,1.9
+2016,15,2015/2016,67,US National,2 wk ahead,1.7
+2016,15,2015/2016,67,US National,3 wk ahead,1.6
+2016,15,2015/2016,67,US National,4 wk ahead,1.4
+2016,15,2015/2016,67,HHS Region 1,Season onset,51
+2016,15,2015/2016,67,HHS Region 1,Season peak week,10
+2016,15,2015/2016,67,HHS Region 1,Season peak percentage,2.5
+2016,15,2015/2016,67,HHS Region 1,1 wk ahead,1.6
+2016,15,2015/2016,67,HHS Region 1,2 wk ahead,1.1
+2016,15,2015/2016,67,HHS Region 1,3 wk ahead,1.1
+2016,15,2015/2016,67,HHS Region 1,4 wk ahead,0.9
+2016,15,2015/2016,67,HHS Region 2,Season onset,4
+2016,15,2015/2016,67,HHS Region 2,Season peak week,11
+2016,15,2015/2016,67,HHS Region 2,Season peak percentage,4.1
+2016,15,2015/2016,67,HHS Region 2,1 wk ahead,2
+2016,15,2015/2016,67,HHS Region 2,2 wk ahead,1.7
+2016,15,2015/2016,67,HHS Region 2,3 wk ahead,1.5
+2016,15,2015/2016,67,HHS Region 2,4 wk ahead,1.3
+2016,15,2015/2016,67,HHS Region 3,Season onset,47
+2016,15,2015/2016,67,HHS Region 3,Season peak week,10
+2016,15,2015/2016,67,HHS Region 3,Season peak percentage,4
+2016,15,2015/2016,67,HHS Region 3,1 wk ahead,2.3
+2016,15,2015/2016,67,HHS Region 3,2 wk ahead,2.2
+2016,15,2015/2016,67,HHS Region 3,3 wk ahead,1.9
+2016,15,2015/2016,67,HHS Region 3,4 wk ahead,1.7
+2016,15,2015/2016,67,HHS Region 4,Season onset,3
+2016,15,2015/2016,67,HHS Region 4,Season peak week,10
+2016,15,2015/2016,67,HHS Region 4,Season peak percentage,3.6
+2016,15,2015/2016,67,HHS Region 4,1 wk ahead,2
+2016,15,2015/2016,67,HHS Region 4,2 wk ahead,1.8
+2016,15,2015/2016,67,HHS Region 4,3 wk ahead,1.7
+2016,15,2015/2016,67,HHS Region 4,4 wk ahead,1.4
+2016,15,2015/2016,67,HHS Region 5,Season onset,7
+2016,15,2015/2016,67,HHS Region 5,Season peak week,10
+2016,15,2015/2016,67,HHS Region 5,Season peak percentage,3.4
+2016,15,2015/2016,67,HHS Region 5,1 wk ahead,1.5
+2016,15,2015/2016,67,HHS Region 5,2 wk ahead,1.3
+2016,15,2015/2016,67,HHS Region 5,3 wk ahead,1
+2016,15,2015/2016,67,HHS Region 5,4 wk ahead,1.1
+2016,15,2015/2016,67,HHS Region 6,Season onset,47
+2016,15,2015/2016,67,HHS Region 6,Season peak week,7
+2016,15,2015/2016,67,HHS Region 6,Season peak percentage,5.3
+2016,15,2015/2016,67,HHS Region 6,1 wk ahead,3.1
+2016,15,2015/2016,67,HHS Region 6,2 wk ahead,2.6
+2016,15,2015/2016,67,HHS Region 6,3 wk ahead,2.5
+2016,15,2015/2016,67,HHS Region 6,4 wk ahead,2.1
+2016,15,2015/2016,67,HHS Region 7,Season onset,7
+2016,15,2015/2016,67,HHS Region 7,Season peak week,10
+2016,15,2015/2016,67,HHS Region 7,Season peak percentage,2.5
+2016,15,2015/2016,67,HHS Region 7,1 wk ahead,1.2
+2016,15,2015/2016,67,HHS Region 7,2 wk ahead,1
+2016,15,2015/2016,67,HHS Region 7,3 wk ahead,0.9
+2016,15,2015/2016,67,HHS Region 7,4 wk ahead,0.7
+2016,15,2015/2016,67,HHS Region 8,Season onset,5
+2016,15,2015/2016,67,HHS Region 8,Season peak week,8
+2016,15,2015/2016,67,HHS Region 8,Season peak week,11
+2016,15,2015/2016,67,HHS Region 8,Season peak percentage,2.2
+2016,15,2015/2016,67,HHS Region 8,1 wk ahead,1.1
+2016,15,2015/2016,67,HHS Region 8,2 wk ahead,1
+2016,15,2015/2016,67,HHS Region 8,3 wk ahead,1
+2016,15,2015/2016,67,HHS Region 8,4 wk ahead,0.8
+2016,15,2015/2016,67,HHS Region 9,Season onset,3
+2016,15,2015/2016,67,HHS Region 9,Season peak week,7
+2016,15,2015/2016,67,HHS Region 9,Season peak percentage,4.4
+2016,15,2015/2016,67,HHS Region 9,1 wk ahead,1.8
+2016,15,2015/2016,67,HHS Region 9,2 wk ahead,1.7
+2016,15,2015/2016,67,HHS Region 9,3 wk ahead,1.8
+2016,15,2015/2016,67,HHS Region 9,4 wk ahead,1.5
+2016,15,2015/2016,67,HHS Region 10,Season onset,2
+2016,15,2015/2016,67,HHS Region 10,Season peak week,7
+2016,15,2015/2016,67,HHS Region 10,Season peak percentage,2.4
+2016,15,2015/2016,67,HHS Region 10,1 wk ahead,0.8
+2016,15,2015/2016,67,HHS Region 10,2 wk ahead,0.7
+2016,15,2015/2016,67,HHS Region 10,3 wk ahead,0.9
+2016,15,2015/2016,67,HHS Region 10,4 wk ahead,0.5
+2016,16,2015/2016,68,US National,Season onset,3
+2016,16,2015/2016,68,US National,Season peak week,10
+2016,16,2015/2016,68,US National,Season peak percentage,3.6
+2016,16,2015/2016,68,US National,1 wk ahead,1.7
+2016,16,2015/2016,68,US National,2 wk ahead,1.6
+2016,16,2015/2016,68,US National,3 wk ahead,1.4
+2016,16,2015/2016,68,US National,4 wk ahead,1.3
+2016,16,2015/2016,68,HHS Region 1,Season onset,51
+2016,16,2015/2016,68,HHS Region 1,Season peak week,10
+2016,16,2015/2016,68,HHS Region 1,Season peak percentage,2.5
+2016,16,2015/2016,68,HHS Region 1,1 wk ahead,1.1
+2016,16,2015/2016,68,HHS Region 1,2 wk ahead,1.1
+2016,16,2015/2016,68,HHS Region 1,3 wk ahead,0.9
+2016,16,2015/2016,68,HHS Region 1,4 wk ahead,0.9
+2016,16,2015/2016,68,HHS Region 2,Season onset,4
+2016,16,2015/2016,68,HHS Region 2,Season peak week,11
+2016,16,2015/2016,68,HHS Region 2,Season peak percentage,4.1
+2016,16,2015/2016,68,HHS Region 2,1 wk ahead,1.7
+2016,16,2015/2016,68,HHS Region 2,2 wk ahead,1.5
+2016,16,2015/2016,68,HHS Region 2,3 wk ahead,1.3
+2016,16,2015/2016,68,HHS Region 2,4 wk ahead,1.3
+2016,16,2015/2016,68,HHS Region 3,Season onset,47
+2016,16,2015/2016,68,HHS Region 3,Season peak week,10
+2016,16,2015/2016,68,HHS Region 3,Season peak percentage,4
+2016,16,2015/2016,68,HHS Region 3,1 wk ahead,2.2
+2016,16,2015/2016,68,HHS Region 3,2 wk ahead,1.9
+2016,16,2015/2016,68,HHS Region 3,3 wk ahead,1.7
+2016,16,2015/2016,68,HHS Region 3,4 wk ahead,1.7
+2016,16,2015/2016,68,HHS Region 4,Season onset,3
+2016,16,2015/2016,68,HHS Region 4,Season peak week,10
+2016,16,2015/2016,68,HHS Region 4,Season peak percentage,3.6
+2016,16,2015/2016,68,HHS Region 4,1 wk ahead,1.8
+2016,16,2015/2016,68,HHS Region 4,2 wk ahead,1.7
+2016,16,2015/2016,68,HHS Region 4,3 wk ahead,1.4
+2016,16,2015/2016,68,HHS Region 4,4 wk ahead,1.2
+2016,16,2015/2016,68,HHS Region 5,Season onset,7
+2016,16,2015/2016,68,HHS Region 5,Season peak week,10
+2016,16,2015/2016,68,HHS Region 5,Season peak percentage,3.4
+2016,16,2015/2016,68,HHS Region 5,1 wk ahead,1.3
+2016,16,2015/2016,68,HHS Region 5,2 wk ahead,1
+2016,16,2015/2016,68,HHS Region 5,3 wk ahead,1.1
+2016,16,2015/2016,68,HHS Region 5,4 wk ahead,1
+2016,16,2015/2016,68,HHS Region 6,Season onset,47
+2016,16,2015/2016,68,HHS Region 6,Season peak week,7
+2016,16,2015/2016,68,HHS Region 6,Season peak percentage,5.3
+2016,16,2015/2016,68,HHS Region 6,1 wk ahead,2.6
+2016,16,2015/2016,68,HHS Region 6,2 wk ahead,2.5
+2016,16,2015/2016,68,HHS Region 6,3 wk ahead,2.1
+2016,16,2015/2016,68,HHS Region 6,4 wk ahead,2.1
+2016,16,2015/2016,68,HHS Region 7,Season onset,7
+2016,16,2015/2016,68,HHS Region 7,Season peak week,10
+2016,16,2015/2016,68,HHS Region 7,Season peak percentage,2.5
+2016,16,2015/2016,68,HHS Region 7,1 wk ahead,1
+2016,16,2015/2016,68,HHS Region 7,2 wk ahead,0.9
+2016,16,2015/2016,68,HHS Region 7,3 wk ahead,0.7
+2016,16,2015/2016,68,HHS Region 7,4 wk ahead,0.6
+2016,16,2015/2016,68,HHS Region 8,Season onset,5
+2016,16,2015/2016,68,HHS Region 8,Season peak week,8
+2016,16,2015/2016,68,HHS Region 8,Season peak week,11
+2016,16,2015/2016,68,HHS Region 8,Season peak percentage,2.2
+2016,16,2015/2016,68,HHS Region 8,1 wk ahead,1
+2016,16,2015/2016,68,HHS Region 8,2 wk ahead,1
+2016,16,2015/2016,68,HHS Region 8,3 wk ahead,0.8
+2016,16,2015/2016,68,HHS Region 8,4 wk ahead,0.7
+2016,16,2015/2016,68,HHS Region 9,Season onset,3
+2016,16,2015/2016,68,HHS Region 9,Season peak week,7
+2016,16,2015/2016,68,HHS Region 9,Season peak percentage,4.4
+2016,16,2015/2016,68,HHS Region 9,1 wk ahead,1.7
+2016,16,2015/2016,68,HHS Region 9,2 wk ahead,1.8
+2016,16,2015/2016,68,HHS Region 9,3 wk ahead,1.5
+2016,16,2015/2016,68,HHS Region 9,4 wk ahead,1.5
+2016,16,2015/2016,68,HHS Region 10,Season onset,2
+2016,16,2015/2016,68,HHS Region 10,Season peak week,7
+2016,16,2015/2016,68,HHS Region 10,Season peak percentage,2.4
+2016,16,2015/2016,68,HHS Region 10,1 wk ahead,0.7
+2016,16,2015/2016,68,HHS Region 10,2 wk ahead,0.9
+2016,16,2015/2016,68,HHS Region 10,3 wk ahead,0.5
+2016,16,2015/2016,68,HHS Region 10,4 wk ahead,0.5
+2016,17,2015/2016,69,US National,Season onset,3
+2016,17,2015/2016,69,US National,Season peak week,10
+2016,17,2015/2016,69,US National,Season peak percentage,3.6
+2016,17,2015/2016,69,US National,1 wk ahead,1.6
+2016,17,2015/2016,69,US National,2 wk ahead,1.4
+2016,17,2015/2016,69,US National,3 wk ahead,1.3
+2016,17,2015/2016,69,US National,4 wk ahead,1.2
+2016,17,2015/2016,69,HHS Region 1,Season onset,51
+2016,17,2015/2016,69,HHS Region 1,Season peak week,10
+2016,17,2015/2016,69,HHS Region 1,Season peak percentage,2.5
+2016,17,2015/2016,69,HHS Region 1,1 wk ahead,1.1
+2016,17,2015/2016,69,HHS Region 1,2 wk ahead,0.9
+2016,17,2015/2016,69,HHS Region 1,3 wk ahead,0.9
+2016,17,2015/2016,69,HHS Region 1,4 wk ahead,0.8
+2016,17,2015/2016,69,HHS Region 2,Season onset,4
+2016,17,2015/2016,69,HHS Region 2,Season peak week,11
+2016,17,2015/2016,69,HHS Region 2,Season peak percentage,4.1
+2016,17,2015/2016,69,HHS Region 2,1 wk ahead,1.5
+2016,17,2015/2016,69,HHS Region 2,2 wk ahead,1.3
+2016,17,2015/2016,69,HHS Region 2,3 wk ahead,1.3
+2016,17,2015/2016,69,HHS Region 2,4 wk ahead,1.2
+2016,17,2015/2016,69,HHS Region 3,Season onset,47
+2016,17,2015/2016,69,HHS Region 3,Season peak week,10
+2016,17,2015/2016,69,HHS Region 3,Season peak percentage,4
+2016,17,2015/2016,69,HHS Region 3,1 wk ahead,1.9
+2016,17,2015/2016,69,HHS Region 3,2 wk ahead,1.7
+2016,17,2015/2016,69,HHS Region 3,3 wk ahead,1.7
+2016,17,2015/2016,69,HHS Region 3,4 wk ahead,1.6
+2016,17,2015/2016,69,HHS Region 4,Season onset,3
+2016,17,2015/2016,69,HHS Region 4,Season peak week,10
+2016,17,2015/2016,69,HHS Region 4,Season peak percentage,3.6
+2016,17,2015/2016,69,HHS Region 4,1 wk ahead,1.7
+2016,17,2015/2016,69,HHS Region 4,2 wk ahead,1.4
+2016,17,2015/2016,69,HHS Region 4,3 wk ahead,1.2
+2016,17,2015/2016,69,HHS Region 4,4 wk ahead,1.1
+2016,17,2015/2016,69,HHS Region 5,Season onset,7
+2016,17,2015/2016,69,HHS Region 5,Season peak week,10
+2016,17,2015/2016,69,HHS Region 5,Season peak percentage,3.4
+2016,17,2015/2016,69,HHS Region 5,1 wk ahead,1
+2016,17,2015/2016,69,HHS Region 5,2 wk ahead,1.1
+2016,17,2015/2016,69,HHS Region 5,3 wk ahead,1
+2016,17,2015/2016,69,HHS Region 5,4 wk ahead,0.8
+2016,17,2015/2016,69,HHS Region 6,Season onset,47
+2016,17,2015/2016,69,HHS Region 6,Season peak week,7
+2016,17,2015/2016,69,HHS Region 6,Season peak percentage,5.3
+2016,17,2015/2016,69,HHS Region 6,1 wk ahead,2.5
+2016,17,2015/2016,69,HHS Region 6,2 wk ahead,2.1
+2016,17,2015/2016,69,HHS Region 6,3 wk ahead,2.1
+2016,17,2015/2016,69,HHS Region 6,4 wk ahead,2.2
+2016,17,2015/2016,69,HHS Region 7,Season onset,7
+2016,17,2015/2016,69,HHS Region 7,Season peak week,10
+2016,17,2015/2016,69,HHS Region 7,Season peak percentage,2.5
+2016,17,2015/2016,69,HHS Region 7,1 wk ahead,0.9
+2016,17,2015/2016,69,HHS Region 7,2 wk ahead,0.7
+2016,17,2015/2016,69,HHS Region 7,3 wk ahead,0.6
+2016,17,2015/2016,69,HHS Region 7,4 wk ahead,0.3
+2016,17,2015/2016,69,HHS Region 8,Season onset,5
+2016,17,2015/2016,69,HHS Region 8,Season peak week,8
+2016,17,2015/2016,69,HHS Region 8,Season peak week,11
+2016,17,2015/2016,69,HHS Region 8,Season peak percentage,2.2
+2016,17,2015/2016,69,HHS Region 8,1 wk ahead,1
+2016,17,2015/2016,69,HHS Region 8,2 wk ahead,0.8
+2016,17,2015/2016,69,HHS Region 8,3 wk ahead,0.7
+2016,17,2015/2016,69,HHS Region 8,4 wk ahead,0.7
+2016,17,2015/2016,69,HHS Region 9,Season onset,3
+2016,17,2015/2016,69,HHS Region 9,Season peak week,7
+2016,17,2015/2016,69,HHS Region 9,Season peak percentage,4.4
+2016,17,2015/2016,69,HHS Region 9,1 wk ahead,1.8
+2016,17,2015/2016,69,HHS Region 9,2 wk ahead,1.5
+2016,17,2015/2016,69,HHS Region 9,3 wk ahead,1.5
+2016,17,2015/2016,69,HHS Region 9,4 wk ahead,1.4
+2016,17,2015/2016,69,HHS Region 10,Season onset,2
+2016,17,2015/2016,69,HHS Region 10,Season peak week,7
+2016,17,2015/2016,69,HHS Region 10,Season peak percentage,2.4
+2016,17,2015/2016,69,HHS Region 10,1 wk ahead,0.9
+2016,17,2015/2016,69,HHS Region 10,2 wk ahead,0.5
+2016,17,2015/2016,69,HHS Region 10,3 wk ahead,0.5
+2016,17,2015/2016,69,HHS Region 10,4 wk ahead,0.2
+2016,18,2015/2016,70,US National,Season onset,3
+2016,18,2015/2016,70,US National,Season peak week,10
+2016,18,2015/2016,70,US National,Season peak percentage,3.6
+2016,18,2015/2016,70,US National,1 wk ahead,1.4
+2016,18,2015/2016,70,US National,2 wk ahead,1.3
+2016,18,2015/2016,70,US National,3 wk ahead,1.2
+2016,18,2015/2016,70,US National,4 wk ahead,1.1
+2016,18,2015/2016,70,HHS Region 1,Season onset,51
+2016,18,2015/2016,70,HHS Region 1,Season peak week,10
+2016,18,2015/2016,70,HHS Region 1,Season peak percentage,2.5
+2016,18,2015/2016,70,HHS Region 1,1 wk ahead,0.9
+2016,18,2015/2016,70,HHS Region 1,2 wk ahead,0.9
+2016,18,2015/2016,70,HHS Region 1,3 wk ahead,0.8
+2016,18,2015/2016,70,HHS Region 1,4 wk ahead,0.7
+2016,18,2015/2016,70,HHS Region 2,Season onset,4
+2016,18,2015/2016,70,HHS Region 2,Season peak week,11
+2016,18,2015/2016,70,HHS Region 2,Season peak percentage,4.1
+2016,18,2015/2016,70,HHS Region 2,1 wk ahead,1.3
+2016,18,2015/2016,70,HHS Region 2,2 wk ahead,1.3
+2016,18,2015/2016,70,HHS Region 2,3 wk ahead,1.2
+2016,18,2015/2016,70,HHS Region 2,4 wk ahead,0.8
+2016,18,2015/2016,70,HHS Region 3,Season onset,47
+2016,18,2015/2016,70,HHS Region 3,Season peak week,10
+2016,18,2015/2016,70,HHS Region 3,Season peak percentage,4
+2016,18,2015/2016,70,HHS Region 3,1 wk ahead,1.7
+2016,18,2015/2016,70,HHS Region 3,2 wk ahead,1.7
+2016,18,2015/2016,70,HHS Region 3,3 wk ahead,1.6
+2016,18,2015/2016,70,HHS Region 3,4 wk ahead,1.8
+2016,18,2015/2016,70,HHS Region 4,Season onset,3
+2016,18,2015/2016,70,HHS Region 4,Season peak week,10
+2016,18,2015/2016,70,HHS Region 4,Season peak percentage,3.6
+2016,18,2015/2016,70,HHS Region 4,1 wk ahead,1.4
+2016,18,2015/2016,70,HHS Region 4,2 wk ahead,1.2
+2016,18,2015/2016,70,HHS Region 4,3 wk ahead,1.1
+2016,18,2015/2016,70,HHS Region 4,4 wk ahead,1.1
+2016,18,2015/2016,70,HHS Region 5,Season onset,7
+2016,18,2015/2016,70,HHS Region 5,Season peak week,10
+2016,18,2015/2016,70,HHS Region 5,Season peak percentage,3.4
+2016,18,2015/2016,70,HHS Region 5,1 wk ahead,1.1
+2016,18,2015/2016,70,HHS Region 5,2 wk ahead,1
+2016,18,2015/2016,70,HHS Region 5,3 wk ahead,0.8
+2016,18,2015/2016,70,HHS Region 5,4 wk ahead,0.9
+2016,18,2015/2016,70,HHS Region 6,Season onset,47
+2016,18,2015/2016,70,HHS Region 6,Season peak week,7
+2016,18,2015/2016,70,HHS Region 6,Season peak percentage,5.3
+2016,18,2015/2016,70,HHS Region 6,1 wk ahead,2.1
+2016,18,2015/2016,70,HHS Region 6,2 wk ahead,2.1
+2016,18,2015/2016,70,HHS Region 6,3 wk ahead,2.2
+2016,18,2015/2016,70,HHS Region 6,4 wk ahead,2
+2016,18,2015/2016,70,HHS Region 7,Season onset,7
+2016,18,2015/2016,70,HHS Region 7,Season peak week,10
+2016,18,2015/2016,70,HHS Region 7,Season peak percentage,2.5
+2016,18,2015/2016,70,HHS Region 7,1 wk ahead,0.7
+2016,18,2015/2016,70,HHS Region 7,2 wk ahead,0.6
+2016,18,2015/2016,70,HHS Region 7,3 wk ahead,0.3
+2016,18,2015/2016,70,HHS Region 7,4 wk ahead,0.4
+2016,18,2015/2016,70,HHS Region 8,Season onset,5
+2016,18,2015/2016,70,HHS Region 8,Season peak week,8
+2016,18,2015/2016,70,HHS Region 8,Season peak week,11
+2016,18,2015/2016,70,HHS Region 8,Season peak percentage,2.2
+2016,18,2015/2016,70,HHS Region 8,1 wk ahead,0.8
+2016,18,2015/2016,70,HHS Region 8,2 wk ahead,0.7
+2016,18,2015/2016,70,HHS Region 8,3 wk ahead,0.7
+2016,18,2015/2016,70,HHS Region 8,4 wk ahead,0.7
+2016,18,2015/2016,70,HHS Region 9,Season onset,3
+2016,18,2015/2016,70,HHS Region 9,Season peak week,7
+2016,18,2015/2016,70,HHS Region 9,Season peak percentage,4.4
+2016,18,2015/2016,70,HHS Region 9,1 wk ahead,1.5
+2016,18,2015/2016,70,HHS Region 9,2 wk ahead,1.5
+2016,18,2015/2016,70,HHS Region 9,3 wk ahead,1.4
+2016,18,2015/2016,70,HHS Region 9,4 wk ahead,1.3
+2016,18,2015/2016,70,HHS Region 10,Season onset,2
+2016,18,2015/2016,70,HHS Region 10,Season peak week,7
+2016,18,2015/2016,70,HHS Region 10,Season peak percentage,2.4
+2016,18,2015/2016,70,HHS Region 10,1 wk ahead,0.5
+2016,18,2015/2016,70,HHS Region 10,2 wk ahead,0.5
+2016,18,2015/2016,70,HHS Region 10,3 wk ahead,0.2
+2016,18,2015/2016,70,HHS Region 10,4 wk ahead,0.2
+2016,19,2015/2016,71,US National,Season onset,3
+2016,19,2015/2016,71,US National,Season peak week,10
+2016,19,2015/2016,71,US National,Season peak percentage,3.6
+2016,19,2015/2016,71,US National,1 wk ahead,1.3
+2016,19,2015/2016,71,US National,2 wk ahead,1.2
+2016,19,2015/2016,71,US National,3 wk ahead,1.1
+2016,19,2015/2016,71,US National,4 wk ahead,1.1
+2016,19,2015/2016,71,HHS Region 1,Season onset,51
+2016,19,2015/2016,71,HHS Region 1,Season peak week,10
+2016,19,2015/2016,71,HHS Region 1,Season peak percentage,2.5
+2016,19,2015/2016,71,HHS Region 1,1 wk ahead,0.9
+2016,19,2015/2016,71,HHS Region 1,2 wk ahead,0.8
+2016,19,2015/2016,71,HHS Region 1,3 wk ahead,0.7
+2016,19,2015/2016,71,HHS Region 1,4 wk ahead,0.7
+2016,19,2015/2016,71,HHS Region 2,Season onset,4
+2016,19,2015/2016,71,HHS Region 2,Season peak week,11
+2016,19,2015/2016,71,HHS Region 2,Season peak percentage,4.1
+2016,19,2015/2016,71,HHS Region 2,1 wk ahead,1.3
+2016,19,2015/2016,71,HHS Region 2,2 wk ahead,1.2
+2016,19,2015/2016,71,HHS Region 2,3 wk ahead,0.8
+2016,19,2015/2016,71,HHS Region 2,4 wk ahead,0.9
+2016,19,2015/2016,71,HHS Region 3,Season onset,47
+2016,19,2015/2016,71,HHS Region 3,Season peak week,10
+2016,19,2015/2016,71,HHS Region 3,Season peak percentage,4
+2016,19,2015/2016,71,HHS Region 3,1 wk ahead,1.7
+2016,19,2015/2016,71,HHS Region 3,2 wk ahead,1.6
+2016,19,2015/2016,71,HHS Region 3,3 wk ahead,1.8
+2016,19,2015/2016,71,HHS Region 3,4 wk ahead,1.5
+2016,19,2015/2016,71,HHS Region 4,Season onset,3
+2016,19,2015/2016,71,HHS Region 4,Season peak week,10
+2016,19,2015/2016,71,HHS Region 4,Season peak percentage,3.6
+2016,19,2015/2016,71,HHS Region 4,1 wk ahead,1.2
+2016,19,2015/2016,71,HHS Region 4,2 wk ahead,1.1
+2016,19,2015/2016,71,HHS Region 4,3 wk ahead,1.1
+2016,19,2015/2016,71,HHS Region 4,4 wk ahead,1
+2016,19,2015/2016,71,HHS Region 5,Season onset,7
+2016,19,2015/2016,71,HHS Region 5,Season peak week,10
+2016,19,2015/2016,71,HHS Region 5,Season peak percentage,3.4
+2016,19,2015/2016,71,HHS Region 5,1 wk ahead,1
+2016,19,2015/2016,71,HHS Region 5,2 wk ahead,0.8
+2016,19,2015/2016,71,HHS Region 5,3 wk ahead,0.9
+2016,19,2015/2016,71,HHS Region 5,4 wk ahead,0.8
+2016,19,2015/2016,71,HHS Region 6,Season onset,47
+2016,19,2015/2016,71,HHS Region 6,Season peak week,7
+2016,19,2015/2016,71,HHS Region 6,Season peak percentage,5.3
+2016,19,2015/2016,71,HHS Region 6,1 wk ahead,2.1
+2016,19,2015/2016,71,HHS Region 6,2 wk ahead,2.2
+2016,19,2015/2016,71,HHS Region 6,3 wk ahead,2
+2016,19,2015/2016,71,HHS Region 6,4 wk ahead,1.6
+2016,19,2015/2016,71,HHS Region 7,Season onset,7
+2016,19,2015/2016,71,HHS Region 7,Season peak week,10
+2016,19,2015/2016,71,HHS Region 7,Season peak percentage,2.5
+2016,19,2015/2016,71,HHS Region 7,1 wk ahead,0.6
+2016,19,2015/2016,71,HHS Region 7,2 wk ahead,0.3
+2016,19,2015/2016,71,HHS Region 7,3 wk ahead,0.4
+2016,19,2015/2016,71,HHS Region 7,4 wk ahead,0.5
+2016,19,2015/2016,71,HHS Region 8,Season onset,5
+2016,19,2015/2016,71,HHS Region 8,Season peak week,8
+2016,19,2015/2016,71,HHS Region 8,Season peak week,11
+2016,19,2015/2016,71,HHS Region 8,Season peak percentage,2.2
+2016,19,2015/2016,71,HHS Region 8,1 wk ahead,0.7
+2016,19,2015/2016,71,HHS Region 8,2 wk ahead,0.7
+2016,19,2015/2016,71,HHS Region 8,3 wk ahead,0.7
+2016,19,2015/2016,71,HHS Region 8,4 wk ahead,0.6
+2016,19,2015/2016,71,HHS Region 9,Season onset,3
+2016,19,2015/2016,71,HHS Region 9,Season peak week,7
+2016,19,2015/2016,71,HHS Region 9,Season peak percentage,4.4
+2016,19,2015/2016,71,HHS Region 9,1 wk ahead,1.5
+2016,19,2015/2016,71,HHS Region 9,2 wk ahead,1.4
+2016,19,2015/2016,71,HHS Region 9,3 wk ahead,1.3
+2016,19,2015/2016,71,HHS Region 9,4 wk ahead,1.3
+2016,19,2015/2016,71,HHS Region 10,Season onset,2
+2016,19,2015/2016,71,HHS Region 10,Season peak week,7
+2016,19,2015/2016,71,HHS Region 10,Season peak percentage,2.4
+2016,19,2015/2016,71,HHS Region 10,1 wk ahead,0.5
+2016,19,2015/2016,71,HHS Region 10,2 wk ahead,0.2
+2016,19,2015/2016,71,HHS Region 10,3 wk ahead,0.2
+2016,19,2015/2016,71,HHS Region 10,4 wk ahead,0.3
+2016,20,2015/2016,72,US National,Season onset,3
+2016,20,2015/2016,72,US National,Season peak week,10
+2016,20,2015/2016,72,US National,Season peak percentage,3.6
+2016,20,2015/2016,72,US National,1 wk ahead,1.2
+2016,20,2015/2016,72,US National,2 wk ahead,1.1
+2016,20,2015/2016,72,US National,3 wk ahead,1.1
+2016,20,2015/2016,72,US National,4 wk ahead,1
+2016,20,2015/2016,72,HHS Region 1,Season onset,51
+2016,20,2015/2016,72,HHS Region 1,Season peak week,10
+2016,20,2015/2016,72,HHS Region 1,Season peak percentage,2.5
+2016,20,2015/2016,72,HHS Region 1,1 wk ahead,0.8
+2016,20,2015/2016,72,HHS Region 1,2 wk ahead,0.7
+2016,20,2015/2016,72,HHS Region 1,3 wk ahead,0.7
+2016,20,2015/2016,72,HHS Region 1,4 wk ahead,0.5
+2016,20,2015/2016,72,HHS Region 2,Season onset,4
+2016,20,2015/2016,72,HHS Region 2,Season peak week,11
+2016,20,2015/2016,72,HHS Region 2,Season peak percentage,4.1
+2016,20,2015/2016,72,HHS Region 2,1 wk ahead,1.2
+2016,20,2015/2016,72,HHS Region 2,2 wk ahead,0.8
+2016,20,2015/2016,72,HHS Region 2,3 wk ahead,0.9
+2016,20,2015/2016,72,HHS Region 2,4 wk ahead,0.8
+2016,20,2015/2016,72,HHS Region 3,Season onset,47
+2016,20,2015/2016,72,HHS Region 3,Season peak week,10
+2016,20,2015/2016,72,HHS Region 3,Season peak percentage,4
+2016,20,2015/2016,72,HHS Region 3,1 wk ahead,1.6
+2016,20,2015/2016,72,HHS Region 3,2 wk ahead,1.8
+2016,20,2015/2016,72,HHS Region 3,3 wk ahead,1.5
+2016,20,2015/2016,72,HHS Region 3,4 wk ahead,1.3
+2016,20,2015/2016,72,HHS Region 4,Season onset,3
+2016,20,2015/2016,72,HHS Region 4,Season peak week,10
+2016,20,2015/2016,72,HHS Region 4,Season peak percentage,3.6
+2016,20,2015/2016,72,HHS Region 4,1 wk ahead,1.1
+2016,20,2015/2016,72,HHS Region 4,2 wk ahead,1.1
+2016,20,2015/2016,72,HHS Region 4,3 wk ahead,1
+2016,20,2015/2016,72,HHS Region 4,4 wk ahead,1
+2016,20,2015/2016,72,HHS Region 5,Season onset,7
+2016,20,2015/2016,72,HHS Region 5,Season peak week,10
+2016,20,2015/2016,72,HHS Region 5,Season peak percentage,3.4
+2016,20,2015/2016,72,HHS Region 5,1 wk ahead,0.8
+2016,20,2015/2016,72,HHS Region 5,2 wk ahead,0.9
+2016,20,2015/2016,72,HHS Region 5,3 wk ahead,0.8
+2016,20,2015/2016,72,HHS Region 5,4 wk ahead,0.7
+2016,20,2015/2016,72,HHS Region 6,Season onset,47
+2016,20,2015/2016,72,HHS Region 6,Season peak week,7
+2016,20,2015/2016,72,HHS Region 6,Season peak percentage,5.3
+2016,20,2015/2016,72,HHS Region 6,1 wk ahead,2.2
+2016,20,2015/2016,72,HHS Region 6,2 wk ahead,2
+2016,20,2015/2016,72,HHS Region 6,3 wk ahead,1.6
+2016,20,2015/2016,72,HHS Region 6,4 wk ahead,1.6
+2016,20,2015/2016,72,HHS Region 7,Season onset,7
+2016,20,2015/2016,72,HHS Region 7,Season peak week,10
+2016,20,2015/2016,72,HHS Region 7,Season peak percentage,2.5
+2016,20,2015/2016,72,HHS Region 7,1 wk ahead,0.3
+2016,20,2015/2016,72,HHS Region 7,2 wk ahead,0.4
+2016,20,2015/2016,72,HHS Region 7,3 wk ahead,0.5
+2016,20,2015/2016,72,HHS Region 7,4 wk ahead,0.3
+2016,20,2015/2016,72,HHS Region 8,Season onset,5
+2016,20,2015/2016,72,HHS Region 8,Season peak week,8
+2016,20,2015/2016,72,HHS Region 8,Season peak week,11
+2016,20,2015/2016,72,HHS Region 8,Season peak percentage,2.2
+2016,20,2015/2016,72,HHS Region 8,1 wk ahead,0.7
+2016,20,2015/2016,72,HHS Region 8,2 wk ahead,0.7
+2016,20,2015/2016,72,HHS Region 8,3 wk ahead,0.6
+2016,20,2015/2016,72,HHS Region 8,4 wk ahead,0.5
+2016,20,2015/2016,72,HHS Region 9,Season onset,3
+2016,20,2015/2016,72,HHS Region 9,Season peak week,7
+2016,20,2015/2016,72,HHS Region 9,Season peak percentage,4.4
+2016,20,2015/2016,72,HHS Region 9,1 wk ahead,1.4
+2016,20,2015/2016,72,HHS Region 9,2 wk ahead,1.3
+2016,20,2015/2016,72,HHS Region 9,3 wk ahead,1.3
+2016,20,2015/2016,72,HHS Region 9,4 wk ahead,1.2
+2016,20,2015/2016,72,HHS Region 10,Season onset,2
+2016,20,2015/2016,72,HHS Region 10,Season peak week,7
+2016,20,2015/2016,72,HHS Region 10,Season peak percentage,2.4
+2016,20,2015/2016,72,HHS Region 10,1 wk ahead,0.2
+2016,20,2015/2016,72,HHS Region 10,2 wk ahead,0.2
+2016,20,2015/2016,72,HHS Region 10,3 wk ahead,0.3
+2016,20,2015/2016,72,HHS Region 10,4 wk ahead,0.3
+2016,40,2016/2017,40,US National,Season onset,50
+2016,40,2016/2017,40,US National,Season peak week,6
+2016,40,2016/2017,40,US National,Season peak percentage,5.1
+2016,40,2016/2017,40,US National,1 wk ahead,1.2
+2016,40,2016/2017,40,US National,2 wk ahead,1.3
+2016,40,2016/2017,40,US National,3 wk ahead,1.4
+2016,40,2016/2017,40,US National,4 wk ahead,1.5
+2016,40,2016/2017,40,HHS Region 1,Season onset,52
+2016,40,2016/2017,40,HHS Region 1,Season peak week,6
+2016,40,2016/2017,40,HHS Region 1,Season peak percentage,3.2
+2016,40,2016/2017,40,HHS Region 1,1 wk ahead,0.7
+2016,40,2016/2017,40,HHS Region 1,2 wk ahead,0.7
+2016,40,2016/2017,40,HHS Region 1,3 wk ahead,0.7
+2016,40,2016/2017,40,HHS Region 1,4 wk ahead,0.9
+2016,40,2016/2017,40,HHS Region 2,Season onset,47
+2016,40,2016/2017,40,HHS Region 2,Season peak week,6
+2016,40,2016/2017,40,HHS Region 2,Season peak percentage,6.9
+2016,40,2016/2017,40,HHS Region 2,1 wk ahead,1.9
+2016,40,2016/2017,40,HHS Region 2,2 wk ahead,1.9
+2016,40,2016/2017,40,HHS Region 2,3 wk ahead,2.1
+2016,40,2016/2017,40,HHS Region 2,4 wk ahead,2.2
+2016,40,2016/2017,40,HHS Region 3,Season onset,51
+2016,40,2016/2017,40,HHS Region 3,Season peak week,7
+2016,40,2016/2017,40,HHS Region 3,Season peak percentage,5.2
+2016,40,2016/2017,40,HHS Region 3,1 wk ahead,1.1
+2016,40,2016/2017,40,HHS Region 3,2 wk ahead,1.2
+2016,40,2016/2017,40,HHS Region 3,3 wk ahead,1.2
+2016,40,2016/2017,40,HHS Region 3,4 wk ahead,1.4
+2016,40,2016/2017,40,HHS Region 4,Season onset,45
+2016,40,2016/2017,40,HHS Region 4,Season peak week,7
+2016,40,2016/2017,40,HHS Region 4,Season peak week,8
+2016,40,2016/2017,40,HHS Region 4,Season peak percentage,5.5
+2016,40,2016/2017,40,HHS Region 4,1 wk ahead,1.2
+2016,40,2016/2017,40,HHS Region 4,2 wk ahead,1.3
+2016,40,2016/2017,40,HHS Region 4,3 wk ahead,1.4
+2016,40,2016/2017,40,HHS Region 4,4 wk ahead,1.6
+2016,40,2016/2017,40,HHS Region 5,Season onset,52
+2016,40,2016/2017,40,HHS Region 5,Season peak week,7
+2016,40,2016/2017,40,HHS Region 5,Season peak week,8
+2016,40,2016/2017,40,HHS Region 5,Season peak percentage,4.3
+2016,40,2016/2017,40,HHS Region 5,1 wk ahead,1
+2016,40,2016/2017,40,HHS Region 5,2 wk ahead,1
+2016,40,2016/2017,40,HHS Region 5,3 wk ahead,1.1
+2016,40,2016/2017,40,HHS Region 5,4 wk ahead,1.3
+2016,40,2016/2017,40,HHS Region 6,Season onset,52
+2016,40,2016/2017,40,HHS Region 6,Season peak week,6
+2016,40,2016/2017,40,HHS Region 6,Season peak percentage,9.9
+2016,40,2016/2017,40,HHS Region 6,1 wk ahead,1.8
+2016,40,2016/2017,40,HHS Region 6,2 wk ahead,1.7
+2016,40,2016/2017,40,HHS Region 6,3 wk ahead,1.9
+2016,40,2016/2017,40,HHS Region 6,4 wk ahead,1.9
+2016,40,2016/2017,40,HHS Region 7,Season onset,51
+2016,40,2016/2017,40,HHS Region 7,Season peak week,6
+2016,40,2016/2017,40,HHS Region 7,Season peak percentage,6.4
+2016,40,2016/2017,40,HHS Region 7,1 wk ahead,0.7
+2016,40,2016/2017,40,HHS Region 7,2 wk ahead,0.8
+2016,40,2016/2017,40,HHS Region 7,3 wk ahead,0.7
+2016,40,2016/2017,40,HHS Region 7,4 wk ahead,0.8
+2016,40,2016/2017,40,HHS Region 8,Season onset,51
+2016,40,2016/2017,40,HHS Region 8,Season peak week,7
+2016,40,2016/2017,40,HHS Region 8,Season peak percentage,2.7
+2016,40,2016/2017,40,HHS Region 8,1 wk ahead,0.9
+2016,40,2016/2017,40,HHS Region 8,2 wk ahead,0.9
+2016,40,2016/2017,40,HHS Region 8,3 wk ahead,0.8
+2016,40,2016/2017,40,HHS Region 8,4 wk ahead,0.5
+2016,40,2016/2017,40,HHS Region 9,Season onset,51
+2016,40,2016/2017,40,HHS Region 9,Season peak week,52
+2016,40,2016/2017,40,HHS Region 9,Season peak percentage,3.3
+2016,40,2016/2017,40,HHS Region 9,1 wk ahead,1.3
+2016,40,2016/2017,40,HHS Region 9,2 wk ahead,1.4
+2016,40,2016/2017,40,HHS Region 9,3 wk ahead,1.4
+2016,40,2016/2017,40,HHS Region 9,4 wk ahead,1.5
+2016,40,2016/2017,40,HHS Region 10,Season onset,50
+2016,40,2016/2017,40,HHS Region 10,Season peak week,52
+2016,40,2016/2017,40,HHS Region 10,Season peak percentage,3.7
+2016,40,2016/2017,40,HHS Region 10,1 wk ahead,0.4
+2016,40,2016/2017,40,HHS Region 10,2 wk ahead,0.5
+2016,40,2016/2017,40,HHS Region 10,3 wk ahead,0.5
+2016,40,2016/2017,40,HHS Region 10,4 wk ahead,0.6
+2016,41,2016/2017,41,US National,Season onset,50
+2016,41,2016/2017,41,US National,Season peak week,6
+2016,41,2016/2017,41,US National,Season peak percentage,5.1
+2016,41,2016/2017,41,US National,1 wk ahead,1.3
+2016,41,2016/2017,41,US National,2 wk ahead,1.4
+2016,41,2016/2017,41,US National,3 wk ahead,1.5
+2016,41,2016/2017,41,US National,4 wk ahead,1.6
+2016,41,2016/2017,41,HHS Region 1,Season onset,52
+2016,41,2016/2017,41,HHS Region 1,Season peak week,6
+2016,41,2016/2017,41,HHS Region 1,Season peak percentage,3.2
+2016,41,2016/2017,41,HHS Region 1,1 wk ahead,0.7
+2016,41,2016/2017,41,HHS Region 1,2 wk ahead,0.7
+2016,41,2016/2017,41,HHS Region 1,3 wk ahead,0.9
+2016,41,2016/2017,41,HHS Region 1,4 wk ahead,0.9
+2016,41,2016/2017,41,HHS Region 2,Season onset,47
+2016,41,2016/2017,41,HHS Region 2,Season peak week,6
+2016,41,2016/2017,41,HHS Region 2,Season peak percentage,6.9
+2016,41,2016/2017,41,HHS Region 2,1 wk ahead,1.9
+2016,41,2016/2017,41,HHS Region 2,2 wk ahead,2.1
+2016,41,2016/2017,41,HHS Region 2,3 wk ahead,2.2
+2016,41,2016/2017,41,HHS Region 2,4 wk ahead,2.5
+2016,41,2016/2017,41,HHS Region 3,Season onset,51
+2016,41,2016/2017,41,HHS Region 3,Season peak week,7
+2016,41,2016/2017,41,HHS Region 3,Season peak percentage,5.2
+2016,41,2016/2017,41,HHS Region 3,1 wk ahead,1.2
+2016,41,2016/2017,41,HHS Region 3,2 wk ahead,1.2
+2016,41,2016/2017,41,HHS Region 3,3 wk ahead,1.4
+2016,41,2016/2017,41,HHS Region 3,4 wk ahead,1.4
+2016,41,2016/2017,41,HHS Region 4,Season onset,45
+2016,41,2016/2017,41,HHS Region 4,Season peak week,7
+2016,41,2016/2017,41,HHS Region 4,Season peak week,8
+2016,41,2016/2017,41,HHS Region 4,Season peak percentage,5.5
+2016,41,2016/2017,41,HHS Region 4,1 wk ahead,1.3
+2016,41,2016/2017,41,HHS Region 4,2 wk ahead,1.4
+2016,41,2016/2017,41,HHS Region 4,3 wk ahead,1.6
+2016,41,2016/2017,41,HHS Region 4,4 wk ahead,1.7
+2016,41,2016/2017,41,HHS Region 5,Season onset,52
+2016,41,2016/2017,41,HHS Region 5,Season peak week,7
+2016,41,2016/2017,41,HHS Region 5,Season peak week,8
+2016,41,2016/2017,41,HHS Region 5,Season peak percentage,4.3
+2016,41,2016/2017,41,HHS Region 5,1 wk ahead,1
+2016,41,2016/2017,41,HHS Region 5,2 wk ahead,1.1
+2016,41,2016/2017,41,HHS Region 5,3 wk ahead,1.3
+2016,41,2016/2017,41,HHS Region 5,4 wk ahead,1.2
+2016,41,2016/2017,41,HHS Region 6,Season onset,52
+2016,41,2016/2017,41,HHS Region 6,Season peak week,6
+2016,41,2016/2017,41,HHS Region 6,Season peak percentage,9.9
+2016,41,2016/2017,41,HHS Region 6,1 wk ahead,1.7
+2016,41,2016/2017,41,HHS Region 6,2 wk ahead,1.9
+2016,41,2016/2017,41,HHS Region 6,3 wk ahead,1.9
+2016,41,2016/2017,41,HHS Region 6,4 wk ahead,2.1
+2016,41,2016/2017,41,HHS Region 7,Season onset,51
+2016,41,2016/2017,41,HHS Region 7,Season peak week,6
+2016,41,2016/2017,41,HHS Region 7,Season peak percentage,6.4
+2016,41,2016/2017,41,HHS Region 7,1 wk ahead,0.8
+2016,41,2016/2017,41,HHS Region 7,2 wk ahead,0.7
+2016,41,2016/2017,41,HHS Region 7,3 wk ahead,0.8
+2016,41,2016/2017,41,HHS Region 7,4 wk ahead,0.9
+2016,41,2016/2017,41,HHS Region 8,Season onset,51
+2016,41,2016/2017,41,HHS Region 8,Season peak week,7
+2016,41,2016/2017,41,HHS Region 8,Season peak percentage,2.7
+2016,41,2016/2017,41,HHS Region 8,1 wk ahead,0.9
+2016,41,2016/2017,41,HHS Region 8,2 wk ahead,0.8
+2016,41,2016/2017,41,HHS Region 8,3 wk ahead,0.5
+2016,41,2016/2017,41,HHS Region 8,4 wk ahead,0.7
+2016,41,2016/2017,41,HHS Region 9,Season onset,51
+2016,41,2016/2017,41,HHS Region 9,Season peak week,52
+2016,41,2016/2017,41,HHS Region 9,Season peak percentage,3.3
+2016,41,2016/2017,41,HHS Region 9,1 wk ahead,1.4
+2016,41,2016/2017,41,HHS Region 9,2 wk ahead,1.4
+2016,41,2016/2017,41,HHS Region 9,3 wk ahead,1.5
+2016,41,2016/2017,41,HHS Region 9,4 wk ahead,1.6
+2016,41,2016/2017,41,HHS Region 10,Season onset,50
+2016,41,2016/2017,41,HHS Region 10,Season peak week,52
+2016,41,2016/2017,41,HHS Region 10,Season peak percentage,3.7
+2016,41,2016/2017,41,HHS Region 10,1 wk ahead,0.5
+2016,41,2016/2017,41,HHS Region 10,2 wk ahead,0.5
+2016,41,2016/2017,41,HHS Region 10,3 wk ahead,0.6
+2016,41,2016/2017,41,HHS Region 10,4 wk ahead,0.7
+2016,42,2016/2017,42,US National,Season onset,50
+2016,42,2016/2017,42,US National,Season peak week,6
+2016,42,2016/2017,42,US National,Season peak percentage,5.1
+2016,42,2016/2017,42,US National,1 wk ahead,1.4
+2016,42,2016/2017,42,US National,2 wk ahead,1.5
+2016,42,2016/2017,42,US National,3 wk ahead,1.6
+2016,42,2016/2017,42,US National,4 wk ahead,1.6
+2016,42,2016/2017,42,HHS Region 1,Season onset,52
+2016,42,2016/2017,42,HHS Region 1,Season peak week,6
+2016,42,2016/2017,42,HHS Region 1,Season peak percentage,3.2
+2016,42,2016/2017,42,HHS Region 1,1 wk ahead,0.7
+2016,42,2016/2017,42,HHS Region 1,2 wk ahead,0.9
+2016,42,2016/2017,42,HHS Region 1,3 wk ahead,0.9
+2016,42,2016/2017,42,HHS Region 1,4 wk ahead,0.9
+2016,42,2016/2017,42,HHS Region 2,Season onset,47
+2016,42,2016/2017,42,HHS Region 2,Season peak week,6
+2016,42,2016/2017,42,HHS Region 2,Season peak percentage,6.9
+2016,42,2016/2017,42,HHS Region 2,1 wk ahead,2.1
+2016,42,2016/2017,42,HHS Region 2,2 wk ahead,2.2
+2016,42,2016/2017,42,HHS Region 2,3 wk ahead,2.5
+2016,42,2016/2017,42,HHS Region 2,4 wk ahead,2.5
+2016,42,2016/2017,42,HHS Region 3,Season onset,51
+2016,42,2016/2017,42,HHS Region 3,Season peak week,7
+2016,42,2016/2017,42,HHS Region 3,Season peak percentage,5.2
+2016,42,2016/2017,42,HHS Region 3,1 wk ahead,1.2
+2016,42,2016/2017,42,HHS Region 3,2 wk ahead,1.4
+2016,42,2016/2017,42,HHS Region 3,3 wk ahead,1.4
+2016,42,2016/2017,42,HHS Region 3,4 wk ahead,1.4
+2016,42,2016/2017,42,HHS Region 4,Season onset,45
+2016,42,2016/2017,42,HHS Region 4,Season peak week,7
+2016,42,2016/2017,42,HHS Region 4,Season peak week,8
+2016,42,2016/2017,42,HHS Region 4,Season peak percentage,5.5
+2016,42,2016/2017,42,HHS Region 4,1 wk ahead,1.4
+2016,42,2016/2017,42,HHS Region 4,2 wk ahead,1.6
+2016,42,2016/2017,42,HHS Region 4,3 wk ahead,1.7
+2016,42,2016/2017,42,HHS Region 4,4 wk ahead,1.9
+2016,42,2016/2017,42,HHS Region 5,Season onset,52
+2016,42,2016/2017,42,HHS Region 5,Season peak week,7
+2016,42,2016/2017,42,HHS Region 5,Season peak week,8
+2016,42,2016/2017,42,HHS Region 5,Season peak percentage,4.3
+2016,42,2016/2017,42,HHS Region 5,1 wk ahead,1.1
+2016,42,2016/2017,42,HHS Region 5,2 wk ahead,1.3
+2016,42,2016/2017,42,HHS Region 5,3 wk ahead,1.2
+2016,42,2016/2017,42,HHS Region 5,4 wk ahead,1.2
+2016,42,2016/2017,42,HHS Region 6,Season onset,52
+2016,42,2016/2017,42,HHS Region 6,Season peak week,6
+2016,42,2016/2017,42,HHS Region 6,Season peak percentage,9.9
+2016,42,2016/2017,42,HHS Region 6,1 wk ahead,1.9
+2016,42,2016/2017,42,HHS Region 6,2 wk ahead,1.9
+2016,42,2016/2017,42,HHS Region 6,3 wk ahead,2.1
+2016,42,2016/2017,42,HHS Region 6,4 wk ahead,2.3
+2016,42,2016/2017,42,HHS Region 7,Season onset,51
+2016,42,2016/2017,42,HHS Region 7,Season peak week,6
+2016,42,2016/2017,42,HHS Region 7,Season peak percentage,6.4
+2016,42,2016/2017,42,HHS Region 7,1 wk ahead,0.7
+2016,42,2016/2017,42,HHS Region 7,2 wk ahead,0.8
+2016,42,2016/2017,42,HHS Region 7,3 wk ahead,0.9
+2016,42,2016/2017,42,HHS Region 7,4 wk ahead,1
+2016,42,2016/2017,42,HHS Region 8,Season onset,51
+2016,42,2016/2017,42,HHS Region 8,Season peak week,7
+2016,42,2016/2017,42,HHS Region 8,Season peak percentage,2.7
+2016,42,2016/2017,42,HHS Region 8,1 wk ahead,0.8
+2016,42,2016/2017,42,HHS Region 8,2 wk ahead,0.5
+2016,42,2016/2017,42,HHS Region 8,3 wk ahead,0.7
+2016,42,2016/2017,42,HHS Region 8,4 wk ahead,0.9
+2016,42,2016/2017,42,HHS Region 9,Season onset,51
+2016,42,2016/2017,42,HHS Region 9,Season peak week,52
+2016,42,2016/2017,42,HHS Region 9,Season peak percentage,3.3
+2016,42,2016/2017,42,HHS Region 9,1 wk ahead,1.4
+2016,42,2016/2017,42,HHS Region 9,2 wk ahead,1.5
+2016,42,2016/2017,42,HHS Region 9,3 wk ahead,1.6
+2016,42,2016/2017,42,HHS Region 9,4 wk ahead,1.7
+2016,42,2016/2017,42,HHS Region 10,Season onset,50
+2016,42,2016/2017,42,HHS Region 10,Season peak week,52
+2016,42,2016/2017,42,HHS Region 10,Season peak percentage,3.7
+2016,42,2016/2017,42,HHS Region 10,1 wk ahead,0.5
+2016,42,2016/2017,42,HHS Region 10,2 wk ahead,0.6
+2016,42,2016/2017,42,HHS Region 10,3 wk ahead,0.7
+2016,42,2016/2017,42,HHS Region 10,4 wk ahead,0.6
+2016,43,2016/2017,43,US National,Season onset,50
+2016,43,2016/2017,43,US National,Season peak week,6
+2016,43,2016/2017,43,US National,Season peak percentage,5.1
+2016,43,2016/2017,43,US National,1 wk ahead,1.5
+2016,43,2016/2017,43,US National,2 wk ahead,1.6
+2016,43,2016/2017,43,US National,3 wk ahead,1.6
+2016,43,2016/2017,43,US National,4 wk ahead,1.9
+2016,43,2016/2017,43,HHS Region 1,Season onset,52
+2016,43,2016/2017,43,HHS Region 1,Season peak week,6
+2016,43,2016/2017,43,HHS Region 1,Season peak percentage,3.2
+2016,43,2016/2017,43,HHS Region 1,1 wk ahead,0.9
+2016,43,2016/2017,43,HHS Region 1,2 wk ahead,0.9
+2016,43,2016/2017,43,HHS Region 1,3 wk ahead,0.9
+2016,43,2016/2017,43,HHS Region 1,4 wk ahead,1
+2016,43,2016/2017,43,HHS Region 2,Season onset,47
+2016,43,2016/2017,43,HHS Region 2,Season peak week,6
+2016,43,2016/2017,43,HHS Region 2,Season peak percentage,6.9
+2016,43,2016/2017,43,HHS Region 2,1 wk ahead,2.2
+2016,43,2016/2017,43,HHS Region 2,2 wk ahead,2.5
+2016,43,2016/2017,43,HHS Region 2,3 wk ahead,2.5
+2016,43,2016/2017,43,HHS Region 2,4 wk ahead,3.3
+2016,43,2016/2017,43,HHS Region 3,Season onset,51
+2016,43,2016/2017,43,HHS Region 3,Season peak week,7
+2016,43,2016/2017,43,HHS Region 3,Season peak percentage,5.2
+2016,43,2016/2017,43,HHS Region 3,1 wk ahead,1.4
+2016,43,2016/2017,43,HHS Region 3,2 wk ahead,1.4
+2016,43,2016/2017,43,HHS Region 3,3 wk ahead,1.4
+2016,43,2016/2017,43,HHS Region 3,4 wk ahead,1.7
+2016,43,2016/2017,43,HHS Region 4,Season onset,45
+2016,43,2016/2017,43,HHS Region 4,Season peak week,7
+2016,43,2016/2017,43,HHS Region 4,Season peak week,8
+2016,43,2016/2017,43,HHS Region 4,Season peak percentage,5.5
+2016,43,2016/2017,43,HHS Region 4,1 wk ahead,1.6
+2016,43,2016/2017,43,HHS Region 4,2 wk ahead,1.7
+2016,43,2016/2017,43,HHS Region 4,3 wk ahead,1.9
+2016,43,2016/2017,43,HHS Region 4,4 wk ahead,2.2
+2016,43,2016/2017,43,HHS Region 5,Season onset,52
+2016,43,2016/2017,43,HHS Region 5,Season peak week,7
+2016,43,2016/2017,43,HHS Region 5,Season peak week,8
+2016,43,2016/2017,43,HHS Region 5,Season peak percentage,4.3
+2016,43,2016/2017,43,HHS Region 5,1 wk ahead,1.3
+2016,43,2016/2017,43,HHS Region 5,2 wk ahead,1.2
+2016,43,2016/2017,43,HHS Region 5,3 wk ahead,1.2
+2016,43,2016/2017,43,HHS Region 5,4 wk ahead,1.3
+2016,43,2016/2017,43,HHS Region 6,Season onset,52
+2016,43,2016/2017,43,HHS Region 6,Season peak week,6
+2016,43,2016/2017,43,HHS Region 6,Season peak percentage,9.9
+2016,43,2016/2017,43,HHS Region 6,1 wk ahead,1.9
+2016,43,2016/2017,43,HHS Region 6,2 wk ahead,2.1
+2016,43,2016/2017,43,HHS Region 6,3 wk ahead,2.3
+2016,43,2016/2017,43,HHS Region 6,4 wk ahead,2.5
+2016,43,2016/2017,43,HHS Region 7,Season onset,51
+2016,43,2016/2017,43,HHS Region 7,Season peak week,6
+2016,43,2016/2017,43,HHS Region 7,Season peak percentage,6.4
+2016,43,2016/2017,43,HHS Region 7,1 wk ahead,0.8
+2016,43,2016/2017,43,HHS Region 7,2 wk ahead,0.9
+2016,43,2016/2017,43,HHS Region 7,3 wk ahead,1
+2016,43,2016/2017,43,HHS Region 7,4 wk ahead,1.4
+2016,43,2016/2017,43,HHS Region 8,Season onset,51
+2016,43,2016/2017,43,HHS Region 8,Season peak week,7
+2016,43,2016/2017,43,HHS Region 8,Season peak percentage,2.7
+2016,43,2016/2017,43,HHS Region 8,1 wk ahead,0.5
+2016,43,2016/2017,43,HHS Region 8,2 wk ahead,0.7
+2016,43,2016/2017,43,HHS Region 8,3 wk ahead,0.9
+2016,43,2016/2017,43,HHS Region 8,4 wk ahead,0.8
+2016,43,2016/2017,43,HHS Region 9,Season onset,51
+2016,43,2016/2017,43,HHS Region 9,Season peak week,52
+2016,43,2016/2017,43,HHS Region 9,Season peak percentage,3.3
+2016,43,2016/2017,43,HHS Region 9,1 wk ahead,1.5
+2016,43,2016/2017,43,HHS Region 9,2 wk ahead,1.6
+2016,43,2016/2017,43,HHS Region 9,3 wk ahead,1.7
+2016,43,2016/2017,43,HHS Region 9,4 wk ahead,2
+2016,43,2016/2017,43,HHS Region 10,Season onset,50
+2016,43,2016/2017,43,HHS Region 10,Season peak week,52
+2016,43,2016/2017,43,HHS Region 10,Season peak percentage,3.7
+2016,43,2016/2017,43,HHS Region 10,1 wk ahead,0.6
+2016,43,2016/2017,43,HHS Region 10,2 wk ahead,0.7
+2016,43,2016/2017,43,HHS Region 10,3 wk ahead,0.6
+2016,43,2016/2017,43,HHS Region 10,4 wk ahead,0.8
+2016,44,2016/2017,44,US National,Season onset,50
+2016,44,2016/2017,44,US National,Season peak week,6
+2016,44,2016/2017,44,US National,Season peak percentage,5.1
+2016,44,2016/2017,44,US National,1 wk ahead,1.6
+2016,44,2016/2017,44,US National,2 wk ahead,1.6
+2016,44,2016/2017,44,US National,3 wk ahead,1.9
+2016,44,2016/2017,44,US National,4 wk ahead,1.8
+2016,44,2016/2017,44,HHS Region 1,Season onset,52
+2016,44,2016/2017,44,HHS Region 1,Season peak week,6
+2016,44,2016/2017,44,HHS Region 1,Season peak percentage,3.2
+2016,44,2016/2017,44,HHS Region 1,1 wk ahead,0.9
+2016,44,2016/2017,44,HHS Region 1,2 wk ahead,0.9
+2016,44,2016/2017,44,HHS Region 1,3 wk ahead,1
+2016,44,2016/2017,44,HHS Region 1,4 wk ahead,0.9
+2016,44,2016/2017,44,HHS Region 2,Season onset,47
+2016,44,2016/2017,44,HHS Region 2,Season peak week,6
+2016,44,2016/2017,44,HHS Region 2,Season peak percentage,6.9
+2016,44,2016/2017,44,HHS Region 2,1 wk ahead,2.5
+2016,44,2016/2017,44,HHS Region 2,2 wk ahead,2.5
+2016,44,2016/2017,44,HHS Region 2,3 wk ahead,3.3
+2016,44,2016/2017,44,HHS Region 2,4 wk ahead,3.2
+2016,44,2016/2017,44,HHS Region 3,Season onset,51
+2016,44,2016/2017,44,HHS Region 3,Season peak week,7
+2016,44,2016/2017,44,HHS Region 3,Season peak percentage,5.2
+2016,44,2016/2017,44,HHS Region 3,1 wk ahead,1.4
+2016,44,2016/2017,44,HHS Region 3,2 wk ahead,1.4
+2016,44,2016/2017,44,HHS Region 3,3 wk ahead,1.7
+2016,44,2016/2017,44,HHS Region 3,4 wk ahead,1.5
+2016,44,2016/2017,44,HHS Region 4,Season onset,45
+2016,44,2016/2017,44,HHS Region 4,Season peak week,7
+2016,44,2016/2017,44,HHS Region 4,Season peak week,8
+2016,44,2016/2017,44,HHS Region 4,Season peak percentage,5.5
+2016,44,2016/2017,44,HHS Region 4,1 wk ahead,1.7
+2016,44,2016/2017,44,HHS Region 4,2 wk ahead,1.9
+2016,44,2016/2017,44,HHS Region 4,3 wk ahead,2.2
+2016,44,2016/2017,44,HHS Region 4,4 wk ahead,1.9
+2016,44,2016/2017,44,HHS Region 5,Season onset,52
+2016,44,2016/2017,44,HHS Region 5,Season peak week,7
+2016,44,2016/2017,44,HHS Region 5,Season peak week,8
+2016,44,2016/2017,44,HHS Region 5,Season peak percentage,4.3
+2016,44,2016/2017,44,HHS Region 5,1 wk ahead,1.2
+2016,44,2016/2017,44,HHS Region 5,2 wk ahead,1.2
+2016,44,2016/2017,44,HHS Region 5,3 wk ahead,1.3
+2016,44,2016/2017,44,HHS Region 5,4 wk ahead,1.2
+2016,44,2016/2017,44,HHS Region 6,Season onset,52
+2016,44,2016/2017,44,HHS Region 6,Season peak week,6
+2016,44,2016/2017,44,HHS Region 6,Season peak percentage,9.9
+2016,44,2016/2017,44,HHS Region 6,1 wk ahead,2.1
+2016,44,2016/2017,44,HHS Region 6,2 wk ahead,2.3
+2016,44,2016/2017,44,HHS Region 6,3 wk ahead,2.5
+2016,44,2016/2017,44,HHS Region 6,4 wk ahead,2.5
+2016,44,2016/2017,44,HHS Region 7,Season onset,51
+2016,44,2016/2017,44,HHS Region 7,Season peak week,6
+2016,44,2016/2017,44,HHS Region 7,Season peak percentage,6.4
+2016,44,2016/2017,44,HHS Region 7,1 wk ahead,0.9
+2016,44,2016/2017,44,HHS Region 7,2 wk ahead,1
+2016,44,2016/2017,44,HHS Region 7,3 wk ahead,1.4
+2016,44,2016/2017,44,HHS Region 7,4 wk ahead,1.4
+2016,44,2016/2017,44,HHS Region 8,Season onset,51
+2016,44,2016/2017,44,HHS Region 8,Season peak week,7
+2016,44,2016/2017,44,HHS Region 8,Season peak percentage,2.7
+2016,44,2016/2017,44,HHS Region 8,1 wk ahead,0.7
+2016,44,2016/2017,44,HHS Region 8,2 wk ahead,0.9
+2016,44,2016/2017,44,HHS Region 8,3 wk ahead,0.8
+2016,44,2016/2017,44,HHS Region 8,4 wk ahead,1.3
+2016,44,2016/2017,44,HHS Region 9,Season onset,51
+2016,44,2016/2017,44,HHS Region 9,Season peak week,52
+2016,44,2016/2017,44,HHS Region 9,Season peak percentage,3.3
+2016,44,2016/2017,44,HHS Region 9,1 wk ahead,1.6
+2016,44,2016/2017,44,HHS Region 9,2 wk ahead,1.7
+2016,44,2016/2017,44,HHS Region 9,3 wk ahead,2
+2016,44,2016/2017,44,HHS Region 9,4 wk ahead,1.9
+2016,44,2016/2017,44,HHS Region 10,Season onset,50
+2016,44,2016/2017,44,HHS Region 10,Season peak week,52
+2016,44,2016/2017,44,HHS Region 10,Season peak percentage,3.7
+2016,44,2016/2017,44,HHS Region 10,1 wk ahead,0.7
+2016,44,2016/2017,44,HHS Region 10,2 wk ahead,0.6
+2016,44,2016/2017,44,HHS Region 10,3 wk ahead,0.8
+2016,44,2016/2017,44,HHS Region 10,4 wk ahead,0.8
+2016,45,2016/2017,45,US National,Season onset,50
+2016,45,2016/2017,45,US National,Season peak week,6
+2016,45,2016/2017,45,US National,Season peak percentage,5.1
+2016,45,2016/2017,45,US National,1 wk ahead,1.6
+2016,45,2016/2017,45,US National,2 wk ahead,1.9
+2016,45,2016/2017,45,US National,3 wk ahead,1.8
+2016,45,2016/2017,45,US National,4 wk ahead,1.9
+2016,45,2016/2017,45,HHS Region 1,Season onset,52
+2016,45,2016/2017,45,HHS Region 1,Season peak week,6
+2016,45,2016/2017,45,HHS Region 1,Season peak percentage,3.2
+2016,45,2016/2017,45,HHS Region 1,1 wk ahead,0.9
+2016,45,2016/2017,45,HHS Region 1,2 wk ahead,1
+2016,45,2016/2017,45,HHS Region 1,3 wk ahead,0.9
+2016,45,2016/2017,45,HHS Region 1,4 wk ahead,0.9
+2016,45,2016/2017,45,HHS Region 2,Season onset,47
+2016,45,2016/2017,45,HHS Region 2,Season peak week,6
+2016,45,2016/2017,45,HHS Region 2,Season peak percentage,6.9
+2016,45,2016/2017,45,HHS Region 2,1 wk ahead,2.5
+2016,45,2016/2017,45,HHS Region 2,2 wk ahead,3.3
+2016,45,2016/2017,45,HHS Region 2,3 wk ahead,3.2
+2016,45,2016/2017,45,HHS Region 2,4 wk ahead,3.3
+2016,45,2016/2017,45,HHS Region 3,Season onset,51
+2016,45,2016/2017,45,HHS Region 3,Season peak week,7
+2016,45,2016/2017,45,HHS Region 3,Season peak percentage,5.2
+2016,45,2016/2017,45,HHS Region 3,1 wk ahead,1.4
+2016,45,2016/2017,45,HHS Region 3,2 wk ahead,1.7
+2016,45,2016/2017,45,HHS Region 3,3 wk ahead,1.5
+2016,45,2016/2017,45,HHS Region 3,4 wk ahead,1.6
+2016,45,2016/2017,45,HHS Region 4,Season onset,45
+2016,45,2016/2017,45,HHS Region 4,Season peak week,7
+2016,45,2016/2017,45,HHS Region 4,Season peak week,8
+2016,45,2016/2017,45,HHS Region 4,Season peak percentage,5.5
+2016,45,2016/2017,45,HHS Region 4,1 wk ahead,1.9
+2016,45,2016/2017,45,HHS Region 4,2 wk ahead,2.2
+2016,45,2016/2017,45,HHS Region 4,3 wk ahead,1.9
+2016,45,2016/2017,45,HHS Region 4,4 wk ahead,1.8
+2016,45,2016/2017,45,HHS Region 5,Season onset,52
+2016,45,2016/2017,45,HHS Region 5,Season peak week,7
+2016,45,2016/2017,45,HHS Region 5,Season peak week,8
+2016,45,2016/2017,45,HHS Region 5,Season peak percentage,4.3
+2016,45,2016/2017,45,HHS Region 5,1 wk ahead,1.2
+2016,45,2016/2017,45,HHS Region 5,2 wk ahead,1.3
+2016,45,2016/2017,45,HHS Region 5,3 wk ahead,1.2
+2016,45,2016/2017,45,HHS Region 5,4 wk ahead,1.5
+2016,45,2016/2017,45,HHS Region 6,Season onset,52
+2016,45,2016/2017,45,HHS Region 6,Season peak week,6
+2016,45,2016/2017,45,HHS Region 6,Season peak percentage,9.9
+2016,45,2016/2017,45,HHS Region 6,1 wk ahead,2.3
+2016,45,2016/2017,45,HHS Region 6,2 wk ahead,2.5
+2016,45,2016/2017,45,HHS Region 6,3 wk ahead,2.5
+2016,45,2016/2017,45,HHS Region 6,4 wk ahead,2.9
+2016,45,2016/2017,45,HHS Region 7,Season onset,51
+2016,45,2016/2017,45,HHS Region 7,Season peak week,6
+2016,45,2016/2017,45,HHS Region 7,Season peak percentage,6.4
+2016,45,2016/2017,45,HHS Region 7,1 wk ahead,1
+2016,45,2016/2017,45,HHS Region 7,2 wk ahead,1.4
+2016,45,2016/2017,45,HHS Region 7,3 wk ahead,1.4
+2016,45,2016/2017,45,HHS Region 7,4 wk ahead,1.3
+2016,45,2016/2017,45,HHS Region 8,Season onset,51
+2016,45,2016/2017,45,HHS Region 8,Season peak week,7
+2016,45,2016/2017,45,HHS Region 8,Season peak percentage,2.7
+2016,45,2016/2017,45,HHS Region 8,1 wk ahead,0.9
+2016,45,2016/2017,45,HHS Region 8,2 wk ahead,0.8
+2016,45,2016/2017,45,HHS Region 8,3 wk ahead,1.3
+2016,45,2016/2017,45,HHS Region 8,4 wk ahead,1.1
+2016,45,2016/2017,45,HHS Region 9,Season onset,51
+2016,45,2016/2017,45,HHS Region 9,Season peak week,52
+2016,45,2016/2017,45,HHS Region 9,Season peak percentage,3.3
+2016,45,2016/2017,45,HHS Region 9,1 wk ahead,1.7
+2016,45,2016/2017,45,HHS Region 9,2 wk ahead,2
+2016,45,2016/2017,45,HHS Region 9,3 wk ahead,1.9
+2016,45,2016/2017,45,HHS Region 9,4 wk ahead,2
+2016,45,2016/2017,45,HHS Region 10,Season onset,50
+2016,45,2016/2017,45,HHS Region 10,Season peak week,52
+2016,45,2016/2017,45,HHS Region 10,Season peak percentage,3.7
+2016,45,2016/2017,45,HHS Region 10,1 wk ahead,0.6
+2016,45,2016/2017,45,HHS Region 10,2 wk ahead,0.8
+2016,45,2016/2017,45,HHS Region 10,3 wk ahead,0.8
+2016,45,2016/2017,45,HHS Region 10,4 wk ahead,0.7
+2016,46,2016/2017,46,US National,Season onset,50
+2016,46,2016/2017,46,US National,Season peak week,6
+2016,46,2016/2017,46,US National,Season peak percentage,5.1
+2016,46,2016/2017,46,US National,1 wk ahead,1.9
+2016,46,2016/2017,46,US National,2 wk ahead,1.8
+2016,46,2016/2017,46,US National,3 wk ahead,1.9
+2016,46,2016/2017,46,US National,4 wk ahead,2.2
+2016,46,2016/2017,46,HHS Region 1,Season onset,52
+2016,46,2016/2017,46,HHS Region 1,Season peak week,6
+2016,46,2016/2017,46,HHS Region 1,Season peak percentage,3.2
+2016,46,2016/2017,46,HHS Region 1,1 wk ahead,1
+2016,46,2016/2017,46,HHS Region 1,2 wk ahead,0.9
+2016,46,2016/2017,46,HHS Region 1,3 wk ahead,0.9
+2016,46,2016/2017,46,HHS Region 1,4 wk ahead,1
+2016,46,2016/2017,46,HHS Region 2,Season onset,47
+2016,46,2016/2017,46,HHS Region 2,Season peak week,6
+2016,46,2016/2017,46,HHS Region 2,Season peak percentage,6.9
+2016,46,2016/2017,46,HHS Region 2,1 wk ahead,3.3
+2016,46,2016/2017,46,HHS Region 2,2 wk ahead,3.2
+2016,46,2016/2017,46,HHS Region 2,3 wk ahead,3.3
+2016,46,2016/2017,46,HHS Region 2,4 wk ahead,3.4
+2016,46,2016/2017,46,HHS Region 3,Season onset,51
+2016,46,2016/2017,46,HHS Region 3,Season peak week,7
+2016,46,2016/2017,46,HHS Region 3,Season peak percentage,5.2
+2016,46,2016/2017,46,HHS Region 3,1 wk ahead,1.7
+2016,46,2016/2017,46,HHS Region 3,2 wk ahead,1.5
+2016,46,2016/2017,46,HHS Region 3,3 wk ahead,1.6
+2016,46,2016/2017,46,HHS Region 3,4 wk ahead,1.9
+2016,46,2016/2017,46,HHS Region 4,Season onset,45
+2016,46,2016/2017,46,HHS Region 4,Season peak week,7
+2016,46,2016/2017,46,HHS Region 4,Season peak week,8
+2016,46,2016/2017,46,HHS Region 4,Season peak percentage,5.5
+2016,46,2016/2017,46,HHS Region 4,1 wk ahead,2.2
+2016,46,2016/2017,46,HHS Region 4,2 wk ahead,1.9
+2016,46,2016/2017,46,HHS Region 4,3 wk ahead,1.8
+2016,46,2016/2017,46,HHS Region 4,4 wk ahead,2.3
+2016,46,2016/2017,46,HHS Region 5,Season onset,52
+2016,46,2016/2017,46,HHS Region 5,Season peak week,7
+2016,46,2016/2017,46,HHS Region 5,Season peak week,8
+2016,46,2016/2017,46,HHS Region 5,Season peak percentage,4.3
+2016,46,2016/2017,46,HHS Region 5,1 wk ahead,1.3
+2016,46,2016/2017,46,HHS Region 5,2 wk ahead,1.2
+2016,46,2016/2017,46,HHS Region 5,3 wk ahead,1.5
+2016,46,2016/2017,46,HHS Region 5,4 wk ahead,1.6
+2016,46,2016/2017,46,HHS Region 6,Season onset,52
+2016,46,2016/2017,46,HHS Region 6,Season peak week,6
+2016,46,2016/2017,46,HHS Region 6,Season peak percentage,9.9
+2016,46,2016/2017,46,HHS Region 6,1 wk ahead,2.5
+2016,46,2016/2017,46,HHS Region 6,2 wk ahead,2.5
+2016,46,2016/2017,46,HHS Region 6,3 wk ahead,2.9
+2016,46,2016/2017,46,HHS Region 6,4 wk ahead,3.4
+2016,46,2016/2017,46,HHS Region 7,Season onset,51
+2016,46,2016/2017,46,HHS Region 7,Season peak week,6
+2016,46,2016/2017,46,HHS Region 7,Season peak percentage,6.4
+2016,46,2016/2017,46,HHS Region 7,1 wk ahead,1.4
+2016,46,2016/2017,46,HHS Region 7,2 wk ahead,1.4
+2016,46,2016/2017,46,HHS Region 7,3 wk ahead,1.3
+2016,46,2016/2017,46,HHS Region 7,4 wk ahead,1.3
+2016,46,2016/2017,46,HHS Region 8,Season onset,51
+2016,46,2016/2017,46,HHS Region 8,Season peak week,7
+2016,46,2016/2017,46,HHS Region 8,Season peak percentage,2.7
+2016,46,2016/2017,46,HHS Region 8,1 wk ahead,0.8
+2016,46,2016/2017,46,HHS Region 8,2 wk ahead,1.3
+2016,46,2016/2017,46,HHS Region 8,3 wk ahead,1.1
+2016,46,2016/2017,46,HHS Region 8,4 wk ahead,1.3
+2016,46,2016/2017,46,HHS Region 9,Season onset,51
+2016,46,2016/2017,46,HHS Region 9,Season peak week,52
+2016,46,2016/2017,46,HHS Region 9,Season peak percentage,3.3
+2016,46,2016/2017,46,HHS Region 9,1 wk ahead,2
+2016,46,2016/2017,46,HHS Region 9,2 wk ahead,1.9
+2016,46,2016/2017,46,HHS Region 9,3 wk ahead,2
+2016,46,2016/2017,46,HHS Region 9,4 wk ahead,2.3
+2016,46,2016/2017,46,HHS Region 10,Season onset,50
+2016,46,2016/2017,46,HHS Region 10,Season peak week,52
+2016,46,2016/2017,46,HHS Region 10,Season peak percentage,3.7
+2016,46,2016/2017,46,HHS Region 10,1 wk ahead,0.8
+2016,46,2016/2017,46,HHS Region 10,2 wk ahead,0.8
+2016,46,2016/2017,46,HHS Region 10,3 wk ahead,0.7
+2016,46,2016/2017,46,HHS Region 10,4 wk ahead,1.5
+2016,47,2016/2017,47,US National,Season onset,50
+2016,47,2016/2017,47,US National,Season peak week,6
+2016,47,2016/2017,47,US National,Season peak percentage,5.1
+2016,47,2016/2017,47,US National,1 wk ahead,1.8
+2016,47,2016/2017,47,US National,2 wk ahead,1.9
+2016,47,2016/2017,47,US National,3 wk ahead,2.2
+2016,47,2016/2017,47,US National,4 wk ahead,2.7
+2016,47,2016/2017,47,HHS Region 1,Season onset,52
+2016,47,2016/2017,47,HHS Region 1,Season peak week,6
+2016,47,2016/2017,47,HHS Region 1,Season peak percentage,3.2
+2016,47,2016/2017,47,HHS Region 1,1 wk ahead,0.9
+2016,47,2016/2017,47,HHS Region 1,2 wk ahead,0.9
+2016,47,2016/2017,47,HHS Region 1,3 wk ahead,1
+2016,47,2016/2017,47,HHS Region 1,4 wk ahead,1.2
+2016,47,2016/2017,47,HHS Region 2,Season onset,47
+2016,47,2016/2017,47,HHS Region 2,Season peak week,6
+2016,47,2016/2017,47,HHS Region 2,Season peak percentage,6.9
+2016,47,2016/2017,47,HHS Region 2,1 wk ahead,3.2
+2016,47,2016/2017,47,HHS Region 2,2 wk ahead,3.3
+2016,47,2016/2017,47,HHS Region 2,3 wk ahead,3.4
+2016,47,2016/2017,47,HHS Region 2,4 wk ahead,4.5
+2016,47,2016/2017,47,HHS Region 3,Season onset,51
+2016,47,2016/2017,47,HHS Region 3,Season peak week,7
+2016,47,2016/2017,47,HHS Region 3,Season peak percentage,5.2
+2016,47,2016/2017,47,HHS Region 3,1 wk ahead,1.5
+2016,47,2016/2017,47,HHS Region 3,2 wk ahead,1.6
+2016,47,2016/2017,47,HHS Region 3,3 wk ahead,1.9
+2016,47,2016/2017,47,HHS Region 3,4 wk ahead,2.2
+2016,47,2016/2017,47,HHS Region 4,Season onset,45
+2016,47,2016/2017,47,HHS Region 4,Season peak week,7
+2016,47,2016/2017,47,HHS Region 4,Season peak week,8
+2016,47,2016/2017,47,HHS Region 4,Season peak percentage,5.5
+2016,47,2016/2017,47,HHS Region 4,1 wk ahead,1.9
+2016,47,2016/2017,47,HHS Region 4,2 wk ahead,1.8
+2016,47,2016/2017,47,HHS Region 4,3 wk ahead,2.3
+2016,47,2016/2017,47,HHS Region 4,4 wk ahead,2.9
+2016,47,2016/2017,47,HHS Region 5,Season onset,52
+2016,47,2016/2017,47,HHS Region 5,Season peak week,7
+2016,47,2016/2017,47,HHS Region 5,Season peak week,8
+2016,47,2016/2017,47,HHS Region 5,Season peak percentage,4.3
+2016,47,2016/2017,47,HHS Region 5,1 wk ahead,1.2
+2016,47,2016/2017,47,HHS Region 5,2 wk ahead,1.5
+2016,47,2016/2017,47,HHS Region 5,3 wk ahead,1.6
+2016,47,2016/2017,47,HHS Region 5,4 wk ahead,1.8
+2016,47,2016/2017,47,HHS Region 6,Season onset,52
+2016,47,2016/2017,47,HHS Region 6,Season peak week,6
+2016,47,2016/2017,47,HHS Region 6,Season peak percentage,9.9
+2016,47,2016/2017,47,HHS Region 6,1 wk ahead,2.5
+2016,47,2016/2017,47,HHS Region 6,2 wk ahead,2.9
+2016,47,2016/2017,47,HHS Region 6,3 wk ahead,3.4
+2016,47,2016/2017,47,HHS Region 6,4 wk ahead,3.9
+2016,47,2016/2017,47,HHS Region 7,Season onset,51
+2016,47,2016/2017,47,HHS Region 7,Season peak week,6
+2016,47,2016/2017,47,HHS Region 7,Season peak percentage,6.4
+2016,47,2016/2017,47,HHS Region 7,1 wk ahead,1.4
+2016,47,2016/2017,47,HHS Region 7,2 wk ahead,1.3
+2016,47,2016/2017,47,HHS Region 7,3 wk ahead,1.3
+2016,47,2016/2017,47,HHS Region 7,4 wk ahead,1.8
+2016,47,2016/2017,47,HHS Region 8,Season onset,51
+2016,47,2016/2017,47,HHS Region 8,Season peak week,7
+2016,47,2016/2017,47,HHS Region 8,Season peak percentage,2.7
+2016,47,2016/2017,47,HHS Region 8,1 wk ahead,1.3
+2016,47,2016/2017,47,HHS Region 8,2 wk ahead,1.1
+2016,47,2016/2017,47,HHS Region 8,3 wk ahead,1.3
+2016,47,2016/2017,47,HHS Region 8,4 wk ahead,2.1
+2016,47,2016/2017,47,HHS Region 9,Season onset,51
+2016,47,2016/2017,47,HHS Region 9,Season peak week,52
+2016,47,2016/2017,47,HHS Region 9,Season peak percentage,3.3
+2016,47,2016/2017,47,HHS Region 9,1 wk ahead,1.9
+2016,47,2016/2017,47,HHS Region 9,2 wk ahead,2
+2016,47,2016/2017,47,HHS Region 9,3 wk ahead,2.3
+2016,47,2016/2017,47,HHS Region 9,4 wk ahead,2.8
+2016,47,2016/2017,47,HHS Region 10,Season onset,50
+2016,47,2016/2017,47,HHS Region 10,Season peak week,52
+2016,47,2016/2017,47,HHS Region 10,Season peak percentage,3.7
+2016,47,2016/2017,47,HHS Region 10,1 wk ahead,0.8
+2016,47,2016/2017,47,HHS Region 10,2 wk ahead,0.7
+2016,47,2016/2017,47,HHS Region 10,3 wk ahead,1.5
+2016,47,2016/2017,47,HHS Region 10,4 wk ahead,2.1
+2016,48,2016/2017,48,US National,Season onset,50
+2016,48,2016/2017,48,US National,Season peak week,6
+2016,48,2016/2017,48,US National,Season peak percentage,5.1
+2016,48,2016/2017,48,US National,1 wk ahead,1.9
+2016,48,2016/2017,48,US National,2 wk ahead,2.2
+2016,48,2016/2017,48,US National,3 wk ahead,2.7
+2016,48,2016/2017,48,US National,4 wk ahead,3.4
+2016,48,2016/2017,48,HHS Region 1,Season onset,52
+2016,48,2016/2017,48,HHS Region 1,Season peak week,6
+2016,48,2016/2017,48,HHS Region 1,Season peak percentage,3.2
+2016,48,2016/2017,48,HHS Region 1,1 wk ahead,0.9
+2016,48,2016/2017,48,HHS Region 1,2 wk ahead,1
+2016,48,2016/2017,48,HHS Region 1,3 wk ahead,1.2
+2016,48,2016/2017,48,HHS Region 1,4 wk ahead,1.4
+2016,48,2016/2017,48,HHS Region 2,Season onset,47
+2016,48,2016/2017,48,HHS Region 2,Season peak week,6
+2016,48,2016/2017,48,HHS Region 2,Season peak percentage,6.9
+2016,48,2016/2017,48,HHS Region 2,1 wk ahead,3.3
+2016,48,2016/2017,48,HHS Region 2,2 wk ahead,3.4
+2016,48,2016/2017,48,HHS Region 2,3 wk ahead,4.5
+2016,48,2016/2017,48,HHS Region 2,4 wk ahead,6
+2016,48,2016/2017,48,HHS Region 3,Season onset,51
+2016,48,2016/2017,48,HHS Region 3,Season peak week,7
+2016,48,2016/2017,48,HHS Region 3,Season peak percentage,5.2
+2016,48,2016/2017,48,HHS Region 3,1 wk ahead,1.6
+2016,48,2016/2017,48,HHS Region 3,2 wk ahead,1.9
+2016,48,2016/2017,48,HHS Region 3,3 wk ahead,2.2
+2016,48,2016/2017,48,HHS Region 3,4 wk ahead,3.1
+2016,48,2016/2017,48,HHS Region 4,Season onset,45
+2016,48,2016/2017,48,HHS Region 4,Season peak week,7
+2016,48,2016/2017,48,HHS Region 4,Season peak week,8
+2016,48,2016/2017,48,HHS Region 4,Season peak percentage,5.5
+2016,48,2016/2017,48,HHS Region 4,1 wk ahead,1.8
+2016,48,2016/2017,48,HHS Region 4,2 wk ahead,2.3
+2016,48,2016/2017,48,HHS Region 4,3 wk ahead,2.9
+2016,48,2016/2017,48,HHS Region 4,4 wk ahead,3.4
+2016,48,2016/2017,48,HHS Region 5,Season onset,52
+2016,48,2016/2017,48,HHS Region 5,Season peak week,7
+2016,48,2016/2017,48,HHS Region 5,Season peak week,8
+2016,48,2016/2017,48,HHS Region 5,Season peak percentage,4.3
+2016,48,2016/2017,48,HHS Region 5,1 wk ahead,1.5
+2016,48,2016/2017,48,HHS Region 5,2 wk ahead,1.6
+2016,48,2016/2017,48,HHS Region 5,3 wk ahead,1.8
+2016,48,2016/2017,48,HHS Region 5,4 wk ahead,2.4
+2016,48,2016/2017,48,HHS Region 6,Season onset,52
+2016,48,2016/2017,48,HHS Region 6,Season peak week,6
+2016,48,2016/2017,48,HHS Region 6,Season peak percentage,9.9
+2016,48,2016/2017,48,HHS Region 6,1 wk ahead,2.9
+2016,48,2016/2017,48,HHS Region 6,2 wk ahead,3.4
+2016,48,2016/2017,48,HHS Region 6,3 wk ahead,3.9
+2016,48,2016/2017,48,HHS Region 6,4 wk ahead,4.2
+2016,48,2016/2017,48,HHS Region 7,Season onset,51
+2016,48,2016/2017,48,HHS Region 7,Season peak week,6
+2016,48,2016/2017,48,HHS Region 7,Season peak percentage,6.4
+2016,48,2016/2017,48,HHS Region 7,1 wk ahead,1.3
+2016,48,2016/2017,48,HHS Region 7,2 wk ahead,1.3
+2016,48,2016/2017,48,HHS Region 7,3 wk ahead,1.8
+2016,48,2016/2017,48,HHS Region 7,4 wk ahead,2.7
+2016,48,2016/2017,48,HHS Region 8,Season onset,51
+2016,48,2016/2017,48,HHS Region 8,Season peak week,7
+2016,48,2016/2017,48,HHS Region 8,Season peak percentage,2.7
+2016,48,2016/2017,48,HHS Region 8,1 wk ahead,1.1
+2016,48,2016/2017,48,HHS Region 8,2 wk ahead,1.3
+2016,48,2016/2017,48,HHS Region 8,3 wk ahead,2.1
+2016,48,2016/2017,48,HHS Region 8,4 wk ahead,1.5
+2016,48,2016/2017,48,HHS Region 9,Season onset,51
+2016,48,2016/2017,48,HHS Region 9,Season peak week,52
+2016,48,2016/2017,48,HHS Region 9,Season peak percentage,3.3
+2016,48,2016/2017,48,HHS Region 9,1 wk ahead,2
+2016,48,2016/2017,48,HHS Region 9,2 wk ahead,2.3
+2016,48,2016/2017,48,HHS Region 9,3 wk ahead,2.8
+2016,48,2016/2017,48,HHS Region 9,4 wk ahead,3.3
+2016,48,2016/2017,48,HHS Region 10,Season onset,50
+2016,48,2016/2017,48,HHS Region 10,Season peak week,52
+2016,48,2016/2017,48,HHS Region 10,Season peak percentage,3.7
+2016,48,2016/2017,48,HHS Region 10,1 wk ahead,0.7
+2016,48,2016/2017,48,HHS Region 10,2 wk ahead,1.5
+2016,48,2016/2017,48,HHS Region 10,3 wk ahead,2.1
+2016,48,2016/2017,48,HHS Region 10,4 wk ahead,3.7
+2016,49,2016/2017,49,US National,Season onset,50
+2016,49,2016/2017,49,US National,Season peak week,6
+2016,49,2016/2017,49,US National,Season peak percentage,5.1
+2016,49,2016/2017,49,US National,1 wk ahead,2.2
+2016,49,2016/2017,49,US National,2 wk ahead,2.7
+2016,49,2016/2017,49,US National,3 wk ahead,3.4
+2016,49,2016/2017,49,US National,4 wk ahead,3.1
+2016,49,2016/2017,49,HHS Region 1,Season onset,52
+2016,49,2016/2017,49,HHS Region 1,Season peak week,6
+2016,49,2016/2017,49,HHS Region 1,Season peak percentage,3.2
+2016,49,2016/2017,49,HHS Region 1,1 wk ahead,1
+2016,49,2016/2017,49,HHS Region 1,2 wk ahead,1.2
+2016,49,2016/2017,49,HHS Region 1,3 wk ahead,1.4
+2016,49,2016/2017,49,HHS Region 1,4 wk ahead,1.6
+2016,49,2016/2017,49,HHS Region 2,Season onset,47
+2016,49,2016/2017,49,HHS Region 2,Season peak week,6
+2016,49,2016/2017,49,HHS Region 2,Season peak percentage,6.9
+2016,49,2016/2017,49,HHS Region 2,1 wk ahead,3.4
+2016,49,2016/2017,49,HHS Region 2,2 wk ahead,4.5
+2016,49,2016/2017,49,HHS Region 2,3 wk ahead,6
+2016,49,2016/2017,49,HHS Region 2,4 wk ahead,5.3
+2016,49,2016/2017,49,HHS Region 3,Season onset,51
+2016,49,2016/2017,49,HHS Region 3,Season peak week,7
+2016,49,2016/2017,49,HHS Region 3,Season peak percentage,5.2
+2016,49,2016/2017,49,HHS Region 3,1 wk ahead,1.9
+2016,49,2016/2017,49,HHS Region 3,2 wk ahead,2.2
+2016,49,2016/2017,49,HHS Region 3,3 wk ahead,3.1
+2016,49,2016/2017,49,HHS Region 3,4 wk ahead,2.7
+2016,49,2016/2017,49,HHS Region 4,Season onset,45
+2016,49,2016/2017,49,HHS Region 4,Season peak week,7
+2016,49,2016/2017,49,HHS Region 4,Season peak week,8
+2016,49,2016/2017,49,HHS Region 4,Season peak percentage,5.5
+2016,49,2016/2017,49,HHS Region 4,1 wk ahead,2.3
+2016,49,2016/2017,49,HHS Region 4,2 wk ahead,2.9
+2016,49,2016/2017,49,HHS Region 4,3 wk ahead,3.4
+2016,49,2016/2017,49,HHS Region 4,4 wk ahead,2.9
+2016,49,2016/2017,49,HHS Region 5,Season onset,52
+2016,49,2016/2017,49,HHS Region 5,Season peak week,7
+2016,49,2016/2017,49,HHS Region 5,Season peak week,8
+2016,49,2016/2017,49,HHS Region 5,Season peak percentage,4.3
+2016,49,2016/2017,49,HHS Region 5,1 wk ahead,1.6
+2016,49,2016/2017,49,HHS Region 5,2 wk ahead,1.8
+2016,49,2016/2017,49,HHS Region 5,3 wk ahead,2.4
+2016,49,2016/2017,49,HHS Region 5,4 wk ahead,2.1
+2016,49,2016/2017,49,HHS Region 6,Season onset,52
+2016,49,2016/2017,49,HHS Region 6,Season peak week,6
+2016,49,2016/2017,49,HHS Region 6,Season peak percentage,9.9
+2016,49,2016/2017,49,HHS Region 6,1 wk ahead,3.4
+2016,49,2016/2017,49,HHS Region 6,2 wk ahead,3.9
+2016,49,2016/2017,49,HHS Region 6,3 wk ahead,4.2
+2016,49,2016/2017,49,HHS Region 6,4 wk ahead,4.1
+2016,49,2016/2017,49,HHS Region 7,Season onset,51
+2016,49,2016/2017,49,HHS Region 7,Season peak week,6
+2016,49,2016/2017,49,HHS Region 7,Season peak percentage,6.4
+2016,49,2016/2017,49,HHS Region 7,1 wk ahead,1.3
+2016,49,2016/2017,49,HHS Region 7,2 wk ahead,1.8
+2016,49,2016/2017,49,HHS Region 7,3 wk ahead,2.7
+2016,49,2016/2017,49,HHS Region 7,4 wk ahead,2.9
+2016,49,2016/2017,49,HHS Region 8,Season onset,51
+2016,49,2016/2017,49,HHS Region 8,Season peak week,7
+2016,49,2016/2017,49,HHS Region 8,Season peak percentage,2.7
+2016,49,2016/2017,49,HHS Region 8,1 wk ahead,1.3
+2016,49,2016/2017,49,HHS Region 8,2 wk ahead,2.1
+2016,49,2016/2017,49,HHS Region 8,3 wk ahead,1.5
+2016,49,2016/2017,49,HHS Region 8,4 wk ahead,2.3
+2016,49,2016/2017,49,HHS Region 9,Season onset,51
+2016,49,2016/2017,49,HHS Region 9,Season peak week,52
+2016,49,2016/2017,49,HHS Region 9,Season peak percentage,3.3
+2016,49,2016/2017,49,HHS Region 9,1 wk ahead,2.3
+2016,49,2016/2017,49,HHS Region 9,2 wk ahead,2.8
+2016,49,2016/2017,49,HHS Region 9,3 wk ahead,3.3
+2016,49,2016/2017,49,HHS Region 9,4 wk ahead,3.1
+2016,49,2016/2017,49,HHS Region 10,Season onset,50
+2016,49,2016/2017,49,HHS Region 10,Season peak week,52
+2016,49,2016/2017,49,HHS Region 10,Season peak percentage,3.7
+2016,49,2016/2017,49,HHS Region 10,1 wk ahead,1.5
+2016,49,2016/2017,49,HHS Region 10,2 wk ahead,2.1
+2016,49,2016/2017,49,HHS Region 10,3 wk ahead,3.7
+2016,49,2016/2017,49,HHS Region 10,4 wk ahead,3
+2016,50,2016/2017,50,US National,Season onset,50
+2016,50,2016/2017,50,US National,Season peak week,6
+2016,50,2016/2017,50,US National,Season peak percentage,5.1
+2016,50,2016/2017,50,US National,1 wk ahead,2.7
+2016,50,2016/2017,50,US National,2 wk ahead,3.4
+2016,50,2016/2017,50,US National,3 wk ahead,3.1
+2016,50,2016/2017,50,US National,4 wk ahead,3.1
+2016,50,2016/2017,50,HHS Region 1,Season onset,52
+2016,50,2016/2017,50,HHS Region 1,Season peak week,6
+2016,50,2016/2017,50,HHS Region 1,Season peak percentage,3.2
+2016,50,2016/2017,50,HHS Region 1,1 wk ahead,1.2
+2016,50,2016/2017,50,HHS Region 1,2 wk ahead,1.4
+2016,50,2016/2017,50,HHS Region 1,3 wk ahead,1.6
+2016,50,2016/2017,50,HHS Region 1,4 wk ahead,1.5
+2016,50,2016/2017,50,HHS Region 2,Season onset,47
+2016,50,2016/2017,50,HHS Region 2,Season peak week,6
+2016,50,2016/2017,50,HHS Region 2,Season peak percentage,6.9
+2016,50,2016/2017,50,HHS Region 2,1 wk ahead,4.5
+2016,50,2016/2017,50,HHS Region 2,2 wk ahead,6
+2016,50,2016/2017,50,HHS Region 2,3 wk ahead,5.3
+2016,50,2016/2017,50,HHS Region 2,4 wk ahead,5.1
+2016,50,2016/2017,50,HHS Region 3,Season onset,51
+2016,50,2016/2017,50,HHS Region 3,Season peak week,7
+2016,50,2016/2017,50,HHS Region 3,Season peak percentage,5.2
+2016,50,2016/2017,50,HHS Region 3,1 wk ahead,2.2
+2016,50,2016/2017,50,HHS Region 3,2 wk ahead,3.1
+2016,50,2016/2017,50,HHS Region 3,3 wk ahead,2.7
+2016,50,2016/2017,50,HHS Region 3,4 wk ahead,2.8
+2016,50,2016/2017,50,HHS Region 4,Season onset,45
+2016,50,2016/2017,50,HHS Region 4,Season peak week,7
+2016,50,2016/2017,50,HHS Region 4,Season peak week,8
+2016,50,2016/2017,50,HHS Region 4,Season peak percentage,5.5
+2016,50,2016/2017,50,HHS Region 4,1 wk ahead,2.9
+2016,50,2016/2017,50,HHS Region 4,2 wk ahead,3.4
+2016,50,2016/2017,50,HHS Region 4,3 wk ahead,2.9
+2016,50,2016/2017,50,HHS Region 4,4 wk ahead,2.9
+2016,50,2016/2017,50,HHS Region 5,Season onset,52
+2016,50,2016/2017,50,HHS Region 5,Season peak week,7
+2016,50,2016/2017,50,HHS Region 5,Season peak week,8
+2016,50,2016/2017,50,HHS Region 5,Season peak percentage,4.3
+2016,50,2016/2017,50,HHS Region 5,1 wk ahead,1.8
+2016,50,2016/2017,50,HHS Region 5,2 wk ahead,2.4
+2016,50,2016/2017,50,HHS Region 5,3 wk ahead,2.1
+2016,50,2016/2017,50,HHS Region 5,4 wk ahead,2.1
+2016,50,2016/2017,50,HHS Region 6,Season onset,52
+2016,50,2016/2017,50,HHS Region 6,Season peak week,6
+2016,50,2016/2017,50,HHS Region 6,Season peak percentage,9.9
+2016,50,2016/2017,50,HHS Region 6,1 wk ahead,3.9
+2016,50,2016/2017,50,HHS Region 6,2 wk ahead,4.2
+2016,50,2016/2017,50,HHS Region 6,3 wk ahead,4.1
+2016,50,2016/2017,50,HHS Region 6,4 wk ahead,4.9
+2016,50,2016/2017,50,HHS Region 7,Season onset,51
+2016,50,2016/2017,50,HHS Region 7,Season peak week,6
+2016,50,2016/2017,50,HHS Region 7,Season peak percentage,6.4
+2016,50,2016/2017,50,HHS Region 7,1 wk ahead,1.8
+2016,50,2016/2017,50,HHS Region 7,2 wk ahead,2.7
+2016,50,2016/2017,50,HHS Region 7,3 wk ahead,2.9
+2016,50,2016/2017,50,HHS Region 7,4 wk ahead,2.8
+2016,50,2016/2017,50,HHS Region 8,Season onset,51
+2016,50,2016/2017,50,HHS Region 8,Season peak week,7
+2016,50,2016/2017,50,HHS Region 8,Season peak percentage,2.7
+2016,50,2016/2017,50,HHS Region 8,1 wk ahead,2.1
+2016,50,2016/2017,50,HHS Region 8,2 wk ahead,1.5
+2016,50,2016/2017,50,HHS Region 8,3 wk ahead,2.3
+2016,50,2016/2017,50,HHS Region 8,4 wk ahead,1.9
+2016,50,2016/2017,50,HHS Region 9,Season onset,51
+2016,50,2016/2017,50,HHS Region 9,Season peak week,52
+2016,50,2016/2017,50,HHS Region 9,Season peak percentage,3.3
+2016,50,2016/2017,50,HHS Region 9,1 wk ahead,2.8
+2016,50,2016/2017,50,HHS Region 9,2 wk ahead,3.3
+2016,50,2016/2017,50,HHS Region 9,3 wk ahead,3.1
+2016,50,2016/2017,50,HHS Region 9,4 wk ahead,2.8
+2016,50,2016/2017,50,HHS Region 10,Season onset,50
+2016,50,2016/2017,50,HHS Region 10,Season peak week,52
+2016,50,2016/2017,50,HHS Region 10,Season peak percentage,3.7
+2016,50,2016/2017,50,HHS Region 10,1 wk ahead,2.1
+2016,50,2016/2017,50,HHS Region 10,2 wk ahead,3.7
+2016,50,2016/2017,50,HHS Region 10,3 wk ahead,3
+2016,50,2016/2017,50,HHS Region 10,4 wk ahead,2.2
+2016,51,2016/2017,51,US National,Season onset,50
+2016,51,2016/2017,51,US National,Season peak week,6
+2016,51,2016/2017,51,US National,Season peak percentage,5.1
+2016,51,2016/2017,51,US National,1 wk ahead,3.4
+2016,51,2016/2017,51,US National,2 wk ahead,3.1
+2016,51,2016/2017,51,US National,3 wk ahead,3.1
+2016,51,2016/2017,51,US National,4 wk ahead,3.5
+2016,51,2016/2017,51,HHS Region 1,Season onset,52
+2016,51,2016/2017,51,HHS Region 1,Season peak week,6
+2016,51,2016/2017,51,HHS Region 1,Season peak percentage,3.2
+2016,51,2016/2017,51,HHS Region 1,1 wk ahead,1.4
+2016,51,2016/2017,51,HHS Region 1,2 wk ahead,1.6
+2016,51,2016/2017,51,HHS Region 1,3 wk ahead,1.5
+2016,51,2016/2017,51,HHS Region 1,4 wk ahead,1.7
+2016,51,2016/2017,51,HHS Region 2,Season onset,47
+2016,51,2016/2017,51,HHS Region 2,Season peak week,6
+2016,51,2016/2017,51,HHS Region 2,Season peak percentage,6.9
+2016,51,2016/2017,51,HHS Region 2,1 wk ahead,6
+2016,51,2016/2017,51,HHS Region 2,2 wk ahead,5.3
+2016,51,2016/2017,51,HHS Region 2,3 wk ahead,5.1
+2016,51,2016/2017,51,HHS Region 2,4 wk ahead,5.7
+2016,51,2016/2017,51,HHS Region 3,Season onset,51
+2016,51,2016/2017,51,HHS Region 3,Season peak week,7
+2016,51,2016/2017,51,HHS Region 3,Season peak percentage,5.2
+2016,51,2016/2017,51,HHS Region 3,1 wk ahead,3.1
+2016,51,2016/2017,51,HHS Region 3,2 wk ahead,2.7
+2016,51,2016/2017,51,HHS Region 3,3 wk ahead,2.8
+2016,51,2016/2017,51,HHS Region 3,4 wk ahead,3.1
+2016,51,2016/2017,51,HHS Region 4,Season onset,45
+2016,51,2016/2017,51,HHS Region 4,Season peak week,7
+2016,51,2016/2017,51,HHS Region 4,Season peak week,8
+2016,51,2016/2017,51,HHS Region 4,Season peak percentage,5.5
+2016,51,2016/2017,51,HHS Region 4,1 wk ahead,3.4
+2016,51,2016/2017,51,HHS Region 4,2 wk ahead,2.9
+2016,51,2016/2017,51,HHS Region 4,3 wk ahead,2.9
+2016,51,2016/2017,51,HHS Region 4,4 wk ahead,3.7
+2016,51,2016/2017,51,HHS Region 5,Season onset,52
+2016,51,2016/2017,51,HHS Region 5,Season peak week,7
+2016,51,2016/2017,51,HHS Region 5,Season peak week,8
+2016,51,2016/2017,51,HHS Region 5,Season peak percentage,4.3
+2016,51,2016/2017,51,HHS Region 5,1 wk ahead,2.4
+2016,51,2016/2017,51,HHS Region 5,2 wk ahead,2.1
+2016,51,2016/2017,51,HHS Region 5,3 wk ahead,2.1
+2016,51,2016/2017,51,HHS Region 5,4 wk ahead,2.4
+2016,51,2016/2017,51,HHS Region 6,Season onset,52
+2016,51,2016/2017,51,HHS Region 6,Season peak week,6
+2016,51,2016/2017,51,HHS Region 6,Season peak percentage,9.9
+2016,51,2016/2017,51,HHS Region 6,1 wk ahead,4.2
+2016,51,2016/2017,51,HHS Region 6,2 wk ahead,4.1
+2016,51,2016/2017,51,HHS Region 6,3 wk ahead,4.9
+2016,51,2016/2017,51,HHS Region 6,4 wk ahead,5.3
+2016,51,2016/2017,51,HHS Region 7,Season onset,51
+2016,51,2016/2017,51,HHS Region 7,Season peak week,6
+2016,51,2016/2017,51,HHS Region 7,Season peak percentage,6.4
+2016,51,2016/2017,51,HHS Region 7,1 wk ahead,2.7
+2016,51,2016/2017,51,HHS Region 7,2 wk ahead,2.9
+2016,51,2016/2017,51,HHS Region 7,3 wk ahead,2.8
+2016,51,2016/2017,51,HHS Region 7,4 wk ahead,3.5
+2016,51,2016/2017,51,HHS Region 8,Season onset,51
+2016,51,2016/2017,51,HHS Region 8,Season peak week,7
+2016,51,2016/2017,51,HHS Region 8,Season peak percentage,2.7
+2016,51,2016/2017,51,HHS Region 8,1 wk ahead,1.5
+2016,51,2016/2017,51,HHS Region 8,2 wk ahead,2.3
+2016,51,2016/2017,51,HHS Region 8,3 wk ahead,1.9
+2016,51,2016/2017,51,HHS Region 8,4 wk ahead,2.3
+2016,51,2016/2017,51,HHS Region 9,Season onset,51
+2016,51,2016/2017,51,HHS Region 9,Season peak week,52
+2016,51,2016/2017,51,HHS Region 9,Season peak percentage,3.3
+2016,51,2016/2017,51,HHS Region 9,1 wk ahead,3.3
+2016,51,2016/2017,51,HHS Region 9,2 wk ahead,3.1
+2016,51,2016/2017,51,HHS Region 9,3 wk ahead,2.8
+2016,51,2016/2017,51,HHS Region 9,4 wk ahead,2.7
+2016,51,2016/2017,51,HHS Region 10,Season onset,50
+2016,51,2016/2017,51,HHS Region 10,Season peak week,52
+2016,51,2016/2017,51,HHS Region 10,Season peak percentage,3.7
+2016,51,2016/2017,51,HHS Region 10,1 wk ahead,3.7
+2016,51,2016/2017,51,HHS Region 10,2 wk ahead,3
+2016,51,2016/2017,51,HHS Region 10,3 wk ahead,2.2
+2016,51,2016/2017,51,HHS Region 10,4 wk ahead,3.3
+2016,52,2016/2017,52,US National,Season onset,50
+2016,52,2016/2017,52,US National,Season peak week,6
+2016,52,2016/2017,52,US National,Season peak percentage,5.1
+2016,52,2016/2017,52,US National,1 wk ahead,3.1
+2016,52,2016/2017,52,US National,2 wk ahead,3.1
+2016,52,2016/2017,52,US National,3 wk ahead,3.5
+2016,52,2016/2017,52,US National,4 wk ahead,3.8
+2016,52,2016/2017,52,HHS Region 1,Season onset,52
+2016,52,2016/2017,52,HHS Region 1,Season peak week,6
+2016,52,2016/2017,52,HHS Region 1,Season peak percentage,3.2
+2016,52,2016/2017,52,HHS Region 1,1 wk ahead,1.6
+2016,52,2016/2017,52,HHS Region 1,2 wk ahead,1.5
+2016,52,2016/2017,52,HHS Region 1,3 wk ahead,1.7
+2016,52,2016/2017,52,HHS Region 1,4 wk ahead,2.1
+2016,52,2016/2017,52,HHS Region 2,Season onset,47
+2016,52,2016/2017,52,HHS Region 2,Season peak week,6
+2016,52,2016/2017,52,HHS Region 2,Season peak percentage,6.9
+2016,52,2016/2017,52,HHS Region 2,1 wk ahead,5.3
+2016,52,2016/2017,52,HHS Region 2,2 wk ahead,5.1
+2016,52,2016/2017,52,HHS Region 2,3 wk ahead,5.7
+2016,52,2016/2017,52,HHS Region 2,4 wk ahead,6
+2016,52,2016/2017,52,HHS Region 3,Season onset,51
+2016,52,2016/2017,52,HHS Region 3,Season peak week,7
+2016,52,2016/2017,52,HHS Region 3,Season peak percentage,5.2
+2016,52,2016/2017,52,HHS Region 3,1 wk ahead,2.7
+2016,52,2016/2017,52,HHS Region 3,2 wk ahead,2.8
+2016,52,2016/2017,52,HHS Region 3,3 wk ahead,3.1
+2016,52,2016/2017,52,HHS Region 3,4 wk ahead,3.5
+2016,52,2016/2017,52,HHS Region 4,Season onset,45
+2016,52,2016/2017,52,HHS Region 4,Season peak week,7
+2016,52,2016/2017,52,HHS Region 4,Season peak week,8
+2016,52,2016/2017,52,HHS Region 4,Season peak percentage,5.5
+2016,52,2016/2017,52,HHS Region 4,1 wk ahead,2.9
+2016,52,2016/2017,52,HHS Region 4,2 wk ahead,2.9
+2016,52,2016/2017,52,HHS Region 4,3 wk ahead,3.7
+2016,52,2016/2017,52,HHS Region 4,4 wk ahead,3.7
+2016,52,2016/2017,52,HHS Region 5,Season onset,52
+2016,52,2016/2017,52,HHS Region 5,Season peak week,7
+2016,52,2016/2017,52,HHS Region 5,Season peak week,8
+2016,52,2016/2017,52,HHS Region 5,Season peak percentage,4.3
+2016,52,2016/2017,52,HHS Region 5,1 wk ahead,2.1
+2016,52,2016/2017,52,HHS Region 5,2 wk ahead,2.1
+2016,52,2016/2017,52,HHS Region 5,3 wk ahead,2.4
+2016,52,2016/2017,52,HHS Region 5,4 wk ahead,2.8
+2016,52,2016/2017,52,HHS Region 6,Season onset,52
+2016,52,2016/2017,52,HHS Region 6,Season peak week,6
+2016,52,2016/2017,52,HHS Region 6,Season peak percentage,9.9
+2016,52,2016/2017,52,HHS Region 6,1 wk ahead,4.1
+2016,52,2016/2017,52,HHS Region 6,2 wk ahead,4.9
+2016,52,2016/2017,52,HHS Region 6,3 wk ahead,5.3
+2016,52,2016/2017,52,HHS Region 6,4 wk ahead,6.1
+2016,52,2016/2017,52,HHS Region 7,Season onset,51
+2016,52,2016/2017,52,HHS Region 7,Season peak week,6
+2016,52,2016/2017,52,HHS Region 7,Season peak percentage,6.4
+2016,52,2016/2017,52,HHS Region 7,1 wk ahead,2.9
+2016,52,2016/2017,52,HHS Region 7,2 wk ahead,2.8
+2016,52,2016/2017,52,HHS Region 7,3 wk ahead,3.5
+2016,52,2016/2017,52,HHS Region 7,4 wk ahead,4.6
+2016,52,2016/2017,52,HHS Region 8,Season onset,51
+2016,52,2016/2017,52,HHS Region 8,Season peak week,7
+2016,52,2016/2017,52,HHS Region 8,Season peak percentage,2.7
+2016,52,2016/2017,52,HHS Region 8,1 wk ahead,2.3
+2016,52,2016/2017,52,HHS Region 8,2 wk ahead,1.9
+2016,52,2016/2017,52,HHS Region 8,3 wk ahead,2.3
+2016,52,2016/2017,52,HHS Region 8,4 wk ahead,2.1
+2016,52,2016/2017,52,HHS Region 9,Season onset,51
+2016,52,2016/2017,52,HHS Region 9,Season peak week,52
+2016,52,2016/2017,52,HHS Region 9,Season peak percentage,3.3
+2016,52,2016/2017,52,HHS Region 9,1 wk ahead,3.1
+2016,52,2016/2017,52,HHS Region 9,2 wk ahead,2.8
+2016,52,2016/2017,52,HHS Region 9,3 wk ahead,2.7
+2016,52,2016/2017,52,HHS Region 9,4 wk ahead,3
+2016,52,2016/2017,52,HHS Region 10,Season onset,50
+2016,52,2016/2017,52,HHS Region 10,Season peak week,52
+2016,52,2016/2017,52,HHS Region 10,Season peak percentage,3.7
+2016,52,2016/2017,52,HHS Region 10,1 wk ahead,3
+2016,52,2016/2017,52,HHS Region 10,2 wk ahead,2.2
+2016,52,2016/2017,52,HHS Region 10,3 wk ahead,3.3
+2016,52,2016/2017,52,HHS Region 10,4 wk ahead,2.5
+2017,1,2016/2017,53,US National,Season onset,50
+2017,1,2016/2017,53,US National,Season peak week,6
+2017,1,2016/2017,53,US National,Season peak percentage,5.1
+2017,1,2016/2017,53,US National,1 wk ahead,3.1
+2017,1,2016/2017,53,US National,2 wk ahead,3.5
+2017,1,2016/2017,53,US National,3 wk ahead,3.8
+2017,1,2016/2017,53,US National,4 wk ahead,4.5
+2017,1,2016/2017,53,HHS Region 1,Season onset,52
+2017,1,2016/2017,53,HHS Region 1,Season peak week,6
+2017,1,2016/2017,53,HHS Region 1,Season peak percentage,3.2
+2017,1,2016/2017,53,HHS Region 1,1 wk ahead,1.5
+2017,1,2016/2017,53,HHS Region 1,2 wk ahead,1.7
+2017,1,2016/2017,53,HHS Region 1,3 wk ahead,2.1
+2017,1,2016/2017,53,HHS Region 1,4 wk ahead,2.5
+2017,1,2016/2017,53,HHS Region 2,Season onset,47
+2017,1,2016/2017,53,HHS Region 2,Season peak week,6
+2017,1,2016/2017,53,HHS Region 2,Season peak percentage,6.9
+2017,1,2016/2017,53,HHS Region 2,1 wk ahead,5.1
+2017,1,2016/2017,53,HHS Region 2,2 wk ahead,5.7
+2017,1,2016/2017,53,HHS Region 2,3 wk ahead,6
+2017,1,2016/2017,53,HHS Region 2,4 wk ahead,6.5
+2017,1,2016/2017,53,HHS Region 3,Season onset,51
+2017,1,2016/2017,53,HHS Region 3,Season peak week,7
+2017,1,2016/2017,53,HHS Region 3,Season peak percentage,5.2
+2017,1,2016/2017,53,HHS Region 3,1 wk ahead,2.8
+2017,1,2016/2017,53,HHS Region 3,2 wk ahead,3.1
+2017,1,2016/2017,53,HHS Region 3,3 wk ahead,3.5
+2017,1,2016/2017,53,HHS Region 3,4 wk ahead,3.7
+2017,1,2016/2017,53,HHS Region 4,Season onset,45
+2017,1,2016/2017,53,HHS Region 4,Season peak week,7
+2017,1,2016/2017,53,HHS Region 4,Season peak week,8
+2017,1,2016/2017,53,HHS Region 4,Season peak percentage,5.5
+2017,1,2016/2017,53,HHS Region 4,1 wk ahead,2.9
+2017,1,2016/2017,53,HHS Region 4,2 wk ahead,3.7
+2017,1,2016/2017,53,HHS Region 4,3 wk ahead,3.7
+2017,1,2016/2017,53,HHS Region 4,4 wk ahead,4.5
+2017,1,2016/2017,53,HHS Region 5,Season onset,52
+2017,1,2016/2017,53,HHS Region 5,Season peak week,7
+2017,1,2016/2017,53,HHS Region 5,Season peak week,8
+2017,1,2016/2017,53,HHS Region 5,Season peak percentage,4.3
+2017,1,2016/2017,53,HHS Region 5,1 wk ahead,2.1
+2017,1,2016/2017,53,HHS Region 5,2 wk ahead,2.4
+2017,1,2016/2017,53,HHS Region 5,3 wk ahead,2.8
+2017,1,2016/2017,53,HHS Region 5,4 wk ahead,3.2
+2017,1,2016/2017,53,HHS Region 6,Season onset,52
+2017,1,2016/2017,53,HHS Region 6,Season peak week,6
+2017,1,2016/2017,53,HHS Region 6,Season peak percentage,9.9
+2017,1,2016/2017,53,HHS Region 6,1 wk ahead,4.9
+2017,1,2016/2017,53,HHS Region 6,2 wk ahead,5.3
+2017,1,2016/2017,53,HHS Region 6,3 wk ahead,6.1
+2017,1,2016/2017,53,HHS Region 6,4 wk ahead,8.2
+2017,1,2016/2017,53,HHS Region 7,Season onset,51
+2017,1,2016/2017,53,HHS Region 7,Season peak week,6
+2017,1,2016/2017,53,HHS Region 7,Season peak percentage,6.4
+2017,1,2016/2017,53,HHS Region 7,1 wk ahead,2.8
+2017,1,2016/2017,53,HHS Region 7,2 wk ahead,3.5
+2017,1,2016/2017,53,HHS Region 7,3 wk ahead,4.6
+2017,1,2016/2017,53,HHS Region 7,4 wk ahead,5.5
+2017,1,2016/2017,53,HHS Region 8,Season onset,51
+2017,1,2016/2017,53,HHS Region 8,Season peak week,7
+2017,1,2016/2017,53,HHS Region 8,Season peak percentage,2.7
+2017,1,2016/2017,53,HHS Region 8,1 wk ahead,1.9
+2017,1,2016/2017,53,HHS Region 8,2 wk ahead,2.3
+2017,1,2016/2017,53,HHS Region 8,3 wk ahead,2.1
+2017,1,2016/2017,53,HHS Region 8,4 wk ahead,2.3
+2017,1,2016/2017,53,HHS Region 9,Season onset,51
+2017,1,2016/2017,53,HHS Region 9,Season peak week,52
+2017,1,2016/2017,53,HHS Region 9,Season peak percentage,3.3
+2017,1,2016/2017,53,HHS Region 9,1 wk ahead,2.8
+2017,1,2016/2017,53,HHS Region 9,2 wk ahead,2.7
+2017,1,2016/2017,53,HHS Region 9,3 wk ahead,3
+2017,1,2016/2017,53,HHS Region 9,4 wk ahead,3.1
+2017,1,2016/2017,53,HHS Region 10,Season onset,50
+2017,1,2016/2017,53,HHS Region 10,Season peak week,52
+2017,1,2016/2017,53,HHS Region 10,Season peak percentage,3.7
+2017,1,2016/2017,53,HHS Region 10,1 wk ahead,2.2
+2017,1,2016/2017,53,HHS Region 10,2 wk ahead,3.3
+2017,1,2016/2017,53,HHS Region 10,3 wk ahead,2.5
+2017,1,2016/2017,53,HHS Region 10,4 wk ahead,2.3
+2017,2,2016/2017,54,US National,Season onset,50
+2017,2,2016/2017,54,US National,Season peak week,6
+2017,2,2016/2017,54,US National,Season peak percentage,5.1
+2017,2,2016/2017,54,US National,1 wk ahead,3.5
+2017,2,2016/2017,54,US National,2 wk ahead,3.8
+2017,2,2016/2017,54,US National,3 wk ahead,4.5
+2017,2,2016/2017,54,US National,4 wk ahead,5.1
+2017,2,2016/2017,54,HHS Region 1,Season onset,52
+2017,2,2016/2017,54,HHS Region 1,Season peak week,6
+2017,2,2016/2017,54,HHS Region 1,Season peak percentage,3.2
+2017,2,2016/2017,54,HHS Region 1,1 wk ahead,1.7
+2017,2,2016/2017,54,HHS Region 1,2 wk ahead,2.1
+2017,2,2016/2017,54,HHS Region 1,3 wk ahead,2.5
+2017,2,2016/2017,54,HHS Region 1,4 wk ahead,3.2
+2017,2,2016/2017,54,HHS Region 2,Season onset,47
+2017,2,2016/2017,54,HHS Region 2,Season peak week,6
+2017,2,2016/2017,54,HHS Region 2,Season peak percentage,6.9
+2017,2,2016/2017,54,HHS Region 2,1 wk ahead,5.7
+2017,2,2016/2017,54,HHS Region 2,2 wk ahead,6
+2017,2,2016/2017,54,HHS Region 2,3 wk ahead,6.5
+2017,2,2016/2017,54,HHS Region 2,4 wk ahead,6.9
+2017,2,2016/2017,54,HHS Region 3,Season onset,51
+2017,2,2016/2017,54,HHS Region 3,Season peak week,7
+2017,2,2016/2017,54,HHS Region 3,Season peak percentage,5.2
+2017,2,2016/2017,54,HHS Region 3,1 wk ahead,3.1
+2017,2,2016/2017,54,HHS Region 3,2 wk ahead,3.5
+2017,2,2016/2017,54,HHS Region 3,3 wk ahead,3.7
+2017,2,2016/2017,54,HHS Region 3,4 wk ahead,5.1
+2017,2,2016/2017,54,HHS Region 4,Season onset,45
+2017,2,2016/2017,54,HHS Region 4,Season peak week,7
+2017,2,2016/2017,54,HHS Region 4,Season peak week,8
+2017,2,2016/2017,54,HHS Region 4,Season peak percentage,5.5
+2017,2,2016/2017,54,HHS Region 4,1 wk ahead,3.7
+2017,2,2016/2017,54,HHS Region 4,2 wk ahead,3.7
+2017,2,2016/2017,54,HHS Region 4,3 wk ahead,4.5
+2017,2,2016/2017,54,HHS Region 4,4 wk ahead,5.1
+2017,2,2016/2017,54,HHS Region 5,Season onset,52
+2017,2,2016/2017,54,HHS Region 5,Season peak week,7
+2017,2,2016/2017,54,HHS Region 5,Season peak week,8
+2017,2,2016/2017,54,HHS Region 5,Season peak percentage,4.3
+2017,2,2016/2017,54,HHS Region 5,1 wk ahead,2.4
+2017,2,2016/2017,54,HHS Region 5,2 wk ahead,2.8
+2017,2,2016/2017,54,HHS Region 5,3 wk ahead,3.2
+2017,2,2016/2017,54,HHS Region 5,4 wk ahead,3.9
+2017,2,2016/2017,54,HHS Region 6,Season onset,52
+2017,2,2016/2017,54,HHS Region 6,Season peak week,6
+2017,2,2016/2017,54,HHS Region 6,Season peak percentage,9.9
+2017,2,2016/2017,54,HHS Region 6,1 wk ahead,5.3
+2017,2,2016/2017,54,HHS Region 6,2 wk ahead,6.1
+2017,2,2016/2017,54,HHS Region 6,3 wk ahead,8.2
+2017,2,2016/2017,54,HHS Region 6,4 wk ahead,9.9
+2017,2,2016/2017,54,HHS Region 7,Season onset,51
+2017,2,2016/2017,54,HHS Region 7,Season peak week,6
+2017,2,2016/2017,54,HHS Region 7,Season peak percentage,6.4
+2017,2,2016/2017,54,HHS Region 7,1 wk ahead,3.5
+2017,2,2016/2017,54,HHS Region 7,2 wk ahead,4.6
+2017,2,2016/2017,54,HHS Region 7,3 wk ahead,5.5
+2017,2,2016/2017,54,HHS Region 7,4 wk ahead,6.4
+2017,2,2016/2017,54,HHS Region 8,Season onset,51
+2017,2,2016/2017,54,HHS Region 8,Season peak week,7
+2017,2,2016/2017,54,HHS Region 8,Season peak percentage,2.7
+2017,2,2016/2017,54,HHS Region 8,1 wk ahead,2.3
+2017,2,2016/2017,54,HHS Region 8,2 wk ahead,2.1
+2017,2,2016/2017,54,HHS Region 8,3 wk ahead,2.3
+2017,2,2016/2017,54,HHS Region 8,4 wk ahead,2.3
+2017,2,2016/2017,54,HHS Region 9,Season onset,51
+2017,2,2016/2017,54,HHS Region 9,Season peak week,52
+2017,2,2016/2017,54,HHS Region 9,Season peak percentage,3.3
+2017,2,2016/2017,54,HHS Region 9,1 wk ahead,2.7
+2017,2,2016/2017,54,HHS Region 9,2 wk ahead,3
+2017,2,2016/2017,54,HHS Region 9,3 wk ahead,3.1
+2017,2,2016/2017,54,HHS Region 9,4 wk ahead,2.7
+2017,2,2016/2017,54,HHS Region 10,Season onset,50
+2017,2,2016/2017,54,HHS Region 10,Season peak week,52
+2017,2,2016/2017,54,HHS Region 10,Season peak percentage,3.7
+2017,2,2016/2017,54,HHS Region 10,1 wk ahead,3.3
+2017,2,2016/2017,54,HHS Region 10,2 wk ahead,2.5
+2017,2,2016/2017,54,HHS Region 10,3 wk ahead,2.3
+2017,2,2016/2017,54,HHS Region 10,4 wk ahead,2
+2017,3,2016/2017,55,US National,Season onset,50
+2017,3,2016/2017,55,US National,Season peak week,6
+2017,3,2016/2017,55,US National,Season peak percentage,5.1
+2017,3,2016/2017,55,US National,1 wk ahead,3.8
+2017,3,2016/2017,55,US National,2 wk ahead,4.5
+2017,3,2016/2017,55,US National,3 wk ahead,5.1
+2017,3,2016/2017,55,US National,4 wk ahead,4.9
+2017,3,2016/2017,55,HHS Region 1,Season onset,52
+2017,3,2016/2017,55,HHS Region 1,Season peak week,6
+2017,3,2016/2017,55,HHS Region 1,Season peak percentage,3.2
+2017,3,2016/2017,55,HHS Region 1,1 wk ahead,2.1
+2017,3,2016/2017,55,HHS Region 1,2 wk ahead,2.5
+2017,3,2016/2017,55,HHS Region 1,3 wk ahead,3.2
+2017,3,2016/2017,55,HHS Region 1,4 wk ahead,3
+2017,3,2016/2017,55,HHS Region 2,Season onset,47
+2017,3,2016/2017,55,HHS Region 2,Season peak week,6
+2017,3,2016/2017,55,HHS Region 2,Season peak percentage,6.9
+2017,3,2016/2017,55,HHS Region 2,1 wk ahead,6
+2017,3,2016/2017,55,HHS Region 2,2 wk ahead,6.5
+2017,3,2016/2017,55,HHS Region 2,3 wk ahead,6.9
+2017,3,2016/2017,55,HHS Region 2,4 wk ahead,5.7
+2017,3,2016/2017,55,HHS Region 3,Season onset,51
+2017,3,2016/2017,55,HHS Region 3,Season peak week,7
+2017,3,2016/2017,55,HHS Region 3,Season peak percentage,5.2
+2017,3,2016/2017,55,HHS Region 3,1 wk ahead,3.5
+2017,3,2016/2017,55,HHS Region 3,2 wk ahead,3.7
+2017,3,2016/2017,55,HHS Region 3,3 wk ahead,5.1
+2017,3,2016/2017,55,HHS Region 3,4 wk ahead,5.2
+2017,3,2016/2017,55,HHS Region 4,Season onset,45
+2017,3,2016/2017,55,HHS Region 4,Season peak week,7
+2017,3,2016/2017,55,HHS Region 4,Season peak week,8
+2017,3,2016/2017,55,HHS Region 4,Season peak percentage,5.5
+2017,3,2016/2017,55,HHS Region 4,1 wk ahead,3.7
+2017,3,2016/2017,55,HHS Region 4,2 wk ahead,4.5
+2017,3,2016/2017,55,HHS Region 4,3 wk ahead,5.1
+2017,3,2016/2017,55,HHS Region 4,4 wk ahead,5.5
+2017,3,2016/2017,55,HHS Region 5,Season onset,52
+2017,3,2016/2017,55,HHS Region 5,Season peak week,7
+2017,3,2016/2017,55,HHS Region 5,Season peak week,8
+2017,3,2016/2017,55,HHS Region 5,Season peak percentage,4.3
+2017,3,2016/2017,55,HHS Region 5,1 wk ahead,2.8
+2017,3,2016/2017,55,HHS Region 5,2 wk ahead,3.2
+2017,3,2016/2017,55,HHS Region 5,3 wk ahead,3.9
+2017,3,2016/2017,55,HHS Region 5,4 wk ahead,4.3
+2017,3,2016/2017,55,HHS Region 6,Season onset,52
+2017,3,2016/2017,55,HHS Region 6,Season peak week,6
+2017,3,2016/2017,55,HHS Region 6,Season peak percentage,9.9
+2017,3,2016/2017,55,HHS Region 6,1 wk ahead,6.1
+2017,3,2016/2017,55,HHS Region 6,2 wk ahead,8.2
+2017,3,2016/2017,55,HHS Region 6,3 wk ahead,9.9
+2017,3,2016/2017,55,HHS Region 6,4 wk ahead,8.8
+2017,3,2016/2017,55,HHS Region 7,Season onset,51
+2017,3,2016/2017,55,HHS Region 7,Season peak week,6
+2017,3,2016/2017,55,HHS Region 7,Season peak percentage,6.4
+2017,3,2016/2017,55,HHS Region 7,1 wk ahead,4.6
+2017,3,2016/2017,55,HHS Region 7,2 wk ahead,5.5
+2017,3,2016/2017,55,HHS Region 7,3 wk ahead,6.4
+2017,3,2016/2017,55,HHS Region 7,4 wk ahead,4.9
+2017,3,2016/2017,55,HHS Region 8,Season onset,51
+2017,3,2016/2017,55,HHS Region 8,Season peak week,7
+2017,3,2016/2017,55,HHS Region 8,Season peak percentage,2.7
+2017,3,2016/2017,55,HHS Region 8,1 wk ahead,2.1
+2017,3,2016/2017,55,HHS Region 8,2 wk ahead,2.3
+2017,3,2016/2017,55,HHS Region 8,3 wk ahead,2.3
+2017,3,2016/2017,55,HHS Region 8,4 wk ahead,2.7
+2017,3,2016/2017,55,HHS Region 9,Season onset,51
+2017,3,2016/2017,55,HHS Region 9,Season peak week,52
+2017,3,2016/2017,55,HHS Region 9,Season peak percentage,3.3
+2017,3,2016/2017,55,HHS Region 9,1 wk ahead,3
+2017,3,2016/2017,55,HHS Region 9,2 wk ahead,3.1
+2017,3,2016/2017,55,HHS Region 9,3 wk ahead,2.7
+2017,3,2016/2017,55,HHS Region 9,4 wk ahead,2.5
+2017,3,2016/2017,55,HHS Region 10,Season onset,50
+2017,3,2016/2017,55,HHS Region 10,Season peak week,52
+2017,3,2016/2017,55,HHS Region 10,Season peak percentage,3.7
+2017,3,2016/2017,55,HHS Region 10,1 wk ahead,2.5
+2017,3,2016/2017,55,HHS Region 10,2 wk ahead,2.3
+2017,3,2016/2017,55,HHS Region 10,3 wk ahead,2
+2017,3,2016/2017,55,HHS Region 10,4 wk ahead,1.8
+2017,4,2016/2017,56,US National,Season onset,50
+2017,4,2016/2017,56,US National,Season peak week,6
+2017,4,2016/2017,56,US National,Season peak percentage,5.1
+2017,4,2016/2017,56,US National,1 wk ahead,4.5
+2017,4,2016/2017,56,US National,2 wk ahead,5.1
+2017,4,2016/2017,56,US National,3 wk ahead,4.9
+2017,4,2016/2017,56,US National,4 wk ahead,4.6
+2017,4,2016/2017,56,HHS Region 1,Season onset,52
+2017,4,2016/2017,56,HHS Region 1,Season peak week,6
+2017,4,2016/2017,56,HHS Region 1,Season peak percentage,3.2
+2017,4,2016/2017,56,HHS Region 1,1 wk ahead,2.5
+2017,4,2016/2017,56,HHS Region 1,2 wk ahead,3.2
+2017,4,2016/2017,56,HHS Region 1,3 wk ahead,3
+2017,4,2016/2017,56,HHS Region 1,4 wk ahead,3
+2017,4,2016/2017,56,HHS Region 2,Season onset,47
+2017,4,2016/2017,56,HHS Region 2,Season peak week,6
+2017,4,2016/2017,56,HHS Region 2,Season peak percentage,6.9
+2017,4,2016/2017,56,HHS Region 2,1 wk ahead,6.5
+2017,4,2016/2017,56,HHS Region 2,2 wk ahead,6.9
+2017,4,2016/2017,56,HHS Region 2,3 wk ahead,5.7
+2017,4,2016/2017,56,HHS Region 2,4 wk ahead,4.7
+2017,4,2016/2017,56,HHS Region 3,Season onset,51
+2017,4,2016/2017,56,HHS Region 3,Season peak week,7
+2017,4,2016/2017,56,HHS Region 3,Season peak percentage,5.2
+2017,4,2016/2017,56,HHS Region 3,1 wk ahead,3.7
+2017,4,2016/2017,56,HHS Region 3,2 wk ahead,5.1
+2017,4,2016/2017,56,HHS Region 3,3 wk ahead,5.2
+2017,4,2016/2017,56,HHS Region 3,4 wk ahead,5
+2017,4,2016/2017,56,HHS Region 4,Season onset,45
+2017,4,2016/2017,56,HHS Region 4,Season peak week,7
+2017,4,2016/2017,56,HHS Region 4,Season peak week,8
+2017,4,2016/2017,56,HHS Region 4,Season peak percentage,5.5
+2017,4,2016/2017,56,HHS Region 4,1 wk ahead,4.5
+2017,4,2016/2017,56,HHS Region 4,2 wk ahead,5.1
+2017,4,2016/2017,56,HHS Region 4,3 wk ahead,5.5
+2017,4,2016/2017,56,HHS Region 4,4 wk ahead,5.5
+2017,4,2016/2017,56,HHS Region 5,Season onset,52
+2017,4,2016/2017,56,HHS Region 5,Season peak week,7
+2017,4,2016/2017,56,HHS Region 5,Season peak week,8
+2017,4,2016/2017,56,HHS Region 5,Season peak percentage,4.3
+2017,4,2016/2017,56,HHS Region 5,1 wk ahead,3.2
+2017,4,2016/2017,56,HHS Region 5,2 wk ahead,3.9
+2017,4,2016/2017,56,HHS Region 5,3 wk ahead,4.3
+2017,4,2016/2017,56,HHS Region 5,4 wk ahead,4.3
+2017,4,2016/2017,56,HHS Region 6,Season onset,52
+2017,4,2016/2017,56,HHS Region 6,Season peak week,6
+2017,4,2016/2017,56,HHS Region 6,Season peak percentage,9.9
+2017,4,2016/2017,56,HHS Region 6,1 wk ahead,8.2
+2017,4,2016/2017,56,HHS Region 6,2 wk ahead,9.9
+2017,4,2016/2017,56,HHS Region 6,3 wk ahead,8.8
+2017,4,2016/2017,56,HHS Region 6,4 wk ahead,8.2
+2017,4,2016/2017,56,HHS Region 7,Season onset,51
+2017,4,2016/2017,56,HHS Region 7,Season peak week,6
+2017,4,2016/2017,56,HHS Region 7,Season peak percentage,6.4
+2017,4,2016/2017,56,HHS Region 7,1 wk ahead,5.5
+2017,4,2016/2017,56,HHS Region 7,2 wk ahead,6.4
+2017,4,2016/2017,56,HHS Region 7,3 wk ahead,4.9
+2017,4,2016/2017,56,HHS Region 7,4 wk ahead,4
+2017,4,2016/2017,56,HHS Region 8,Season onset,51
+2017,4,2016/2017,56,HHS Region 8,Season peak week,7
+2017,4,2016/2017,56,HHS Region 8,Season peak percentage,2.7
+2017,4,2016/2017,56,HHS Region 8,1 wk ahead,2.3
+2017,4,2016/2017,56,HHS Region 8,2 wk ahead,2.3
+2017,4,2016/2017,56,HHS Region 8,3 wk ahead,2.7
+2017,4,2016/2017,56,HHS Region 8,4 wk ahead,1.6
+2017,4,2016/2017,56,HHS Region 9,Season onset,51
+2017,4,2016/2017,56,HHS Region 9,Season peak week,52
+2017,4,2016/2017,56,HHS Region 9,Season peak percentage,3.3
+2017,4,2016/2017,56,HHS Region 9,1 wk ahead,3.1
+2017,4,2016/2017,56,HHS Region 9,2 wk ahead,2.7
+2017,4,2016/2017,56,HHS Region 9,3 wk ahead,2.5
+2017,4,2016/2017,56,HHS Region 9,4 wk ahead,2.5
+2017,4,2016/2017,56,HHS Region 10,Season onset,50
+2017,4,2016/2017,56,HHS Region 10,Season peak week,52
+2017,4,2016/2017,56,HHS Region 10,Season peak percentage,3.7
+2017,4,2016/2017,56,HHS Region 10,1 wk ahead,2.3
+2017,4,2016/2017,56,HHS Region 10,2 wk ahead,2
+2017,4,2016/2017,56,HHS Region 10,3 wk ahead,1.8
+2017,4,2016/2017,56,HHS Region 10,4 wk ahead,1.5
+2017,5,2016/2017,57,US National,Season onset,50
+2017,5,2016/2017,57,US National,Season peak week,6
+2017,5,2016/2017,57,US National,Season peak percentage,5.1
+2017,5,2016/2017,57,US National,1 wk ahead,5.1
+2017,5,2016/2017,57,US National,2 wk ahead,4.9
+2017,5,2016/2017,57,US National,3 wk ahead,4.6
+2017,5,2016/2017,57,US National,4 wk ahead,3.6
+2017,5,2016/2017,57,HHS Region 1,Season onset,52
+2017,5,2016/2017,57,HHS Region 1,Season peak week,6
+2017,5,2016/2017,57,HHS Region 1,Season peak percentage,3.2
+2017,5,2016/2017,57,HHS Region 1,1 wk ahead,3.2
+2017,5,2016/2017,57,HHS Region 1,2 wk ahead,3
+2017,5,2016/2017,57,HHS Region 1,3 wk ahead,3
+2017,5,2016/2017,57,HHS Region 1,4 wk ahead,2.2
+2017,5,2016/2017,57,HHS Region 2,Season onset,47
+2017,5,2016/2017,57,HHS Region 2,Season peak week,6
+2017,5,2016/2017,57,HHS Region 2,Season peak percentage,6.9
+2017,5,2016/2017,57,HHS Region 2,1 wk ahead,6.9
+2017,5,2016/2017,57,HHS Region 2,2 wk ahead,5.7
+2017,5,2016/2017,57,HHS Region 2,3 wk ahead,4.7
+2017,5,2016/2017,57,HHS Region 2,4 wk ahead,3.1
+2017,5,2016/2017,57,HHS Region 3,Season onset,51
+2017,5,2016/2017,57,HHS Region 3,Season peak week,7
+2017,5,2016/2017,57,HHS Region 3,Season peak percentage,5.2
+2017,5,2016/2017,57,HHS Region 3,1 wk ahead,5.1
+2017,5,2016/2017,57,HHS Region 3,2 wk ahead,5.2
+2017,5,2016/2017,57,HHS Region 3,3 wk ahead,5
+2017,5,2016/2017,57,HHS Region 3,4 wk ahead,3.2
+2017,5,2016/2017,57,HHS Region 4,Season onset,45
+2017,5,2016/2017,57,HHS Region 4,Season peak week,7
+2017,5,2016/2017,57,HHS Region 4,Season peak week,8
+2017,5,2016/2017,57,HHS Region 4,Season peak percentage,5.5
+2017,5,2016/2017,57,HHS Region 4,1 wk ahead,5.1
+2017,5,2016/2017,57,HHS Region 4,2 wk ahead,5.5
+2017,5,2016/2017,57,HHS Region 4,3 wk ahead,5.5
+2017,5,2016/2017,57,HHS Region 4,4 wk ahead,4.5
+2017,5,2016/2017,57,HHS Region 5,Season onset,52
+2017,5,2016/2017,57,HHS Region 5,Season peak week,7
+2017,5,2016/2017,57,HHS Region 5,Season peak week,8
+2017,5,2016/2017,57,HHS Region 5,Season peak percentage,4.3
+2017,5,2016/2017,57,HHS Region 5,1 wk ahead,3.9
+2017,5,2016/2017,57,HHS Region 5,2 wk ahead,4.3
+2017,5,2016/2017,57,HHS Region 5,3 wk ahead,4.3
+2017,5,2016/2017,57,HHS Region 5,4 wk ahead,3
+2017,5,2016/2017,57,HHS Region 6,Season onset,52
+2017,5,2016/2017,57,HHS Region 6,Season peak week,6
+2017,5,2016/2017,57,HHS Region 6,Season peak percentage,9.9
+2017,5,2016/2017,57,HHS Region 6,1 wk ahead,9.9
+2017,5,2016/2017,57,HHS Region 6,2 wk ahead,8.8
+2017,5,2016/2017,57,HHS Region 6,3 wk ahead,8.2
+2017,5,2016/2017,57,HHS Region 6,4 wk ahead,6.9
+2017,5,2016/2017,57,HHS Region 7,Season onset,51
+2017,5,2016/2017,57,HHS Region 7,Season peak week,6
+2017,5,2016/2017,57,HHS Region 7,Season peak percentage,6.4
+2017,5,2016/2017,57,HHS Region 7,1 wk ahead,6.4
+2017,5,2016/2017,57,HHS Region 7,2 wk ahead,4.9
+2017,5,2016/2017,57,HHS Region 7,3 wk ahead,4
+2017,5,2016/2017,57,HHS Region 7,4 wk ahead,2.8
+2017,5,2016/2017,57,HHS Region 8,Season onset,51
+2017,5,2016/2017,57,HHS Region 8,Season peak week,7
+2017,5,2016/2017,57,HHS Region 8,Season peak percentage,2.7
+2017,5,2016/2017,57,HHS Region 8,1 wk ahead,2.3
+2017,5,2016/2017,57,HHS Region 8,2 wk ahead,2.7
+2017,5,2016/2017,57,HHS Region 8,3 wk ahead,1.6
+2017,5,2016/2017,57,HHS Region 8,4 wk ahead,1.5
+2017,5,2016/2017,57,HHS Region 9,Season onset,51
+2017,5,2016/2017,57,HHS Region 9,Season peak week,52
+2017,5,2016/2017,57,HHS Region 9,Season peak percentage,3.3
+2017,5,2016/2017,57,HHS Region 9,1 wk ahead,2.7
+2017,5,2016/2017,57,HHS Region 9,2 wk ahead,2.5
+2017,5,2016/2017,57,HHS Region 9,3 wk ahead,2.5
+2017,5,2016/2017,57,HHS Region 9,4 wk ahead,2.3
+2017,5,2016/2017,57,HHS Region 10,Season onset,50
+2017,5,2016/2017,57,HHS Region 10,Season peak week,52
+2017,5,2016/2017,57,HHS Region 10,Season peak percentage,3.7
+2017,5,2016/2017,57,HHS Region 10,1 wk ahead,2
+2017,5,2016/2017,57,HHS Region 10,2 wk ahead,1.8
+2017,5,2016/2017,57,HHS Region 10,3 wk ahead,1.5
+2017,5,2016/2017,57,HHS Region 10,4 wk ahead,1.5
+2017,6,2016/2017,58,US National,Season onset,50
+2017,6,2016/2017,58,US National,Season peak week,6
+2017,6,2016/2017,58,US National,Season peak percentage,5.1
+2017,6,2016/2017,58,US National,1 wk ahead,4.9
+2017,6,2016/2017,58,US National,2 wk ahead,4.6
+2017,6,2016/2017,58,US National,3 wk ahead,3.6
+2017,6,2016/2017,58,US National,4 wk ahead,3.5
+2017,6,2016/2017,58,HHS Region 1,Season onset,52
+2017,6,2016/2017,58,HHS Region 1,Season peak week,6
+2017,6,2016/2017,58,HHS Region 1,Season peak percentage,3.2
+2017,6,2016/2017,58,HHS Region 1,1 wk ahead,3
+2017,6,2016/2017,58,HHS Region 1,2 wk ahead,3
+2017,6,2016/2017,58,HHS Region 1,3 wk ahead,2.2
+2017,6,2016/2017,58,HHS Region 1,4 wk ahead,2.1
+2017,6,2016/2017,58,HHS Region 2,Season onset,47
+2017,6,2016/2017,58,HHS Region 2,Season peak week,6
+2017,6,2016/2017,58,HHS Region 2,Season peak percentage,6.9
+2017,6,2016/2017,58,HHS Region 2,1 wk ahead,5.7
+2017,6,2016/2017,58,HHS Region 2,2 wk ahead,4.7
+2017,6,2016/2017,58,HHS Region 2,3 wk ahead,3.1
+2017,6,2016/2017,58,HHS Region 2,4 wk ahead,3.1
+2017,6,2016/2017,58,HHS Region 3,Season onset,51
+2017,6,2016/2017,58,HHS Region 3,Season peak week,7
+2017,6,2016/2017,58,HHS Region 3,Season peak percentage,5.2
+2017,6,2016/2017,58,HHS Region 3,1 wk ahead,5.2
+2017,6,2016/2017,58,HHS Region 3,2 wk ahead,5
+2017,6,2016/2017,58,HHS Region 3,3 wk ahead,3.2
+2017,6,2016/2017,58,HHS Region 3,4 wk ahead,3.2
+2017,6,2016/2017,58,HHS Region 4,Season onset,45
+2017,6,2016/2017,58,HHS Region 4,Season peak week,7
+2017,6,2016/2017,58,HHS Region 4,Season peak week,8
+2017,6,2016/2017,58,HHS Region 4,Season peak percentage,5.5
+2017,6,2016/2017,58,HHS Region 4,1 wk ahead,5.5
+2017,6,2016/2017,58,HHS Region 4,2 wk ahead,5.5
+2017,6,2016/2017,58,HHS Region 4,3 wk ahead,4.5
+2017,6,2016/2017,58,HHS Region 4,4 wk ahead,4.5
+2017,6,2016/2017,58,HHS Region 5,Season onset,52
+2017,6,2016/2017,58,HHS Region 5,Season peak week,7
+2017,6,2016/2017,58,HHS Region 5,Season peak week,8
+2017,6,2016/2017,58,HHS Region 5,Season peak percentage,4.3
+2017,6,2016/2017,58,HHS Region 5,1 wk ahead,4.3
+2017,6,2016/2017,58,HHS Region 5,2 wk ahead,4.3
+2017,6,2016/2017,58,HHS Region 5,3 wk ahead,3
+2017,6,2016/2017,58,HHS Region 5,4 wk ahead,3.3
+2017,6,2016/2017,58,HHS Region 6,Season onset,52
+2017,6,2016/2017,58,HHS Region 6,Season peak week,6
+2017,6,2016/2017,58,HHS Region 6,Season peak percentage,9.9
+2017,6,2016/2017,58,HHS Region 6,1 wk ahead,8.8
+2017,6,2016/2017,58,HHS Region 6,2 wk ahead,8.2
+2017,6,2016/2017,58,HHS Region 6,3 wk ahead,6.9
+2017,6,2016/2017,58,HHS Region 6,4 wk ahead,6.5
+2017,6,2016/2017,58,HHS Region 7,Season onset,51
+2017,6,2016/2017,58,HHS Region 7,Season peak week,6
+2017,6,2016/2017,58,HHS Region 7,Season peak percentage,6.4
+2017,6,2016/2017,58,HHS Region 7,1 wk ahead,4.9
+2017,6,2016/2017,58,HHS Region 7,2 wk ahead,4
+2017,6,2016/2017,58,HHS Region 7,3 wk ahead,2.8
+2017,6,2016/2017,58,HHS Region 7,4 wk ahead,2.8
+2017,6,2016/2017,58,HHS Region 8,Season onset,51
+2017,6,2016/2017,58,HHS Region 8,Season peak week,7
+2017,6,2016/2017,58,HHS Region 8,Season peak percentage,2.7
+2017,6,2016/2017,58,HHS Region 8,1 wk ahead,2.7
+2017,6,2016/2017,58,HHS Region 8,2 wk ahead,1.6
+2017,6,2016/2017,58,HHS Region 8,3 wk ahead,1.5
+2017,6,2016/2017,58,HHS Region 8,4 wk ahead,1.4
+2017,6,2016/2017,58,HHS Region 9,Season onset,51
+2017,6,2016/2017,58,HHS Region 9,Season peak week,52
+2017,6,2016/2017,58,HHS Region 9,Season peak percentage,3.3
+2017,6,2016/2017,58,HHS Region 9,1 wk ahead,2.5
+2017,6,2016/2017,58,HHS Region 9,2 wk ahead,2.5
+2017,6,2016/2017,58,HHS Region 9,3 wk ahead,2.3
+2017,6,2016/2017,58,HHS Region 9,4 wk ahead,2.3
+2017,6,2016/2017,58,HHS Region 10,Season onset,50
+2017,6,2016/2017,58,HHS Region 10,Season peak week,52
+2017,6,2016/2017,58,HHS Region 10,Season peak percentage,3.7
+2017,6,2016/2017,58,HHS Region 10,1 wk ahead,1.8
+2017,6,2016/2017,58,HHS Region 10,2 wk ahead,1.5
+2017,6,2016/2017,58,HHS Region 10,3 wk ahead,1.5
+2017,6,2016/2017,58,HHS Region 10,4 wk ahead,1
+2017,7,2016/2017,59,US National,Season onset,50
+2017,7,2016/2017,59,US National,Season peak week,6
+2017,7,2016/2017,59,US National,Season peak percentage,5.1
+2017,7,2016/2017,59,US National,1 wk ahead,4.6
+2017,7,2016/2017,59,US National,2 wk ahead,3.6
+2017,7,2016/2017,59,US National,3 wk ahead,3.5
+2017,7,2016/2017,59,US National,4 wk ahead,3.2
+2017,7,2016/2017,59,HHS Region 1,Season onset,52
+2017,7,2016/2017,59,HHS Region 1,Season peak week,6
+2017,7,2016/2017,59,HHS Region 1,Season peak percentage,3.2
+2017,7,2016/2017,59,HHS Region 1,1 wk ahead,3
+2017,7,2016/2017,59,HHS Region 1,2 wk ahead,2.2
+2017,7,2016/2017,59,HHS Region 1,3 wk ahead,2.1
+2017,7,2016/2017,59,HHS Region 1,4 wk ahead,2.1
+2017,7,2016/2017,59,HHS Region 2,Season onset,47
+2017,7,2016/2017,59,HHS Region 2,Season peak week,6
+2017,7,2016/2017,59,HHS Region 2,Season peak percentage,6.9
+2017,7,2016/2017,59,HHS Region 2,1 wk ahead,4.7
+2017,7,2016/2017,59,HHS Region 2,2 wk ahead,3.1
+2017,7,2016/2017,59,HHS Region 2,3 wk ahead,3.1
+2017,7,2016/2017,59,HHS Region 2,4 wk ahead,3.3
+2017,7,2016/2017,59,HHS Region 3,Season onset,51
+2017,7,2016/2017,59,HHS Region 3,Season peak week,7
+2017,7,2016/2017,59,HHS Region 3,Season peak percentage,5.2
+2017,7,2016/2017,59,HHS Region 3,1 wk ahead,5
+2017,7,2016/2017,59,HHS Region 3,2 wk ahead,3.2
+2017,7,2016/2017,59,HHS Region 3,3 wk ahead,3.2
+2017,7,2016/2017,59,HHS Region 3,4 wk ahead,3.4
+2017,7,2016/2017,59,HHS Region 4,Season onset,45
+2017,7,2016/2017,59,HHS Region 4,Season peak week,7
+2017,7,2016/2017,59,HHS Region 4,Season peak week,8
+2017,7,2016/2017,59,HHS Region 4,Season peak percentage,5.5
+2017,7,2016/2017,59,HHS Region 4,1 wk ahead,5.5
+2017,7,2016/2017,59,HHS Region 4,2 wk ahead,4.5
+2017,7,2016/2017,59,HHS Region 4,3 wk ahead,4.5
+2017,7,2016/2017,59,HHS Region 4,4 wk ahead,3.9
+2017,7,2016/2017,59,HHS Region 5,Season onset,52
+2017,7,2016/2017,59,HHS Region 5,Season peak week,7
+2017,7,2016/2017,59,HHS Region 5,Season peak week,8
+2017,7,2016/2017,59,HHS Region 5,Season peak percentage,4.3
+2017,7,2016/2017,59,HHS Region 5,1 wk ahead,4.3
+2017,7,2016/2017,59,HHS Region 5,2 wk ahead,3
+2017,7,2016/2017,59,HHS Region 5,3 wk ahead,3.3
+2017,7,2016/2017,59,HHS Region 5,4 wk ahead,3
+2017,7,2016/2017,59,HHS Region 6,Season onset,52
+2017,7,2016/2017,59,HHS Region 6,Season peak week,6
+2017,7,2016/2017,59,HHS Region 6,Season peak percentage,9.9
+2017,7,2016/2017,59,HHS Region 6,1 wk ahead,8.2
+2017,7,2016/2017,59,HHS Region 6,2 wk ahead,6.9
+2017,7,2016/2017,59,HHS Region 6,3 wk ahead,6.5
+2017,7,2016/2017,59,HHS Region 6,4 wk ahead,5.4
+2017,7,2016/2017,59,HHS Region 7,Season onset,51
+2017,7,2016/2017,59,HHS Region 7,Season peak week,6
+2017,7,2016/2017,59,HHS Region 7,Season peak percentage,6.4
+2017,7,2016/2017,59,HHS Region 7,1 wk ahead,4
+2017,7,2016/2017,59,HHS Region 7,2 wk ahead,2.8
+2017,7,2016/2017,59,HHS Region 7,3 wk ahead,2.8
+2017,7,2016/2017,59,HHS Region 7,4 wk ahead,2.4
+2017,7,2016/2017,59,HHS Region 8,Season onset,51
+2017,7,2016/2017,59,HHS Region 8,Season peak week,7
+2017,7,2016/2017,59,HHS Region 8,Season peak percentage,2.7
+2017,7,2016/2017,59,HHS Region 8,1 wk ahead,1.6
+2017,7,2016/2017,59,HHS Region 8,2 wk ahead,1.5
+2017,7,2016/2017,59,HHS Region 8,3 wk ahead,1.4
+2017,7,2016/2017,59,HHS Region 8,4 wk ahead,1.1
+2017,7,2016/2017,59,HHS Region 9,Season onset,51
+2017,7,2016/2017,59,HHS Region 9,Season peak week,52
+2017,7,2016/2017,59,HHS Region 9,Season peak percentage,3.3
+2017,7,2016/2017,59,HHS Region 9,1 wk ahead,2.5
+2017,7,2016/2017,59,HHS Region 9,2 wk ahead,2.3
+2017,7,2016/2017,59,HHS Region 9,3 wk ahead,2.3
+2017,7,2016/2017,59,HHS Region 9,4 wk ahead,2.3
+2017,7,2016/2017,59,HHS Region 10,Season onset,50
+2017,7,2016/2017,59,HHS Region 10,Season peak week,52
+2017,7,2016/2017,59,HHS Region 10,Season peak percentage,3.7
+2017,7,2016/2017,59,HHS Region 10,1 wk ahead,1.5
+2017,7,2016/2017,59,HHS Region 10,2 wk ahead,1.5
+2017,7,2016/2017,59,HHS Region 10,3 wk ahead,1
+2017,7,2016/2017,59,HHS Region 10,4 wk ahead,1.3
+2017,8,2016/2017,60,US National,Season onset,50
+2017,8,2016/2017,60,US National,Season peak week,6
+2017,8,2016/2017,60,US National,Season peak percentage,5.1
+2017,8,2016/2017,60,US National,1 wk ahead,3.6
+2017,8,2016/2017,60,US National,2 wk ahead,3.5
+2017,8,2016/2017,60,US National,3 wk ahead,3.2
+2017,8,2016/2017,60,US National,4 wk ahead,3.1
+2017,8,2016/2017,60,HHS Region 1,Season onset,52
+2017,8,2016/2017,60,HHS Region 1,Season peak week,6
+2017,8,2016/2017,60,HHS Region 1,Season peak percentage,3.2
+2017,8,2016/2017,60,HHS Region 1,1 wk ahead,2.2
+2017,8,2016/2017,60,HHS Region 1,2 wk ahead,2.1
+2017,8,2016/2017,60,HHS Region 1,3 wk ahead,2.1
+2017,8,2016/2017,60,HHS Region 1,4 wk ahead,1.9
+2017,8,2016/2017,60,HHS Region 2,Season onset,47
+2017,8,2016/2017,60,HHS Region 2,Season peak week,6
+2017,8,2016/2017,60,HHS Region 2,Season peak percentage,6.9
+2017,8,2016/2017,60,HHS Region 2,1 wk ahead,3.1
+2017,8,2016/2017,60,HHS Region 2,2 wk ahead,3.1
+2017,8,2016/2017,60,HHS Region 2,3 wk ahead,3.3
+2017,8,2016/2017,60,HHS Region 2,4 wk ahead,3.1
+2017,8,2016/2017,60,HHS Region 3,Season onset,51
+2017,8,2016/2017,60,HHS Region 3,Season peak week,7
+2017,8,2016/2017,60,HHS Region 3,Season peak percentage,5.2
+2017,8,2016/2017,60,HHS Region 3,1 wk ahead,3.2
+2017,8,2016/2017,60,HHS Region 3,2 wk ahead,3.2
+2017,8,2016/2017,60,HHS Region 3,3 wk ahead,3.4
+2017,8,2016/2017,60,HHS Region 3,4 wk ahead,3
+2017,8,2016/2017,60,HHS Region 4,Season onset,45
+2017,8,2016/2017,60,HHS Region 4,Season peak week,7
+2017,8,2016/2017,60,HHS Region 4,Season peak week,8
+2017,8,2016/2017,60,HHS Region 4,Season peak percentage,5.5
+2017,8,2016/2017,60,HHS Region 4,1 wk ahead,4.5
+2017,8,2016/2017,60,HHS Region 4,2 wk ahead,4.5
+2017,8,2016/2017,60,HHS Region 4,3 wk ahead,3.9
+2017,8,2016/2017,60,HHS Region 4,4 wk ahead,4.7
+2017,8,2016/2017,60,HHS Region 5,Season onset,52
+2017,8,2016/2017,60,HHS Region 5,Season peak week,7
+2017,8,2016/2017,60,HHS Region 5,Season peak week,8
+2017,8,2016/2017,60,HHS Region 5,Season peak percentage,4.3
+2017,8,2016/2017,60,HHS Region 5,1 wk ahead,3
+2017,8,2016/2017,60,HHS Region 5,2 wk ahead,3.3
+2017,8,2016/2017,60,HHS Region 5,3 wk ahead,3
+2017,8,2016/2017,60,HHS Region 5,4 wk ahead,2.8
+2017,8,2016/2017,60,HHS Region 6,Season onset,52
+2017,8,2016/2017,60,HHS Region 6,Season peak week,6
+2017,8,2016/2017,60,HHS Region 6,Season peak percentage,9.9
+2017,8,2016/2017,60,HHS Region 6,1 wk ahead,6.9
+2017,8,2016/2017,60,HHS Region 6,2 wk ahead,6.5
+2017,8,2016/2017,60,HHS Region 6,3 wk ahead,5.4
+2017,8,2016/2017,60,HHS Region 6,4 wk ahead,4.4
+2017,8,2016/2017,60,HHS Region 7,Season onset,51
+2017,8,2016/2017,60,HHS Region 7,Season peak week,6
+2017,8,2016/2017,60,HHS Region 7,Season peak percentage,6.4
+2017,8,2016/2017,60,HHS Region 7,1 wk ahead,2.8
+2017,8,2016/2017,60,HHS Region 7,2 wk ahead,2.8
+2017,8,2016/2017,60,HHS Region 7,3 wk ahead,2.4
+2017,8,2016/2017,60,HHS Region 7,4 wk ahead,2
+2017,8,2016/2017,60,HHS Region 8,Season onset,51
+2017,8,2016/2017,60,HHS Region 8,Season peak week,7
+2017,8,2016/2017,60,HHS Region 8,Season peak percentage,2.7
+2017,8,2016/2017,60,HHS Region 8,1 wk ahead,1.5
+2017,8,2016/2017,60,HHS Region 8,2 wk ahead,1.4
+2017,8,2016/2017,60,HHS Region 8,3 wk ahead,1.1
+2017,8,2016/2017,60,HHS Region 8,4 wk ahead,1.3
+2017,8,2016/2017,60,HHS Region 9,Season onset,51
+2017,8,2016/2017,60,HHS Region 9,Season peak week,52
+2017,8,2016/2017,60,HHS Region 9,Season peak percentage,3.3
+2017,8,2016/2017,60,HHS Region 9,1 wk ahead,2.3
+2017,8,2016/2017,60,HHS Region 9,2 wk ahead,2.3
+2017,8,2016/2017,60,HHS Region 9,3 wk ahead,2.3
+2017,8,2016/2017,60,HHS Region 9,4 wk ahead,2
+2017,8,2016/2017,60,HHS Region 10,Season onset,50
+2017,8,2016/2017,60,HHS Region 10,Season peak week,52
+2017,8,2016/2017,60,HHS Region 10,Season peak percentage,3.7
+2017,8,2016/2017,60,HHS Region 10,1 wk ahead,1.5
+2017,8,2016/2017,60,HHS Region 10,2 wk ahead,1
+2017,8,2016/2017,60,HHS Region 10,3 wk ahead,1.3
+2017,8,2016/2017,60,HHS Region 10,4 wk ahead,0.9
+2017,9,2016/2017,61,US National,Season onset,50
+2017,9,2016/2017,61,US National,Season peak week,6
+2017,9,2016/2017,61,US National,Season peak percentage,5.1
+2017,9,2016/2017,61,US National,1 wk ahead,3.5
+2017,9,2016/2017,61,US National,2 wk ahead,3.2
+2017,9,2016/2017,61,US National,3 wk ahead,3.1
+2017,9,2016/2017,61,US National,4 wk ahead,2.8
+2017,9,2016/2017,61,HHS Region 1,Season onset,52
+2017,9,2016/2017,61,HHS Region 1,Season peak week,6
+2017,9,2016/2017,61,HHS Region 1,Season peak percentage,3.2
+2017,9,2016/2017,61,HHS Region 1,1 wk ahead,2.1
+2017,9,2016/2017,61,HHS Region 1,2 wk ahead,2.1
+2017,9,2016/2017,61,HHS Region 1,3 wk ahead,1.9
+2017,9,2016/2017,61,HHS Region 1,4 wk ahead,2
+2017,9,2016/2017,61,HHS Region 2,Season onset,47
+2017,9,2016/2017,61,HHS Region 2,Season peak week,6
+2017,9,2016/2017,61,HHS Region 2,Season peak percentage,6.9
+2017,9,2016/2017,61,HHS Region 2,1 wk ahead,3.1
+2017,9,2016/2017,61,HHS Region 2,2 wk ahead,3.3
+2017,9,2016/2017,61,HHS Region 2,3 wk ahead,3.1
+2017,9,2016/2017,61,HHS Region 2,4 wk ahead,3.7
+2017,9,2016/2017,61,HHS Region 3,Season onset,51
+2017,9,2016/2017,61,HHS Region 3,Season peak week,7
+2017,9,2016/2017,61,HHS Region 3,Season peak percentage,5.2
+2017,9,2016/2017,61,HHS Region 3,1 wk ahead,3.2
+2017,9,2016/2017,61,HHS Region 3,2 wk ahead,3.4
+2017,9,2016/2017,61,HHS Region 3,3 wk ahead,3
+2017,9,2016/2017,61,HHS Region 3,4 wk ahead,3.2
+2017,9,2016/2017,61,HHS Region 4,Season onset,45
+2017,9,2016/2017,61,HHS Region 4,Season peak week,7
+2017,9,2016/2017,61,HHS Region 4,Season peak week,8
+2017,9,2016/2017,61,HHS Region 4,Season peak percentage,5.5
+2017,9,2016/2017,61,HHS Region 4,1 wk ahead,4.5
+2017,9,2016/2017,61,HHS Region 4,2 wk ahead,3.9
+2017,9,2016/2017,61,HHS Region 4,3 wk ahead,4.7
+2017,9,2016/2017,61,HHS Region 4,4 wk ahead,3.7
+2017,9,2016/2017,61,HHS Region 5,Season onset,52
+2017,9,2016/2017,61,HHS Region 5,Season peak week,7
+2017,9,2016/2017,61,HHS Region 5,Season peak week,8
+2017,9,2016/2017,61,HHS Region 5,Season peak percentage,4.3
+2017,9,2016/2017,61,HHS Region 5,1 wk ahead,3.3
+2017,9,2016/2017,61,HHS Region 5,2 wk ahead,3
+2017,9,2016/2017,61,HHS Region 5,3 wk ahead,2.8
+2017,9,2016/2017,61,HHS Region 5,4 wk ahead,2.4
+2017,9,2016/2017,61,HHS Region 6,Season onset,52
+2017,9,2016/2017,61,HHS Region 6,Season peak week,6
+2017,9,2016/2017,61,HHS Region 6,Season peak percentage,9.9
+2017,9,2016/2017,61,HHS Region 6,1 wk ahead,6.5
+2017,9,2016/2017,61,HHS Region 6,2 wk ahead,5.4
+2017,9,2016/2017,61,HHS Region 6,3 wk ahead,4.4
+2017,9,2016/2017,61,HHS Region 6,4 wk ahead,3.7
+2017,9,2016/2017,61,HHS Region 7,Season onset,51
+2017,9,2016/2017,61,HHS Region 7,Season peak week,6
+2017,9,2016/2017,61,HHS Region 7,Season peak percentage,6.4
+2017,9,2016/2017,61,HHS Region 7,1 wk ahead,2.8
+2017,9,2016/2017,61,HHS Region 7,2 wk ahead,2.4
+2017,9,2016/2017,61,HHS Region 7,3 wk ahead,2
+2017,9,2016/2017,61,HHS Region 7,4 wk ahead,1.7
+2017,9,2016/2017,61,HHS Region 8,Season onset,51
+2017,9,2016/2017,61,HHS Region 8,Season peak week,7
+2017,9,2016/2017,61,HHS Region 8,Season peak percentage,2.7
+2017,9,2016/2017,61,HHS Region 8,1 wk ahead,1.4
+2017,9,2016/2017,61,HHS Region 8,2 wk ahead,1.1
+2017,9,2016/2017,61,HHS Region 8,3 wk ahead,1.3
+2017,9,2016/2017,61,HHS Region 8,4 wk ahead,1.1
+2017,9,2016/2017,61,HHS Region 9,Season onset,51
+2017,9,2016/2017,61,HHS Region 9,Season peak week,52
+2017,9,2016/2017,61,HHS Region 9,Season peak percentage,3.3
+2017,9,2016/2017,61,HHS Region 9,1 wk ahead,2.3
+2017,9,2016/2017,61,HHS Region 9,2 wk ahead,2.3
+2017,9,2016/2017,61,HHS Region 9,3 wk ahead,2
+2017,9,2016/2017,61,HHS Region 9,4 wk ahead,2.1
+2017,9,2016/2017,61,HHS Region 10,Season onset,50
+2017,9,2016/2017,61,HHS Region 10,Season peak week,52
+2017,9,2016/2017,61,HHS Region 10,Season peak percentage,3.7
+2017,9,2016/2017,61,HHS Region 10,1 wk ahead,1
+2017,9,2016/2017,61,HHS Region 10,2 wk ahead,1.3
+2017,9,2016/2017,61,HHS Region 10,3 wk ahead,0.9
+2017,9,2016/2017,61,HHS Region 10,4 wk ahead,0.9
+2017,10,2016/2017,62,US National,Season onset,50
+2017,10,2016/2017,62,US National,Season peak week,6
+2017,10,2016/2017,62,US National,Season peak percentage,5.1
+2017,10,2016/2017,62,US National,1 wk ahead,3.2
+2017,10,2016/2017,62,US National,2 wk ahead,3.1
+2017,10,2016/2017,62,US National,3 wk ahead,2.8
+2017,10,2016/2017,62,US National,4 wk ahead,2.4
+2017,10,2016/2017,62,HHS Region 1,Season onset,52
+2017,10,2016/2017,62,HHS Region 1,Season peak week,6
+2017,10,2016/2017,62,HHS Region 1,Season peak percentage,3.2
+2017,10,2016/2017,62,HHS Region 1,1 wk ahead,2.1
+2017,10,2016/2017,62,HHS Region 1,2 wk ahead,1.9
+2017,10,2016/2017,62,HHS Region 1,3 wk ahead,2
+2017,10,2016/2017,62,HHS Region 1,4 wk ahead,2.2
+2017,10,2016/2017,62,HHS Region 2,Season onset,47
+2017,10,2016/2017,62,HHS Region 2,Season peak week,6
+2017,10,2016/2017,62,HHS Region 2,Season peak percentage,6.9
+2017,10,2016/2017,62,HHS Region 2,1 wk ahead,3.3
+2017,10,2016/2017,62,HHS Region 2,2 wk ahead,3.1
+2017,10,2016/2017,62,HHS Region 2,3 wk ahead,3.7
+2017,10,2016/2017,62,HHS Region 2,4 wk ahead,3.7
+2017,10,2016/2017,62,HHS Region 3,Season onset,51
+2017,10,2016/2017,62,HHS Region 3,Season peak week,7
+2017,10,2016/2017,62,HHS Region 3,Season peak percentage,5.2
+2017,10,2016/2017,62,HHS Region 3,1 wk ahead,3.4
+2017,10,2016/2017,62,HHS Region 3,2 wk ahead,3
+2017,10,2016/2017,62,HHS Region 3,3 wk ahead,3.2
+2017,10,2016/2017,62,HHS Region 3,4 wk ahead,2.2
+2017,10,2016/2017,62,HHS Region 4,Season onset,45
+2017,10,2016/2017,62,HHS Region 4,Season peak week,7
+2017,10,2016/2017,62,HHS Region 4,Season peak week,8
+2017,10,2016/2017,62,HHS Region 4,Season peak percentage,5.5
+2017,10,2016/2017,62,HHS Region 4,1 wk ahead,3.9
+2017,10,2016/2017,62,HHS Region 4,2 wk ahead,4.7
+2017,10,2016/2017,62,HHS Region 4,3 wk ahead,3.7
+2017,10,2016/2017,62,HHS Region 4,4 wk ahead,2.7
+2017,10,2016/2017,62,HHS Region 5,Season onset,52
+2017,10,2016/2017,62,HHS Region 5,Season peak week,7
+2017,10,2016/2017,62,HHS Region 5,Season peak week,8
+2017,10,2016/2017,62,HHS Region 5,Season peak percentage,4.3
+2017,10,2016/2017,62,HHS Region 5,1 wk ahead,3
+2017,10,2016/2017,62,HHS Region 5,2 wk ahead,2.8
+2017,10,2016/2017,62,HHS Region 5,3 wk ahead,2.4
+2017,10,2016/2017,62,HHS Region 5,4 wk ahead,2.1
+2017,10,2016/2017,62,HHS Region 6,Season onset,52
+2017,10,2016/2017,62,HHS Region 6,Season peak week,6
+2017,10,2016/2017,62,HHS Region 6,Season peak percentage,9.9
+2017,10,2016/2017,62,HHS Region 6,1 wk ahead,5.4
+2017,10,2016/2017,62,HHS Region 6,2 wk ahead,4.4
+2017,10,2016/2017,62,HHS Region 6,3 wk ahead,3.7
+2017,10,2016/2017,62,HHS Region 6,4 wk ahead,3.4
+2017,10,2016/2017,62,HHS Region 7,Season onset,51
+2017,10,2016/2017,62,HHS Region 7,Season peak week,6
+2017,10,2016/2017,62,HHS Region 7,Season peak percentage,6.4
+2017,10,2016/2017,62,HHS Region 7,1 wk ahead,2.4
+2017,10,2016/2017,62,HHS Region 7,2 wk ahead,2
+2017,10,2016/2017,62,HHS Region 7,3 wk ahead,1.7
+2017,10,2016/2017,62,HHS Region 7,4 wk ahead,1.4
+2017,10,2016/2017,62,HHS Region 8,Season onset,51
+2017,10,2016/2017,62,HHS Region 8,Season peak week,7
+2017,10,2016/2017,62,HHS Region 8,Season peak percentage,2.7
+2017,10,2016/2017,62,HHS Region 8,1 wk ahead,1.1
+2017,10,2016/2017,62,HHS Region 8,2 wk ahead,1.3
+2017,10,2016/2017,62,HHS Region 8,3 wk ahead,1.1
+2017,10,2016/2017,62,HHS Region 8,4 wk ahead,1.1
+2017,10,2016/2017,62,HHS Region 9,Season onset,51
+2017,10,2016/2017,62,HHS Region 9,Season peak week,52
+2017,10,2016/2017,62,HHS Region 9,Season peak percentage,3.3
+2017,10,2016/2017,62,HHS Region 9,1 wk ahead,2.3
+2017,10,2016/2017,62,HHS Region 9,2 wk ahead,2
+2017,10,2016/2017,62,HHS Region 9,3 wk ahead,2.1
+2017,10,2016/2017,62,HHS Region 9,4 wk ahead,1.9
+2017,10,2016/2017,62,HHS Region 10,Season onset,50
+2017,10,2016/2017,62,HHS Region 10,Season peak week,52
+2017,10,2016/2017,62,HHS Region 10,Season peak percentage,3.7
+2017,10,2016/2017,62,HHS Region 10,1 wk ahead,1.3
+2017,10,2016/2017,62,HHS Region 10,2 wk ahead,0.9
+2017,10,2016/2017,62,HHS Region 10,3 wk ahead,0.9
+2017,10,2016/2017,62,HHS Region 10,4 wk ahead,0.8
+2017,11,2016/2017,63,US National,Season onset,50
+2017,11,2016/2017,63,US National,Season peak week,6
+2017,11,2016/2017,63,US National,Season peak percentage,5.1
+2017,11,2016/2017,63,US National,1 wk ahead,3.1
+2017,11,2016/2017,63,US National,2 wk ahead,2.8
+2017,11,2016/2017,63,US National,3 wk ahead,2.4
+2017,11,2016/2017,63,US National,4 wk ahead,2
+2017,11,2016/2017,63,HHS Region 1,Season onset,52
+2017,11,2016/2017,63,HHS Region 1,Season peak week,6
+2017,11,2016/2017,63,HHS Region 1,Season peak percentage,3.2
+2017,11,2016/2017,63,HHS Region 1,1 wk ahead,1.9
+2017,11,2016/2017,63,HHS Region 1,2 wk ahead,2
+2017,11,2016/2017,63,HHS Region 1,3 wk ahead,2.2
+2017,11,2016/2017,63,HHS Region 1,4 wk ahead,1.8
+2017,11,2016/2017,63,HHS Region 2,Season onset,47
+2017,11,2016/2017,63,HHS Region 2,Season peak week,6
+2017,11,2016/2017,63,HHS Region 2,Season peak percentage,6.9
+2017,11,2016/2017,63,HHS Region 2,1 wk ahead,3.1
+2017,11,2016/2017,63,HHS Region 2,2 wk ahead,3.7
+2017,11,2016/2017,63,HHS Region 2,3 wk ahead,3.7
+2017,11,2016/2017,63,HHS Region 2,4 wk ahead,3.1
+2017,11,2016/2017,63,HHS Region 3,Season onset,51
+2017,11,2016/2017,63,HHS Region 3,Season peak week,7
+2017,11,2016/2017,63,HHS Region 3,Season peak percentage,5.2
+2017,11,2016/2017,63,HHS Region 3,1 wk ahead,3
+2017,11,2016/2017,63,HHS Region 3,2 wk ahead,3.2
+2017,11,2016/2017,63,HHS Region 3,3 wk ahead,2.2
+2017,11,2016/2017,63,HHS Region 3,4 wk ahead,1.7
+2017,11,2016/2017,63,HHS Region 4,Season onset,45
+2017,11,2016/2017,63,HHS Region 4,Season peak week,7
+2017,11,2016/2017,63,HHS Region 4,Season peak week,8
+2017,11,2016/2017,63,HHS Region 4,Season peak percentage,5.5
+2017,11,2016/2017,63,HHS Region 4,1 wk ahead,4.7
+2017,11,2016/2017,63,HHS Region 4,2 wk ahead,3.7
+2017,11,2016/2017,63,HHS Region 4,3 wk ahead,2.7
+2017,11,2016/2017,63,HHS Region 4,4 wk ahead,2.2
+2017,11,2016/2017,63,HHS Region 5,Season onset,52
+2017,11,2016/2017,63,HHS Region 5,Season peak week,7
+2017,11,2016/2017,63,HHS Region 5,Season peak week,8
+2017,11,2016/2017,63,HHS Region 5,Season peak percentage,4.3
+2017,11,2016/2017,63,HHS Region 5,1 wk ahead,2.8
+2017,11,2016/2017,63,HHS Region 5,2 wk ahead,2.4
+2017,11,2016/2017,63,HHS Region 5,3 wk ahead,2.1
+2017,11,2016/2017,63,HHS Region 5,4 wk ahead,1.6
+2017,11,2016/2017,63,HHS Region 6,Season onset,52
+2017,11,2016/2017,63,HHS Region 6,Season peak week,6
+2017,11,2016/2017,63,HHS Region 6,Season peak percentage,9.9
+2017,11,2016/2017,63,HHS Region 6,1 wk ahead,4.4
+2017,11,2016/2017,63,HHS Region 6,2 wk ahead,3.7
+2017,11,2016/2017,63,HHS Region 6,3 wk ahead,3.4
+2017,11,2016/2017,63,HHS Region 6,4 wk ahead,3
+2017,11,2016/2017,63,HHS Region 7,Season onset,51
+2017,11,2016/2017,63,HHS Region 7,Season peak week,6
+2017,11,2016/2017,63,HHS Region 7,Season peak percentage,6.4
+2017,11,2016/2017,63,HHS Region 7,1 wk ahead,2
+2017,11,2016/2017,63,HHS Region 7,2 wk ahead,1.7
+2017,11,2016/2017,63,HHS Region 7,3 wk ahead,1.4
+2017,11,2016/2017,63,HHS Region 7,4 wk ahead,1
+2017,11,2016/2017,63,HHS Region 8,Season onset,51
+2017,11,2016/2017,63,HHS Region 8,Season peak week,7
+2017,11,2016/2017,63,HHS Region 8,Season peak percentage,2.7
+2017,11,2016/2017,63,HHS Region 8,1 wk ahead,1.3
+2017,11,2016/2017,63,HHS Region 8,2 wk ahead,1.1
+2017,11,2016/2017,63,HHS Region 8,3 wk ahead,1.1
+2017,11,2016/2017,63,HHS Region 8,4 wk ahead,0.8
+2017,11,2016/2017,63,HHS Region 9,Season onset,51
+2017,11,2016/2017,63,HHS Region 9,Season peak week,52
+2017,11,2016/2017,63,HHS Region 9,Season peak percentage,3.3
+2017,11,2016/2017,63,HHS Region 9,1 wk ahead,2
+2017,11,2016/2017,63,HHS Region 9,2 wk ahead,2.1
+2017,11,2016/2017,63,HHS Region 9,3 wk ahead,1.9
+2017,11,2016/2017,63,HHS Region 9,4 wk ahead,1.7
+2017,11,2016/2017,63,HHS Region 10,Season onset,50
+2017,11,2016/2017,63,HHS Region 10,Season peak week,52
+2017,11,2016/2017,63,HHS Region 10,Season peak percentage,3.7
+2017,11,2016/2017,63,HHS Region 10,1 wk ahead,0.9
+2017,11,2016/2017,63,HHS Region 10,2 wk ahead,0.9
+2017,11,2016/2017,63,HHS Region 10,3 wk ahead,0.8
+2017,11,2016/2017,63,HHS Region 10,4 wk ahead,0.7
+2017,12,2016/2017,64,US National,Season onset,50
+2017,12,2016/2017,64,US National,Season peak week,6
+2017,12,2016/2017,64,US National,Season peak percentage,5.1
+2017,12,2016/2017,64,US National,1 wk ahead,2.8
+2017,12,2016/2017,64,US National,2 wk ahead,2.4
+2017,12,2016/2017,64,US National,3 wk ahead,2
+2017,12,2016/2017,64,US National,4 wk ahead,1.8
+2017,12,2016/2017,64,HHS Region 1,Season onset,52
+2017,12,2016/2017,64,HHS Region 1,Season peak week,6
+2017,12,2016/2017,64,HHS Region 1,Season peak percentage,3.2
+2017,12,2016/2017,64,HHS Region 1,1 wk ahead,2
+2017,12,2016/2017,64,HHS Region 1,2 wk ahead,2.2
+2017,12,2016/2017,64,HHS Region 1,3 wk ahead,1.8
+2017,12,2016/2017,64,HHS Region 1,4 wk ahead,1.5
+2017,12,2016/2017,64,HHS Region 2,Season onset,47
+2017,12,2016/2017,64,HHS Region 2,Season peak week,6
+2017,12,2016/2017,64,HHS Region 2,Season peak percentage,6.9
+2017,12,2016/2017,64,HHS Region 2,1 wk ahead,3.7
+2017,12,2016/2017,64,HHS Region 2,2 wk ahead,3.7
+2017,12,2016/2017,64,HHS Region 2,3 wk ahead,3.1
+2017,12,2016/2017,64,HHS Region 2,4 wk ahead,2.3
+2017,12,2016/2017,64,HHS Region 3,Season onset,51
+2017,12,2016/2017,64,HHS Region 3,Season peak week,7
+2017,12,2016/2017,64,HHS Region 3,Season peak percentage,5.2
+2017,12,2016/2017,64,HHS Region 3,1 wk ahead,3.2
+2017,12,2016/2017,64,HHS Region 3,2 wk ahead,2.2
+2017,12,2016/2017,64,HHS Region 3,3 wk ahead,1.7
+2017,12,2016/2017,64,HHS Region 3,4 wk ahead,1.4
+2017,12,2016/2017,64,HHS Region 4,Season onset,45
+2017,12,2016/2017,64,HHS Region 4,Season peak week,7
+2017,12,2016/2017,64,HHS Region 4,Season peak week,8
+2017,12,2016/2017,64,HHS Region 4,Season peak percentage,5.5
+2017,12,2016/2017,64,HHS Region 4,1 wk ahead,3.7
+2017,12,2016/2017,64,HHS Region 4,2 wk ahead,2.7
+2017,12,2016/2017,64,HHS Region 4,3 wk ahead,2.2
+2017,12,2016/2017,64,HHS Region 4,4 wk ahead,1.8
+2017,12,2016/2017,64,HHS Region 5,Season onset,52
+2017,12,2016/2017,64,HHS Region 5,Season peak week,7
+2017,12,2016/2017,64,HHS Region 5,Season peak week,8
+2017,12,2016/2017,64,HHS Region 5,Season peak percentage,4.3
+2017,12,2016/2017,64,HHS Region 5,1 wk ahead,2.4
+2017,12,2016/2017,64,HHS Region 5,2 wk ahead,2.1
+2017,12,2016/2017,64,HHS Region 5,3 wk ahead,1.6
+2017,12,2016/2017,64,HHS Region 5,4 wk ahead,1.4
+2017,12,2016/2017,64,HHS Region 6,Season onset,52
+2017,12,2016/2017,64,HHS Region 6,Season peak week,6
+2017,12,2016/2017,64,HHS Region 6,Season peak percentage,9.9
+2017,12,2016/2017,64,HHS Region 6,1 wk ahead,3.7
+2017,12,2016/2017,64,HHS Region 6,2 wk ahead,3.4
+2017,12,2016/2017,64,HHS Region 6,3 wk ahead,3
+2017,12,2016/2017,64,HHS Region 6,4 wk ahead,2.9
+2017,12,2016/2017,64,HHS Region 7,Season onset,51
+2017,12,2016/2017,64,HHS Region 7,Season peak week,6
+2017,12,2016/2017,64,HHS Region 7,Season peak percentage,6.4
+2017,12,2016/2017,64,HHS Region 7,1 wk ahead,1.7
+2017,12,2016/2017,64,HHS Region 7,2 wk ahead,1.4
+2017,12,2016/2017,64,HHS Region 7,3 wk ahead,1
+2017,12,2016/2017,64,HHS Region 7,4 wk ahead,0.9
+2017,12,2016/2017,64,HHS Region 8,Season onset,51
+2017,12,2016/2017,64,HHS Region 8,Season peak week,7
+2017,12,2016/2017,64,HHS Region 8,Season peak percentage,2.7
+2017,12,2016/2017,64,HHS Region 8,1 wk ahead,1.1
+2017,12,2016/2017,64,HHS Region 8,2 wk ahead,1.1
+2017,12,2016/2017,64,HHS Region 8,3 wk ahead,0.8
+2017,12,2016/2017,64,HHS Region 8,4 wk ahead,0.9
+2017,12,2016/2017,64,HHS Region 9,Season onset,51
+2017,12,2016/2017,64,HHS Region 9,Season peak week,52
+2017,12,2016/2017,64,HHS Region 9,Season peak percentage,3.3
+2017,12,2016/2017,64,HHS Region 9,1 wk ahead,2.1
+2017,12,2016/2017,64,HHS Region 9,2 wk ahead,1.9
+2017,12,2016/2017,64,HHS Region 9,3 wk ahead,1.7
+2017,12,2016/2017,64,HHS Region 9,4 wk ahead,1.7
+2017,12,2016/2017,64,HHS Region 10,Season onset,50
+2017,12,2016/2017,64,HHS Region 10,Season peak week,52
+2017,12,2016/2017,64,HHS Region 10,Season peak percentage,3.7
+2017,12,2016/2017,64,HHS Region 10,1 wk ahead,0.9
+2017,12,2016/2017,64,HHS Region 10,2 wk ahead,0.8
+2017,12,2016/2017,64,HHS Region 10,3 wk ahead,0.7
+2017,12,2016/2017,64,HHS Region 10,4 wk ahead,0.6
+2017,13,2016/2017,65,US National,Season onset,50
+2017,13,2016/2017,65,US National,Season peak week,6
+2017,13,2016/2017,65,US National,Season peak percentage,5.1
+2017,13,2016/2017,65,US National,1 wk ahead,2.4
+2017,13,2016/2017,65,US National,2 wk ahead,2
+2017,13,2016/2017,65,US National,3 wk ahead,1.8
+2017,13,2016/2017,65,US National,4 wk ahead,1.6
+2017,13,2016/2017,65,HHS Region 1,Season onset,52
+2017,13,2016/2017,65,HHS Region 1,Season peak week,6
+2017,13,2016/2017,65,HHS Region 1,Season peak percentage,3.2
+2017,13,2016/2017,65,HHS Region 1,1 wk ahead,2.2
+2017,13,2016/2017,65,HHS Region 1,2 wk ahead,1.8
+2017,13,2016/2017,65,HHS Region 1,3 wk ahead,1.5
+2017,13,2016/2017,65,HHS Region 1,4 wk ahead,1.1
+2017,13,2016/2017,65,HHS Region 2,Season onset,47
+2017,13,2016/2017,65,HHS Region 2,Season peak week,6
+2017,13,2016/2017,65,HHS Region 2,Season peak percentage,6.9
+2017,13,2016/2017,65,HHS Region 2,1 wk ahead,3.7
+2017,13,2016/2017,65,HHS Region 2,2 wk ahead,3.1
+2017,13,2016/2017,65,HHS Region 2,3 wk ahead,2.3
+2017,13,2016/2017,65,HHS Region 2,4 wk ahead,2.4
+2017,13,2016/2017,65,HHS Region 3,Season onset,51
+2017,13,2016/2017,65,HHS Region 3,Season peak week,7
+2017,13,2016/2017,65,HHS Region 3,Season peak percentage,5.2
+2017,13,2016/2017,65,HHS Region 3,1 wk ahead,2.2
+2017,13,2016/2017,65,HHS Region 3,2 wk ahead,1.7
+2017,13,2016/2017,65,HHS Region 3,3 wk ahead,1.4
+2017,13,2016/2017,65,HHS Region 3,4 wk ahead,1.1
+2017,13,2016/2017,65,HHS Region 4,Season onset,45
+2017,13,2016/2017,65,HHS Region 4,Season peak week,7
+2017,13,2016/2017,65,HHS Region 4,Season peak week,8
+2017,13,2016/2017,65,HHS Region 4,Season peak percentage,5.5
+2017,13,2016/2017,65,HHS Region 4,1 wk ahead,2.7
+2017,13,2016/2017,65,HHS Region 4,2 wk ahead,2.2
+2017,13,2016/2017,65,HHS Region 4,3 wk ahead,1.8
+2017,13,2016/2017,65,HHS Region 4,4 wk ahead,1.5
+2017,13,2016/2017,65,HHS Region 5,Season onset,52
+2017,13,2016/2017,65,HHS Region 5,Season peak week,7
+2017,13,2016/2017,65,HHS Region 5,Season peak week,8
+2017,13,2016/2017,65,HHS Region 5,Season peak percentage,4.3
+2017,13,2016/2017,65,HHS Region 5,1 wk ahead,2.1
+2017,13,2016/2017,65,HHS Region 5,2 wk ahead,1.6
+2017,13,2016/2017,65,HHS Region 5,3 wk ahead,1.4
+2017,13,2016/2017,65,HHS Region 5,4 wk ahead,1.3
+2017,13,2016/2017,65,HHS Region 6,Season onset,52
+2017,13,2016/2017,65,HHS Region 6,Season peak week,6
+2017,13,2016/2017,65,HHS Region 6,Season peak percentage,9.9
+2017,13,2016/2017,65,HHS Region 6,1 wk ahead,3.4
+2017,13,2016/2017,65,HHS Region 6,2 wk ahead,3
+2017,13,2016/2017,65,HHS Region 6,3 wk ahead,2.9
+2017,13,2016/2017,65,HHS Region 6,4 wk ahead,2.5
+2017,13,2016/2017,65,HHS Region 7,Season onset,51
+2017,13,2016/2017,65,HHS Region 7,Season peak week,6
+2017,13,2016/2017,65,HHS Region 7,Season peak percentage,6.4
+2017,13,2016/2017,65,HHS Region 7,1 wk ahead,1.4
+2017,13,2016/2017,65,HHS Region 7,2 wk ahead,1
+2017,13,2016/2017,65,HHS Region 7,3 wk ahead,0.9
+2017,13,2016/2017,65,HHS Region 7,4 wk ahead,0.8
+2017,13,2016/2017,65,HHS Region 8,Season onset,51
+2017,13,2016/2017,65,HHS Region 8,Season peak week,7
+2017,13,2016/2017,65,HHS Region 8,Season peak percentage,2.7
+2017,13,2016/2017,65,HHS Region 8,1 wk ahead,1.1
+2017,13,2016/2017,65,HHS Region 8,2 wk ahead,0.8
+2017,13,2016/2017,65,HHS Region 8,3 wk ahead,0.9
+2017,13,2016/2017,65,HHS Region 8,4 wk ahead,1
+2017,13,2016/2017,65,HHS Region 9,Season onset,51
+2017,13,2016/2017,65,HHS Region 9,Season peak week,52
+2017,13,2016/2017,65,HHS Region 9,Season peak percentage,3.3
+2017,13,2016/2017,65,HHS Region 9,1 wk ahead,1.9
+2017,13,2016/2017,65,HHS Region 9,2 wk ahead,1.7
+2017,13,2016/2017,65,HHS Region 9,3 wk ahead,1.7
+2017,13,2016/2017,65,HHS Region 9,4 wk ahead,1.8
+2017,13,2016/2017,65,HHS Region 10,Season onset,50
+2017,13,2016/2017,65,HHS Region 10,Season peak week,52
+2017,13,2016/2017,65,HHS Region 10,Season peak percentage,3.7
+2017,13,2016/2017,65,HHS Region 10,1 wk ahead,0.8
+2017,13,2016/2017,65,HHS Region 10,2 wk ahead,0.7
+2017,13,2016/2017,65,HHS Region 10,3 wk ahead,0.6
+2017,13,2016/2017,65,HHS Region 10,4 wk ahead,0.5
+2017,14,2016/2017,66,US National,Season onset,50
+2017,14,2016/2017,66,US National,Season peak week,6
+2017,14,2016/2017,66,US National,Season peak percentage,5.1
+2017,14,2016/2017,66,US National,1 wk ahead,2
+2017,14,2016/2017,66,US National,2 wk ahead,1.8
+2017,14,2016/2017,66,US National,3 wk ahead,1.6
+2017,14,2016/2017,66,US National,4 wk ahead,1.4
+2017,14,2016/2017,66,HHS Region 1,Season onset,52
+2017,14,2016/2017,66,HHS Region 1,Season peak week,6
+2017,14,2016/2017,66,HHS Region 1,Season peak percentage,3.2
+2017,14,2016/2017,66,HHS Region 1,1 wk ahead,1.8
+2017,14,2016/2017,66,HHS Region 1,2 wk ahead,1.5
+2017,14,2016/2017,66,HHS Region 1,3 wk ahead,1.1
+2017,14,2016/2017,66,HHS Region 1,4 wk ahead,0.9
+2017,14,2016/2017,66,HHS Region 2,Season onset,47
+2017,14,2016/2017,66,HHS Region 2,Season peak week,6
+2017,14,2016/2017,66,HHS Region 2,Season peak percentage,6.9
+2017,14,2016/2017,66,HHS Region 2,1 wk ahead,3.1
+2017,14,2016/2017,66,HHS Region 2,2 wk ahead,2.3
+2017,14,2016/2017,66,HHS Region 2,3 wk ahead,2.4
+2017,14,2016/2017,66,HHS Region 2,4 wk ahead,2
+2017,14,2016/2017,66,HHS Region 3,Season onset,51
+2017,14,2016/2017,66,HHS Region 3,Season peak week,7
+2017,14,2016/2017,66,HHS Region 3,Season peak percentage,5.2
+2017,14,2016/2017,66,HHS Region 3,1 wk ahead,1.7
+2017,14,2016/2017,66,HHS Region 3,2 wk ahead,1.4
+2017,14,2016/2017,66,HHS Region 3,3 wk ahead,1.1
+2017,14,2016/2017,66,HHS Region 3,4 wk ahead,1.1
+2017,14,2016/2017,66,HHS Region 4,Season onset,45
+2017,14,2016/2017,66,HHS Region 4,Season peak week,7
+2017,14,2016/2017,66,HHS Region 4,Season peak week,8
+2017,14,2016/2017,66,HHS Region 4,Season peak percentage,5.5
+2017,14,2016/2017,66,HHS Region 4,1 wk ahead,2.2
+2017,14,2016/2017,66,HHS Region 4,2 wk ahead,1.8
+2017,14,2016/2017,66,HHS Region 4,3 wk ahead,1.5
+2017,14,2016/2017,66,HHS Region 4,4 wk ahead,1.2
+2017,14,2016/2017,66,HHS Region 5,Season onset,52
+2017,14,2016/2017,66,HHS Region 5,Season peak week,7
+2017,14,2016/2017,66,HHS Region 5,Season peak week,8
+2017,14,2016/2017,66,HHS Region 5,Season peak percentage,4.3
+2017,14,2016/2017,66,HHS Region 5,1 wk ahead,1.6
+2017,14,2016/2017,66,HHS Region 5,2 wk ahead,1.4
+2017,14,2016/2017,66,HHS Region 5,3 wk ahead,1.3
+2017,14,2016/2017,66,HHS Region 5,4 wk ahead,1.1
+2017,14,2016/2017,66,HHS Region 6,Season onset,52
+2017,14,2016/2017,66,HHS Region 6,Season peak week,6
+2017,14,2016/2017,66,HHS Region 6,Season peak percentage,9.9
+2017,14,2016/2017,66,HHS Region 6,1 wk ahead,3
+2017,14,2016/2017,66,HHS Region 6,2 wk ahead,2.9
+2017,14,2016/2017,66,HHS Region 6,3 wk ahead,2.5
+2017,14,2016/2017,66,HHS Region 6,4 wk ahead,2.3
+2017,14,2016/2017,66,HHS Region 7,Season onset,51
+2017,14,2016/2017,66,HHS Region 7,Season peak week,6
+2017,14,2016/2017,66,HHS Region 7,Season peak percentage,6.4
+2017,14,2016/2017,66,HHS Region 7,1 wk ahead,1
+2017,14,2016/2017,66,HHS Region 7,2 wk ahead,0.9
+2017,14,2016/2017,66,HHS Region 7,3 wk ahead,0.8
+2017,14,2016/2017,66,HHS Region 7,4 wk ahead,0.7
+2017,14,2016/2017,66,HHS Region 8,Season onset,51
+2017,14,2016/2017,66,HHS Region 8,Season peak week,7
+2017,14,2016/2017,66,HHS Region 8,Season peak percentage,2.7
+2017,14,2016/2017,66,HHS Region 8,1 wk ahead,0.8
+2017,14,2016/2017,66,HHS Region 8,2 wk ahead,0.9
+2017,14,2016/2017,66,HHS Region 8,3 wk ahead,1
+2017,14,2016/2017,66,HHS Region 8,4 wk ahead,1
+2017,14,2016/2017,66,HHS Region 9,Season onset,51
+2017,14,2016/2017,66,HHS Region 9,Season peak week,52
+2017,14,2016/2017,66,HHS Region 9,Season peak percentage,3.3
+2017,14,2016/2017,66,HHS Region 9,1 wk ahead,1.7
+2017,14,2016/2017,66,HHS Region 9,2 wk ahead,1.7
+2017,14,2016/2017,66,HHS Region 9,3 wk ahead,1.8
+2017,14,2016/2017,66,HHS Region 9,4 wk ahead,1.7
+2017,14,2016/2017,66,HHS Region 10,Season onset,50
+2017,14,2016/2017,66,HHS Region 10,Season peak week,52
+2017,14,2016/2017,66,HHS Region 10,Season peak percentage,3.7
+2017,14,2016/2017,66,HHS Region 10,1 wk ahead,0.7
+2017,14,2016/2017,66,HHS Region 10,2 wk ahead,0.6
+2017,14,2016/2017,66,HHS Region 10,3 wk ahead,0.5
+2017,14,2016/2017,66,HHS Region 10,4 wk ahead,0.7
+2017,15,2016/2017,67,US National,Season onset,50
+2017,15,2016/2017,67,US National,Season peak week,6
+2017,15,2016/2017,67,US National,Season peak percentage,5.1
+2017,15,2016/2017,67,US National,1 wk ahead,1.8
+2017,15,2016/2017,67,US National,2 wk ahead,1.6
+2017,15,2016/2017,67,US National,3 wk ahead,1.4
+2017,15,2016/2017,67,US National,4 wk ahead,1.3
+2017,15,2016/2017,67,HHS Region 1,Season onset,52
+2017,15,2016/2017,67,HHS Region 1,Season peak week,6
+2017,15,2016/2017,67,HHS Region 1,Season peak percentage,3.2
+2017,15,2016/2017,67,HHS Region 1,1 wk ahead,1.5
+2017,15,2016/2017,67,HHS Region 1,2 wk ahead,1.1
+2017,15,2016/2017,67,HHS Region 1,3 wk ahead,0.9
+2017,15,2016/2017,67,HHS Region 1,4 wk ahead,0.7
+2017,15,2016/2017,67,HHS Region 2,Season onset,47
+2017,15,2016/2017,67,HHS Region 2,Season peak week,6
+2017,15,2016/2017,67,HHS Region 2,Season peak percentage,6.9
+2017,15,2016/2017,67,HHS Region 2,1 wk ahead,2.3
+2017,15,2016/2017,67,HHS Region 2,2 wk ahead,2.4
+2017,15,2016/2017,67,HHS Region 2,3 wk ahead,2
+2017,15,2016/2017,67,HHS Region 2,4 wk ahead,2
+2017,15,2016/2017,67,HHS Region 3,Season onset,51
+2017,15,2016/2017,67,HHS Region 3,Season peak week,7
+2017,15,2016/2017,67,HHS Region 3,Season peak percentage,5.2
+2017,15,2016/2017,67,HHS Region 3,1 wk ahead,1.4
+2017,15,2016/2017,67,HHS Region 3,2 wk ahead,1.1
+2017,15,2016/2017,67,HHS Region 3,3 wk ahead,1.1
+2017,15,2016/2017,67,HHS Region 3,4 wk ahead,0.9
+2017,15,2016/2017,67,HHS Region 4,Season onset,45
+2017,15,2016/2017,67,HHS Region 4,Season peak week,7
+2017,15,2016/2017,67,HHS Region 4,Season peak week,8
+2017,15,2016/2017,67,HHS Region 4,Season peak percentage,5.5
+2017,15,2016/2017,67,HHS Region 4,1 wk ahead,1.8
+2017,15,2016/2017,67,HHS Region 4,2 wk ahead,1.5
+2017,15,2016/2017,67,HHS Region 4,3 wk ahead,1.2
+2017,15,2016/2017,67,HHS Region 4,4 wk ahead,1.4
+2017,15,2016/2017,67,HHS Region 5,Season onset,52
+2017,15,2016/2017,67,HHS Region 5,Season peak week,7
+2017,15,2016/2017,67,HHS Region 5,Season peak week,8
+2017,15,2016/2017,67,HHS Region 5,Season peak percentage,4.3
+2017,15,2016/2017,67,HHS Region 5,1 wk ahead,1.4
+2017,15,2016/2017,67,HHS Region 5,2 wk ahead,1.3
+2017,15,2016/2017,67,HHS Region 5,3 wk ahead,1.1
+2017,15,2016/2017,67,HHS Region 5,4 wk ahead,1.1
+2017,15,2016/2017,67,HHS Region 6,Season onset,52
+2017,15,2016/2017,67,HHS Region 6,Season peak week,6
+2017,15,2016/2017,67,HHS Region 6,Season peak percentage,9.9
+2017,15,2016/2017,67,HHS Region 6,1 wk ahead,2.9
+2017,15,2016/2017,67,HHS Region 6,2 wk ahead,2.5
+2017,15,2016/2017,67,HHS Region 6,3 wk ahead,2.3
+2017,15,2016/2017,67,HHS Region 6,4 wk ahead,1.7
+2017,15,2016/2017,67,HHS Region 7,Season onset,51
+2017,15,2016/2017,67,HHS Region 7,Season peak week,6
+2017,15,2016/2017,67,HHS Region 7,Season peak percentage,6.4
+2017,15,2016/2017,67,HHS Region 7,1 wk ahead,0.9
+2017,15,2016/2017,67,HHS Region 7,2 wk ahead,0.8
+2017,15,2016/2017,67,HHS Region 7,3 wk ahead,0.7
+2017,15,2016/2017,67,HHS Region 7,4 wk ahead,0.4
+2017,15,2016/2017,67,HHS Region 8,Season onset,51
+2017,15,2016/2017,67,HHS Region 8,Season peak week,7
+2017,15,2016/2017,67,HHS Region 8,Season peak percentage,2.7
+2017,15,2016/2017,67,HHS Region 8,1 wk ahead,0.9
+2017,15,2016/2017,67,HHS Region 8,2 wk ahead,1
+2017,15,2016/2017,67,HHS Region 8,3 wk ahead,1
+2017,15,2016/2017,67,HHS Region 8,4 wk ahead,0.6
+2017,15,2016/2017,67,HHS Region 9,Season onset,51
+2017,15,2016/2017,67,HHS Region 9,Season peak week,52
+2017,15,2016/2017,67,HHS Region 9,Season peak percentage,3.3
+2017,15,2016/2017,67,HHS Region 9,1 wk ahead,1.7
+2017,15,2016/2017,67,HHS Region 9,2 wk ahead,1.8
+2017,15,2016/2017,67,HHS Region 9,3 wk ahead,1.7
+2017,15,2016/2017,67,HHS Region 9,4 wk ahead,1.6
+2017,15,2016/2017,67,HHS Region 10,Season onset,50
+2017,15,2016/2017,67,HHS Region 10,Season peak week,52
+2017,15,2016/2017,67,HHS Region 10,Season peak percentage,3.7
+2017,15,2016/2017,67,HHS Region 10,1 wk ahead,0.6
+2017,15,2016/2017,67,HHS Region 10,2 wk ahead,0.5
+2017,15,2016/2017,67,HHS Region 10,3 wk ahead,0.7
+2017,15,2016/2017,67,HHS Region 10,4 wk ahead,0.5
+2017,16,2016/2017,68,US National,Season onset,50
+2017,16,2016/2017,68,US National,Season peak week,6
+2017,16,2016/2017,68,US National,Season peak percentage,5.1
+2017,16,2016/2017,68,US National,1 wk ahead,1.6
+2017,16,2016/2017,68,US National,2 wk ahead,1.4
+2017,16,2016/2017,68,US National,3 wk ahead,1.3
+2017,16,2016/2017,68,US National,4 wk ahead,1.3
+2017,16,2016/2017,68,HHS Region 1,Season onset,52
+2017,16,2016/2017,68,HHS Region 1,Season peak week,6
+2017,16,2016/2017,68,HHS Region 1,Season peak percentage,3.2
+2017,16,2016/2017,68,HHS Region 1,1 wk ahead,1.1
+2017,16,2016/2017,68,HHS Region 1,2 wk ahead,0.9
+2017,16,2016/2017,68,HHS Region 1,3 wk ahead,0.7
+2017,16,2016/2017,68,HHS Region 1,4 wk ahead,0.7
+2017,16,2016/2017,68,HHS Region 2,Season onset,47
+2017,16,2016/2017,68,HHS Region 2,Season peak week,6
+2017,16,2016/2017,68,HHS Region 2,Season peak percentage,6.9
+2017,16,2016/2017,68,HHS Region 2,1 wk ahead,2.4
+2017,16,2016/2017,68,HHS Region 2,2 wk ahead,2
+2017,16,2016/2017,68,HHS Region 2,3 wk ahead,2
+2017,16,2016/2017,68,HHS Region 2,4 wk ahead,2.1
+2017,16,2016/2017,68,HHS Region 3,Season onset,51
+2017,16,2016/2017,68,HHS Region 3,Season peak week,7
+2017,16,2016/2017,68,HHS Region 3,Season peak percentage,5.2
+2017,16,2016/2017,68,HHS Region 3,1 wk ahead,1.1
+2017,16,2016/2017,68,HHS Region 3,2 wk ahead,1.1
+2017,16,2016/2017,68,HHS Region 3,3 wk ahead,0.9
+2017,16,2016/2017,68,HHS Region 3,4 wk ahead,1
+2017,16,2016/2017,68,HHS Region 4,Season onset,45
+2017,16,2016/2017,68,HHS Region 4,Season peak week,7
+2017,16,2016/2017,68,HHS Region 4,Season peak week,8
+2017,16,2016/2017,68,HHS Region 4,Season peak percentage,5.5
+2017,16,2016/2017,68,HHS Region 4,1 wk ahead,1.5
+2017,16,2016/2017,68,HHS Region 4,2 wk ahead,1.2
+2017,16,2016/2017,68,HHS Region 4,3 wk ahead,1.4
+2017,16,2016/2017,68,HHS Region 4,4 wk ahead,1.3
+2017,16,2016/2017,68,HHS Region 5,Season onset,52
+2017,16,2016/2017,68,HHS Region 5,Season peak week,7
+2017,16,2016/2017,68,HHS Region 5,Season peak week,8
+2017,16,2016/2017,68,HHS Region 5,Season peak percentage,4.3
+2017,16,2016/2017,68,HHS Region 5,1 wk ahead,1.3
+2017,16,2016/2017,68,HHS Region 5,2 wk ahead,1.1
+2017,16,2016/2017,68,HHS Region 5,3 wk ahead,1.1
+2017,16,2016/2017,68,HHS Region 5,4 wk ahead,0.9
+2017,16,2016/2017,68,HHS Region 6,Season onset,52
+2017,16,2016/2017,68,HHS Region 6,Season peak week,6
+2017,16,2016/2017,68,HHS Region 6,Season peak percentage,9.9
+2017,16,2016/2017,68,HHS Region 6,1 wk ahead,2.5
+2017,16,2016/2017,68,HHS Region 6,2 wk ahead,2.3
+2017,16,2016/2017,68,HHS Region 6,3 wk ahead,1.7
+2017,16,2016/2017,68,HHS Region 6,4 wk ahead,2.1
+2017,16,2016/2017,68,HHS Region 7,Season onset,51
+2017,16,2016/2017,68,HHS Region 7,Season peak week,6
+2017,16,2016/2017,68,HHS Region 7,Season peak percentage,6.4
+2017,16,2016/2017,68,HHS Region 7,1 wk ahead,0.8
+2017,16,2016/2017,68,HHS Region 7,2 wk ahead,0.7
+2017,16,2016/2017,68,HHS Region 7,3 wk ahead,0.4
+2017,16,2016/2017,68,HHS Region 7,4 wk ahead,0.3
+2017,16,2016/2017,68,HHS Region 8,Season onset,51
+2017,16,2016/2017,68,HHS Region 8,Season peak week,7
+2017,16,2016/2017,68,HHS Region 8,Season peak percentage,2.7
+2017,16,2016/2017,68,HHS Region 8,1 wk ahead,1
+2017,16,2016/2017,68,HHS Region 8,2 wk ahead,1
+2017,16,2016/2017,68,HHS Region 8,3 wk ahead,0.6
+2017,16,2016/2017,68,HHS Region 8,4 wk ahead,0.8
+2017,16,2016/2017,68,HHS Region 9,Season onset,51
+2017,16,2016/2017,68,HHS Region 9,Season peak week,52
+2017,16,2016/2017,68,HHS Region 9,Season peak percentage,3.3
+2017,16,2016/2017,68,HHS Region 9,1 wk ahead,1.8
+2017,16,2016/2017,68,HHS Region 9,2 wk ahead,1.7
+2017,16,2016/2017,68,HHS Region 9,3 wk ahead,1.6
+2017,16,2016/2017,68,HHS Region 9,4 wk ahead,1.6
+2017,16,2016/2017,68,HHS Region 10,Season onset,50
+2017,16,2016/2017,68,HHS Region 10,Season peak week,52
+2017,16,2016/2017,68,HHS Region 10,Season peak percentage,3.7
+2017,16,2016/2017,68,HHS Region 10,1 wk ahead,0.5
+2017,16,2016/2017,68,HHS Region 10,2 wk ahead,0.7
+2017,16,2016/2017,68,HHS Region 10,3 wk ahead,0.5
+2017,16,2016/2017,68,HHS Region 10,4 wk ahead,0.6
+2017,17,2016/2017,69,US National,Season onset,50
+2017,17,2016/2017,69,US National,Season peak week,6
+2017,17,2016/2017,69,US National,Season peak percentage,5.1
+2017,17,2016/2017,69,US National,1 wk ahead,1.4
+2017,17,2016/2017,69,US National,2 wk ahead,1.3
+2017,17,2016/2017,69,US National,3 wk ahead,1.3
+2017,17,2016/2017,69,US National,4 wk ahead,1.2
+2017,17,2016/2017,69,HHS Region 1,Season onset,52
+2017,17,2016/2017,69,HHS Region 1,Season peak week,6
+2017,17,2016/2017,69,HHS Region 1,Season peak percentage,3.2
+2017,17,2016/2017,69,HHS Region 1,1 wk ahead,0.9
+2017,17,2016/2017,69,HHS Region 1,2 wk ahead,0.7
+2017,17,2016/2017,69,HHS Region 1,3 wk ahead,0.7
+2017,17,2016/2017,69,HHS Region 1,4 wk ahead,0.6
+2017,17,2016/2017,69,HHS Region 2,Season onset,47
+2017,17,2016/2017,69,HHS Region 2,Season peak week,6
+2017,17,2016/2017,69,HHS Region 2,Season peak percentage,6.9
+2017,17,2016/2017,69,HHS Region 2,1 wk ahead,2
+2017,17,2016/2017,69,HHS Region 2,2 wk ahead,2
+2017,17,2016/2017,69,HHS Region 2,3 wk ahead,2.1
+2017,17,2016/2017,69,HHS Region 2,4 wk ahead,1.8
+2017,17,2016/2017,69,HHS Region 3,Season onset,51
+2017,17,2016/2017,69,HHS Region 3,Season peak week,7
+2017,17,2016/2017,69,HHS Region 3,Season peak percentage,5.2
+2017,17,2016/2017,69,HHS Region 3,1 wk ahead,1.1
+2017,17,2016/2017,69,HHS Region 3,2 wk ahead,0.9
+2017,17,2016/2017,69,HHS Region 3,3 wk ahead,1
+2017,17,2016/2017,69,HHS Region 3,4 wk ahead,0.9
+2017,17,2016/2017,69,HHS Region 4,Season onset,45
+2017,17,2016/2017,69,HHS Region 4,Season peak week,7
+2017,17,2016/2017,69,HHS Region 4,Season peak week,8
+2017,17,2016/2017,69,HHS Region 4,Season peak percentage,5.5
+2017,17,2016/2017,69,HHS Region 4,1 wk ahead,1.2
+2017,17,2016/2017,69,HHS Region 4,2 wk ahead,1.4
+2017,17,2016/2017,69,HHS Region 4,3 wk ahead,1.3
+2017,17,2016/2017,69,HHS Region 4,4 wk ahead,1.2
+2017,17,2016/2017,69,HHS Region 5,Season onset,52
+2017,17,2016/2017,69,HHS Region 5,Season peak week,7
+2017,17,2016/2017,69,HHS Region 5,Season peak week,8
+2017,17,2016/2017,69,HHS Region 5,Season peak percentage,4.3
+2017,17,2016/2017,69,HHS Region 5,1 wk ahead,1.1
+2017,17,2016/2017,69,HHS Region 5,2 wk ahead,1.1
+2017,17,2016/2017,69,HHS Region 5,3 wk ahead,0.9
+2017,17,2016/2017,69,HHS Region 5,4 wk ahead,0.8
+2017,17,2016/2017,69,HHS Region 6,Season onset,52
+2017,17,2016/2017,69,HHS Region 6,Season peak week,6
+2017,17,2016/2017,69,HHS Region 6,Season peak percentage,9.9
+2017,17,2016/2017,69,HHS Region 6,1 wk ahead,2.3
+2017,17,2016/2017,69,HHS Region 6,2 wk ahead,1.7
+2017,17,2016/2017,69,HHS Region 6,3 wk ahead,2.1
+2017,17,2016/2017,69,HHS Region 6,4 wk ahead,1.9
+2017,17,2016/2017,69,HHS Region 7,Season onset,51
+2017,17,2016/2017,69,HHS Region 7,Season peak week,6
+2017,17,2016/2017,69,HHS Region 7,Season peak percentage,6.4
+2017,17,2016/2017,69,HHS Region 7,1 wk ahead,0.7
+2017,17,2016/2017,69,HHS Region 7,2 wk ahead,0.4
+2017,17,2016/2017,69,HHS Region 7,3 wk ahead,0.3
+2017,17,2016/2017,69,HHS Region 7,4 wk ahead,0.2
+2017,17,2016/2017,69,HHS Region 8,Season onset,51
+2017,17,2016/2017,69,HHS Region 8,Season peak week,7
+2017,17,2016/2017,69,HHS Region 8,Season peak percentage,2.7
+2017,17,2016/2017,69,HHS Region 8,1 wk ahead,1
+2017,17,2016/2017,69,HHS Region 8,2 wk ahead,0.6
+2017,17,2016/2017,69,HHS Region 8,3 wk ahead,0.8
+2017,17,2016/2017,69,HHS Region 8,4 wk ahead,0.9
+2017,17,2016/2017,69,HHS Region 9,Season onset,51
+2017,17,2016/2017,69,HHS Region 9,Season peak week,52
+2017,17,2016/2017,69,HHS Region 9,Season peak percentage,3.3
+2017,17,2016/2017,69,HHS Region 9,1 wk ahead,1.7
+2017,17,2016/2017,69,HHS Region 9,2 wk ahead,1.6
+2017,17,2016/2017,69,HHS Region 9,3 wk ahead,1.6
+2017,17,2016/2017,69,HHS Region 9,4 wk ahead,1.5
+2017,17,2016/2017,69,HHS Region 10,Season onset,50
+2017,17,2016/2017,69,HHS Region 10,Season peak week,52
+2017,17,2016/2017,69,HHS Region 10,Season peak percentage,3.7
+2017,17,2016/2017,69,HHS Region 10,1 wk ahead,0.7
+2017,17,2016/2017,69,HHS Region 10,2 wk ahead,0.5
+2017,17,2016/2017,69,HHS Region 10,3 wk ahead,0.6
+2017,17,2016/2017,69,HHS Region 10,4 wk ahead,0.3
+2017,18,2016/2017,70,US National,Season onset,50
+2017,18,2016/2017,70,US National,Season peak week,6
+2017,18,2016/2017,70,US National,Season peak percentage,5.1
+2017,18,2016/2017,70,US National,1 wk ahead,1.3
+2017,18,2016/2017,70,US National,2 wk ahead,1.3
+2017,18,2016/2017,70,US National,3 wk ahead,1.2
+2017,18,2016/2017,70,US National,4 wk ahead,1.1
+2017,18,2016/2017,70,HHS Region 1,Season onset,52
+2017,18,2016/2017,70,HHS Region 1,Season peak week,6
+2017,18,2016/2017,70,HHS Region 1,Season peak percentage,3.2
+2017,18,2016/2017,70,HHS Region 1,1 wk ahead,0.7
+2017,18,2016/2017,70,HHS Region 1,2 wk ahead,0.7
+2017,18,2016/2017,70,HHS Region 1,3 wk ahead,0.6
+2017,18,2016/2017,70,HHS Region 1,4 wk ahead,0.7
+2017,18,2016/2017,70,HHS Region 2,Season onset,47
+2017,18,2016/2017,70,HHS Region 2,Season peak week,6
+2017,18,2016/2017,70,HHS Region 2,Season peak percentage,6.9
+2017,18,2016/2017,70,HHS Region 2,1 wk ahead,2
+2017,18,2016/2017,70,HHS Region 2,2 wk ahead,2.1
+2017,18,2016/2017,70,HHS Region 2,3 wk ahead,1.8
+2017,18,2016/2017,70,HHS Region 2,4 wk ahead,2
+2017,18,2016/2017,70,HHS Region 3,Season onset,51
+2017,18,2016/2017,70,HHS Region 3,Season peak week,7
+2017,18,2016/2017,70,HHS Region 3,Season peak percentage,5.2
+2017,18,2016/2017,70,HHS Region 3,1 wk ahead,0.9
+2017,18,2016/2017,70,HHS Region 3,2 wk ahead,1
+2017,18,2016/2017,70,HHS Region 3,3 wk ahead,0.9
+2017,18,2016/2017,70,HHS Region 3,4 wk ahead,1
+2017,18,2016/2017,70,HHS Region 4,Season onset,45
+2017,18,2016/2017,70,HHS Region 4,Season peak week,7
+2017,18,2016/2017,70,HHS Region 4,Season peak week,8
+2017,18,2016/2017,70,HHS Region 4,Season peak percentage,5.5
+2017,18,2016/2017,70,HHS Region 4,1 wk ahead,1.4
+2017,18,2016/2017,70,HHS Region 4,2 wk ahead,1.3
+2017,18,2016/2017,70,HHS Region 4,3 wk ahead,1.2
+2017,18,2016/2017,70,HHS Region 4,4 wk ahead,1
+2017,18,2016/2017,70,HHS Region 5,Season onset,52
+2017,18,2016/2017,70,HHS Region 5,Season peak week,7
+2017,18,2016/2017,70,HHS Region 5,Season peak week,8
+2017,18,2016/2017,70,HHS Region 5,Season peak percentage,4.3
+2017,18,2016/2017,70,HHS Region 5,1 wk ahead,1.1
+2017,18,2016/2017,70,HHS Region 5,2 wk ahead,0.9
+2017,18,2016/2017,70,HHS Region 5,3 wk ahead,0.8
+2017,18,2016/2017,70,HHS Region 5,4 wk ahead,0.8
+2017,18,2016/2017,70,HHS Region 6,Season onset,52
+2017,18,2016/2017,70,HHS Region 6,Season peak week,6
+2017,18,2016/2017,70,HHS Region 6,Season peak percentage,9.9
+2017,18,2016/2017,70,HHS Region 6,1 wk ahead,1.7
+2017,18,2016/2017,70,HHS Region 6,2 wk ahead,2.1
+2017,18,2016/2017,70,HHS Region 6,3 wk ahead,1.9
+2017,18,2016/2017,70,HHS Region 6,4 wk ahead,1.6
+2017,18,2016/2017,70,HHS Region 7,Season onset,51
+2017,18,2016/2017,70,HHS Region 7,Season peak week,6
+2017,18,2016/2017,70,HHS Region 7,Season peak percentage,6.4
+2017,18,2016/2017,70,HHS Region 7,1 wk ahead,0.4
+2017,18,2016/2017,70,HHS Region 7,2 wk ahead,0.3
+2017,18,2016/2017,70,HHS Region 7,3 wk ahead,0.2
+2017,18,2016/2017,70,HHS Region 7,4 wk ahead,0.2
+2017,18,2016/2017,70,HHS Region 8,Season onset,51
+2017,18,2016/2017,70,HHS Region 8,Season peak week,7
+2017,18,2016/2017,70,HHS Region 8,Season peak percentage,2.7
+2017,18,2016/2017,70,HHS Region 8,1 wk ahead,0.6
+2017,18,2016/2017,70,HHS Region 8,2 wk ahead,0.8
+2017,18,2016/2017,70,HHS Region 8,3 wk ahead,0.9
+2017,18,2016/2017,70,HHS Region 8,4 wk ahead,0.6
+2017,18,2016/2017,70,HHS Region 9,Season onset,51
+2017,18,2016/2017,70,HHS Region 9,Season peak week,52
+2017,18,2016/2017,70,HHS Region 9,Season peak percentage,3.3
+2017,18,2016/2017,70,HHS Region 9,1 wk ahead,1.6
+2017,18,2016/2017,70,HHS Region 9,2 wk ahead,1.6
+2017,18,2016/2017,70,HHS Region 9,3 wk ahead,1.5
+2017,18,2016/2017,70,HHS Region 9,4 wk ahead,1.5
+2017,18,2016/2017,70,HHS Region 10,Season onset,50
+2017,18,2016/2017,70,HHS Region 10,Season peak week,52
+2017,18,2016/2017,70,HHS Region 10,Season peak percentage,3.7
+2017,18,2016/2017,70,HHS Region 10,1 wk ahead,0.5
+2017,18,2016/2017,70,HHS Region 10,2 wk ahead,0.6
+2017,18,2016/2017,70,HHS Region 10,3 wk ahead,0.3
+2017,18,2016/2017,70,HHS Region 10,4 wk ahead,0.4
+2017,19,2016/2017,71,US National,Season onset,50
+2017,19,2016/2017,71,US National,Season peak week,6
+2017,19,2016/2017,71,US National,Season peak percentage,5.1
+2017,19,2016/2017,71,US National,1 wk ahead,1.3
+2017,19,2016/2017,71,US National,2 wk ahead,1.2
+2017,19,2016/2017,71,US National,3 wk ahead,1.1
+2017,19,2016/2017,71,US National,4 wk ahead,1.1
+2017,19,2016/2017,71,HHS Region 1,Season onset,52
+2017,19,2016/2017,71,HHS Region 1,Season peak week,6
+2017,19,2016/2017,71,HHS Region 1,Season peak percentage,3.2
+2017,19,2016/2017,71,HHS Region 1,1 wk ahead,0.7
+2017,19,2016/2017,71,HHS Region 1,2 wk ahead,0.6
+2017,19,2016/2017,71,HHS Region 1,3 wk ahead,0.7
+2017,19,2016/2017,71,HHS Region 1,4 wk ahead,0.6
+2017,19,2016/2017,71,HHS Region 2,Season onset,47
+2017,19,2016/2017,71,HHS Region 2,Season peak week,6
+2017,19,2016/2017,71,HHS Region 2,Season peak percentage,6.9
+2017,19,2016/2017,71,HHS Region 2,1 wk ahead,2.1
+2017,19,2016/2017,71,HHS Region 2,2 wk ahead,1.8
+2017,19,2016/2017,71,HHS Region 2,3 wk ahead,2
+2017,19,2016/2017,71,HHS Region 2,4 wk ahead,1.9
+2017,19,2016/2017,71,HHS Region 3,Season onset,51
+2017,19,2016/2017,71,HHS Region 3,Season peak week,7
+2017,19,2016/2017,71,HHS Region 3,Season peak percentage,5.2
+2017,19,2016/2017,71,HHS Region 3,1 wk ahead,1
+2017,19,2016/2017,71,HHS Region 3,2 wk ahead,0.9
+2017,19,2016/2017,71,HHS Region 3,3 wk ahead,1
+2017,19,2016/2017,71,HHS Region 3,4 wk ahead,0.9
+2017,19,2016/2017,71,HHS Region 4,Season onset,45
+2017,19,2016/2017,71,HHS Region 4,Season peak week,7
+2017,19,2016/2017,71,HHS Region 4,Season peak week,8
+2017,19,2016/2017,71,HHS Region 4,Season peak percentage,5.5
+2017,19,2016/2017,71,HHS Region 4,1 wk ahead,1.3
+2017,19,2016/2017,71,HHS Region 4,2 wk ahead,1.2
+2017,19,2016/2017,71,HHS Region 4,3 wk ahead,1
+2017,19,2016/2017,71,HHS Region 4,4 wk ahead,0.9
+2017,19,2016/2017,71,HHS Region 5,Season onset,52
+2017,19,2016/2017,71,HHS Region 5,Season peak week,7
+2017,19,2016/2017,71,HHS Region 5,Season peak week,8
+2017,19,2016/2017,71,HHS Region 5,Season peak percentage,4.3
+2017,19,2016/2017,71,HHS Region 5,1 wk ahead,0.9
+2017,19,2016/2017,71,HHS Region 5,2 wk ahead,0.8
+2017,19,2016/2017,71,HHS Region 5,3 wk ahead,0.8
+2017,19,2016/2017,71,HHS Region 5,4 wk ahead,0.7
+2017,19,2016/2017,71,HHS Region 6,Season onset,52
+2017,19,2016/2017,71,HHS Region 6,Season peak week,6
+2017,19,2016/2017,71,HHS Region 6,Season peak percentage,9.9
+2017,19,2016/2017,71,HHS Region 6,1 wk ahead,2.1
+2017,19,2016/2017,71,HHS Region 6,2 wk ahead,1.9
+2017,19,2016/2017,71,HHS Region 6,3 wk ahead,1.6
+2017,19,2016/2017,71,HHS Region 6,4 wk ahead,1.6
+2017,19,2016/2017,71,HHS Region 7,Season onset,51
+2017,19,2016/2017,71,HHS Region 7,Season peak week,6
+2017,19,2016/2017,71,HHS Region 7,Season peak percentage,6.4
+2017,19,2016/2017,71,HHS Region 7,1 wk ahead,0.3
+2017,19,2016/2017,71,HHS Region 7,2 wk ahead,0.2
+2017,19,2016/2017,71,HHS Region 7,3 wk ahead,0.2
+2017,19,2016/2017,71,HHS Region 7,4 wk ahead,0.2
+2017,19,2016/2017,71,HHS Region 8,Season onset,51
+2017,19,2016/2017,71,HHS Region 8,Season peak week,7
+2017,19,2016/2017,71,HHS Region 8,Season peak percentage,2.7
+2017,19,2016/2017,71,HHS Region 8,1 wk ahead,0.8
+2017,19,2016/2017,71,HHS Region 8,2 wk ahead,0.9
+2017,19,2016/2017,71,HHS Region 8,3 wk ahead,0.6
+2017,19,2016/2017,71,HHS Region 8,4 wk ahead,0.4
+2017,19,2016/2017,71,HHS Region 9,Season onset,51
+2017,19,2016/2017,71,HHS Region 9,Season peak week,52
+2017,19,2016/2017,71,HHS Region 9,Season peak percentage,3.3
+2017,19,2016/2017,71,HHS Region 9,1 wk ahead,1.6
+2017,19,2016/2017,71,HHS Region 9,2 wk ahead,1.5
+2017,19,2016/2017,71,HHS Region 9,3 wk ahead,1.5
+2017,19,2016/2017,71,HHS Region 9,4 wk ahead,1.6
+2017,19,2016/2017,71,HHS Region 10,Season onset,50
+2017,19,2016/2017,71,HHS Region 10,Season peak week,52
+2017,19,2016/2017,71,HHS Region 10,Season peak percentage,3.7
+2017,19,2016/2017,71,HHS Region 10,1 wk ahead,0.6
+2017,19,2016/2017,71,HHS Region 10,2 wk ahead,0.3
+2017,19,2016/2017,71,HHS Region 10,3 wk ahead,0.4
+2017,19,2016/2017,71,HHS Region 10,4 wk ahead,0.2
+2017,20,2016/2017,72,US National,Season onset,50
+2017,20,2016/2017,72,US National,Season peak week,6
+2017,20,2016/2017,72,US National,Season peak percentage,5.1
+2017,20,2016/2017,72,US National,1 wk ahead,1.2
+2017,20,2016/2017,72,US National,2 wk ahead,1.1
+2017,20,2016/2017,72,US National,3 wk ahead,1.1
+2017,20,2016/2017,72,US National,4 wk ahead,0.9
+2017,20,2016/2017,72,HHS Region 1,Season onset,52
+2017,20,2016/2017,72,HHS Region 1,Season peak week,6
+2017,20,2016/2017,72,HHS Region 1,Season peak percentage,3.2
+2017,20,2016/2017,72,HHS Region 1,1 wk ahead,0.6
+2017,20,2016/2017,72,HHS Region 1,2 wk ahead,0.7
+2017,20,2016/2017,72,HHS Region 1,3 wk ahead,0.6
+2017,20,2016/2017,72,HHS Region 1,4 wk ahead,0.5
+2017,20,2016/2017,72,HHS Region 2,Season onset,47
+2017,20,2016/2017,72,HHS Region 2,Season peak week,6
+2017,20,2016/2017,72,HHS Region 2,Season peak percentage,6.9
+2017,20,2016/2017,72,HHS Region 2,1 wk ahead,1.8
+2017,20,2016/2017,72,HHS Region 2,2 wk ahead,2
+2017,20,2016/2017,72,HHS Region 2,3 wk ahead,1.9
+2017,20,2016/2017,72,HHS Region 2,4 wk ahead,1.7
+2017,20,2016/2017,72,HHS Region 3,Season onset,51
+2017,20,2016/2017,72,HHS Region 3,Season peak week,7
+2017,20,2016/2017,72,HHS Region 3,Season peak percentage,5.2
+2017,20,2016/2017,72,HHS Region 3,1 wk ahead,0.9
+2017,20,2016/2017,72,HHS Region 3,2 wk ahead,1
+2017,20,2016/2017,72,HHS Region 3,3 wk ahead,0.9
+2017,20,2016/2017,72,HHS Region 3,4 wk ahead,0.8
+2017,20,2016/2017,72,HHS Region 4,Season onset,45
+2017,20,2016/2017,72,HHS Region 4,Season peak week,7
+2017,20,2016/2017,72,HHS Region 4,Season peak week,8
+2017,20,2016/2017,72,HHS Region 4,Season peak percentage,5.5
+2017,20,2016/2017,72,HHS Region 4,1 wk ahead,1.2
+2017,20,2016/2017,72,HHS Region 4,2 wk ahead,1
+2017,20,2016/2017,72,HHS Region 4,3 wk ahead,0.9
+2017,20,2016/2017,72,HHS Region 4,4 wk ahead,0.7
+2017,20,2016/2017,72,HHS Region 5,Season onset,52
+2017,20,2016/2017,72,HHS Region 5,Season peak week,7
+2017,20,2016/2017,72,HHS Region 5,Season peak week,8
+2017,20,2016/2017,72,HHS Region 5,Season peak percentage,4.3
+2017,20,2016/2017,72,HHS Region 5,1 wk ahead,0.8
+2017,20,2016/2017,72,HHS Region 5,2 wk ahead,0.8
+2017,20,2016/2017,72,HHS Region 5,3 wk ahead,0.7
+2017,20,2016/2017,72,HHS Region 5,4 wk ahead,0.6
+2017,20,2016/2017,72,HHS Region 6,Season onset,52
+2017,20,2016/2017,72,HHS Region 6,Season peak week,6
+2017,20,2016/2017,72,HHS Region 6,Season peak percentage,9.9
+2017,20,2016/2017,72,HHS Region 6,1 wk ahead,1.9
+2017,20,2016/2017,72,HHS Region 6,2 wk ahead,1.6
+2017,20,2016/2017,72,HHS Region 6,3 wk ahead,1.6
+2017,20,2016/2017,72,HHS Region 6,4 wk ahead,1.4
+2017,20,2016/2017,72,HHS Region 7,Season onset,51
+2017,20,2016/2017,72,HHS Region 7,Season peak week,6
+2017,20,2016/2017,72,HHS Region 7,Season peak percentage,6.4
+2017,20,2016/2017,72,HHS Region 7,1 wk ahead,0.2
+2017,20,2016/2017,72,HHS Region 7,2 wk ahead,0.2
+2017,20,2016/2017,72,HHS Region 7,3 wk ahead,0.2
+2017,20,2016/2017,72,HHS Region 7,4 wk ahead,0.2
+2017,20,2016/2017,72,HHS Region 8,Season onset,51
+2017,20,2016/2017,72,HHS Region 8,Season peak week,7
+2017,20,2016/2017,72,HHS Region 8,Season peak percentage,2.7
+2017,20,2016/2017,72,HHS Region 8,1 wk ahead,0.9
+2017,20,2016/2017,72,HHS Region 8,2 wk ahead,0.6
+2017,20,2016/2017,72,HHS Region 8,3 wk ahead,0.4
+2017,20,2016/2017,72,HHS Region 8,4 wk ahead,0.2
+2017,20,2016/2017,72,HHS Region 9,Season onset,51
+2017,20,2016/2017,72,HHS Region 9,Season peak week,52
+2017,20,2016/2017,72,HHS Region 9,Season peak percentage,3.3
+2017,20,2016/2017,72,HHS Region 9,1 wk ahead,1.5
+2017,20,2016/2017,72,HHS Region 9,2 wk ahead,1.5
+2017,20,2016/2017,72,HHS Region 9,3 wk ahead,1.6
+2017,20,2016/2017,72,HHS Region 9,4 wk ahead,1.3
+2017,20,2016/2017,72,HHS Region 10,Season onset,50
+2017,20,2016/2017,72,HHS Region 10,Season peak week,52
+2017,20,2016/2017,72,HHS Region 10,Season peak percentage,3.7
+2017,20,2016/2017,72,HHS Region 10,1 wk ahead,0.3
+2017,20,2016/2017,72,HHS Region 10,2 wk ahead,0.4
+2017,20,2016/2017,72,HHS Region 10,3 wk ahead,0.2
+2017,20,2016/2017,72,HHS Region 10,4 wk ahead,0.3

--- a/scripts/calculate-targets.R
+++ b/scripts/calculate-targets.R
@@ -1,0 +1,159 @@
+library("pipeR")
+library("epiforecast")
+
+## Different location naming schemes:
+fluview.location.epidata.names = c("nat", paste0("hhs",1:10))
+fluview.location.spreadsheet.names = c("US National", paste0("HHS Region ",1:10))
+
+## Load in the baselines and epidata:
+epidata.cache.dir = "~/.epiforecast-cache"
+if (!dir.exists(epidata.cache.dir)) {
+  dir.create(epidata.cache.dir)
+}
+fluview.baseline.info = fetchUpdatingResource(
+  function() {
+    LICENSE=RCurl::getURL("https://raw.githubusercontent.com/cdcepi/FluSight-forecasts/master/LICENSE")
+    wILI_Baseline=read.csv(textConnection(RCurl::getURL("https://raw.githubusercontent.com/cdcepi/FluSight-forecasts/master/wILI_Baseline.csv")), row.names=1L, check.names=FALSE, stringsAsFactors=FALSE)
+    cat("LICENSE for wILI_Baseline.csv:")
+    cat(LICENSE)
+    return (list(
+      LICENSE=LICENSE,
+      wILI_Baseline=wILI_Baseline
+    ))
+  },
+  function(fetch.response) {
+    return ()
+  },
+  cache.file.prefix=file.path(epidata.cache.dir,"fluview_baselines"),
+  cache.invalidation.period=as.difftime(1L, units="weeks")
+)
+fluview.baseline.ls.mat =
+  fluview.baseline.info[["wILI_Baseline"]] %>>%
+  as.matrix() %>>%
+  ## Adjust rownames to match 2016/2017 spreadsheet Location names:
+  magrittr::set_rownames(rownames(.) %>>%
+                         stringr::str_replace_all("Region", "HHS Region ") %>>%
+                         dplyr::recode("National"="US National")
+                         ) %>>%
+  ## Re-order rows so HHS Region i is at index i and US National is at 11L:
+  magrittr::extract(c(2:11,1L),) %>>%
+  ## Set dimnames names:
+  structure(dimnames=dimnames(.) %>>%
+              setNames(c("Location", "Season"))) %>>%
+  {.}
+fluview.baseline.df =
+  reshape2::melt(fluview.baseline.ls.mat, value.name="baseline") %>>%
+  dplyr::mutate(season.int=Season %>>%
+                  as.character() %>>%
+                  stringr::str_replace_all("/.*","") %>>%
+                  as.integer()) %>>%
+  {.}
+fluview.current.l.dfs = fluview.location.epidata.names %>>%
+  setNames(fluview.location.spreadsheet.names) %>>%
+  lapply(function(fluview.location.epidata.name) {
+  fetchEpidataDF(
+    "fluview", fluview.location.epidata.name,
+    first.week.of.season=usa.flu.first.week.of.season,
+    cache.file.prefix=file.path(epidata.cache.dir,paste0("fluview_",fluview.location.epidata.name,"_",Sys.Date()))
+  )
+})
+## fluview.history.l.dfs =
+##   fluview.location.epidata.names %>>%
+##   setNames(fluview.location.spreadsheet.names) %>>%
+##   lapply(function(fluview.location.epidata.name) {
+##     fetchEpidataHistoryDF(
+##       "fluview", fluview.location.epidata.name, 0:51,
+##       first.week.of.season=usa.flu.first.week.of.season,
+##       cache.file.prefix=file.path(epidata.cache.dir,paste0("fluview_",fluview.location.epidata.name))
+##     )
+##   })
+
+##' Fetch settings needed for target calculations
+##'
+##' Get the baseline (onset threshold) wILI (length-1 numeric), flags for
+##' in-season weeks (52/53-length logical vector), and "time of forecast"
+##' (length-1 integer) --- time 1 is week 31, time 2 is week 32, etc.
+flusight2016_settings = function(forecast.epiweek, forecast.Location) {
+  forecast.smw = epiforecast:::yearWeekToSeasonModelWeekDF(
+                                 forecast.epiweek%/%100L, forecast.epiweek%%100L,
+                                 40L, 3L)
+  mimicked.baseline = epiforecast::mimicPastDF(
+                                     fluview.baseline.df,
+                                     "season.int", forecast.smw[["season"]],
+                                     nontime.index.colnames="Location") %>>%
+    with(baseline[Location==forecast.Location])
+  n.weeks.in.season = epiforecast::lastWeekNumber(forecast.smw[["season"]], 3L)
+  is.inseason = usa_flu_inseason_flags(n.weeks.in.season)
+  mimicked.time.of.forecast = model_week_to_time(forecast.smw[["model.week"]],
+                                                 usa.flu.first.week.of.season)
+  flusight2016.settings = list(
+    baseline=mimicked.baseline,
+    is.inseason=is.inseason,
+    target.time.of.forecast=mimicked.time.of.forecast
+  )
+  return (flusight2016.settings)
+}
+
+## Set weeks & locations & targets for which to perform calculations:
+input.epiweeks = 2010:2016 %>>%
+  epiforecast::DatesOfSeason(40L,0L,3L) %>>%
+  dplyr::combine() %>>%
+  epiforecast::DateToYearWeekWdayDF(0L,3L) %>>%
+  dplyr::filter(! week %>>% dplyr::between(21L,39L)) %>>%
+  with(year*100L+week)
+input.Locations = fluview.location.spreadsheet.names
+input.targets = epiforecast:::flusight2016.targets
+
+## This is slow for some reason, so set up parallelism:
+options(mc.cores=parallel::detectCores()-1L)
+
+target.multival.df =
+  ## for each input epiweek...
+  input.epiweeks %>>%
+  parallel::mclapply(function(input.epiweek) {
+    print(input.epiweek) # progress indicator
+    ## calculate other types of timing information:
+    input.year = input.epiweek %/% 100L
+    input.week = input.epiweek %% 100L
+    input.smw = epiforecast:::yearWeekToSeasonModelWeekDF(input.year, input.week, 40L, 3L)
+    input.season = input.smw[["season"]]
+    input.model.week = input.smw[["model.week"]]
+    input.Season = paste0(input.season, "/", input.season+1L)
+    ## for each input Location...
+    input.Locations %>>% stats::setNames(input.Locations) %>>%
+      lapply(function(input.Location) {
+        ## get trajectory, round it, get Season & Location specific settings:
+        trajectory = fluview.current.l.dfs[[input.Location]] %>>%
+          with(wili[season==input.season])
+        rounded.trajectory = epiforecast:::flusight2016_target_trajectory_preprocessor(trajectory)
+        target.settings = flusight2016_settings(input.epiweek, input.Location)
+        ## calculate the valid target values, convert to Bin_start_incl string
+        ## representations with some indexing information:
+        input.targets %>>%
+          lapply(function(input.target) {
+            ## multival: list of valid value(s) using target-specific class:
+            multival = do.call(input.target[["for_processed_trajectory"]],
+                               c(list(rounded.trajectory),
+                                 target.settings))
+            ## valid.bin.starts: corresponding Bin_start_incl string(s)
+            valid.bin.starts = do.call(input.target[["unit"]][["to_string"]],
+                                       c(list(multival),
+                                         target.settings))
+            ## put in tibble with some indexing information
+            tibble::tibble(
+                      Year = input.year,
+                      `Calendar Week` = input.week,
+                      Season = input.Season,
+                      `Model Week` = input.model.week,
+                      `Valid Bin_start_incl` = valid.bin.starts
+                    )
+            ## bind everything together into a single tibble:
+          }) %>>% dplyr::bind_rows(.id="Target")
+      }) %>>% dplyr::bind_rows(.id="Location")
+  }) %>>% dplyr::bind_rows() %>>%
+  ## reorder columns:
+  dplyr::select(Year, `Calendar Week`, Season, `Model Week`, Location, Target, `Valid Bin_start_incl`) %>>%
+  {.}
+
+## write the results:
+readr::write_csv(target.multival.df, "../scores/target-multivals.csv")


### PR DESCRIPTION
- scripts/target-multivals.csv: for each season, forecast week, location, and
  target in the retrospective study, calculate the "valid Bin_start_incl"
  values.
  + Targets other than Season peak week will have only one valid Bin_start_incl
    value for each <season, forecast week, location, target> combination: the
    Bin_start_incl corresponding to the observed value of the target
  + Season peak week can sometimes have more than one valid Bin_start_incl
    value, if multiple weeks are tied for the highest rounded wILI value.
  + Target calculations currently use the wILI data available *at the time the
    script is run* (rather than, e.g., data available at the first forecast of
    the following season).
  + Results are saved in scores/target-multivals.csv

- scores/target-multivals.csv: precomputed output of the above script.