### PR TITLE
Use issue week 28 or nearby data as ground truth rather than current

### DIFF
--- a/scores/target-multivals.csv
+++ b/scores/target-multivals.csv
@@ -1,8 +1,9 @@
 Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,40,2010/2011,40,US National,Season onset,51
 2010,40,2010/2011,40,US National,Season peak week,5
+2010,40,2010/2011,40,US National,Season peak week,6
 2010,40,2010/2011,40,US National,Season peak week,7
-2010,40,2010/2011,40,US National,Season peak percentage,4.6
+2010,40,2010/2011,40,US National,Season peak percentage,4.5
 2010,40,2010/2011,40,US National,1 wk ahead,1.2
 2010,40,2010/2011,40,US National,2 wk ahead,1.3
 2010,40,2010/2011,40,US National,3 wk ahead,1.3
@@ -29,11 +30,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,40,2010/2011,40,HHS Region 3,2 wk ahead,1.1
 2010,40,2010/2011,40,HHS Region 3,3 wk ahead,1.1
 2010,40,2010/2011,40,HHS Region 3,4 wk ahead,1.2
-2010,40,2010/2011,40,HHS Region 4,Season onset,50
+2010,40,2010/2011,40,HHS Region 4,Season onset,49
 2010,40,2010/2011,40,HHS Region 4,Season peak week,5
-2010,40,2010/2011,40,HHS Region 4,Season peak percentage,5.5
-2010,40,2010/2011,40,HHS Region 4,1 wk ahead,1.1
-2010,40,2010/2011,40,HHS Region 4,2 wk ahead,1
+2010,40,2010/2011,40,HHS Region 4,Season peak percentage,5.6
+2010,40,2010/2011,40,HHS Region 4,1 wk ahead,1
+2010,40,2010/2011,40,HHS Region 4,2 wk ahead,1.1
 2010,40,2010/2011,40,HHS Region 4,3 wk ahead,1.2
 2010,40,2010/2011,40,HHS Region 4,4 wk ahead,1.4
 2010,40,2010/2011,40,HHS Region 5,Season onset,3
@@ -49,7 +50,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,40,2010/2011,40,HHS Region 6,1 wk ahead,1.9
 2010,40,2010/2011,40,HHS Region 6,2 wk ahead,2
 2010,40,2010/2011,40,HHS Region 6,3 wk ahead,2
-2010,40,2010/2011,40,HHS Region 6,4 wk ahead,2.2
+2010,40,2010/2011,40,HHS Region 6,4 wk ahead,2.3
 2010,40,2010/2011,40,HHS Region 7,Season onset,4
 2010,40,2010/2011,40,HHS Region 7,Season peak week,8
 2010,40,2010/2011,40,HHS Region 7,Season peak percentage,4.7
@@ -64,9 +65,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,40,2010/2011,40,HHS Region 8,2 wk ahead,0.6
 2010,40,2010/2011,40,HHS Region 8,3 wk ahead,0.7
 2010,40,2010/2011,40,HHS Region 8,4 wk ahead,0.8
-2010,40,2010/2011,40,HHS Region 9,Season onset,6
+2010,40,2010/2011,40,HHS Region 9,Season onset,none
 2010,40,2010/2011,40,HHS Region 9,Season peak week,7
-2010,40,2010/2011,40,HHS Region 9,Season peak week,8
 2010,40,2010/2011,40,HHS Region 9,Season peak percentage,4.7
 2010,40,2010/2011,40,HHS Region 9,1 wk ahead,1.9
 2010,40,2010/2011,40,HHS Region 9,2 wk ahead,2
@@ -81,8 +81,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,40,2010/2011,40,HHS Region 10,4 wk ahead,0.9
 2010,41,2010/2011,41,US National,Season onset,51
 2010,41,2010/2011,41,US National,Season peak week,5
+2010,41,2010/2011,41,US National,Season peak week,6
 2010,41,2010/2011,41,US National,Season peak week,7
-2010,41,2010/2011,41,US National,Season peak percentage,4.6
+2010,41,2010/2011,41,US National,Season peak percentage,4.5
 2010,41,2010/2011,41,US National,1 wk ahead,1.3
 2010,41,2010/2011,41,US National,2 wk ahead,1.3
 2010,41,2010/2011,41,US National,3 wk ahead,1.4
@@ -109,10 +110,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,41,2010/2011,41,HHS Region 3,2 wk ahead,1.1
 2010,41,2010/2011,41,HHS Region 3,3 wk ahead,1.2
 2010,41,2010/2011,41,HHS Region 3,4 wk ahead,1.3
-2010,41,2010/2011,41,HHS Region 4,Season onset,50
+2010,41,2010/2011,41,HHS Region 4,Season onset,49
 2010,41,2010/2011,41,HHS Region 4,Season peak week,5
-2010,41,2010/2011,41,HHS Region 4,Season peak percentage,5.5
-2010,41,2010/2011,41,HHS Region 4,1 wk ahead,1
+2010,41,2010/2011,41,HHS Region 4,Season peak percentage,5.6
+2010,41,2010/2011,41,HHS Region 4,1 wk ahead,1.1
 2010,41,2010/2011,41,HHS Region 4,2 wk ahead,1.2
 2010,41,2010/2011,41,HHS Region 4,3 wk ahead,1.4
 2010,41,2010/2011,41,HHS Region 4,4 wk ahead,1.6
@@ -128,7 +129,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,41,2010/2011,41,HHS Region 6,Season peak percentage,7.9
 2010,41,2010/2011,41,HHS Region 6,1 wk ahead,2
 2010,41,2010/2011,41,HHS Region 6,2 wk ahead,2
-2010,41,2010/2011,41,HHS Region 6,3 wk ahead,2.2
+2010,41,2010/2011,41,HHS Region 6,3 wk ahead,2.3
 2010,41,2010/2011,41,HHS Region 6,4 wk ahead,2.4
 2010,41,2010/2011,41,HHS Region 7,Season onset,4
 2010,41,2010/2011,41,HHS Region 7,Season peak week,8
@@ -144,9 +145,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,41,2010/2011,41,HHS Region 8,2 wk ahead,0.7
 2010,41,2010/2011,41,HHS Region 8,3 wk ahead,0.8
 2010,41,2010/2011,41,HHS Region 8,4 wk ahead,0.7
-2010,41,2010/2011,41,HHS Region 9,Season onset,6
+2010,41,2010/2011,41,HHS Region 9,Season onset,none
 2010,41,2010/2011,41,HHS Region 9,Season peak week,7
-2010,41,2010/2011,41,HHS Region 9,Season peak week,8
 2010,41,2010/2011,41,HHS Region 9,Season peak percentage,4.7
 2010,41,2010/2011,41,HHS Region 9,1 wk ahead,2
 2010,41,2010/2011,41,HHS Region 9,2 wk ahead,1.8
@@ -161,8 +161,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,41,2010/2011,41,HHS Region 10,4 wk ahead,1
 2010,42,2010/2011,42,US National,Season onset,51
 2010,42,2010/2011,42,US National,Season peak week,5
+2010,42,2010/2011,42,US National,Season peak week,6
 2010,42,2010/2011,42,US National,Season peak week,7
-2010,42,2010/2011,42,US National,Season peak percentage,4.6
+2010,42,2010/2011,42,US National,Season peak percentage,4.5
 2010,42,2010/2011,42,US National,1 wk ahead,1.3
 2010,42,2010/2011,42,US National,2 wk ahead,1.4
 2010,42,2010/2011,42,US National,3 wk ahead,1.5
@@ -189,25 +190,25 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,42,2010/2011,42,HHS Region 3,2 wk ahead,1.2
 2010,42,2010/2011,42,HHS Region 3,3 wk ahead,1.3
 2010,42,2010/2011,42,HHS Region 3,4 wk ahead,1.3
-2010,42,2010/2011,42,HHS Region 4,Season onset,50
+2010,42,2010/2011,42,HHS Region 4,Season onset,49
 2010,42,2010/2011,42,HHS Region 4,Season peak week,5
-2010,42,2010/2011,42,HHS Region 4,Season peak percentage,5.5
+2010,42,2010/2011,42,HHS Region 4,Season peak percentage,5.6
 2010,42,2010/2011,42,HHS Region 4,1 wk ahead,1.2
 2010,42,2010/2011,42,HHS Region 4,2 wk ahead,1.4
 2010,42,2010/2011,42,HHS Region 4,3 wk ahead,1.6
-2010,42,2010/2011,42,HHS Region 4,4 wk ahead,1.8
+2010,42,2010/2011,42,HHS Region 4,4 wk ahead,1.9
 2010,42,2010/2011,42,HHS Region 5,Season onset,3
 2010,42,2010/2011,42,HHS Region 5,Season peak week,5
 2010,42,2010/2011,42,HHS Region 5,Season peak percentage,3.8
 2010,42,2010/2011,42,HHS Region 5,1 wk ahead,0.9
 2010,42,2010/2011,42,HHS Region 5,2 wk ahead,1
 2010,42,2010/2011,42,HHS Region 5,3 wk ahead,0.9
-2010,42,2010/2011,42,HHS Region 5,4 wk ahead,0.9
+2010,42,2010/2011,42,HHS Region 5,4 wk ahead,1
 2010,42,2010/2011,42,HHS Region 6,Season onset,3
 2010,42,2010/2011,42,HHS Region 6,Season peak week,7
 2010,42,2010/2011,42,HHS Region 6,Season peak percentage,7.9
 2010,42,2010/2011,42,HHS Region 6,1 wk ahead,2
-2010,42,2010/2011,42,HHS Region 6,2 wk ahead,2.2
+2010,42,2010/2011,42,HHS Region 6,2 wk ahead,2.3
 2010,42,2010/2011,42,HHS Region 6,3 wk ahead,2.4
 2010,42,2010/2011,42,HHS Region 6,4 wk ahead,2.4
 2010,42,2010/2011,42,HHS Region 7,Season onset,4
@@ -224,9 +225,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,42,2010/2011,42,HHS Region 8,2 wk ahead,0.8
 2010,42,2010/2011,42,HHS Region 8,3 wk ahead,0.7
 2010,42,2010/2011,42,HHS Region 8,4 wk ahead,0.7
-2010,42,2010/2011,42,HHS Region 9,Season onset,6
+2010,42,2010/2011,42,HHS Region 9,Season onset,none
 2010,42,2010/2011,42,HHS Region 9,Season peak week,7
-2010,42,2010/2011,42,HHS Region 9,Season peak week,8
 2010,42,2010/2011,42,HHS Region 9,Season peak percentage,4.7
 2010,42,2010/2011,42,HHS Region 9,1 wk ahead,1.8
 2010,42,2010/2011,42,HHS Region 9,2 wk ahead,2.3
@@ -241,8 +241,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,42,2010/2011,42,HHS Region 10,4 wk ahead,1.2
 2010,43,2010/2011,43,US National,Season onset,51
 2010,43,2010/2011,43,US National,Season peak week,5
+2010,43,2010/2011,43,US National,Season peak week,6
 2010,43,2010/2011,43,US National,Season peak week,7
-2010,43,2010/2011,43,US National,Season peak percentage,4.6
+2010,43,2010/2011,43,US National,Season peak percentage,4.5
 2010,43,2010/2011,43,US National,1 wk ahead,1.4
 2010,43,2010/2011,43,US National,2 wk ahead,1.5
 2010,43,2010/2011,43,US National,3 wk ahead,1.6
@@ -269,24 +270,24 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,43,2010/2011,43,HHS Region 3,2 wk ahead,1.3
 2010,43,2010/2011,43,HHS Region 3,3 wk ahead,1.3
 2010,43,2010/2011,43,HHS Region 3,4 wk ahead,1.5
-2010,43,2010/2011,43,HHS Region 4,Season onset,50
+2010,43,2010/2011,43,HHS Region 4,Season onset,49
 2010,43,2010/2011,43,HHS Region 4,Season peak week,5
-2010,43,2010/2011,43,HHS Region 4,Season peak percentage,5.5
+2010,43,2010/2011,43,HHS Region 4,Season peak percentage,5.6
 2010,43,2010/2011,43,HHS Region 4,1 wk ahead,1.4
 2010,43,2010/2011,43,HHS Region 4,2 wk ahead,1.6
-2010,43,2010/2011,43,HHS Region 4,3 wk ahead,1.8
+2010,43,2010/2011,43,HHS Region 4,3 wk ahead,1.9
 2010,43,2010/2011,43,HHS Region 4,4 wk ahead,2.2
 2010,43,2010/2011,43,HHS Region 5,Season onset,3
 2010,43,2010/2011,43,HHS Region 5,Season peak week,5
 2010,43,2010/2011,43,HHS Region 5,Season peak percentage,3.8
 2010,43,2010/2011,43,HHS Region 5,1 wk ahead,1
 2010,43,2010/2011,43,HHS Region 5,2 wk ahead,0.9
-2010,43,2010/2011,43,HHS Region 5,3 wk ahead,0.9
+2010,43,2010/2011,43,HHS Region 5,3 wk ahead,1
 2010,43,2010/2011,43,HHS Region 5,4 wk ahead,1
 2010,43,2010/2011,43,HHS Region 6,Season onset,3
 2010,43,2010/2011,43,HHS Region 6,Season peak week,7
 2010,43,2010/2011,43,HHS Region 6,Season peak percentage,7.9
-2010,43,2010/2011,43,HHS Region 6,1 wk ahead,2.2
+2010,43,2010/2011,43,HHS Region 6,1 wk ahead,2.3
 2010,43,2010/2011,43,HHS Region 6,2 wk ahead,2.4
 2010,43,2010/2011,43,HHS Region 6,3 wk ahead,2.4
 2010,43,2010/2011,43,HHS Region 6,4 wk ahead,2.6
@@ -304,9 +305,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,43,2010/2011,43,HHS Region 8,2 wk ahead,0.7
 2010,43,2010/2011,43,HHS Region 8,3 wk ahead,0.7
 2010,43,2010/2011,43,HHS Region 8,4 wk ahead,0.7
-2010,43,2010/2011,43,HHS Region 9,Season onset,6
+2010,43,2010/2011,43,HHS Region 9,Season onset,none
 2010,43,2010/2011,43,HHS Region 9,Season peak week,7
-2010,43,2010/2011,43,HHS Region 9,Season peak week,8
 2010,43,2010/2011,43,HHS Region 9,Season peak percentage,4.7
 2010,43,2010/2011,43,HHS Region 9,1 wk ahead,2.3
 2010,43,2010/2011,43,HHS Region 9,2 wk ahead,2.3
@@ -321,8 +321,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,43,2010/2011,43,HHS Region 10,4 wk ahead,1.7
 2010,44,2010/2011,44,US National,Season onset,51
 2010,44,2010/2011,44,US National,Season peak week,5
+2010,44,2010/2011,44,US National,Season peak week,6
 2010,44,2010/2011,44,US National,Season peak week,7
-2010,44,2010/2011,44,US National,Season peak percentage,4.6
+2010,44,2010/2011,44,US National,Season peak percentage,4.5
 2010,44,2010/2011,44,US National,1 wk ahead,1.5
 2010,44,2010/2011,44,US National,2 wk ahead,1.6
 2010,44,2010/2011,44,US National,3 wk ahead,1.8
@@ -349,18 +350,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,44,2010/2011,44,HHS Region 3,2 wk ahead,1.3
 2010,44,2010/2011,44,HHS Region 3,3 wk ahead,1.5
 2010,44,2010/2011,44,HHS Region 3,4 wk ahead,1.5
-2010,44,2010/2011,44,HHS Region 4,Season onset,50
+2010,44,2010/2011,44,HHS Region 4,Season onset,49
 2010,44,2010/2011,44,HHS Region 4,Season peak week,5
-2010,44,2010/2011,44,HHS Region 4,Season peak percentage,5.5
+2010,44,2010/2011,44,HHS Region 4,Season peak percentage,5.6
 2010,44,2010/2011,44,HHS Region 4,1 wk ahead,1.6
-2010,44,2010/2011,44,HHS Region 4,2 wk ahead,1.8
+2010,44,2010/2011,44,HHS Region 4,2 wk ahead,1.9
 2010,44,2010/2011,44,HHS Region 4,3 wk ahead,2.2
-2010,44,2010/2011,44,HHS Region 4,4 wk ahead,1.9
+2010,44,2010/2011,44,HHS Region 4,4 wk ahead,2
 2010,44,2010/2011,44,HHS Region 5,Season onset,3
 2010,44,2010/2011,44,HHS Region 5,Season peak week,5
 2010,44,2010/2011,44,HHS Region 5,Season peak percentage,3.8
 2010,44,2010/2011,44,HHS Region 5,1 wk ahead,0.9
-2010,44,2010/2011,44,HHS Region 5,2 wk ahead,0.9
+2010,44,2010/2011,44,HHS Region 5,2 wk ahead,1
 2010,44,2010/2011,44,HHS Region 5,3 wk ahead,1
 2010,44,2010/2011,44,HHS Region 5,4 wk ahead,0.9
 2010,44,2010/2011,44,HHS Region 6,Season onset,3
@@ -384,9 +385,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,44,2010/2011,44,HHS Region 8,2 wk ahead,0.7
 2010,44,2010/2011,44,HHS Region 8,3 wk ahead,0.7
 2010,44,2010/2011,44,HHS Region 8,4 wk ahead,0.7
-2010,44,2010/2011,44,HHS Region 9,Season onset,6
+2010,44,2010/2011,44,HHS Region 9,Season onset,none
 2010,44,2010/2011,44,HHS Region 9,Season peak week,7
-2010,44,2010/2011,44,HHS Region 9,Season peak week,8
 2010,44,2010/2011,44,HHS Region 9,Season peak percentage,4.7
 2010,44,2010/2011,44,HHS Region 9,1 wk ahead,2.3
 2010,44,2010/2011,44,HHS Region 9,2 wk ahead,2.5
@@ -401,8 +401,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,44,2010/2011,44,HHS Region 10,4 wk ahead,1
 2010,45,2010/2011,45,US National,Season onset,51
 2010,45,2010/2011,45,US National,Season peak week,5
+2010,45,2010/2011,45,US National,Season peak week,6
 2010,45,2010/2011,45,US National,Season peak week,7
-2010,45,2010/2011,45,US National,Season peak percentage,4.6
+2010,45,2010/2011,45,US National,Season peak percentage,4.5
 2010,45,2010/2011,45,US National,1 wk ahead,1.6
 2010,45,2010/2011,45,US National,2 wk ahead,1.8
 2010,45,2010/2011,45,US National,3 wk ahead,1.7
@@ -429,17 +430,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,45,2010/2011,45,HHS Region 3,2 wk ahead,1.5
 2010,45,2010/2011,45,HHS Region 3,3 wk ahead,1.5
 2010,45,2010/2011,45,HHS Region 3,4 wk ahead,1.5
-2010,45,2010/2011,45,HHS Region 4,Season onset,50
+2010,45,2010/2011,45,HHS Region 4,Season onset,49
 2010,45,2010/2011,45,HHS Region 4,Season peak week,5
-2010,45,2010/2011,45,HHS Region 4,Season peak percentage,5.5
-2010,45,2010/2011,45,HHS Region 4,1 wk ahead,1.8
+2010,45,2010/2011,45,HHS Region 4,Season peak percentage,5.6
+2010,45,2010/2011,45,HHS Region 4,1 wk ahead,1.9
 2010,45,2010/2011,45,HHS Region 4,2 wk ahead,2.2
-2010,45,2010/2011,45,HHS Region 4,3 wk ahead,1.9
-2010,45,2010/2011,45,HHS Region 4,4 wk ahead,2.2
+2010,45,2010/2011,45,HHS Region 4,3 wk ahead,2
+2010,45,2010/2011,45,HHS Region 4,4 wk ahead,2.3
 2010,45,2010/2011,45,HHS Region 5,Season onset,3
 2010,45,2010/2011,45,HHS Region 5,Season peak week,5
 2010,45,2010/2011,45,HHS Region 5,Season peak percentage,3.8
-2010,45,2010/2011,45,HHS Region 5,1 wk ahead,0.9
+2010,45,2010/2011,45,HHS Region 5,1 wk ahead,1
 2010,45,2010/2011,45,HHS Region 5,2 wk ahead,1
 2010,45,2010/2011,45,HHS Region 5,3 wk ahead,0.9
 2010,45,2010/2011,45,HHS Region 5,4 wk ahead,1
@@ -464,9 +465,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,45,2010/2011,45,HHS Region 8,2 wk ahead,0.7
 2010,45,2010/2011,45,HHS Region 8,3 wk ahead,0.7
 2010,45,2010/2011,45,HHS Region 8,4 wk ahead,0.8
-2010,45,2010/2011,45,HHS Region 9,Season onset,6
+2010,45,2010/2011,45,HHS Region 9,Season onset,none
 2010,45,2010/2011,45,HHS Region 9,Season peak week,7
-2010,45,2010/2011,45,HHS Region 9,Season peak week,8
 2010,45,2010/2011,45,HHS Region 9,Season peak percentage,4.7
 2010,45,2010/2011,45,HHS Region 9,1 wk ahead,2.5
 2010,45,2010/2011,45,HHS Region 9,2 wk ahead,2.8
@@ -481,12 +481,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,45,2010/2011,45,HHS Region 10,4 wk ahead,1.1
 2010,46,2010/2011,46,US National,Season onset,51
 2010,46,2010/2011,46,US National,Season peak week,5
+2010,46,2010/2011,46,US National,Season peak week,6
 2010,46,2010/2011,46,US National,Season peak week,7
-2010,46,2010/2011,46,US National,Season peak percentage,4.6
+2010,46,2010/2011,46,US National,Season peak percentage,4.5
 2010,46,2010/2011,46,US National,1 wk ahead,1.8
 2010,46,2010/2011,46,US National,2 wk ahead,1.7
 2010,46,2010/2011,46,US National,3 wk ahead,1.9
-2010,46,2010/2011,46,US National,4 wk ahead,2.3
+2010,46,2010/2011,46,US National,4 wk ahead,2.4
 2010,46,2010/2011,46,HHS Region 1,Season onset,4
 2010,46,2010/2011,46,HHS Region 1,Season peak week,7
 2010,46,2010/2011,46,HHS Region 1,Season peak week,8
@@ -509,13 +510,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,46,2010/2011,46,HHS Region 3,2 wk ahead,1.5
 2010,46,2010/2011,46,HHS Region 3,3 wk ahead,1.5
 2010,46,2010/2011,46,HHS Region 3,4 wk ahead,1.6
-2010,46,2010/2011,46,HHS Region 4,Season onset,50
+2010,46,2010/2011,46,HHS Region 4,Season onset,49
 2010,46,2010/2011,46,HHS Region 4,Season peak week,5
-2010,46,2010/2011,46,HHS Region 4,Season peak percentage,5.5
+2010,46,2010/2011,46,HHS Region 4,Season peak percentage,5.6
 2010,46,2010/2011,46,HHS Region 4,1 wk ahead,2.2
-2010,46,2010/2011,46,HHS Region 4,2 wk ahead,1.9
-2010,46,2010/2011,46,HHS Region 4,3 wk ahead,2.2
-2010,46,2010/2011,46,HHS Region 4,4 wk ahead,3.3
+2010,46,2010/2011,46,HHS Region 4,2 wk ahead,2
+2010,46,2010/2011,46,HHS Region 4,3 wk ahead,2.3
+2010,46,2010/2011,46,HHS Region 4,4 wk ahead,3.4
 2010,46,2010/2011,46,HHS Region 5,Season onset,3
 2010,46,2010/2011,46,HHS Region 5,Season peak week,5
 2010,46,2010/2011,46,HHS Region 5,Season peak percentage,3.8
@@ -544,14 +545,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,46,2010/2011,46,HHS Region 8,2 wk ahead,0.7
 2010,46,2010/2011,46,HHS Region 8,3 wk ahead,0.8
 2010,46,2010/2011,46,HHS Region 8,4 wk ahead,0.8
-2010,46,2010/2011,46,HHS Region 9,Season onset,6
+2010,46,2010/2011,46,HHS Region 9,Season onset,none
 2010,46,2010/2011,46,HHS Region 9,Season peak week,7
-2010,46,2010/2011,46,HHS Region 9,Season peak week,8
 2010,46,2010/2011,46,HHS Region 9,Season peak percentage,4.7
 2010,46,2010/2011,46,HHS Region 9,1 wk ahead,2.8
 2010,46,2010/2011,46,HHS Region 9,2 wk ahead,2.4
 2010,46,2010/2011,46,HHS Region 9,3 wk ahead,2.9
-2010,46,2010/2011,46,HHS Region 9,4 wk ahead,3.4
+2010,46,2010/2011,46,HHS Region 9,4 wk ahead,3.6
 2010,46,2010/2011,46,HHS Region 10,Season onset,5
 2010,46,2010/2011,46,HHS Region 10,Season peak week,7
 2010,46,2010/2011,46,HHS Region 10,Season peak percentage,3.9
@@ -561,12 +561,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,46,2010/2011,46,HHS Region 10,4 wk ahead,1
 2010,47,2010/2011,47,US National,Season onset,51
 2010,47,2010/2011,47,US National,Season peak week,5
+2010,47,2010/2011,47,US National,Season peak week,6
 2010,47,2010/2011,47,US National,Season peak week,7
-2010,47,2010/2011,47,US National,Season peak percentage,4.6
+2010,47,2010/2011,47,US National,Season peak percentage,4.5
 2010,47,2010/2011,47,US National,1 wk ahead,1.7
 2010,47,2010/2011,47,US National,2 wk ahead,1.9
-2010,47,2010/2011,47,US National,3 wk ahead,2.3
-2010,47,2010/2011,47,US National,4 wk ahead,3
+2010,47,2010/2011,47,US National,3 wk ahead,2.4
+2010,47,2010/2011,47,US National,4 wk ahead,3.1
 2010,47,2010/2011,47,HHS Region 1,Season onset,4
 2010,47,2010/2011,47,HHS Region 1,Season peak week,7
 2010,47,2010/2011,47,HHS Region 1,Season peak week,8
@@ -589,12 +590,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,47,2010/2011,47,HHS Region 3,2 wk ahead,1.5
 2010,47,2010/2011,47,HHS Region 3,3 wk ahead,1.6
 2010,47,2010/2011,47,HHS Region 3,4 wk ahead,2.2
-2010,47,2010/2011,47,HHS Region 4,Season onset,50
+2010,47,2010/2011,47,HHS Region 4,Season onset,49
 2010,47,2010/2011,47,HHS Region 4,Season peak week,5
-2010,47,2010/2011,47,HHS Region 4,Season peak percentage,5.5
-2010,47,2010/2011,47,HHS Region 4,1 wk ahead,1.9
-2010,47,2010/2011,47,HHS Region 4,2 wk ahead,2.2
-2010,47,2010/2011,47,HHS Region 4,3 wk ahead,3.3
+2010,47,2010/2011,47,HHS Region 4,Season peak percentage,5.6
+2010,47,2010/2011,47,HHS Region 4,1 wk ahead,2
+2010,47,2010/2011,47,HHS Region 4,2 wk ahead,2.3
+2010,47,2010/2011,47,HHS Region 4,3 wk ahead,3.4
 2010,47,2010/2011,47,HHS Region 4,4 wk ahead,4.4
 2010,47,2010/2011,47,HHS Region 5,Season onset,3
 2010,47,2010/2011,47,HHS Region 5,Season peak week,5
@@ -624,14 +625,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,47,2010/2011,47,HHS Region 8,2 wk ahead,0.8
 2010,47,2010/2011,47,HHS Region 8,3 wk ahead,0.8
 2010,47,2010/2011,47,HHS Region 8,4 wk ahead,0.9
-2010,47,2010/2011,47,HHS Region 9,Season onset,6
+2010,47,2010/2011,47,HHS Region 9,Season onset,none
 2010,47,2010/2011,47,HHS Region 9,Season peak week,7
-2010,47,2010/2011,47,HHS Region 9,Season peak week,8
 2010,47,2010/2011,47,HHS Region 9,Season peak percentage,4.7
 2010,47,2010/2011,47,HHS Region 9,1 wk ahead,2.4
 2010,47,2010/2011,47,HHS Region 9,2 wk ahead,2.9
-2010,47,2010/2011,47,HHS Region 9,3 wk ahead,3.4
-2010,47,2010/2011,47,HHS Region 9,4 wk ahead,4.2
+2010,47,2010/2011,47,HHS Region 9,3 wk ahead,3.6
+2010,47,2010/2011,47,HHS Region 9,4 wk ahead,4.6
 2010,47,2010/2011,47,HHS Region 10,Season onset,5
 2010,47,2010/2011,47,HHS Region 10,Season peak week,7
 2010,47,2010/2011,47,HHS Region 10,Season peak percentage,3.9
@@ -641,11 +641,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,47,2010/2011,47,HHS Region 10,4 wk ahead,1.3
 2010,48,2010/2011,48,US National,Season onset,51
 2010,48,2010/2011,48,US National,Season peak week,5
+2010,48,2010/2011,48,US National,Season peak week,6
 2010,48,2010/2011,48,US National,Season peak week,7
-2010,48,2010/2011,48,US National,Season peak percentage,4.6
+2010,48,2010/2011,48,US National,Season peak percentage,4.5
 2010,48,2010/2011,48,US National,1 wk ahead,1.9
-2010,48,2010/2011,48,US National,2 wk ahead,2.3
-2010,48,2010/2011,48,US National,3 wk ahead,3
+2010,48,2010/2011,48,US National,2 wk ahead,2.4
+2010,48,2010/2011,48,US National,3 wk ahead,3.1
 2010,48,2010/2011,48,US National,4 wk ahead,3.1
 2010,48,2010/2011,48,HHS Region 1,Season onset,4
 2010,48,2010/2011,48,HHS Region 1,Season peak week,7
@@ -669,11 +670,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,48,2010/2011,48,HHS Region 3,2 wk ahead,1.6
 2010,48,2010/2011,48,HHS Region 3,3 wk ahead,2.2
 2010,48,2010/2011,48,HHS Region 3,4 wk ahead,2.6
-2010,48,2010/2011,48,HHS Region 4,Season onset,50
+2010,48,2010/2011,48,HHS Region 4,Season onset,49
 2010,48,2010/2011,48,HHS Region 4,Season peak week,5
-2010,48,2010/2011,48,HHS Region 4,Season peak percentage,5.5
-2010,48,2010/2011,48,HHS Region 4,1 wk ahead,2.2
-2010,48,2010/2011,48,HHS Region 4,2 wk ahead,3.3
+2010,48,2010/2011,48,HHS Region 4,Season peak percentage,5.6
+2010,48,2010/2011,48,HHS Region 4,1 wk ahead,2.3
+2010,48,2010/2011,48,HHS Region 4,2 wk ahead,3.4
 2010,48,2010/2011,48,HHS Region 4,3 wk ahead,4.4
 2010,48,2010/2011,48,HHS Region 4,4 wk ahead,4
 2010,48,2010/2011,48,HHS Region 5,Season onset,3
@@ -704,13 +705,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,48,2010/2011,48,HHS Region 8,2 wk ahead,0.8
 2010,48,2010/2011,48,HHS Region 8,3 wk ahead,0.9
 2010,48,2010/2011,48,HHS Region 8,4 wk ahead,1
-2010,48,2010/2011,48,HHS Region 9,Season onset,6
+2010,48,2010/2011,48,HHS Region 9,Season onset,none
 2010,48,2010/2011,48,HHS Region 9,Season peak week,7
-2010,48,2010/2011,48,HHS Region 9,Season peak week,8
 2010,48,2010/2011,48,HHS Region 9,Season peak percentage,4.7
 2010,48,2010/2011,48,HHS Region 9,1 wk ahead,2.9
-2010,48,2010/2011,48,HHS Region 9,2 wk ahead,3.4
-2010,48,2010/2011,48,HHS Region 9,3 wk ahead,4.2
+2010,48,2010/2011,48,HHS Region 9,2 wk ahead,3.6
+2010,48,2010/2011,48,HHS Region 9,3 wk ahead,4.6
 2010,48,2010/2011,48,HHS Region 9,4 wk ahead,4.2
 2010,48,2010/2011,48,HHS Region 10,Season onset,5
 2010,48,2010/2011,48,HHS Region 10,Season peak week,7
@@ -721,10 +721,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,48,2010/2011,48,HHS Region 10,4 wk ahead,2.4
 2010,49,2010/2011,49,US National,Season onset,51
 2010,49,2010/2011,49,US National,Season peak week,5
+2010,49,2010/2011,49,US National,Season peak week,6
 2010,49,2010/2011,49,US National,Season peak week,7
-2010,49,2010/2011,49,US National,Season peak percentage,4.6
-2010,49,2010/2011,49,US National,1 wk ahead,2.3
-2010,49,2010/2011,49,US National,2 wk ahead,3
+2010,49,2010/2011,49,US National,Season peak percentage,4.5
+2010,49,2010/2011,49,US National,1 wk ahead,2.4
+2010,49,2010/2011,49,US National,2 wk ahead,3.1
 2010,49,2010/2011,49,US National,3 wk ahead,3.1
 2010,49,2010/2011,49,US National,4 wk ahead,2.5
 2010,49,2010/2011,49,HHS Region 1,Season onset,4
@@ -749,13 +750,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,49,2010/2011,49,HHS Region 3,2 wk ahead,2.2
 2010,49,2010/2011,49,HHS Region 3,3 wk ahead,2.6
 2010,49,2010/2011,49,HHS Region 3,4 wk ahead,2.2
-2010,49,2010/2011,49,HHS Region 4,Season onset,50
+2010,49,2010/2011,49,HHS Region 4,Season onset,49
 2010,49,2010/2011,49,HHS Region 4,Season peak week,5
-2010,49,2010/2011,49,HHS Region 4,Season peak percentage,5.5
-2010,49,2010/2011,49,HHS Region 4,1 wk ahead,3.3
+2010,49,2010/2011,49,HHS Region 4,Season peak percentage,5.6
+2010,49,2010/2011,49,HHS Region 4,1 wk ahead,3.4
 2010,49,2010/2011,49,HHS Region 4,2 wk ahead,4.4
 2010,49,2010/2011,49,HHS Region 4,3 wk ahead,4
-2010,49,2010/2011,49,HHS Region 4,4 wk ahead,3.3
+2010,49,2010/2011,49,HHS Region 4,4 wk ahead,3.2
 2010,49,2010/2011,49,HHS Region 5,Season onset,3
 2010,49,2010/2011,49,HHS Region 5,Season peak week,5
 2010,49,2010/2011,49,HHS Region 5,Season peak percentage,3.8
@@ -784,12 +785,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,49,2010/2011,49,HHS Region 8,2 wk ahead,0.9
 2010,49,2010/2011,49,HHS Region 8,3 wk ahead,1
 2010,49,2010/2011,49,HHS Region 8,4 wk ahead,0.7
-2010,49,2010/2011,49,HHS Region 9,Season onset,6
+2010,49,2010/2011,49,HHS Region 9,Season onset,none
 2010,49,2010/2011,49,HHS Region 9,Season peak week,7
-2010,49,2010/2011,49,HHS Region 9,Season peak week,8
 2010,49,2010/2011,49,HHS Region 9,Season peak percentage,4.7
-2010,49,2010/2011,49,HHS Region 9,1 wk ahead,3.4
-2010,49,2010/2011,49,HHS Region 9,2 wk ahead,4.2
+2010,49,2010/2011,49,HHS Region 9,1 wk ahead,3.6
+2010,49,2010/2011,49,HHS Region 9,2 wk ahead,4.6
 2010,49,2010/2011,49,HHS Region 9,3 wk ahead,4.2
 2010,49,2010/2011,49,HHS Region 9,4 wk ahead,3.2
 2010,49,2010/2011,49,HHS Region 10,Season onset,5
@@ -801,9 +801,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,49,2010/2011,49,HHS Region 10,4 wk ahead,1.4
 2010,50,2010/2011,50,US National,Season onset,51
 2010,50,2010/2011,50,US National,Season peak week,5
+2010,50,2010/2011,50,US National,Season peak week,6
 2010,50,2010/2011,50,US National,Season peak week,7
-2010,50,2010/2011,50,US National,Season peak percentage,4.6
-2010,50,2010/2011,50,US National,1 wk ahead,3
+2010,50,2010/2011,50,US National,Season peak percentage,4.5
+2010,50,2010/2011,50,US National,1 wk ahead,3.1
 2010,50,2010/2011,50,US National,2 wk ahead,3.1
 2010,50,2010/2011,50,US National,3 wk ahead,2.5
 2010,50,2010/2011,50,US National,4 wk ahead,2.9
@@ -829,12 +830,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,50,2010/2011,50,HHS Region 3,2 wk ahead,2.6
 2010,50,2010/2011,50,HHS Region 3,3 wk ahead,2.2
 2010,50,2010/2011,50,HHS Region 3,4 wk ahead,2.5
-2010,50,2010/2011,50,HHS Region 4,Season onset,50
+2010,50,2010/2011,50,HHS Region 4,Season onset,49
 2010,50,2010/2011,50,HHS Region 4,Season peak week,5
-2010,50,2010/2011,50,HHS Region 4,Season peak percentage,5.5
+2010,50,2010/2011,50,HHS Region 4,Season peak percentage,5.6
 2010,50,2010/2011,50,HHS Region 4,1 wk ahead,4.4
 2010,50,2010/2011,50,HHS Region 4,2 wk ahead,4
-2010,50,2010/2011,50,HHS Region 4,3 wk ahead,3.3
+2010,50,2010/2011,50,HHS Region 4,3 wk ahead,3.2
 2010,50,2010/2011,50,HHS Region 4,4 wk ahead,3.6
 2010,50,2010/2011,50,HHS Region 5,Season onset,3
 2010,50,2010/2011,50,HHS Region 5,Season peak week,5
@@ -864,11 +865,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,50,2010/2011,50,HHS Region 8,2 wk ahead,1
 2010,50,2010/2011,50,HHS Region 8,3 wk ahead,0.7
 2010,50,2010/2011,50,HHS Region 8,4 wk ahead,1.4
-2010,50,2010/2011,50,HHS Region 9,Season onset,6
+2010,50,2010/2011,50,HHS Region 9,Season onset,none
 2010,50,2010/2011,50,HHS Region 9,Season peak week,7
-2010,50,2010/2011,50,HHS Region 9,Season peak week,8
 2010,50,2010/2011,50,HHS Region 9,Season peak percentage,4.7
-2010,50,2010/2011,50,HHS Region 9,1 wk ahead,4.2
+2010,50,2010/2011,50,HHS Region 9,1 wk ahead,4.6
 2010,50,2010/2011,50,HHS Region 9,2 wk ahead,4.2
 2010,50,2010/2011,50,HHS Region 9,3 wk ahead,3.2
 2010,50,2010/2011,50,HHS Region 9,4 wk ahead,3.4
@@ -881,8 +881,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,50,2010/2011,50,HHS Region 10,4 wk ahead,1.5
 2010,51,2010/2011,51,US National,Season onset,51
 2010,51,2010/2011,51,US National,Season peak week,5
+2010,51,2010/2011,51,US National,Season peak week,6
 2010,51,2010/2011,51,US National,Season peak week,7
-2010,51,2010/2011,51,US National,Season peak percentage,4.6
+2010,51,2010/2011,51,US National,Season peak percentage,4.5
 2010,51,2010/2011,51,US National,1 wk ahead,3.1
 2010,51,2010/2011,51,US National,2 wk ahead,2.5
 2010,51,2010/2011,51,US National,3 wk ahead,2.9
@@ -909,11 +910,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,51,2010/2011,51,HHS Region 3,2 wk ahead,2.2
 2010,51,2010/2011,51,HHS Region 3,3 wk ahead,2.5
 2010,51,2010/2011,51,HHS Region 3,4 wk ahead,3.3
-2010,51,2010/2011,51,HHS Region 4,Season onset,50
+2010,51,2010/2011,51,HHS Region 4,Season onset,49
 2010,51,2010/2011,51,HHS Region 4,Season peak week,5
-2010,51,2010/2011,51,HHS Region 4,Season peak percentage,5.5
+2010,51,2010/2011,51,HHS Region 4,Season peak percentage,5.6
 2010,51,2010/2011,51,HHS Region 4,1 wk ahead,4
-2010,51,2010/2011,51,HHS Region 4,2 wk ahead,3.3
+2010,51,2010/2011,51,HHS Region 4,2 wk ahead,3.2
 2010,51,2010/2011,51,HHS Region 4,3 wk ahead,3.6
 2010,51,2010/2011,51,HHS Region 4,4 wk ahead,4.2
 2010,51,2010/2011,51,HHS Region 5,Season onset,3
@@ -929,7 +930,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,51,2010/2011,51,HHS Region 6,1 wk ahead,3.8
 2010,51,2010/2011,51,HHS Region 6,2 wk ahead,3.3
 2010,51,2010/2011,51,HHS Region 6,3 wk ahead,4.4
-2010,51,2010/2011,51,HHS Region 6,4 wk ahead,5.7
+2010,51,2010/2011,51,HHS Region 6,4 wk ahead,5.8
 2010,51,2010/2011,51,HHS Region 7,Season onset,4
 2010,51,2010/2011,51,HHS Region 7,Season peak week,8
 2010,51,2010/2011,51,HHS Region 7,Season peak percentage,4.7
@@ -944,9 +945,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,51,2010/2011,51,HHS Region 8,2 wk ahead,0.7
 2010,51,2010/2011,51,HHS Region 8,3 wk ahead,1.4
 2010,51,2010/2011,51,HHS Region 8,4 wk ahead,1.4
-2010,51,2010/2011,51,HHS Region 9,Season onset,6
+2010,51,2010/2011,51,HHS Region 9,Season onset,none
 2010,51,2010/2011,51,HHS Region 9,Season peak week,7
-2010,51,2010/2011,51,HHS Region 9,Season peak week,8
 2010,51,2010/2011,51,HHS Region 9,Season peak percentage,4.7
 2010,51,2010/2011,51,HHS Region 9,1 wk ahead,4.2
 2010,51,2010/2011,51,HHS Region 9,2 wk ahead,3.2
@@ -961,8 +961,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,51,2010/2011,51,HHS Region 10,4 wk ahead,1.5
 2010,52,2010/2011,52,US National,Season onset,51
 2010,52,2010/2011,52,US National,Season peak week,5
+2010,52,2010/2011,52,US National,Season peak week,6
 2010,52,2010/2011,52,US National,Season peak week,7
-2010,52,2010/2011,52,US National,Season peak percentage,4.6
+2010,52,2010/2011,52,US National,Season peak percentage,4.5
 2010,52,2010/2011,52,US National,1 wk ahead,2.5
 2010,52,2010/2011,52,US National,2 wk ahead,2.9
 2010,52,2010/2011,52,US National,3 wk ahead,3.4
@@ -989,10 +990,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,52,2010/2011,52,HHS Region 3,2 wk ahead,2.5
 2010,52,2010/2011,52,HHS Region 3,3 wk ahead,3.3
 2010,52,2010/2011,52,HHS Region 3,4 wk ahead,4
-2010,52,2010/2011,52,HHS Region 4,Season onset,50
+2010,52,2010/2011,52,HHS Region 4,Season onset,49
 2010,52,2010/2011,52,HHS Region 4,Season peak week,5
-2010,52,2010/2011,52,HHS Region 4,Season peak percentage,5.5
-2010,52,2010/2011,52,HHS Region 4,1 wk ahead,3.3
+2010,52,2010/2011,52,HHS Region 4,Season peak percentage,5.6
+2010,52,2010/2011,52,HHS Region 4,1 wk ahead,3.2
 2010,52,2010/2011,52,HHS Region 4,2 wk ahead,3.6
 2010,52,2010/2011,52,HHS Region 4,3 wk ahead,4.2
 2010,52,2010/2011,52,HHS Region 4,4 wk ahead,5
@@ -1008,8 +1009,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,52,2010/2011,52,HHS Region 6,Season peak percentage,7.9
 2010,52,2010/2011,52,HHS Region 6,1 wk ahead,3.3
 2010,52,2010/2011,52,HHS Region 6,2 wk ahead,4.4
-2010,52,2010/2011,52,HHS Region 6,3 wk ahead,5.7
-2010,52,2010/2011,52,HHS Region 6,4 wk ahead,6.9
+2010,52,2010/2011,52,HHS Region 6,3 wk ahead,5.8
+2010,52,2010/2011,52,HHS Region 6,4 wk ahead,7
 2010,52,2010/2011,52,HHS Region 7,Season onset,4
 2010,52,2010/2011,52,HHS Region 7,Season peak week,8
 2010,52,2010/2011,52,HHS Region 7,Season peak percentage,4.7
@@ -1024,9 +1025,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,52,2010/2011,52,HHS Region 8,2 wk ahead,1.4
 2010,52,2010/2011,52,HHS Region 8,3 wk ahead,1.4
 2010,52,2010/2011,52,HHS Region 8,4 wk ahead,1.5
-2010,52,2010/2011,52,HHS Region 9,Season onset,6
+2010,52,2010/2011,52,HHS Region 9,Season onset,none
 2010,52,2010/2011,52,HHS Region 9,Season peak week,7
-2010,52,2010/2011,52,HHS Region 9,Season peak week,8
 2010,52,2010/2011,52,HHS Region 9,Season peak percentage,4.7
 2010,52,2010/2011,52,HHS Region 9,1 wk ahead,3.2
 2010,52,2010/2011,52,HHS Region 9,2 wk ahead,3.4
@@ -1041,12 +1041,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,52,2010/2011,52,HHS Region 10,4 wk ahead,2.1
 2011,1,2010/2011,53,US National,Season onset,51
 2011,1,2010/2011,53,US National,Season peak week,5
+2011,1,2010/2011,53,US National,Season peak week,6
 2011,1,2010/2011,53,US National,Season peak week,7
-2011,1,2010/2011,53,US National,Season peak percentage,4.6
+2011,1,2010/2011,53,US National,Season peak percentage,4.5
 2011,1,2010/2011,53,US National,1 wk ahead,2.9
 2011,1,2010/2011,53,US National,2 wk ahead,3.4
 2011,1,2010/2011,53,US National,3 wk ahead,4.2
-2011,1,2010/2011,53,US National,4 wk ahead,4.6
+2011,1,2010/2011,53,US National,4 wk ahead,4.5
 2011,1,2010/2011,53,HHS Region 1,Season onset,4
 2011,1,2010/2011,53,HHS Region 1,Season peak week,7
 2011,1,2010/2011,53,HHS Region 1,Season peak week,8
@@ -1061,7 +1062,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,1,2010/2011,53,HHS Region 2,1 wk ahead,3.8
 2011,1,2010/2011,53,HHS Region 2,2 wk ahead,3.7
 2011,1,2010/2011,53,HHS Region 2,3 wk ahead,3.9
-2011,1,2010/2011,53,HHS Region 2,4 wk ahead,4.1
+2011,1,2010/2011,53,HHS Region 2,4 wk ahead,3.8
 2011,1,2010/2011,53,HHS Region 3,Season onset,3
 2011,1,2010/2011,53,HHS Region 3,Season peak week,5
 2011,1,2010/2011,53,HHS Region 3,Season peak percentage,4.4
@@ -1069,13 +1070,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,1,2010/2011,53,HHS Region 3,2 wk ahead,3.3
 2011,1,2010/2011,53,HHS Region 3,3 wk ahead,4
 2011,1,2010/2011,53,HHS Region 3,4 wk ahead,4.4
-2011,1,2010/2011,53,HHS Region 4,Season onset,50
+2011,1,2010/2011,53,HHS Region 4,Season onset,49
 2011,1,2010/2011,53,HHS Region 4,Season peak week,5
-2011,1,2010/2011,53,HHS Region 4,Season peak percentage,5.5
+2011,1,2010/2011,53,HHS Region 4,Season peak percentage,5.6
 2011,1,2010/2011,53,HHS Region 4,1 wk ahead,3.6
 2011,1,2010/2011,53,HHS Region 4,2 wk ahead,4.2
 2011,1,2010/2011,53,HHS Region 4,3 wk ahead,5
-2011,1,2010/2011,53,HHS Region 4,4 wk ahead,5.5
+2011,1,2010/2011,53,HHS Region 4,4 wk ahead,5.6
 2011,1,2010/2011,53,HHS Region 5,Season onset,3
 2011,1,2010/2011,53,HHS Region 5,Season peak week,5
 2011,1,2010/2011,53,HHS Region 5,Season peak percentage,3.8
@@ -1087,8 +1088,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,1,2010/2011,53,HHS Region 6,Season peak week,7
 2011,1,2010/2011,53,HHS Region 6,Season peak percentage,7.9
 2011,1,2010/2011,53,HHS Region 6,1 wk ahead,4.4
-2011,1,2010/2011,53,HHS Region 6,2 wk ahead,5.7
-2011,1,2010/2011,53,HHS Region 6,3 wk ahead,6.9
+2011,1,2010/2011,53,HHS Region 6,2 wk ahead,5.8
+2011,1,2010/2011,53,HHS Region 6,3 wk ahead,7
 2011,1,2010/2011,53,HHS Region 6,4 wk ahead,7.6
 2011,1,2010/2011,53,HHS Region 7,Season onset,4
 2011,1,2010/2011,53,HHS Region 7,Season peak week,8
@@ -1104,9 +1105,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,1,2010/2011,53,HHS Region 8,2 wk ahead,1.4
 2011,1,2010/2011,53,HHS Region 8,3 wk ahead,1.5
 2011,1,2010/2011,53,HHS Region 8,4 wk ahead,2.2
-2011,1,2010/2011,53,HHS Region 9,Season onset,6
+2011,1,2010/2011,53,HHS Region 9,Season onset,none
 2011,1,2010/2011,53,HHS Region 9,Season peak week,7
-2011,1,2010/2011,53,HHS Region 9,Season peak week,8
 2011,1,2010/2011,53,HHS Region 9,Season peak percentage,4.7
 2011,1,2010/2011,53,HHS Region 9,1 wk ahead,3.4
 2011,1,2010/2011,53,HHS Region 9,2 wk ahead,3.8
@@ -1121,11 +1121,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,1,2010/2011,53,HHS Region 10,4 wk ahead,2.6
 2011,2,2010/2011,54,US National,Season onset,51
 2011,2,2010/2011,54,US National,Season peak week,5
+2011,2,2010/2011,54,US National,Season peak week,6
 2011,2,2010/2011,54,US National,Season peak week,7
-2011,2,2010/2011,54,US National,Season peak percentage,4.6
+2011,2,2010/2011,54,US National,Season peak percentage,4.5
 2011,2,2010/2011,54,US National,1 wk ahead,3.4
 2011,2,2010/2011,54,US National,2 wk ahead,4.2
-2011,2,2010/2011,54,US National,3 wk ahead,4.6
+2011,2,2010/2011,54,US National,3 wk ahead,4.5
 2011,2,2010/2011,54,US National,4 wk ahead,4.5
 2011,2,2010/2011,54,HHS Region 1,Season onset,4
 2011,2,2010/2011,54,HHS Region 1,Season peak week,7
@@ -1140,7 +1141,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,2,2010/2011,54,HHS Region 2,Season peak percentage,4.5
 2011,2,2010/2011,54,HHS Region 2,1 wk ahead,3.7
 2011,2,2010/2011,54,HHS Region 2,2 wk ahead,3.9
-2011,2,2010/2011,54,HHS Region 2,3 wk ahead,4.1
+2011,2,2010/2011,54,HHS Region 2,3 wk ahead,3.8
 2011,2,2010/2011,54,HHS Region 2,4 wk ahead,4.1
 2011,2,2010/2011,54,HHS Region 3,Season onset,3
 2011,2,2010/2011,54,HHS Region 3,Season peak week,5
@@ -1148,14 +1149,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,2,2010/2011,54,HHS Region 3,1 wk ahead,3.3
 2011,2,2010/2011,54,HHS Region 3,2 wk ahead,4
 2011,2,2010/2011,54,HHS Region 3,3 wk ahead,4.4
-2011,2,2010/2011,54,HHS Region 3,4 wk ahead,4.1
-2011,2,2010/2011,54,HHS Region 4,Season onset,50
+2011,2,2010/2011,54,HHS Region 3,4 wk ahead,4
+2011,2,2010/2011,54,HHS Region 4,Season onset,49
 2011,2,2010/2011,54,HHS Region 4,Season peak week,5
-2011,2,2010/2011,54,HHS Region 4,Season peak percentage,5.5
+2011,2,2010/2011,54,HHS Region 4,Season peak percentage,5.6
 2011,2,2010/2011,54,HHS Region 4,1 wk ahead,4.2
 2011,2,2010/2011,54,HHS Region 4,2 wk ahead,5
-2011,2,2010/2011,54,HHS Region 4,3 wk ahead,5.5
-2011,2,2010/2011,54,HHS Region 4,4 wk ahead,5.2
+2011,2,2010/2011,54,HHS Region 4,3 wk ahead,5.6
+2011,2,2010/2011,54,HHS Region 4,4 wk ahead,5.3
 2011,2,2010/2011,54,HHS Region 5,Season onset,3
 2011,2,2010/2011,54,HHS Region 5,Season peak week,5
 2011,2,2010/2011,54,HHS Region 5,Season peak percentage,3.8
@@ -1166,8 +1167,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,2,2010/2011,54,HHS Region 6,Season onset,3
 2011,2,2010/2011,54,HHS Region 6,Season peak week,7
 2011,2,2010/2011,54,HHS Region 6,Season peak percentage,7.9
-2011,2,2010/2011,54,HHS Region 6,1 wk ahead,5.7
-2011,2,2010/2011,54,HHS Region 6,2 wk ahead,6.9
+2011,2,2010/2011,54,HHS Region 6,1 wk ahead,5.8
+2011,2,2010/2011,54,HHS Region 6,2 wk ahead,7
 2011,2,2010/2011,54,HHS Region 6,3 wk ahead,7.6
 2011,2,2010/2011,54,HHS Region 6,4 wk ahead,7.8
 2011,2,2010/2011,54,HHS Region 7,Season onset,4
@@ -1184,9 +1185,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,2,2010/2011,54,HHS Region 8,2 wk ahead,1.5
 2011,2,2010/2011,54,HHS Region 8,3 wk ahead,2.2
 2011,2,2010/2011,54,HHS Region 8,4 wk ahead,2.5
-2011,2,2010/2011,54,HHS Region 9,Season onset,6
+2011,2,2010/2011,54,HHS Region 9,Season onset,none
 2011,2,2010/2011,54,HHS Region 9,Season peak week,7
-2011,2,2010/2011,54,HHS Region 9,Season peak week,8
 2011,2,2010/2011,54,HHS Region 9,Season peak percentage,4.7
 2011,2,2010/2011,54,HHS Region 9,1 wk ahead,3.8
 2011,2,2010/2011,54,HHS Region 9,2 wk ahead,4.2
@@ -1201,12 +1201,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,2,2010/2011,54,HHS Region 10,4 wk ahead,2.5
 2011,3,2010/2011,55,US National,Season onset,51
 2011,3,2010/2011,55,US National,Season peak week,5
+2011,3,2010/2011,55,US National,Season peak week,6
 2011,3,2010/2011,55,US National,Season peak week,7
-2011,3,2010/2011,55,US National,Season peak percentage,4.6
+2011,3,2010/2011,55,US National,Season peak percentage,4.5
 2011,3,2010/2011,55,US National,1 wk ahead,4.2
-2011,3,2010/2011,55,US National,2 wk ahead,4.6
+2011,3,2010/2011,55,US National,2 wk ahead,4.5
 2011,3,2010/2011,55,US National,3 wk ahead,4.5
-2011,3,2010/2011,55,US National,4 wk ahead,4.6
+2011,3,2010/2011,55,US National,4 wk ahead,4.5
 2011,3,2010/2011,55,HHS Region 1,Season onset,4
 2011,3,2010/2011,55,HHS Region 1,Season peak week,7
 2011,3,2010/2011,55,HHS Region 1,Season peak week,8
@@ -1219,7 +1220,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,3,2010/2011,55,HHS Region 2,Season peak week,52
 2011,3,2010/2011,55,HHS Region 2,Season peak percentage,4.5
 2011,3,2010/2011,55,HHS Region 2,1 wk ahead,3.9
-2011,3,2010/2011,55,HHS Region 2,2 wk ahead,4.1
+2011,3,2010/2011,55,HHS Region 2,2 wk ahead,3.8
 2011,3,2010/2011,55,HHS Region 2,3 wk ahead,4.1
 2011,3,2010/2011,55,HHS Region 2,4 wk ahead,4.3
 2011,3,2010/2011,55,HHS Region 3,Season onset,3
@@ -1227,14 +1228,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,3,2010/2011,55,HHS Region 3,Season peak percentage,4.4
 2011,3,2010/2011,55,HHS Region 3,1 wk ahead,4
 2011,3,2010/2011,55,HHS Region 3,2 wk ahead,4.4
-2011,3,2010/2011,55,HHS Region 3,3 wk ahead,4.1
+2011,3,2010/2011,55,HHS Region 3,3 wk ahead,4
 2011,3,2010/2011,55,HHS Region 3,4 wk ahead,4
-2011,3,2010/2011,55,HHS Region 4,Season onset,50
+2011,3,2010/2011,55,HHS Region 4,Season onset,49
 2011,3,2010/2011,55,HHS Region 4,Season peak week,5
-2011,3,2010/2011,55,HHS Region 4,Season peak percentage,5.5
+2011,3,2010/2011,55,HHS Region 4,Season peak percentage,5.6
 2011,3,2010/2011,55,HHS Region 4,1 wk ahead,5
-2011,3,2010/2011,55,HHS Region 4,2 wk ahead,5.5
-2011,3,2010/2011,55,HHS Region 4,3 wk ahead,5.2
+2011,3,2010/2011,55,HHS Region 4,2 wk ahead,5.6
+2011,3,2010/2011,55,HHS Region 4,3 wk ahead,5.3
 2011,3,2010/2011,55,HHS Region 4,4 wk ahead,4.8
 2011,3,2010/2011,55,HHS Region 5,Season onset,3
 2011,3,2010/2011,55,HHS Region 5,Season peak week,5
@@ -1246,7 +1247,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,3,2010/2011,55,HHS Region 6,Season onset,3
 2011,3,2010/2011,55,HHS Region 6,Season peak week,7
 2011,3,2010/2011,55,HHS Region 6,Season peak percentage,7.9
-2011,3,2010/2011,55,HHS Region 6,1 wk ahead,6.9
+2011,3,2010/2011,55,HHS Region 6,1 wk ahead,7
 2011,3,2010/2011,55,HHS Region 6,2 wk ahead,7.6
 2011,3,2010/2011,55,HHS Region 6,3 wk ahead,7.8
 2011,3,2010/2011,55,HHS Region 6,4 wk ahead,7.9
@@ -1264,9 +1265,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,3,2010/2011,55,HHS Region 8,2 wk ahead,2.2
 2011,3,2010/2011,55,HHS Region 8,3 wk ahead,2.5
 2011,3,2010/2011,55,HHS Region 8,4 wk ahead,2.7
-2011,3,2010/2011,55,HHS Region 9,Season onset,6
+2011,3,2010/2011,55,HHS Region 9,Season onset,none
 2011,3,2010/2011,55,HHS Region 9,Season peak week,7
-2011,3,2010/2011,55,HHS Region 9,Season peak week,8
 2011,3,2010/2011,55,HHS Region 9,Season peak percentage,4.7
 2011,3,2010/2011,55,HHS Region 9,1 wk ahead,4.2
 2011,3,2010/2011,55,HHS Region 9,2 wk ahead,4
@@ -1281,12 +1281,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,3,2010/2011,55,HHS Region 10,4 wk ahead,3.9
 2011,4,2010/2011,56,US National,Season onset,51
 2011,4,2010/2011,56,US National,Season peak week,5
+2011,4,2010/2011,56,US National,Season peak week,6
 2011,4,2010/2011,56,US National,Season peak week,7
-2011,4,2010/2011,56,US National,Season peak percentage,4.6
-2011,4,2010/2011,56,US National,1 wk ahead,4.6
+2011,4,2010/2011,56,US National,Season peak percentage,4.5
+2011,4,2010/2011,56,US National,1 wk ahead,4.5
 2011,4,2010/2011,56,US National,2 wk ahead,4.5
-2011,4,2010/2011,56,US National,3 wk ahead,4.6
-2011,4,2010/2011,56,US National,4 wk ahead,4.1
+2011,4,2010/2011,56,US National,3 wk ahead,4.5
+2011,4,2010/2011,56,US National,4 wk ahead,3.9
 2011,4,2010/2011,56,HHS Region 1,Season onset,4
 2011,4,2010/2011,56,HHS Region 1,Season peak week,7
 2011,4,2010/2011,56,HHS Region 1,Season peak week,8
@@ -1298,7 +1299,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,4,2010/2011,56,HHS Region 2,Season onset,49
 2011,4,2010/2011,56,HHS Region 2,Season peak week,52
 2011,4,2010/2011,56,HHS Region 2,Season peak percentage,4.5
-2011,4,2010/2011,56,HHS Region 2,1 wk ahead,4.1
+2011,4,2010/2011,56,HHS Region 2,1 wk ahead,3.8
 2011,4,2010/2011,56,HHS Region 2,2 wk ahead,4.1
 2011,4,2010/2011,56,HHS Region 2,3 wk ahead,4.3
 2011,4,2010/2011,56,HHS Region 2,4 wk ahead,4.3
@@ -1306,14 +1307,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,4,2010/2011,56,HHS Region 3,Season peak week,5
 2011,4,2010/2011,56,HHS Region 3,Season peak percentage,4.4
 2011,4,2010/2011,56,HHS Region 3,1 wk ahead,4.4
-2011,4,2010/2011,56,HHS Region 3,2 wk ahead,4.1
+2011,4,2010/2011,56,HHS Region 3,2 wk ahead,4
 2011,4,2010/2011,56,HHS Region 3,3 wk ahead,4
 2011,4,2010/2011,56,HHS Region 3,4 wk ahead,3.6
-2011,4,2010/2011,56,HHS Region 4,Season onset,50
+2011,4,2010/2011,56,HHS Region 4,Season onset,49
 2011,4,2010/2011,56,HHS Region 4,Season peak week,5
-2011,4,2010/2011,56,HHS Region 4,Season peak percentage,5.5
-2011,4,2010/2011,56,HHS Region 4,1 wk ahead,5.5
-2011,4,2010/2011,56,HHS Region 4,2 wk ahead,5.2
+2011,4,2010/2011,56,HHS Region 4,Season peak percentage,5.6
+2011,4,2010/2011,56,HHS Region 4,1 wk ahead,5.6
+2011,4,2010/2011,56,HHS Region 4,2 wk ahead,5.3
 2011,4,2010/2011,56,HHS Region 4,3 wk ahead,4.8
 2011,4,2010/2011,56,HHS Region 4,4 wk ahead,3.9
 2011,4,2010/2011,56,HHS Region 5,Season onset,3
@@ -1329,7 +1330,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,4,2010/2011,56,HHS Region 6,1 wk ahead,7.6
 2011,4,2010/2011,56,HHS Region 6,2 wk ahead,7.8
 2011,4,2010/2011,56,HHS Region 6,3 wk ahead,7.9
-2011,4,2010/2011,56,HHS Region 6,4 wk ahead,6.3
+2011,4,2010/2011,56,HHS Region 6,4 wk ahead,6.2
 2011,4,2010/2011,56,HHS Region 7,Season onset,4
 2011,4,2010/2011,56,HHS Region 7,Season peak week,8
 2011,4,2010/2011,56,HHS Region 7,Season peak percentage,4.7
@@ -1343,15 +1344,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,4,2010/2011,56,HHS Region 8,1 wk ahead,2.2
 2011,4,2010/2011,56,HHS Region 8,2 wk ahead,2.5
 2011,4,2010/2011,56,HHS Region 8,3 wk ahead,2.7
-2011,4,2010/2011,56,HHS Region 8,4 wk ahead,2.5
-2011,4,2010/2011,56,HHS Region 9,Season onset,6
+2011,4,2010/2011,56,HHS Region 8,4 wk ahead,2.6
+2011,4,2010/2011,56,HHS Region 9,Season onset,none
 2011,4,2010/2011,56,HHS Region 9,Season peak week,7
-2011,4,2010/2011,56,HHS Region 9,Season peak week,8
 2011,4,2010/2011,56,HHS Region 9,Season peak percentage,4.7
 2011,4,2010/2011,56,HHS Region 9,1 wk ahead,4
 2011,4,2010/2011,56,HHS Region 9,2 wk ahead,4.5
 2011,4,2010/2011,56,HHS Region 9,3 wk ahead,4.7
-2011,4,2010/2011,56,HHS Region 9,4 wk ahead,4.7
+2011,4,2010/2011,56,HHS Region 9,4 wk ahead,3.9
 2011,4,2010/2011,56,HHS Region 10,Season onset,5
 2011,4,2010/2011,56,HHS Region 10,Season peak week,7
 2011,4,2010/2011,56,HHS Region 10,Season peak percentage,3.9
@@ -1361,11 +1361,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,4,2010/2011,56,HHS Region 10,4 wk ahead,3.5
 2011,5,2010/2011,57,US National,Season onset,51
 2011,5,2010/2011,57,US National,Season peak week,5
+2011,5,2010/2011,57,US National,Season peak week,6
 2011,5,2010/2011,57,US National,Season peak week,7
-2011,5,2010/2011,57,US National,Season peak percentage,4.6
+2011,5,2010/2011,57,US National,Season peak percentage,4.5
 2011,5,2010/2011,57,US National,1 wk ahead,4.5
-2011,5,2010/2011,57,US National,2 wk ahead,4.6
-2011,5,2010/2011,57,US National,3 wk ahead,4.1
+2011,5,2010/2011,57,US National,2 wk ahead,4.5
+2011,5,2010/2011,57,US National,3 wk ahead,3.9
 2011,5,2010/2011,57,US National,4 wk ahead,3.4
 2011,5,2010/2011,57,HHS Region 1,Season onset,4
 2011,5,2010/2011,57,HHS Region 1,Season peak week,7
@@ -1385,14 +1386,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,5,2010/2011,57,HHS Region 3,Season onset,3
 2011,5,2010/2011,57,HHS Region 3,Season peak week,5
 2011,5,2010/2011,57,HHS Region 3,Season peak percentage,4.4
-2011,5,2010/2011,57,HHS Region 3,1 wk ahead,4.1
+2011,5,2010/2011,57,HHS Region 3,1 wk ahead,4
 2011,5,2010/2011,57,HHS Region 3,2 wk ahead,4
 2011,5,2010/2011,57,HHS Region 3,3 wk ahead,3.6
 2011,5,2010/2011,57,HHS Region 3,4 wk ahead,3
-2011,5,2010/2011,57,HHS Region 4,Season onset,50
+2011,5,2010/2011,57,HHS Region 4,Season onset,49
 2011,5,2010/2011,57,HHS Region 4,Season peak week,5
-2011,5,2010/2011,57,HHS Region 4,Season peak percentage,5.5
-2011,5,2010/2011,57,HHS Region 4,1 wk ahead,5.2
+2011,5,2010/2011,57,HHS Region 4,Season peak percentage,5.6
+2011,5,2010/2011,57,HHS Region 4,1 wk ahead,5.3
 2011,5,2010/2011,57,HHS Region 4,2 wk ahead,4.8
 2011,5,2010/2011,57,HHS Region 4,3 wk ahead,3.9
 2011,5,2010/2011,57,HHS Region 4,4 wk ahead,2.8
@@ -1402,14 +1403,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,5,2010/2011,57,HHS Region 5,1 wk ahead,3.3
 2011,5,2010/2011,57,HHS Region 5,2 wk ahead,3.3
 2011,5,2010/2011,57,HHS Region 5,3 wk ahead,3.1
-2011,5,2010/2011,57,HHS Region 5,4 wk ahead,2.9
+2011,5,2010/2011,57,HHS Region 5,4 wk ahead,2.8
 2011,5,2010/2011,57,HHS Region 6,Season onset,3
 2011,5,2010/2011,57,HHS Region 6,Season peak week,7
 2011,5,2010/2011,57,HHS Region 6,Season peak percentage,7.9
 2011,5,2010/2011,57,HHS Region 6,1 wk ahead,7.8
 2011,5,2010/2011,57,HHS Region 6,2 wk ahead,7.9
-2011,5,2010/2011,57,HHS Region 6,3 wk ahead,6.3
-2011,5,2010/2011,57,HHS Region 6,4 wk ahead,4.7
+2011,5,2010/2011,57,HHS Region 6,3 wk ahead,6.2
+2011,5,2010/2011,57,HHS Region 6,4 wk ahead,4.8
 2011,5,2010/2011,57,HHS Region 7,Season onset,4
 2011,5,2010/2011,57,HHS Region 7,Season peak week,8
 2011,5,2010/2011,57,HHS Region 7,Season peak percentage,4.7
@@ -1422,16 +1423,15 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,5,2010/2011,57,HHS Region 8,Season peak percentage,2.7
 2011,5,2010/2011,57,HHS Region 8,1 wk ahead,2.5
 2011,5,2010/2011,57,HHS Region 8,2 wk ahead,2.7
-2011,5,2010/2011,57,HHS Region 8,3 wk ahead,2.5
-2011,5,2010/2011,57,HHS Region 8,4 wk ahead,2.2
-2011,5,2010/2011,57,HHS Region 9,Season onset,6
+2011,5,2010/2011,57,HHS Region 8,3 wk ahead,2.6
+2011,5,2010/2011,57,HHS Region 8,4 wk ahead,2.3
+2011,5,2010/2011,57,HHS Region 9,Season onset,none
 2011,5,2010/2011,57,HHS Region 9,Season peak week,7
-2011,5,2010/2011,57,HHS Region 9,Season peak week,8
 2011,5,2010/2011,57,HHS Region 9,Season peak percentage,4.7
 2011,5,2010/2011,57,HHS Region 9,1 wk ahead,4.5
 2011,5,2010/2011,57,HHS Region 9,2 wk ahead,4.7
-2011,5,2010/2011,57,HHS Region 9,3 wk ahead,4.7
-2011,5,2010/2011,57,HHS Region 9,4 wk ahead,4.5
+2011,5,2010/2011,57,HHS Region 9,3 wk ahead,3.9
+2011,5,2010/2011,57,HHS Region 9,4 wk ahead,4.6
 2011,5,2010/2011,57,HHS Region 10,Season onset,5
 2011,5,2010/2011,57,HHS Region 10,Season peak week,7
 2011,5,2010/2011,57,HHS Region 10,Season peak percentage,3.9
@@ -1441,10 +1441,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,5,2010/2011,57,HHS Region 10,4 wk ahead,3.3
 2011,6,2010/2011,58,US National,Season onset,51
 2011,6,2010/2011,58,US National,Season peak week,5
+2011,6,2010/2011,58,US National,Season peak week,6
 2011,6,2010/2011,58,US National,Season peak week,7
-2011,6,2010/2011,58,US National,Season peak percentage,4.6
-2011,6,2010/2011,58,US National,1 wk ahead,4.6
-2011,6,2010/2011,58,US National,2 wk ahead,4.1
+2011,6,2010/2011,58,US National,Season peak percentage,4.5
+2011,6,2010/2011,58,US National,1 wk ahead,4.5
+2011,6,2010/2011,58,US National,2 wk ahead,3.9
 2011,6,2010/2011,58,US National,3 wk ahead,3.4
 2011,6,2010/2011,58,US National,4 wk ahead,3
 2011,6,2010/2011,58,HHS Region 1,Season onset,4
@@ -1469,26 +1470,26 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,6,2010/2011,58,HHS Region 3,2 wk ahead,3.6
 2011,6,2010/2011,58,HHS Region 3,3 wk ahead,3
 2011,6,2010/2011,58,HHS Region 3,4 wk ahead,2.6
-2011,6,2010/2011,58,HHS Region 4,Season onset,50
+2011,6,2010/2011,58,HHS Region 4,Season onset,49
 2011,6,2010/2011,58,HHS Region 4,Season peak week,5
-2011,6,2010/2011,58,HHS Region 4,Season peak percentage,5.5
+2011,6,2010/2011,58,HHS Region 4,Season peak percentage,5.6
 2011,6,2010/2011,58,HHS Region 4,1 wk ahead,4.8
 2011,6,2010/2011,58,HHS Region 4,2 wk ahead,3.9
 2011,6,2010/2011,58,HHS Region 4,3 wk ahead,2.8
-2011,6,2010/2011,58,HHS Region 4,4 wk ahead,2.5
+2011,6,2010/2011,58,HHS Region 4,4 wk ahead,2.6
 2011,6,2010/2011,58,HHS Region 5,Season onset,3
 2011,6,2010/2011,58,HHS Region 5,Season peak week,5
 2011,6,2010/2011,58,HHS Region 5,Season peak percentage,3.8
 2011,6,2010/2011,58,HHS Region 5,1 wk ahead,3.3
 2011,6,2010/2011,58,HHS Region 5,2 wk ahead,3.1
-2011,6,2010/2011,58,HHS Region 5,3 wk ahead,2.9
-2011,6,2010/2011,58,HHS Region 5,4 wk ahead,2.5
+2011,6,2010/2011,58,HHS Region 5,3 wk ahead,2.8
+2011,6,2010/2011,58,HHS Region 5,4 wk ahead,2.4
 2011,6,2010/2011,58,HHS Region 6,Season onset,3
 2011,6,2010/2011,58,HHS Region 6,Season peak week,7
 2011,6,2010/2011,58,HHS Region 6,Season peak percentage,7.9
 2011,6,2010/2011,58,HHS Region 6,1 wk ahead,7.9
-2011,6,2010/2011,58,HHS Region 6,2 wk ahead,6.3
-2011,6,2010/2011,58,HHS Region 6,3 wk ahead,4.7
+2011,6,2010/2011,58,HHS Region 6,2 wk ahead,6.2
+2011,6,2010/2011,58,HHS Region 6,3 wk ahead,4.8
 2011,6,2010/2011,58,HHS Region 6,4 wk ahead,3.6
 2011,6,2010/2011,58,HHS Region 7,Season onset,4
 2011,6,2010/2011,58,HHS Region 7,Season peak week,8
@@ -1501,17 +1502,16 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,6,2010/2011,58,HHS Region 8,Season peak week,7
 2011,6,2010/2011,58,HHS Region 8,Season peak percentage,2.7
 2011,6,2010/2011,58,HHS Region 8,1 wk ahead,2.7
-2011,6,2010/2011,58,HHS Region 8,2 wk ahead,2.5
-2011,6,2010/2011,58,HHS Region 8,3 wk ahead,2.2
-2011,6,2010/2011,58,HHS Region 8,4 wk ahead,2.1
-2011,6,2010/2011,58,HHS Region 9,Season onset,6
+2011,6,2010/2011,58,HHS Region 8,2 wk ahead,2.6
+2011,6,2010/2011,58,HHS Region 8,3 wk ahead,2.3
+2011,6,2010/2011,58,HHS Region 8,4 wk ahead,2.2
+2011,6,2010/2011,58,HHS Region 9,Season onset,none
 2011,6,2010/2011,58,HHS Region 9,Season peak week,7
-2011,6,2010/2011,58,HHS Region 9,Season peak week,8
 2011,6,2010/2011,58,HHS Region 9,Season peak percentage,4.7
 2011,6,2010/2011,58,HHS Region 9,1 wk ahead,4.7
-2011,6,2010/2011,58,HHS Region 9,2 wk ahead,4.7
-2011,6,2010/2011,58,HHS Region 9,3 wk ahead,4.5
-2011,6,2010/2011,58,HHS Region 9,4 wk ahead,4.2
+2011,6,2010/2011,58,HHS Region 9,2 wk ahead,3.9
+2011,6,2010/2011,58,HHS Region 9,3 wk ahead,4.6
+2011,6,2010/2011,58,HHS Region 9,4 wk ahead,4.3
 2011,6,2010/2011,58,HHS Region 10,Season onset,5
 2011,6,2010/2011,58,HHS Region 10,Season peak week,7
 2011,6,2010/2011,58,HHS Region 10,Season peak percentage,3.9
@@ -1521,9 +1521,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,6,2010/2011,58,HHS Region 10,4 wk ahead,3.2
 2011,7,2010/2011,59,US National,Season onset,51
 2011,7,2010/2011,59,US National,Season peak week,5
+2011,7,2010/2011,59,US National,Season peak week,6
 2011,7,2010/2011,59,US National,Season peak week,7
-2011,7,2010/2011,59,US National,Season peak percentage,4.6
-2011,7,2010/2011,59,US National,1 wk ahead,4.1
+2011,7,2010/2011,59,US National,Season peak percentage,4.5
+2011,7,2010/2011,59,US National,1 wk ahead,3.9
 2011,7,2010/2011,59,US National,2 wk ahead,3.4
 2011,7,2010/2011,59,US National,3 wk ahead,3
 2011,7,2010/2011,59,US National,4 wk ahead,2.6
@@ -1541,7 +1542,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,7,2010/2011,59,HHS Region 2,1 wk ahead,4.3
 2011,7,2010/2011,59,HHS Region 2,2 wk ahead,3.4
 2011,7,2010/2011,59,HHS Region 2,3 wk ahead,3.2
-2011,7,2010/2011,59,HHS Region 2,4 wk ahead,3.2
+2011,7,2010/2011,59,HHS Region 2,4 wk ahead,3.1
 2011,7,2010/2011,59,HHS Region 3,Season onset,3
 2011,7,2010/2011,59,HHS Region 3,Season peak week,5
 2011,7,2010/2011,59,HHS Region 3,Season peak percentage,4.4
@@ -1549,25 +1550,25 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,7,2010/2011,59,HHS Region 3,2 wk ahead,3
 2011,7,2010/2011,59,HHS Region 3,3 wk ahead,2.6
 2011,7,2010/2011,59,HHS Region 3,4 wk ahead,2
-2011,7,2010/2011,59,HHS Region 4,Season onset,50
+2011,7,2010/2011,59,HHS Region 4,Season onset,49
 2011,7,2010/2011,59,HHS Region 4,Season peak week,5
-2011,7,2010/2011,59,HHS Region 4,Season peak percentage,5.5
+2011,7,2010/2011,59,HHS Region 4,Season peak percentage,5.6
 2011,7,2010/2011,59,HHS Region 4,1 wk ahead,3.9
 2011,7,2010/2011,59,HHS Region 4,2 wk ahead,2.8
-2011,7,2010/2011,59,HHS Region 4,3 wk ahead,2.5
+2011,7,2010/2011,59,HHS Region 4,3 wk ahead,2.6
 2011,7,2010/2011,59,HHS Region 4,4 wk ahead,2
 2011,7,2010/2011,59,HHS Region 5,Season onset,3
 2011,7,2010/2011,59,HHS Region 5,Season peak week,5
 2011,7,2010/2011,59,HHS Region 5,Season peak percentage,3.8
 2011,7,2010/2011,59,HHS Region 5,1 wk ahead,3.1
-2011,7,2010/2011,59,HHS Region 5,2 wk ahead,2.9
-2011,7,2010/2011,59,HHS Region 5,3 wk ahead,2.5
+2011,7,2010/2011,59,HHS Region 5,2 wk ahead,2.8
+2011,7,2010/2011,59,HHS Region 5,3 wk ahead,2.4
 2011,7,2010/2011,59,HHS Region 5,4 wk ahead,2.4
 2011,7,2010/2011,59,HHS Region 6,Season onset,3
 2011,7,2010/2011,59,HHS Region 6,Season peak week,7
 2011,7,2010/2011,59,HHS Region 6,Season peak percentage,7.9
-2011,7,2010/2011,59,HHS Region 6,1 wk ahead,6.3
-2011,7,2010/2011,59,HHS Region 6,2 wk ahead,4.7
+2011,7,2010/2011,59,HHS Region 6,1 wk ahead,6.2
+2011,7,2010/2011,59,HHS Region 6,2 wk ahead,4.8
 2011,7,2010/2011,59,HHS Region 6,3 wk ahead,3.6
 2011,7,2010/2011,59,HHS Region 6,4 wk ahead,3
 2011,7,2010/2011,59,HHS Region 7,Season onset,4
@@ -1580,18 +1581,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,7,2010/2011,59,HHS Region 8,Season onset,5
 2011,7,2010/2011,59,HHS Region 8,Season peak week,7
 2011,7,2010/2011,59,HHS Region 8,Season peak percentage,2.7
-2011,7,2010/2011,59,HHS Region 8,1 wk ahead,2.5
-2011,7,2010/2011,59,HHS Region 8,2 wk ahead,2.2
-2011,7,2010/2011,59,HHS Region 8,3 wk ahead,2.1
+2011,7,2010/2011,59,HHS Region 8,1 wk ahead,2.6
+2011,7,2010/2011,59,HHS Region 8,2 wk ahead,2.3
+2011,7,2010/2011,59,HHS Region 8,3 wk ahead,2.2
 2011,7,2010/2011,59,HHS Region 8,4 wk ahead,1.7
-2011,7,2010/2011,59,HHS Region 9,Season onset,6
+2011,7,2010/2011,59,HHS Region 9,Season onset,none
 2011,7,2010/2011,59,HHS Region 9,Season peak week,7
-2011,7,2010/2011,59,HHS Region 9,Season peak week,8
 2011,7,2010/2011,59,HHS Region 9,Season peak percentage,4.7
-2011,7,2010/2011,59,HHS Region 9,1 wk ahead,4.7
-2011,7,2010/2011,59,HHS Region 9,2 wk ahead,4.5
-2011,7,2010/2011,59,HHS Region 9,3 wk ahead,4.2
-2011,7,2010/2011,59,HHS Region 9,4 wk ahead,3.9
+2011,7,2010/2011,59,HHS Region 9,1 wk ahead,3.9
+2011,7,2010/2011,59,HHS Region 9,2 wk ahead,4.6
+2011,7,2010/2011,59,HHS Region 9,3 wk ahead,4.3
+2011,7,2010/2011,59,HHS Region 9,4 wk ahead,4
 2011,7,2010/2011,59,HHS Region 10,Season onset,5
 2011,7,2010/2011,59,HHS Region 10,Season peak week,7
 2011,7,2010/2011,59,HHS Region 10,Season peak percentage,3.9
@@ -1601,8 +1601,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,7,2010/2011,59,HHS Region 10,4 wk ahead,3.1
 2011,8,2010/2011,60,US National,Season onset,51
 2011,8,2010/2011,60,US National,Season peak week,5
+2011,8,2010/2011,60,US National,Season peak week,6
 2011,8,2010/2011,60,US National,Season peak week,7
-2011,8,2010/2011,60,US National,Season peak percentage,4.6
+2011,8,2010/2011,60,US National,Season peak percentage,4.5
 2011,8,2010/2011,60,US National,1 wk ahead,3.4
 2011,8,2010/2011,60,US National,2 wk ahead,3
 2011,8,2010/2011,60,US National,3 wk ahead,2.6
@@ -1620,7 +1621,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,8,2010/2011,60,HHS Region 2,Season peak percentage,4.5
 2011,8,2010/2011,60,HHS Region 2,1 wk ahead,3.4
 2011,8,2010/2011,60,HHS Region 2,2 wk ahead,3.2
-2011,8,2010/2011,60,HHS Region 2,3 wk ahead,3.2
+2011,8,2010/2011,60,HHS Region 2,3 wk ahead,3.1
 2011,8,2010/2011,60,HHS Region 2,4 wk ahead,2.5
 2011,8,2010/2011,60,HHS Region 3,Season onset,3
 2011,8,2010/2011,60,HHS Region 3,Season peak week,5
@@ -1629,24 +1630,24 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,8,2010/2011,60,HHS Region 3,2 wk ahead,2.6
 2011,8,2010/2011,60,HHS Region 3,3 wk ahead,2
 2011,8,2010/2011,60,HHS Region 3,4 wk ahead,1.7
-2011,8,2010/2011,60,HHS Region 4,Season onset,50
+2011,8,2010/2011,60,HHS Region 4,Season onset,49
 2011,8,2010/2011,60,HHS Region 4,Season peak week,5
-2011,8,2010/2011,60,HHS Region 4,Season peak percentage,5.5
+2011,8,2010/2011,60,HHS Region 4,Season peak percentage,5.6
 2011,8,2010/2011,60,HHS Region 4,1 wk ahead,2.8
-2011,8,2010/2011,60,HHS Region 4,2 wk ahead,2.5
+2011,8,2010/2011,60,HHS Region 4,2 wk ahead,2.6
 2011,8,2010/2011,60,HHS Region 4,3 wk ahead,2
 2011,8,2010/2011,60,HHS Region 4,4 wk ahead,1.6
 2011,8,2010/2011,60,HHS Region 5,Season onset,3
 2011,8,2010/2011,60,HHS Region 5,Season peak week,5
 2011,8,2010/2011,60,HHS Region 5,Season peak percentage,3.8
-2011,8,2010/2011,60,HHS Region 5,1 wk ahead,2.9
-2011,8,2010/2011,60,HHS Region 5,2 wk ahead,2.5
+2011,8,2010/2011,60,HHS Region 5,1 wk ahead,2.8
+2011,8,2010/2011,60,HHS Region 5,2 wk ahead,2.4
 2011,8,2010/2011,60,HHS Region 5,3 wk ahead,2.4
 2011,8,2010/2011,60,HHS Region 5,4 wk ahead,1.6
 2011,8,2010/2011,60,HHS Region 6,Season onset,3
 2011,8,2010/2011,60,HHS Region 6,Season peak week,7
 2011,8,2010/2011,60,HHS Region 6,Season peak percentage,7.9
-2011,8,2010/2011,60,HHS Region 6,1 wk ahead,4.7
+2011,8,2010/2011,60,HHS Region 6,1 wk ahead,4.8
 2011,8,2010/2011,60,HHS Region 6,2 wk ahead,3.6
 2011,8,2010/2011,60,HHS Region 6,3 wk ahead,3
 2011,8,2010/2011,60,HHS Region 6,4 wk ahead,2.9
@@ -1660,18 +1661,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,8,2010/2011,60,HHS Region 8,Season onset,5
 2011,8,2010/2011,60,HHS Region 8,Season peak week,7
 2011,8,2010/2011,60,HHS Region 8,Season peak percentage,2.7
-2011,8,2010/2011,60,HHS Region 8,1 wk ahead,2.2
-2011,8,2010/2011,60,HHS Region 8,2 wk ahead,2.1
+2011,8,2010/2011,60,HHS Region 8,1 wk ahead,2.3
+2011,8,2010/2011,60,HHS Region 8,2 wk ahead,2.2
 2011,8,2010/2011,60,HHS Region 8,3 wk ahead,1.7
 2011,8,2010/2011,60,HHS Region 8,4 wk ahead,1.4
-2011,8,2010/2011,60,HHS Region 9,Season onset,6
+2011,8,2010/2011,60,HHS Region 9,Season onset,none
 2011,8,2010/2011,60,HHS Region 9,Season peak week,7
-2011,8,2010/2011,60,HHS Region 9,Season peak week,8
 2011,8,2010/2011,60,HHS Region 9,Season peak percentage,4.7
-2011,8,2010/2011,60,HHS Region 9,1 wk ahead,4.5
-2011,8,2010/2011,60,HHS Region 9,2 wk ahead,4.2
-2011,8,2010/2011,60,HHS Region 9,3 wk ahead,3.9
-2011,8,2010/2011,60,HHS Region 9,4 wk ahead,3
+2011,8,2010/2011,60,HHS Region 9,1 wk ahead,4.6
+2011,8,2010/2011,60,HHS Region 9,2 wk ahead,4.3
+2011,8,2010/2011,60,HHS Region 9,3 wk ahead,4
+2011,8,2010/2011,60,HHS Region 9,4 wk ahead,3.1
 2011,8,2010/2011,60,HHS Region 10,Season onset,5
 2011,8,2010/2011,60,HHS Region 10,Season peak week,7
 2011,8,2010/2011,60,HHS Region 10,Season peak percentage,3.9
@@ -1681,8 +1681,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,8,2010/2011,60,HHS Region 10,4 wk ahead,2.8
 2011,9,2010/2011,61,US National,Season onset,51
 2011,9,2010/2011,61,US National,Season peak week,5
+2011,9,2010/2011,61,US National,Season peak week,6
 2011,9,2010/2011,61,US National,Season peak week,7
-2011,9,2010/2011,61,US National,Season peak percentage,4.6
+2011,9,2010/2011,61,US National,Season peak percentage,4.5
 2011,9,2010/2011,61,US National,1 wk ahead,3
 2011,9,2010/2011,61,US National,2 wk ahead,2.6
 2011,9,2010/2011,61,US National,3 wk ahead,2.1
@@ -1699,7 +1700,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,9,2010/2011,61,HHS Region 2,Season peak week,52
 2011,9,2010/2011,61,HHS Region 2,Season peak percentage,4.5
 2011,9,2010/2011,61,HHS Region 2,1 wk ahead,3.2
-2011,9,2010/2011,61,HHS Region 2,2 wk ahead,3.2
+2011,9,2010/2011,61,HHS Region 2,2 wk ahead,3.1
 2011,9,2010/2011,61,HHS Region 2,3 wk ahead,2.5
 2011,9,2010/2011,61,HHS Region 2,4 wk ahead,2.7
 2011,9,2010/2011,61,HHS Region 3,Season onset,3
@@ -1709,17 +1710,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,9,2010/2011,61,HHS Region 3,2 wk ahead,2
 2011,9,2010/2011,61,HHS Region 3,3 wk ahead,1.7
 2011,9,2010/2011,61,HHS Region 3,4 wk ahead,1.5
-2011,9,2010/2011,61,HHS Region 4,Season onset,50
+2011,9,2010/2011,61,HHS Region 4,Season onset,49
 2011,9,2010/2011,61,HHS Region 4,Season peak week,5
-2011,9,2010/2011,61,HHS Region 4,Season peak percentage,5.5
-2011,9,2010/2011,61,HHS Region 4,1 wk ahead,2.5
+2011,9,2010/2011,61,HHS Region 4,Season peak percentage,5.6
+2011,9,2010/2011,61,HHS Region 4,1 wk ahead,2.6
 2011,9,2010/2011,61,HHS Region 4,2 wk ahead,2
 2011,9,2010/2011,61,HHS Region 4,3 wk ahead,1.6
 2011,9,2010/2011,61,HHS Region 4,4 wk ahead,1.5
 2011,9,2010/2011,61,HHS Region 5,Season onset,3
 2011,9,2010/2011,61,HHS Region 5,Season peak week,5
 2011,9,2010/2011,61,HHS Region 5,Season peak percentage,3.8
-2011,9,2010/2011,61,HHS Region 5,1 wk ahead,2.5
+2011,9,2010/2011,61,HHS Region 5,1 wk ahead,2.4
 2011,9,2010/2011,61,HHS Region 5,2 wk ahead,2.4
 2011,9,2010/2011,61,HHS Region 5,3 wk ahead,1.6
 2011,9,2010/2011,61,HHS Region 5,4 wk ahead,1.5
@@ -1736,33 +1737,33 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,9,2010/2011,61,HHS Region 7,1 wk ahead,3.5
 2011,9,2010/2011,61,HHS Region 7,2 wk ahead,2.3
 2011,9,2010/2011,61,HHS Region 7,3 wk ahead,1.7
-2011,9,2010/2011,61,HHS Region 7,4 wk ahead,1.4
+2011,9,2010/2011,61,HHS Region 7,4 wk ahead,1.5
 2011,9,2010/2011,61,HHS Region 8,Season onset,5
 2011,9,2010/2011,61,HHS Region 8,Season peak week,7
 2011,9,2010/2011,61,HHS Region 8,Season peak percentage,2.7
-2011,9,2010/2011,61,HHS Region 8,1 wk ahead,2.1
+2011,9,2010/2011,61,HHS Region 8,1 wk ahead,2.2
 2011,9,2010/2011,61,HHS Region 8,2 wk ahead,1.7
 2011,9,2010/2011,61,HHS Region 8,3 wk ahead,1.4
 2011,9,2010/2011,61,HHS Region 8,4 wk ahead,1.1
-2011,9,2010/2011,61,HHS Region 9,Season onset,6
+2011,9,2010/2011,61,HHS Region 9,Season onset,none
 2011,9,2010/2011,61,HHS Region 9,Season peak week,7
-2011,9,2010/2011,61,HHS Region 9,Season peak week,8
 2011,9,2010/2011,61,HHS Region 9,Season peak percentage,4.7
-2011,9,2010/2011,61,HHS Region 9,1 wk ahead,4.2
-2011,9,2010/2011,61,HHS Region 9,2 wk ahead,3.9
-2011,9,2010/2011,61,HHS Region 9,3 wk ahead,3
-2011,9,2010/2011,61,HHS Region 9,4 wk ahead,2.8
+2011,9,2010/2011,61,HHS Region 9,1 wk ahead,4.3
+2011,9,2010/2011,61,HHS Region 9,2 wk ahead,4
+2011,9,2010/2011,61,HHS Region 9,3 wk ahead,3.1
+2011,9,2010/2011,61,HHS Region 9,4 wk ahead,2.9
 2011,9,2010/2011,61,HHS Region 10,Season onset,5
 2011,9,2010/2011,61,HHS Region 10,Season peak week,7
 2011,9,2010/2011,61,HHS Region 10,Season peak percentage,3.9
 2011,9,2010/2011,61,HHS Region 10,1 wk ahead,3.2
 2011,9,2010/2011,61,HHS Region 10,2 wk ahead,3.1
 2011,9,2010/2011,61,HHS Region 10,3 wk ahead,2.8
-2011,9,2010/2011,61,HHS Region 10,4 wk ahead,1.7
+2011,9,2010/2011,61,HHS Region 10,4 wk ahead,1.5
 2011,10,2010/2011,62,US National,Season onset,51
 2011,10,2010/2011,62,US National,Season peak week,5
+2011,10,2010/2011,62,US National,Season peak week,6
 2011,10,2010/2011,62,US National,Season peak week,7
-2011,10,2010/2011,62,US National,Season peak percentage,4.6
+2011,10,2010/2011,62,US National,Season peak percentage,4.5
 2011,10,2010/2011,62,US National,1 wk ahead,2.6
 2011,10,2010/2011,62,US National,2 wk ahead,2.1
 2011,10,2010/2011,62,US National,3 wk ahead,1.9
@@ -1778,7 +1779,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,10,2010/2011,62,HHS Region 2,Season onset,49
 2011,10,2010/2011,62,HHS Region 2,Season peak week,52
 2011,10,2010/2011,62,HHS Region 2,Season peak percentage,4.5
-2011,10,2010/2011,62,HHS Region 2,1 wk ahead,3.2
+2011,10,2010/2011,62,HHS Region 2,1 wk ahead,3.1
 2011,10,2010/2011,62,HHS Region 2,2 wk ahead,2.5
 2011,10,2010/2011,62,HHS Region 2,3 wk ahead,2.7
 2011,10,2010/2011,62,HHS Region 2,4 wk ahead,2.5
@@ -1789,9 +1790,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,10,2010/2011,62,HHS Region 3,2 wk ahead,1.7
 2011,10,2010/2011,62,HHS Region 3,3 wk ahead,1.5
 2011,10,2010/2011,62,HHS Region 3,4 wk ahead,1.5
-2011,10,2010/2011,62,HHS Region 4,Season onset,50
+2011,10,2010/2011,62,HHS Region 4,Season onset,49
 2011,10,2010/2011,62,HHS Region 4,Season peak week,5
-2011,10,2010/2011,62,HHS Region 4,Season peak percentage,5.5
+2011,10,2010/2011,62,HHS Region 4,Season peak percentage,5.6
 2011,10,2010/2011,62,HHS Region 4,1 wk ahead,2
 2011,10,2010/2011,62,HHS Region 4,2 wk ahead,1.6
 2011,10,2010/2011,62,HHS Region 4,3 wk ahead,1.5
@@ -1802,20 +1803,20 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,10,2010/2011,62,HHS Region 5,1 wk ahead,2.4
 2011,10,2010/2011,62,HHS Region 5,2 wk ahead,1.6
 2011,10,2010/2011,62,HHS Region 5,3 wk ahead,1.5
-2011,10,2010/2011,62,HHS Region 5,4 wk ahead,1.3
+2011,10,2010/2011,62,HHS Region 5,4 wk ahead,1.2
 2011,10,2010/2011,62,HHS Region 6,Season onset,3
 2011,10,2010/2011,62,HHS Region 6,Season peak week,7
 2011,10,2010/2011,62,HHS Region 6,Season peak percentage,7.9
 2011,10,2010/2011,62,HHS Region 6,1 wk ahead,3
 2011,10,2010/2011,62,HHS Region 6,2 wk ahead,2.9
 2011,10,2010/2011,62,HHS Region 6,3 wk ahead,2
-2011,10,2010/2011,62,HHS Region 6,4 wk ahead,1.8
+2011,10,2010/2011,62,HHS Region 6,4 wk ahead,1.9
 2011,10,2010/2011,62,HHS Region 7,Season onset,4
 2011,10,2010/2011,62,HHS Region 7,Season peak week,8
 2011,10,2010/2011,62,HHS Region 7,Season peak percentage,4.7
 2011,10,2010/2011,62,HHS Region 7,1 wk ahead,2.3
 2011,10,2010/2011,62,HHS Region 7,2 wk ahead,1.7
-2011,10,2010/2011,62,HHS Region 7,3 wk ahead,1.4
+2011,10,2010/2011,62,HHS Region 7,3 wk ahead,1.5
 2011,10,2010/2011,62,HHS Region 7,4 wk ahead,1.2
 2011,10,2010/2011,62,HHS Region 8,Season onset,5
 2011,10,2010/2011,62,HHS Region 8,Season peak week,7
@@ -1824,25 +1825,25 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,10,2010/2011,62,HHS Region 8,2 wk ahead,1.4
 2011,10,2010/2011,62,HHS Region 8,3 wk ahead,1.1
 2011,10,2010/2011,62,HHS Region 8,4 wk ahead,0.8
-2011,10,2010/2011,62,HHS Region 9,Season onset,6
+2011,10,2010/2011,62,HHS Region 9,Season onset,none
 2011,10,2010/2011,62,HHS Region 9,Season peak week,7
-2011,10,2010/2011,62,HHS Region 9,Season peak week,8
 2011,10,2010/2011,62,HHS Region 9,Season peak percentage,4.7
-2011,10,2010/2011,62,HHS Region 9,1 wk ahead,3.9
-2011,10,2010/2011,62,HHS Region 9,2 wk ahead,3
-2011,10,2010/2011,62,HHS Region 9,3 wk ahead,2.8
-2011,10,2010/2011,62,HHS Region 9,4 wk ahead,2.4
+2011,10,2010/2011,62,HHS Region 9,1 wk ahead,4
+2011,10,2010/2011,62,HHS Region 9,2 wk ahead,3.1
+2011,10,2010/2011,62,HHS Region 9,3 wk ahead,2.9
+2011,10,2010/2011,62,HHS Region 9,4 wk ahead,2.5
 2011,10,2010/2011,62,HHS Region 10,Season onset,5
 2011,10,2010/2011,62,HHS Region 10,Season peak week,7
 2011,10,2010/2011,62,HHS Region 10,Season peak percentage,3.9
 2011,10,2010/2011,62,HHS Region 10,1 wk ahead,3.1
 2011,10,2010/2011,62,HHS Region 10,2 wk ahead,2.8
-2011,10,2010/2011,62,HHS Region 10,3 wk ahead,1.7
+2011,10,2010/2011,62,HHS Region 10,3 wk ahead,1.5
 2011,10,2010/2011,62,HHS Region 10,4 wk ahead,1.2
 2011,11,2010/2011,63,US National,Season onset,51
 2011,11,2010/2011,63,US National,Season peak week,5
+2011,11,2010/2011,63,US National,Season peak week,6
 2011,11,2010/2011,63,US National,Season peak week,7
-2011,11,2010/2011,63,US National,Season peak percentage,4.6
+2011,11,2010/2011,63,US National,Season peak percentage,4.5
 2011,11,2010/2011,63,US National,1 wk ahead,2.1
 2011,11,2010/2011,63,US National,2 wk ahead,1.9
 2011,11,2010/2011,63,US National,3 wk ahead,1.6
@@ -1861,7 +1862,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,11,2010/2011,63,HHS Region 2,1 wk ahead,2.5
 2011,11,2010/2011,63,HHS Region 2,2 wk ahead,2.7
 2011,11,2010/2011,63,HHS Region 2,3 wk ahead,2.5
-2011,11,2010/2011,63,HHS Region 2,4 wk ahead,2.2
+2011,11,2010/2011,63,HHS Region 2,4 wk ahead,2.3
 2011,11,2010/2011,63,HHS Region 3,Season onset,3
 2011,11,2010/2011,63,HHS Region 3,Season peak week,5
 2011,11,2010/2011,63,HHS Region 3,Season peak percentage,4.4
@@ -1869,9 +1870,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,11,2010/2011,63,HHS Region 3,2 wk ahead,1.5
 2011,11,2010/2011,63,HHS Region 3,3 wk ahead,1.5
 2011,11,2010/2011,63,HHS Region 3,4 wk ahead,1.4
-2011,11,2010/2011,63,HHS Region 4,Season onset,50
+2011,11,2010/2011,63,HHS Region 4,Season onset,49
 2011,11,2010/2011,63,HHS Region 4,Season peak week,5
-2011,11,2010/2011,63,HHS Region 4,Season peak percentage,5.5
+2011,11,2010/2011,63,HHS Region 4,Season peak percentage,5.6
 2011,11,2010/2011,63,HHS Region 4,1 wk ahead,1.6
 2011,11,2010/2011,63,HHS Region 4,2 wk ahead,1.5
 2011,11,2010/2011,63,HHS Region 4,3 wk ahead,1.3
@@ -1881,20 +1882,20 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,11,2010/2011,63,HHS Region 5,Season peak percentage,3.8
 2011,11,2010/2011,63,HHS Region 5,1 wk ahead,1.6
 2011,11,2010/2011,63,HHS Region 5,2 wk ahead,1.5
-2011,11,2010/2011,63,HHS Region 5,3 wk ahead,1.3
+2011,11,2010/2011,63,HHS Region 5,3 wk ahead,1.2
 2011,11,2010/2011,63,HHS Region 5,4 wk ahead,0.9
 2011,11,2010/2011,63,HHS Region 6,Season onset,3
 2011,11,2010/2011,63,HHS Region 6,Season peak week,7
 2011,11,2010/2011,63,HHS Region 6,Season peak percentage,7.9
 2011,11,2010/2011,63,HHS Region 6,1 wk ahead,2.9
 2011,11,2010/2011,63,HHS Region 6,2 wk ahead,2
-2011,11,2010/2011,63,HHS Region 6,3 wk ahead,1.8
+2011,11,2010/2011,63,HHS Region 6,3 wk ahead,1.9
 2011,11,2010/2011,63,HHS Region 6,4 wk ahead,1.5
 2011,11,2010/2011,63,HHS Region 7,Season onset,4
 2011,11,2010/2011,63,HHS Region 7,Season peak week,8
 2011,11,2010/2011,63,HHS Region 7,Season peak percentage,4.7
 2011,11,2010/2011,63,HHS Region 7,1 wk ahead,1.7
-2011,11,2010/2011,63,HHS Region 7,2 wk ahead,1.4
+2011,11,2010/2011,63,HHS Region 7,2 wk ahead,1.5
 2011,11,2010/2011,63,HHS Region 7,3 wk ahead,1.2
 2011,11,2010/2011,63,HHS Region 7,4 wk ahead,1
 2011,11,2010/2011,63,HHS Region 8,Season onset,5
@@ -1904,25 +1905,25 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,11,2010/2011,63,HHS Region 8,2 wk ahead,1.1
 2011,11,2010/2011,63,HHS Region 8,3 wk ahead,0.8
 2011,11,2010/2011,63,HHS Region 8,4 wk ahead,0.8
-2011,11,2010/2011,63,HHS Region 9,Season onset,6
+2011,11,2010/2011,63,HHS Region 9,Season onset,none
 2011,11,2010/2011,63,HHS Region 9,Season peak week,7
-2011,11,2010/2011,63,HHS Region 9,Season peak week,8
 2011,11,2010/2011,63,HHS Region 9,Season peak percentage,4.7
-2011,11,2010/2011,63,HHS Region 9,1 wk ahead,3
-2011,11,2010/2011,63,HHS Region 9,2 wk ahead,2.8
-2011,11,2010/2011,63,HHS Region 9,3 wk ahead,2.4
-2011,11,2010/2011,63,HHS Region 9,4 wk ahead,2.3
+2011,11,2010/2011,63,HHS Region 9,1 wk ahead,3.1
+2011,11,2010/2011,63,HHS Region 9,2 wk ahead,2.9
+2011,11,2010/2011,63,HHS Region 9,3 wk ahead,2.5
+2011,11,2010/2011,63,HHS Region 9,4 wk ahead,2.2
 2011,11,2010/2011,63,HHS Region 10,Season onset,5
 2011,11,2010/2011,63,HHS Region 10,Season peak week,7
 2011,11,2010/2011,63,HHS Region 10,Season peak percentage,3.9
 2011,11,2010/2011,63,HHS Region 10,1 wk ahead,2.8
-2011,11,2010/2011,63,HHS Region 10,2 wk ahead,1.7
+2011,11,2010/2011,63,HHS Region 10,2 wk ahead,1.5
 2011,11,2010/2011,63,HHS Region 10,3 wk ahead,1.2
 2011,11,2010/2011,63,HHS Region 10,4 wk ahead,1.2
 2011,12,2010/2011,64,US National,Season onset,51
 2011,12,2010/2011,64,US National,Season peak week,5
+2011,12,2010/2011,64,US National,Season peak week,6
 2011,12,2010/2011,64,US National,Season peak week,7
-2011,12,2010/2011,64,US National,Season peak percentage,4.6
+2011,12,2010/2011,64,US National,Season peak percentage,4.5
 2011,12,2010/2011,64,US National,1 wk ahead,1.9
 2011,12,2010/2011,64,US National,2 wk ahead,1.6
 2011,12,2010/2011,64,US National,3 wk ahead,1.4
@@ -1940,8 +1941,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,12,2010/2011,64,HHS Region 2,Season peak percentage,4.5
 2011,12,2010/2011,64,HHS Region 2,1 wk ahead,2.7
 2011,12,2010/2011,64,HHS Region 2,2 wk ahead,2.5
-2011,12,2010/2011,64,HHS Region 2,3 wk ahead,2.2
-2011,12,2010/2011,64,HHS Region 2,4 wk ahead,2.2
+2011,12,2010/2011,64,HHS Region 2,3 wk ahead,2.3
+2011,12,2010/2011,64,HHS Region 2,4 wk ahead,2.4
 2011,12,2010/2011,64,HHS Region 3,Season onset,3
 2011,12,2010/2011,64,HHS Region 3,Season peak week,5
 2011,12,2010/2011,64,HHS Region 3,Season peak percentage,4.4
@@ -1949,9 +1950,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,12,2010/2011,64,HHS Region 3,2 wk ahead,1.5
 2011,12,2010/2011,64,HHS Region 3,3 wk ahead,1.4
 2011,12,2010/2011,64,HHS Region 3,4 wk ahead,1.2
-2011,12,2010/2011,64,HHS Region 4,Season onset,50
+2011,12,2010/2011,64,HHS Region 4,Season onset,49
 2011,12,2010/2011,64,HHS Region 4,Season peak week,5
-2011,12,2010/2011,64,HHS Region 4,Season peak percentage,5.5
+2011,12,2010/2011,64,HHS Region 4,Season peak percentage,5.6
 2011,12,2010/2011,64,HHS Region 4,1 wk ahead,1.5
 2011,12,2010/2011,64,HHS Region 4,2 wk ahead,1.3
 2011,12,2010/2011,64,HHS Region 4,3 wk ahead,1.2
@@ -1960,20 +1961,20 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,12,2010/2011,64,HHS Region 5,Season peak week,5
 2011,12,2010/2011,64,HHS Region 5,Season peak percentage,3.8
 2011,12,2010/2011,64,HHS Region 5,1 wk ahead,1.5
-2011,12,2010/2011,64,HHS Region 5,2 wk ahead,1.3
+2011,12,2010/2011,64,HHS Region 5,2 wk ahead,1.2
 2011,12,2010/2011,64,HHS Region 5,3 wk ahead,0.9
 2011,12,2010/2011,64,HHS Region 5,4 wk ahead,0.9
 2011,12,2010/2011,64,HHS Region 6,Season onset,3
 2011,12,2010/2011,64,HHS Region 6,Season peak week,7
 2011,12,2010/2011,64,HHS Region 6,Season peak percentage,7.9
 2011,12,2010/2011,64,HHS Region 6,1 wk ahead,2
-2011,12,2010/2011,64,HHS Region 6,2 wk ahead,1.8
+2011,12,2010/2011,64,HHS Region 6,2 wk ahead,1.9
 2011,12,2010/2011,64,HHS Region 6,3 wk ahead,1.5
 2011,12,2010/2011,64,HHS Region 6,4 wk ahead,1.5
 2011,12,2010/2011,64,HHS Region 7,Season onset,4
 2011,12,2010/2011,64,HHS Region 7,Season peak week,8
 2011,12,2010/2011,64,HHS Region 7,Season peak percentage,4.7
-2011,12,2010/2011,64,HHS Region 7,1 wk ahead,1.4
+2011,12,2010/2011,64,HHS Region 7,1 wk ahead,1.5
 2011,12,2010/2011,64,HHS Region 7,2 wk ahead,1.2
 2011,12,2010/2011,64,HHS Region 7,3 wk ahead,1
 2011,12,2010/2011,64,HHS Region 7,4 wk ahead,0.8
@@ -1984,25 +1985,25 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,12,2010/2011,64,HHS Region 8,2 wk ahead,0.8
 2011,12,2010/2011,64,HHS Region 8,3 wk ahead,0.8
 2011,12,2010/2011,64,HHS Region 8,4 wk ahead,0.6
-2011,12,2010/2011,64,HHS Region 9,Season onset,6
+2011,12,2010/2011,64,HHS Region 9,Season onset,none
 2011,12,2010/2011,64,HHS Region 9,Season peak week,7
-2011,12,2010/2011,64,HHS Region 9,Season peak week,8
 2011,12,2010/2011,64,HHS Region 9,Season peak percentage,4.7
-2011,12,2010/2011,64,HHS Region 9,1 wk ahead,2.8
-2011,12,2010/2011,64,HHS Region 9,2 wk ahead,2.4
-2011,12,2010/2011,64,HHS Region 9,3 wk ahead,2.3
-2011,12,2010/2011,64,HHS Region 9,4 wk ahead,2.1
+2011,12,2010/2011,64,HHS Region 9,1 wk ahead,2.9
+2011,12,2010/2011,64,HHS Region 9,2 wk ahead,2.5
+2011,12,2010/2011,64,HHS Region 9,3 wk ahead,2.2
+2011,12,2010/2011,64,HHS Region 9,4 wk ahead,2.2
 2011,12,2010/2011,64,HHS Region 10,Season onset,5
 2011,12,2010/2011,64,HHS Region 10,Season peak week,7
 2011,12,2010/2011,64,HHS Region 10,Season peak percentage,3.9
-2011,12,2010/2011,64,HHS Region 10,1 wk ahead,1.7
+2011,12,2010/2011,64,HHS Region 10,1 wk ahead,1.5
 2011,12,2010/2011,64,HHS Region 10,2 wk ahead,1.2
 2011,12,2010/2011,64,HHS Region 10,3 wk ahead,1.2
-2011,12,2010/2011,64,HHS Region 10,4 wk ahead,1.3
+2011,12,2010/2011,64,HHS Region 10,4 wk ahead,1.2
 2011,13,2010/2011,65,US National,Season onset,51
 2011,13,2010/2011,65,US National,Season peak week,5
+2011,13,2010/2011,65,US National,Season peak week,6
 2011,13,2010/2011,65,US National,Season peak week,7
-2011,13,2010/2011,65,US National,Season peak percentage,4.6
+2011,13,2010/2011,65,US National,Season peak percentage,4.5
 2011,13,2010/2011,65,US National,1 wk ahead,1.6
 2011,13,2010/2011,65,US National,2 wk ahead,1.4
 2011,13,2010/2011,65,US National,3 wk ahead,1.3
@@ -2019,9 +2020,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,13,2010/2011,65,HHS Region 2,Season peak week,52
 2011,13,2010/2011,65,HHS Region 2,Season peak percentage,4.5
 2011,13,2010/2011,65,HHS Region 2,1 wk ahead,2.5
-2011,13,2010/2011,65,HHS Region 2,2 wk ahead,2.2
-2011,13,2010/2011,65,HHS Region 2,3 wk ahead,2.2
-2011,13,2010/2011,65,HHS Region 2,4 wk ahead,1.7
+2011,13,2010/2011,65,HHS Region 2,2 wk ahead,2.3
+2011,13,2010/2011,65,HHS Region 2,3 wk ahead,2.4
+2011,13,2010/2011,65,HHS Region 2,4 wk ahead,1.8
 2011,13,2010/2011,65,HHS Region 3,Season onset,3
 2011,13,2010/2011,65,HHS Region 3,Season peak week,5
 2011,13,2010/2011,65,HHS Region 3,Season peak percentage,4.4
@@ -2029,9 +2030,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,13,2010/2011,65,HHS Region 3,2 wk ahead,1.4
 2011,13,2010/2011,65,HHS Region 3,3 wk ahead,1.2
 2011,13,2010/2011,65,HHS Region 3,4 wk ahead,0.9
-2011,13,2010/2011,65,HHS Region 4,Season onset,50
+2011,13,2010/2011,65,HHS Region 4,Season onset,49
 2011,13,2010/2011,65,HHS Region 4,Season peak week,5
-2011,13,2010/2011,65,HHS Region 4,Season peak percentage,5.5
+2011,13,2010/2011,65,HHS Region 4,Season peak percentage,5.6
 2011,13,2010/2011,65,HHS Region 4,1 wk ahead,1.3
 2011,13,2010/2011,65,HHS Region 4,2 wk ahead,1.2
 2011,13,2010/2011,65,HHS Region 4,3 wk ahead,1.1
@@ -2039,14 +2040,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,13,2010/2011,65,HHS Region 5,Season onset,3
 2011,13,2010/2011,65,HHS Region 5,Season peak week,5
 2011,13,2010/2011,65,HHS Region 5,Season peak percentage,3.8
-2011,13,2010/2011,65,HHS Region 5,1 wk ahead,1.3
+2011,13,2010/2011,65,HHS Region 5,1 wk ahead,1.2
 2011,13,2010/2011,65,HHS Region 5,2 wk ahead,0.9
 2011,13,2010/2011,65,HHS Region 5,3 wk ahead,0.9
 2011,13,2010/2011,65,HHS Region 5,4 wk ahead,0.8
 2011,13,2010/2011,65,HHS Region 6,Season onset,3
 2011,13,2010/2011,65,HHS Region 6,Season peak week,7
 2011,13,2010/2011,65,HHS Region 6,Season peak percentage,7.9
-2011,13,2010/2011,65,HHS Region 6,1 wk ahead,1.8
+2011,13,2010/2011,65,HHS Region 6,1 wk ahead,1.9
 2011,13,2010/2011,65,HHS Region 6,2 wk ahead,1.5
 2011,13,2010/2011,65,HHS Region 6,3 wk ahead,1.5
 2011,13,2010/2011,65,HHS Region 6,4 wk ahead,1.3
@@ -2056,7 +2057,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,13,2010/2011,65,HHS Region 7,1 wk ahead,1.2
 2011,13,2010/2011,65,HHS Region 7,2 wk ahead,1
 2011,13,2010/2011,65,HHS Region 7,3 wk ahead,0.8
-2011,13,2010/2011,65,HHS Region 7,4 wk ahead,0.6
+2011,13,2010/2011,65,HHS Region 7,4 wk ahead,0.7
 2011,13,2010/2011,65,HHS Region 8,Season onset,5
 2011,13,2010/2011,65,HHS Region 8,Season peak week,7
 2011,13,2010/2011,65,HHS Region 8,Season peak percentage,2.7
@@ -2064,29 +2065,29 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,13,2010/2011,65,HHS Region 8,2 wk ahead,0.8
 2011,13,2010/2011,65,HHS Region 8,3 wk ahead,0.6
 2011,13,2010/2011,65,HHS Region 8,4 wk ahead,0.6
-2011,13,2010/2011,65,HHS Region 9,Season onset,6
+2011,13,2010/2011,65,HHS Region 9,Season onset,none
 2011,13,2010/2011,65,HHS Region 9,Season peak week,7
-2011,13,2010/2011,65,HHS Region 9,Season peak week,8
 2011,13,2010/2011,65,HHS Region 9,Season peak percentage,4.7
-2011,13,2010/2011,65,HHS Region 9,1 wk ahead,2.4
-2011,13,2010/2011,65,HHS Region 9,2 wk ahead,2.3
-2011,13,2010/2011,65,HHS Region 9,3 wk ahead,2.1
-2011,13,2010/2011,65,HHS Region 9,4 wk ahead,2.1
+2011,13,2010/2011,65,HHS Region 9,1 wk ahead,2.5
+2011,13,2010/2011,65,HHS Region 9,2 wk ahead,2.2
+2011,13,2010/2011,65,HHS Region 9,3 wk ahead,2.2
+2011,13,2010/2011,65,HHS Region 9,4 wk ahead,2.2
 2011,13,2010/2011,65,HHS Region 10,Season onset,5
 2011,13,2010/2011,65,HHS Region 10,Season peak week,7
 2011,13,2010/2011,65,HHS Region 10,Season peak percentage,3.9
 2011,13,2010/2011,65,HHS Region 10,1 wk ahead,1.2
 2011,13,2010/2011,65,HHS Region 10,2 wk ahead,1.2
-2011,13,2010/2011,65,HHS Region 10,3 wk ahead,1.3
-2011,13,2010/2011,65,HHS Region 10,4 wk ahead,0.9
+2011,13,2010/2011,65,HHS Region 10,3 wk ahead,1.2
+2011,13,2010/2011,65,HHS Region 10,4 wk ahead,0.8
 2011,14,2010/2011,66,US National,Season onset,51
 2011,14,2010/2011,66,US National,Season peak week,5
+2011,14,2010/2011,66,US National,Season peak week,6
 2011,14,2010/2011,66,US National,Season peak week,7
-2011,14,2010/2011,66,US National,Season peak percentage,4.6
+2011,14,2010/2011,66,US National,Season peak percentage,4.5
 2011,14,2010/2011,66,US National,1 wk ahead,1.4
 2011,14,2010/2011,66,US National,2 wk ahead,1.3
 2011,14,2010/2011,66,US National,3 wk ahead,1.2
-2011,14,2010/2011,66,US National,4 wk ahead,1.1
+2011,14,2010/2011,66,US National,4 wk ahead,1.2
 2011,14,2010/2011,66,HHS Region 1,Season onset,4
 2011,14,2010/2011,66,HHS Region 1,Season peak week,7
 2011,14,2010/2011,66,HHS Region 1,Season peak week,8
@@ -2098,20 +2099,20 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,14,2010/2011,66,HHS Region 2,Season onset,49
 2011,14,2010/2011,66,HHS Region 2,Season peak week,52
 2011,14,2010/2011,66,HHS Region 2,Season peak percentage,4.5
-2011,14,2010/2011,66,HHS Region 2,1 wk ahead,2.2
-2011,14,2010/2011,66,HHS Region 2,2 wk ahead,2.2
-2011,14,2010/2011,66,HHS Region 2,3 wk ahead,1.7
-2011,14,2010/2011,66,HHS Region 2,4 wk ahead,1.6
+2011,14,2010/2011,66,HHS Region 2,1 wk ahead,2.3
+2011,14,2010/2011,66,HHS Region 2,2 wk ahead,2.4
+2011,14,2010/2011,66,HHS Region 2,3 wk ahead,1.8
+2011,14,2010/2011,66,HHS Region 2,4 wk ahead,1.8
 2011,14,2010/2011,66,HHS Region 3,Season onset,3
 2011,14,2010/2011,66,HHS Region 3,Season peak week,5
 2011,14,2010/2011,66,HHS Region 3,Season peak percentage,4.4
 2011,14,2010/2011,66,HHS Region 3,1 wk ahead,1.4
 2011,14,2010/2011,66,HHS Region 3,2 wk ahead,1.2
 2011,14,2010/2011,66,HHS Region 3,3 wk ahead,0.9
-2011,14,2010/2011,66,HHS Region 3,4 wk ahead,1
-2011,14,2010/2011,66,HHS Region 4,Season onset,50
+2011,14,2010/2011,66,HHS Region 3,4 wk ahead,1.1
+2011,14,2010/2011,66,HHS Region 4,Season onset,49
 2011,14,2010/2011,66,HHS Region 4,Season peak week,5
-2011,14,2010/2011,66,HHS Region 4,Season peak percentage,5.5
+2011,14,2010/2011,66,HHS Region 4,Season peak percentage,5.6
 2011,14,2010/2011,66,HHS Region 4,1 wk ahead,1.2
 2011,14,2010/2011,66,HHS Region 4,2 wk ahead,1.1
 2011,14,2010/2011,66,HHS Region 4,3 wk ahead,1.1
@@ -2129,13 +2130,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,14,2010/2011,66,HHS Region 6,1 wk ahead,1.5
 2011,14,2010/2011,66,HHS Region 6,2 wk ahead,1.5
 2011,14,2010/2011,66,HHS Region 6,3 wk ahead,1.3
-2011,14,2010/2011,66,HHS Region 6,4 wk ahead,1.4
+2011,14,2010/2011,66,HHS Region 6,4 wk ahead,1.3
 2011,14,2010/2011,66,HHS Region 7,Season onset,4
 2011,14,2010/2011,66,HHS Region 7,Season peak week,8
 2011,14,2010/2011,66,HHS Region 7,Season peak percentage,4.7
 2011,14,2010/2011,66,HHS Region 7,1 wk ahead,1
 2011,14,2010/2011,66,HHS Region 7,2 wk ahead,0.8
-2011,14,2010/2011,66,HHS Region 7,3 wk ahead,0.6
+2011,14,2010/2011,66,HHS Region 7,3 wk ahead,0.7
 2011,14,2010/2011,66,HHS Region 7,4 wk ahead,0.5
 2011,14,2010/2011,66,HHS Region 8,Season onset,5
 2011,14,2010/2011,66,HHS Region 8,Season peak week,7
@@ -2144,28 +2145,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,14,2010/2011,66,HHS Region 8,2 wk ahead,0.6
 2011,14,2010/2011,66,HHS Region 8,3 wk ahead,0.6
 2011,14,2010/2011,66,HHS Region 8,4 wk ahead,0.5
-2011,14,2010/2011,66,HHS Region 9,Season onset,6
+2011,14,2010/2011,66,HHS Region 9,Season onset,none
 2011,14,2010/2011,66,HHS Region 9,Season peak week,7
-2011,14,2010/2011,66,HHS Region 9,Season peak week,8
 2011,14,2010/2011,66,HHS Region 9,Season peak percentage,4.7
-2011,14,2010/2011,66,HHS Region 9,1 wk ahead,2.3
-2011,14,2010/2011,66,HHS Region 9,2 wk ahead,2.1
-2011,14,2010/2011,66,HHS Region 9,3 wk ahead,2.1
-2011,14,2010/2011,66,HHS Region 9,4 wk ahead,1.9
+2011,14,2010/2011,66,HHS Region 9,1 wk ahead,2.2
+2011,14,2010/2011,66,HHS Region 9,2 wk ahead,2.2
+2011,14,2010/2011,66,HHS Region 9,3 wk ahead,2.2
+2011,14,2010/2011,66,HHS Region 9,4 wk ahead,2
 2011,14,2010/2011,66,HHS Region 10,Season onset,5
 2011,14,2010/2011,66,HHS Region 10,Season peak week,7
 2011,14,2010/2011,66,HHS Region 10,Season peak percentage,3.9
 2011,14,2010/2011,66,HHS Region 10,1 wk ahead,1.2
-2011,14,2010/2011,66,HHS Region 10,2 wk ahead,1.3
-2011,14,2010/2011,66,HHS Region 10,3 wk ahead,0.9
+2011,14,2010/2011,66,HHS Region 10,2 wk ahead,1.2
+2011,14,2010/2011,66,HHS Region 10,3 wk ahead,0.8
 2011,14,2010/2011,66,HHS Region 10,4 wk ahead,0.9
 2011,15,2010/2011,67,US National,Season onset,51
 2011,15,2010/2011,67,US National,Season peak week,5
+2011,15,2010/2011,67,US National,Season peak week,6
 2011,15,2010/2011,67,US National,Season peak week,7
-2011,15,2010/2011,67,US National,Season peak percentage,4.6
+2011,15,2010/2011,67,US National,Season peak percentage,4.5
 2011,15,2010/2011,67,US National,1 wk ahead,1.3
 2011,15,2010/2011,67,US National,2 wk ahead,1.2
-2011,15,2010/2011,67,US National,3 wk ahead,1.1
+2011,15,2010/2011,67,US National,3 wk ahead,1.2
 2011,15,2010/2011,67,US National,4 wk ahead,1.1
 2011,15,2010/2011,67,HHS Region 1,Season onset,4
 2011,15,2010/2011,67,HHS Region 1,Season peak week,7
@@ -2178,24 +2179,24 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,15,2010/2011,67,HHS Region 2,Season onset,49
 2011,15,2010/2011,67,HHS Region 2,Season peak week,52
 2011,15,2010/2011,67,HHS Region 2,Season peak percentage,4.5
-2011,15,2010/2011,67,HHS Region 2,1 wk ahead,2.2
-2011,15,2010/2011,67,HHS Region 2,2 wk ahead,1.7
-2011,15,2010/2011,67,HHS Region 2,3 wk ahead,1.6
+2011,15,2010/2011,67,HHS Region 2,1 wk ahead,2.4
+2011,15,2010/2011,67,HHS Region 2,2 wk ahead,1.8
+2011,15,2010/2011,67,HHS Region 2,3 wk ahead,1.8
 2011,15,2010/2011,67,HHS Region 2,4 wk ahead,1.7
 2011,15,2010/2011,67,HHS Region 3,Season onset,3
 2011,15,2010/2011,67,HHS Region 3,Season peak week,5
 2011,15,2010/2011,67,HHS Region 3,Season peak percentage,4.4
 2011,15,2010/2011,67,HHS Region 3,1 wk ahead,1.2
 2011,15,2010/2011,67,HHS Region 3,2 wk ahead,0.9
-2011,15,2010/2011,67,HHS Region 3,3 wk ahead,1
-2011,15,2010/2011,67,HHS Region 3,4 wk ahead,0.9
-2011,15,2010/2011,67,HHS Region 4,Season onset,50
+2011,15,2010/2011,67,HHS Region 3,3 wk ahead,1.1
+2011,15,2010/2011,67,HHS Region 3,4 wk ahead,1.1
+2011,15,2010/2011,67,HHS Region 4,Season onset,49
 2011,15,2010/2011,67,HHS Region 4,Season peak week,5
-2011,15,2010/2011,67,HHS Region 4,Season peak percentage,5.5
+2011,15,2010/2011,67,HHS Region 4,Season peak percentage,5.6
 2011,15,2010/2011,67,HHS Region 4,1 wk ahead,1.1
 2011,15,2010/2011,67,HHS Region 4,2 wk ahead,1.1
 2011,15,2010/2011,67,HHS Region 4,3 wk ahead,1
-2011,15,2010/2011,67,HHS Region 4,4 wk ahead,0.9
+2011,15,2010/2011,67,HHS Region 4,4 wk ahead,1
 2011,15,2010/2011,67,HHS Region 5,Season onset,3
 2011,15,2010/2011,67,HHS Region 5,Season peak week,5
 2011,15,2010/2011,67,HHS Region 5,Season peak percentage,3.8
@@ -2208,13 +2209,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,15,2010/2011,67,HHS Region 6,Season peak percentage,7.9
 2011,15,2010/2011,67,HHS Region 6,1 wk ahead,1.5
 2011,15,2010/2011,67,HHS Region 6,2 wk ahead,1.3
-2011,15,2010/2011,67,HHS Region 6,3 wk ahead,1.4
+2011,15,2010/2011,67,HHS Region 6,3 wk ahead,1.3
 2011,15,2010/2011,67,HHS Region 6,4 wk ahead,1.4
 2011,15,2010/2011,67,HHS Region 7,Season onset,4
 2011,15,2010/2011,67,HHS Region 7,Season peak week,8
 2011,15,2010/2011,67,HHS Region 7,Season peak percentage,4.7
 2011,15,2010/2011,67,HHS Region 7,1 wk ahead,0.8
-2011,15,2010/2011,67,HHS Region 7,2 wk ahead,0.6
+2011,15,2010/2011,67,HHS Region 7,2 wk ahead,0.7
 2011,15,2010/2011,67,HHS Region 7,3 wk ahead,0.5
 2011,15,2010/2011,67,HHS Region 7,4 wk ahead,0.6
 2011,15,2010/2011,67,HHS Region 8,Season onset,5
@@ -2223,28 +2224,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,15,2010/2011,67,HHS Region 8,1 wk ahead,0.6
 2011,15,2010/2011,67,HHS Region 8,2 wk ahead,0.6
 2011,15,2010/2011,67,HHS Region 8,3 wk ahead,0.5
-2011,15,2010/2011,67,HHS Region 8,4 wk ahead,0.5
-2011,15,2010/2011,67,HHS Region 9,Season onset,6
+2011,15,2010/2011,67,HHS Region 8,4 wk ahead,0.4
+2011,15,2010/2011,67,HHS Region 9,Season onset,none
 2011,15,2010/2011,67,HHS Region 9,Season peak week,7
-2011,15,2010/2011,67,HHS Region 9,Season peak week,8
 2011,15,2010/2011,67,HHS Region 9,Season peak percentage,4.7
-2011,15,2010/2011,67,HHS Region 9,1 wk ahead,2.1
-2011,15,2010/2011,67,HHS Region 9,2 wk ahead,2.1
-2011,15,2010/2011,67,HHS Region 9,3 wk ahead,1.9
-2011,15,2010/2011,67,HHS Region 9,4 wk ahead,1.9
+2011,15,2010/2011,67,HHS Region 9,1 wk ahead,2.2
+2011,15,2010/2011,67,HHS Region 9,2 wk ahead,2.2
+2011,15,2010/2011,67,HHS Region 9,3 wk ahead,2
+2011,15,2010/2011,67,HHS Region 9,4 wk ahead,1
 2011,15,2010/2011,67,HHS Region 10,Season onset,5
 2011,15,2010/2011,67,HHS Region 10,Season peak week,7
 2011,15,2010/2011,67,HHS Region 10,Season peak percentage,3.9
-2011,15,2010/2011,67,HHS Region 10,1 wk ahead,1.3
-2011,15,2010/2011,67,HHS Region 10,2 wk ahead,0.9
+2011,15,2010/2011,67,HHS Region 10,1 wk ahead,1.2
+2011,15,2010/2011,67,HHS Region 10,2 wk ahead,0.8
 2011,15,2010/2011,67,HHS Region 10,3 wk ahead,0.9
-2011,15,2010/2011,67,HHS Region 10,4 wk ahead,0.8
+2011,15,2010/2011,67,HHS Region 10,4 wk ahead,0.9
 2011,16,2010/2011,68,US National,Season onset,51
 2011,16,2010/2011,68,US National,Season peak week,5
+2011,16,2010/2011,68,US National,Season peak week,6
 2011,16,2010/2011,68,US National,Season peak week,7
-2011,16,2010/2011,68,US National,Season peak percentage,4.6
+2011,16,2010/2011,68,US National,Season peak percentage,4.5
 2011,16,2010/2011,68,US National,1 wk ahead,1.2
-2011,16,2010/2011,68,US National,2 wk ahead,1.1
+2011,16,2010/2011,68,US National,2 wk ahead,1.2
 2011,16,2010/2011,68,US National,3 wk ahead,1.1
 2011,16,2010/2011,68,US National,4 wk ahead,1.1
 2011,16,2010/2011,68,HHS Region 1,Season onset,4
@@ -2254,28 +2255,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,16,2010/2011,68,HHS Region 1,1 wk ahead,0.7
 2011,16,2010/2011,68,HHS Region 1,2 wk ahead,0.6
 2011,16,2010/2011,68,HHS Region 1,3 wk ahead,0.5
-2011,16,2010/2011,68,HHS Region 1,4 wk ahead,0.5
+2011,16,2010/2011,68,HHS Region 1,4 wk ahead,0.4
 2011,16,2010/2011,68,HHS Region 2,Season onset,49
 2011,16,2010/2011,68,HHS Region 2,Season peak week,52
 2011,16,2010/2011,68,HHS Region 2,Season peak percentage,4.5
-2011,16,2010/2011,68,HHS Region 2,1 wk ahead,1.7
-2011,16,2010/2011,68,HHS Region 2,2 wk ahead,1.6
+2011,16,2010/2011,68,HHS Region 2,1 wk ahead,1.8
+2011,16,2010/2011,68,HHS Region 2,2 wk ahead,1.8
 2011,16,2010/2011,68,HHS Region 2,3 wk ahead,1.7
-2011,16,2010/2011,68,HHS Region 2,4 wk ahead,1.4
+2011,16,2010/2011,68,HHS Region 2,4 wk ahead,1.3
 2011,16,2010/2011,68,HHS Region 3,Season onset,3
 2011,16,2010/2011,68,HHS Region 3,Season peak week,5
 2011,16,2010/2011,68,HHS Region 3,Season peak percentage,4.4
 2011,16,2010/2011,68,HHS Region 3,1 wk ahead,0.9
-2011,16,2010/2011,68,HHS Region 3,2 wk ahead,1
-2011,16,2010/2011,68,HHS Region 3,3 wk ahead,0.9
-2011,16,2010/2011,68,HHS Region 3,4 wk ahead,1
-2011,16,2010/2011,68,HHS Region 4,Season onset,50
+2011,16,2010/2011,68,HHS Region 3,2 wk ahead,1.1
+2011,16,2010/2011,68,HHS Region 3,3 wk ahead,1.1
+2011,16,2010/2011,68,HHS Region 3,4 wk ahead,1.2
+2011,16,2010/2011,68,HHS Region 4,Season onset,49
 2011,16,2010/2011,68,HHS Region 4,Season peak week,5
-2011,16,2010/2011,68,HHS Region 4,Season peak percentage,5.5
+2011,16,2010/2011,68,HHS Region 4,Season peak percentage,5.6
 2011,16,2010/2011,68,HHS Region 4,1 wk ahead,1.1
 2011,16,2010/2011,68,HHS Region 4,2 wk ahead,1
-2011,16,2010/2011,68,HHS Region 4,3 wk ahead,0.9
-2011,16,2010/2011,68,HHS Region 4,4 wk ahead,0.9
+2011,16,2010/2011,68,HHS Region 4,3 wk ahead,1
+2011,16,2010/2011,68,HHS Region 4,4 wk ahead,1
 2011,16,2010/2011,68,HHS Region 5,Season onset,3
 2011,16,2010/2011,68,HHS Region 5,Season peak week,5
 2011,16,2010/2011,68,HHS Region 5,Season peak percentage,3.8
@@ -2287,43 +2288,43 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,16,2010/2011,68,HHS Region 6,Season peak week,7
 2011,16,2010/2011,68,HHS Region 6,Season peak percentage,7.9
 2011,16,2010/2011,68,HHS Region 6,1 wk ahead,1.3
-2011,16,2010/2011,68,HHS Region 6,2 wk ahead,1.4
+2011,16,2010/2011,68,HHS Region 6,2 wk ahead,1.3
 2011,16,2010/2011,68,HHS Region 6,3 wk ahead,1.4
-2011,16,2010/2011,68,HHS Region 6,4 wk ahead,1.2
+2011,16,2010/2011,68,HHS Region 6,4 wk ahead,1.1
 2011,16,2010/2011,68,HHS Region 7,Season onset,4
 2011,16,2010/2011,68,HHS Region 7,Season peak week,8
 2011,16,2010/2011,68,HHS Region 7,Season peak percentage,4.7
-2011,16,2010/2011,68,HHS Region 7,1 wk ahead,0.6
+2011,16,2010/2011,68,HHS Region 7,1 wk ahead,0.7
 2011,16,2010/2011,68,HHS Region 7,2 wk ahead,0.5
 2011,16,2010/2011,68,HHS Region 7,3 wk ahead,0.6
-2011,16,2010/2011,68,HHS Region 7,4 wk ahead,0.5
+2011,16,2010/2011,68,HHS Region 7,4 wk ahead,0.6
 2011,16,2010/2011,68,HHS Region 8,Season onset,5
 2011,16,2010/2011,68,HHS Region 8,Season peak week,7
 2011,16,2010/2011,68,HHS Region 8,Season peak percentage,2.7
 2011,16,2010/2011,68,HHS Region 8,1 wk ahead,0.6
 2011,16,2010/2011,68,HHS Region 8,2 wk ahead,0.5
-2011,16,2010/2011,68,HHS Region 8,3 wk ahead,0.5
+2011,16,2010/2011,68,HHS Region 8,3 wk ahead,0.4
 2011,16,2010/2011,68,HHS Region 8,4 wk ahead,0.5
-2011,16,2010/2011,68,HHS Region 9,Season onset,6
+2011,16,2010/2011,68,HHS Region 9,Season onset,none
 2011,16,2010/2011,68,HHS Region 9,Season peak week,7
-2011,16,2010/2011,68,HHS Region 9,Season peak week,8
 2011,16,2010/2011,68,HHS Region 9,Season peak percentage,4.7
-2011,16,2010/2011,68,HHS Region 9,1 wk ahead,2.1
-2011,16,2010/2011,68,HHS Region 9,2 wk ahead,1.9
-2011,16,2010/2011,68,HHS Region 9,3 wk ahead,1.9
-2011,16,2010/2011,68,HHS Region 9,4 wk ahead,1.8
+2011,16,2010/2011,68,HHS Region 9,1 wk ahead,2.2
+2011,16,2010/2011,68,HHS Region 9,2 wk ahead,2
+2011,16,2010/2011,68,HHS Region 9,3 wk ahead,1
+2011,16,2010/2011,68,HHS Region 9,4 wk ahead,0.7
 2011,16,2010/2011,68,HHS Region 10,Season onset,5
 2011,16,2010/2011,68,HHS Region 10,Season peak week,7
 2011,16,2010/2011,68,HHS Region 10,Season peak percentage,3.9
-2011,16,2010/2011,68,HHS Region 10,1 wk ahead,0.9
+2011,16,2010/2011,68,HHS Region 10,1 wk ahead,0.8
 2011,16,2010/2011,68,HHS Region 10,2 wk ahead,0.9
-2011,16,2010/2011,68,HHS Region 10,3 wk ahead,0.8
-2011,16,2010/2011,68,HHS Region 10,4 wk ahead,0.8
+2011,16,2010/2011,68,HHS Region 10,3 wk ahead,0.9
+2011,16,2010/2011,68,HHS Region 10,4 wk ahead,1
 2011,17,2010/2011,69,US National,Season onset,51
 2011,17,2010/2011,69,US National,Season peak week,5
+2011,17,2010/2011,69,US National,Season peak week,6
 2011,17,2010/2011,69,US National,Season peak week,7
-2011,17,2010/2011,69,US National,Season peak percentage,4.6
-2011,17,2010/2011,69,US National,1 wk ahead,1.1
+2011,17,2010/2011,69,US National,Season peak percentage,4.5
+2011,17,2010/2011,69,US National,1 wk ahead,1.2
 2011,17,2010/2011,69,US National,2 wk ahead,1.1
 2011,17,2010/2011,69,US National,3 wk ahead,1.1
 2011,17,2010/2011,69,US National,4 wk ahead,1.1
@@ -2333,28 +2334,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,17,2010/2011,69,HHS Region 1,Season peak percentage,2.3
 2011,17,2010/2011,69,HHS Region 1,1 wk ahead,0.6
 2011,17,2010/2011,69,HHS Region 1,2 wk ahead,0.5
-2011,17,2010/2011,69,HHS Region 1,3 wk ahead,0.5
+2011,17,2010/2011,69,HHS Region 1,3 wk ahead,0.4
 2011,17,2010/2011,69,HHS Region 1,4 wk ahead,0.6
 2011,17,2010/2011,69,HHS Region 2,Season onset,49
 2011,17,2010/2011,69,HHS Region 2,Season peak week,52
 2011,17,2010/2011,69,HHS Region 2,Season peak percentage,4.5
-2011,17,2010/2011,69,HHS Region 2,1 wk ahead,1.6
+2011,17,2010/2011,69,HHS Region 2,1 wk ahead,1.8
 2011,17,2010/2011,69,HHS Region 2,2 wk ahead,1.7
-2011,17,2010/2011,69,HHS Region 2,3 wk ahead,1.4
+2011,17,2010/2011,69,HHS Region 2,3 wk ahead,1.3
 2011,17,2010/2011,69,HHS Region 2,4 wk ahead,1.9
 2011,17,2010/2011,69,HHS Region 3,Season onset,3
 2011,17,2010/2011,69,HHS Region 3,Season peak week,5
 2011,17,2010/2011,69,HHS Region 3,Season peak percentage,4.4
-2011,17,2010/2011,69,HHS Region 3,1 wk ahead,1
-2011,17,2010/2011,69,HHS Region 3,2 wk ahead,0.9
-2011,17,2010/2011,69,HHS Region 3,3 wk ahead,1
+2011,17,2010/2011,69,HHS Region 3,1 wk ahead,1.1
+2011,17,2010/2011,69,HHS Region 3,2 wk ahead,1.1
+2011,17,2010/2011,69,HHS Region 3,3 wk ahead,1.2
 2011,17,2010/2011,69,HHS Region 3,4 wk ahead,0.9
-2011,17,2010/2011,69,HHS Region 4,Season onset,50
+2011,17,2010/2011,69,HHS Region 4,Season onset,49
 2011,17,2010/2011,69,HHS Region 4,Season peak week,5
-2011,17,2010/2011,69,HHS Region 4,Season peak percentage,5.5
+2011,17,2010/2011,69,HHS Region 4,Season peak percentage,5.6
 2011,17,2010/2011,69,HHS Region 4,1 wk ahead,1
-2011,17,2010/2011,69,HHS Region 4,2 wk ahead,0.9
-2011,17,2010/2011,69,HHS Region 4,3 wk ahead,0.9
+2011,17,2010/2011,69,HHS Region 4,2 wk ahead,1
+2011,17,2010/2011,69,HHS Region 4,3 wk ahead,1
 2011,17,2010/2011,69,HHS Region 4,4 wk ahead,0.9
 2011,17,2010/2011,69,HHS Region 5,Season onset,3
 2011,17,2010/2011,69,HHS Region 5,Season peak week,5
@@ -2366,43 +2367,43 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,17,2010/2011,69,HHS Region 6,Season onset,3
 2011,17,2010/2011,69,HHS Region 6,Season peak week,7
 2011,17,2010/2011,69,HHS Region 6,Season peak percentage,7.9
-2011,17,2010/2011,69,HHS Region 6,1 wk ahead,1.4
+2011,17,2010/2011,69,HHS Region 6,1 wk ahead,1.3
 2011,17,2010/2011,69,HHS Region 6,2 wk ahead,1.4
-2011,17,2010/2011,69,HHS Region 6,3 wk ahead,1.2
+2011,17,2010/2011,69,HHS Region 6,3 wk ahead,1.1
 2011,17,2010/2011,69,HHS Region 6,4 wk ahead,1.1
 2011,17,2010/2011,69,HHS Region 7,Season onset,4
 2011,17,2010/2011,69,HHS Region 7,Season peak week,8
 2011,17,2010/2011,69,HHS Region 7,Season peak percentage,4.7
 2011,17,2010/2011,69,HHS Region 7,1 wk ahead,0.5
 2011,17,2010/2011,69,HHS Region 7,2 wk ahead,0.6
-2011,17,2010/2011,69,HHS Region 7,3 wk ahead,0.5
+2011,17,2010/2011,69,HHS Region 7,3 wk ahead,0.6
 2011,17,2010/2011,69,HHS Region 7,4 wk ahead,0.5
 2011,17,2010/2011,69,HHS Region 8,Season onset,5
 2011,17,2010/2011,69,HHS Region 8,Season peak week,7
 2011,17,2010/2011,69,HHS Region 8,Season peak percentage,2.7
 2011,17,2010/2011,69,HHS Region 8,1 wk ahead,0.5
-2011,17,2010/2011,69,HHS Region 8,2 wk ahead,0.5
+2011,17,2010/2011,69,HHS Region 8,2 wk ahead,0.4
 2011,17,2010/2011,69,HHS Region 8,3 wk ahead,0.5
 2011,17,2010/2011,69,HHS Region 8,4 wk ahead,0.4
-2011,17,2010/2011,69,HHS Region 9,Season onset,6
+2011,17,2010/2011,69,HHS Region 9,Season onset,none
 2011,17,2010/2011,69,HHS Region 9,Season peak week,7
-2011,17,2010/2011,69,HHS Region 9,Season peak week,8
 2011,17,2010/2011,69,HHS Region 9,Season peak percentage,4.7
-2011,17,2010/2011,69,HHS Region 9,1 wk ahead,1.9
-2011,17,2010/2011,69,HHS Region 9,2 wk ahead,1.9
-2011,17,2010/2011,69,HHS Region 9,3 wk ahead,1.8
+2011,17,2010/2011,69,HHS Region 9,1 wk ahead,2
+2011,17,2010/2011,69,HHS Region 9,2 wk ahead,1
+2011,17,2010/2011,69,HHS Region 9,3 wk ahead,0.7
 2011,17,2010/2011,69,HHS Region 9,4 wk ahead,1.8
 2011,17,2010/2011,69,HHS Region 10,Season onset,5
 2011,17,2010/2011,69,HHS Region 10,Season peak week,7
 2011,17,2010/2011,69,HHS Region 10,Season peak percentage,3.9
 2011,17,2010/2011,69,HHS Region 10,1 wk ahead,0.9
-2011,17,2010/2011,69,HHS Region 10,2 wk ahead,0.8
-2011,17,2010/2011,69,HHS Region 10,3 wk ahead,0.8
+2011,17,2010/2011,69,HHS Region 10,2 wk ahead,0.9
+2011,17,2010/2011,69,HHS Region 10,3 wk ahead,1
 2011,17,2010/2011,69,HHS Region 10,4 wk ahead,0.5
 2011,18,2010/2011,70,US National,Season onset,51
 2011,18,2010/2011,70,US National,Season peak week,5
+2011,18,2010/2011,70,US National,Season peak week,6
 2011,18,2010/2011,70,US National,Season peak week,7
-2011,18,2010/2011,70,US National,Season peak percentage,4.6
+2011,18,2010/2011,70,US National,Season peak percentage,4.5
 2011,18,2010/2011,70,US National,1 wk ahead,1.1
 2011,18,2010/2011,70,US National,2 wk ahead,1.1
 2011,18,2010/2011,70,US National,3 wk ahead,1.1
@@ -2412,28 +2413,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,18,2010/2011,70,HHS Region 1,Season peak week,8
 2011,18,2010/2011,70,HHS Region 1,Season peak percentage,2.3
 2011,18,2010/2011,70,HHS Region 1,1 wk ahead,0.5
-2011,18,2010/2011,70,HHS Region 1,2 wk ahead,0.5
+2011,18,2010/2011,70,HHS Region 1,2 wk ahead,0.4
 2011,18,2010/2011,70,HHS Region 1,3 wk ahead,0.6
 2011,18,2010/2011,70,HHS Region 1,4 wk ahead,0.6
 2011,18,2010/2011,70,HHS Region 2,Season onset,49
 2011,18,2010/2011,70,HHS Region 2,Season peak week,52
 2011,18,2010/2011,70,HHS Region 2,Season peak percentage,4.5
 2011,18,2010/2011,70,HHS Region 2,1 wk ahead,1.7
-2011,18,2010/2011,70,HHS Region 2,2 wk ahead,1.4
+2011,18,2010/2011,70,HHS Region 2,2 wk ahead,1.3
 2011,18,2010/2011,70,HHS Region 2,3 wk ahead,1.9
 2011,18,2010/2011,70,HHS Region 2,4 wk ahead,1.8
 2011,18,2010/2011,70,HHS Region 3,Season onset,3
 2011,18,2010/2011,70,HHS Region 3,Season peak week,5
 2011,18,2010/2011,70,HHS Region 3,Season peak percentage,4.4
-2011,18,2010/2011,70,HHS Region 3,1 wk ahead,0.9
-2011,18,2010/2011,70,HHS Region 3,2 wk ahead,1
+2011,18,2010/2011,70,HHS Region 3,1 wk ahead,1.1
+2011,18,2010/2011,70,HHS Region 3,2 wk ahead,1.2
 2011,18,2010/2011,70,HHS Region 3,3 wk ahead,0.9
 2011,18,2010/2011,70,HHS Region 3,4 wk ahead,0.9
-2011,18,2010/2011,70,HHS Region 4,Season onset,50
+2011,18,2010/2011,70,HHS Region 4,Season onset,49
 2011,18,2010/2011,70,HHS Region 4,Season peak week,5
-2011,18,2010/2011,70,HHS Region 4,Season peak percentage,5.5
-2011,18,2010/2011,70,HHS Region 4,1 wk ahead,0.9
-2011,18,2010/2011,70,HHS Region 4,2 wk ahead,0.9
+2011,18,2010/2011,70,HHS Region 4,Season peak percentage,5.6
+2011,18,2010/2011,70,HHS Region 4,1 wk ahead,1
+2011,18,2010/2011,70,HHS Region 4,2 wk ahead,1
 2011,18,2010/2011,70,HHS Region 4,3 wk ahead,0.9
 2011,18,2010/2011,70,HHS Region 4,4 wk ahead,1
 2011,18,2010/2011,70,HHS Region 5,Season onset,3
@@ -2447,42 +2448,42 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,18,2010/2011,70,HHS Region 6,Season peak week,7
 2011,18,2010/2011,70,HHS Region 6,Season peak percentage,7.9
 2011,18,2010/2011,70,HHS Region 6,1 wk ahead,1.4
-2011,18,2010/2011,70,HHS Region 6,2 wk ahead,1.2
+2011,18,2010/2011,70,HHS Region 6,2 wk ahead,1.1
 2011,18,2010/2011,70,HHS Region 6,3 wk ahead,1.1
 2011,18,2010/2011,70,HHS Region 6,4 wk ahead,1.2
 2011,18,2010/2011,70,HHS Region 7,Season onset,4
 2011,18,2010/2011,70,HHS Region 7,Season peak week,8
 2011,18,2010/2011,70,HHS Region 7,Season peak percentage,4.7
 2011,18,2010/2011,70,HHS Region 7,1 wk ahead,0.6
-2011,18,2010/2011,70,HHS Region 7,2 wk ahead,0.5
+2011,18,2010/2011,70,HHS Region 7,2 wk ahead,0.6
 2011,18,2010/2011,70,HHS Region 7,3 wk ahead,0.5
 2011,18,2010/2011,70,HHS Region 7,4 wk ahead,0.2
 2011,18,2010/2011,70,HHS Region 8,Season onset,5
 2011,18,2010/2011,70,HHS Region 8,Season peak week,7
 2011,18,2010/2011,70,HHS Region 8,Season peak percentage,2.7
-2011,18,2010/2011,70,HHS Region 8,1 wk ahead,0.5
+2011,18,2010/2011,70,HHS Region 8,1 wk ahead,0.4
 2011,18,2010/2011,70,HHS Region 8,2 wk ahead,0.5
 2011,18,2010/2011,70,HHS Region 8,3 wk ahead,0.4
 2011,18,2010/2011,70,HHS Region 8,4 wk ahead,0.4
-2011,18,2010/2011,70,HHS Region 9,Season onset,6
+2011,18,2010/2011,70,HHS Region 9,Season onset,none
 2011,18,2010/2011,70,HHS Region 9,Season peak week,7
-2011,18,2010/2011,70,HHS Region 9,Season peak week,8
 2011,18,2010/2011,70,HHS Region 9,Season peak percentage,4.7
-2011,18,2010/2011,70,HHS Region 9,1 wk ahead,1.9
-2011,18,2010/2011,70,HHS Region 9,2 wk ahead,1.8
+2011,18,2010/2011,70,HHS Region 9,1 wk ahead,1
+2011,18,2010/2011,70,HHS Region 9,2 wk ahead,0.7
 2011,18,2010/2011,70,HHS Region 9,3 wk ahead,1.8
 2011,18,2010/2011,70,HHS Region 9,4 wk ahead,2.2
 2011,18,2010/2011,70,HHS Region 10,Season onset,5
 2011,18,2010/2011,70,HHS Region 10,Season peak week,7
 2011,18,2010/2011,70,HHS Region 10,Season peak percentage,3.9
-2011,18,2010/2011,70,HHS Region 10,1 wk ahead,0.8
-2011,18,2010/2011,70,HHS Region 10,2 wk ahead,0.8
+2011,18,2010/2011,70,HHS Region 10,1 wk ahead,0.9
+2011,18,2010/2011,70,HHS Region 10,2 wk ahead,1
 2011,18,2010/2011,70,HHS Region 10,3 wk ahead,0.5
 2011,18,2010/2011,70,HHS Region 10,4 wk ahead,0.7
 2011,19,2010/2011,71,US National,Season onset,51
 2011,19,2010/2011,71,US National,Season peak week,5
+2011,19,2010/2011,71,US National,Season peak week,6
 2011,19,2010/2011,71,US National,Season peak week,7
-2011,19,2010/2011,71,US National,Season peak percentage,4.6
+2011,19,2010/2011,71,US National,Season peak percentage,4.5
 2011,19,2010/2011,71,US National,1 wk ahead,1.1
 2011,19,2010/2011,71,US National,2 wk ahead,1.1
 2011,19,2010/2011,71,US National,3 wk ahead,1.2
@@ -2491,28 +2492,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,19,2010/2011,71,HHS Region 1,Season peak week,7
 2011,19,2010/2011,71,HHS Region 1,Season peak week,8
 2011,19,2010/2011,71,HHS Region 1,Season peak percentage,2.3
-2011,19,2010/2011,71,HHS Region 1,1 wk ahead,0.5
+2011,19,2010/2011,71,HHS Region 1,1 wk ahead,0.4
 2011,19,2010/2011,71,HHS Region 1,2 wk ahead,0.6
 2011,19,2010/2011,71,HHS Region 1,3 wk ahead,0.6
 2011,19,2010/2011,71,HHS Region 1,4 wk ahead,0.5
 2011,19,2010/2011,71,HHS Region 2,Season onset,49
 2011,19,2010/2011,71,HHS Region 2,Season peak week,52
 2011,19,2010/2011,71,HHS Region 2,Season peak percentage,4.5
-2011,19,2010/2011,71,HHS Region 2,1 wk ahead,1.4
+2011,19,2010/2011,71,HHS Region 2,1 wk ahead,1.3
 2011,19,2010/2011,71,HHS Region 2,2 wk ahead,1.9
 2011,19,2010/2011,71,HHS Region 2,3 wk ahead,1.8
 2011,19,2010/2011,71,HHS Region 2,4 wk ahead,1.3
 2011,19,2010/2011,71,HHS Region 3,Season onset,3
 2011,19,2010/2011,71,HHS Region 3,Season peak week,5
 2011,19,2010/2011,71,HHS Region 3,Season peak percentage,4.4
-2011,19,2010/2011,71,HHS Region 3,1 wk ahead,1
+2011,19,2010/2011,71,HHS Region 3,1 wk ahead,1.2
 2011,19,2010/2011,71,HHS Region 3,2 wk ahead,0.9
 2011,19,2010/2011,71,HHS Region 3,3 wk ahead,0.9
 2011,19,2010/2011,71,HHS Region 3,4 wk ahead,1.1
-2011,19,2010/2011,71,HHS Region 4,Season onset,50
+2011,19,2010/2011,71,HHS Region 4,Season onset,49
 2011,19,2010/2011,71,HHS Region 4,Season peak week,5
-2011,19,2010/2011,71,HHS Region 4,Season peak percentage,5.5
-2011,19,2010/2011,71,HHS Region 4,1 wk ahead,0.9
+2011,19,2010/2011,71,HHS Region 4,Season peak percentage,5.6
+2011,19,2010/2011,71,HHS Region 4,1 wk ahead,1
 2011,19,2010/2011,71,HHS Region 4,2 wk ahead,0.9
 2011,19,2010/2011,71,HHS Region 4,3 wk ahead,1
 2011,19,2010/2011,71,HHS Region 4,4 wk ahead,0.9
@@ -2526,14 +2527,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,19,2010/2011,71,HHS Region 6,Season onset,3
 2011,19,2010/2011,71,HHS Region 6,Season peak week,7
 2011,19,2010/2011,71,HHS Region 6,Season peak percentage,7.9
-2011,19,2010/2011,71,HHS Region 6,1 wk ahead,1.2
+2011,19,2010/2011,71,HHS Region 6,1 wk ahead,1.1
 2011,19,2010/2011,71,HHS Region 6,2 wk ahead,1.1
 2011,19,2010/2011,71,HHS Region 6,3 wk ahead,1.2
 2011,19,2010/2011,71,HHS Region 6,4 wk ahead,0.9
 2011,19,2010/2011,71,HHS Region 7,Season onset,4
 2011,19,2010/2011,71,HHS Region 7,Season peak week,8
 2011,19,2010/2011,71,HHS Region 7,Season peak percentage,4.7
-2011,19,2010/2011,71,HHS Region 7,1 wk ahead,0.5
+2011,19,2010/2011,71,HHS Region 7,1 wk ahead,0.6
 2011,19,2010/2011,71,HHS Region 7,2 wk ahead,0.5
 2011,19,2010/2011,71,HHS Region 7,3 wk ahead,0.2
 2011,19,2010/2011,71,HHS Region 7,4 wk ahead,0.2
@@ -2544,25 +2545,25 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,19,2010/2011,71,HHS Region 8,2 wk ahead,0.4
 2011,19,2010/2011,71,HHS Region 8,3 wk ahead,0.4
 2011,19,2010/2011,71,HHS Region 8,4 wk ahead,0.3
-2011,19,2010/2011,71,HHS Region 9,Season onset,6
+2011,19,2010/2011,71,HHS Region 9,Season onset,none
 2011,19,2010/2011,71,HHS Region 9,Season peak week,7
-2011,19,2010/2011,71,HHS Region 9,Season peak week,8
 2011,19,2010/2011,71,HHS Region 9,Season peak percentage,4.7
-2011,19,2010/2011,71,HHS Region 9,1 wk ahead,1.8
+2011,19,2010/2011,71,HHS Region 9,1 wk ahead,0.7
 2011,19,2010/2011,71,HHS Region 9,2 wk ahead,1.8
 2011,19,2010/2011,71,HHS Region 9,3 wk ahead,2.2
 2011,19,2010/2011,71,HHS Region 9,4 wk ahead,1.9
 2011,19,2010/2011,71,HHS Region 10,Season onset,5
 2011,19,2010/2011,71,HHS Region 10,Season peak week,7
 2011,19,2010/2011,71,HHS Region 10,Season peak percentage,3.9
-2011,19,2010/2011,71,HHS Region 10,1 wk ahead,0.8
+2011,19,2010/2011,71,HHS Region 10,1 wk ahead,1
 2011,19,2010/2011,71,HHS Region 10,2 wk ahead,0.5
 2011,19,2010/2011,71,HHS Region 10,3 wk ahead,0.7
 2011,19,2010/2011,71,HHS Region 10,4 wk ahead,0.6
 2011,20,2010/2011,72,US National,Season onset,51
 2011,20,2010/2011,72,US National,Season peak week,5
+2011,20,2010/2011,72,US National,Season peak week,6
 2011,20,2010/2011,72,US National,Season peak week,7
-2011,20,2010/2011,72,US National,Season peak percentage,4.6
+2011,20,2010/2011,72,US National,Season peak percentage,4.5
 2011,20,2010/2011,72,US National,1 wk ahead,1.1
 2011,20,2010/2011,72,US National,2 wk ahead,1.2
 2011,20,2010/2011,72,US National,3 wk ahead,1
@@ -2589,9 +2590,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,20,2010/2011,72,HHS Region 3,2 wk ahead,0.9
 2011,20,2010/2011,72,HHS Region 3,3 wk ahead,1.1
 2011,20,2010/2011,72,HHS Region 3,4 wk ahead,1
-2011,20,2010/2011,72,HHS Region 4,Season onset,50
+2011,20,2010/2011,72,HHS Region 4,Season onset,49
 2011,20,2010/2011,72,HHS Region 4,Season peak week,5
-2011,20,2010/2011,72,HHS Region 4,Season peak percentage,5.5
+2011,20,2010/2011,72,HHS Region 4,Season peak percentage,5.6
 2011,20,2010/2011,72,HHS Region 4,1 wk ahead,0.9
 2011,20,2010/2011,72,HHS Region 4,2 wk ahead,1
 2011,20,2010/2011,72,HHS Region 4,3 wk ahead,0.9
@@ -2624,9 +2625,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,20,2010/2011,72,HHS Region 8,2 wk ahead,0.4
 2011,20,2010/2011,72,HHS Region 8,3 wk ahead,0.3
 2011,20,2010/2011,72,HHS Region 8,4 wk ahead,0.3
-2011,20,2010/2011,72,HHS Region 9,Season onset,6
+2011,20,2010/2011,72,HHS Region 9,Season onset,none
 2011,20,2010/2011,72,HHS Region 9,Season peak week,7
-2011,20,2010/2011,72,HHS Region 9,Season peak week,8
 2011,20,2010/2011,72,HHS Region 9,Season peak percentage,4.7
 2011,20,2010/2011,72,HHS Region 9,1 wk ahead,1.8
 2011,20,2010/2011,72,HHS Region 9,2 wk ahead,2.2
@@ -2648,6 +2648,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,40,2011/2012,40,US National,4 wk ahead,1.4
 2011,40,2011/2012,40,HHS Region 1,Season onset,none
 2011,40,2011/2012,40,HHS Region 1,Season peak week,52
+2011,40,2011/2012,40,HHS Region 1,Season peak week,8
 2011,40,2011/2012,40,HHS Region 1,Season peak percentage,1
 2011,40,2011/2012,40,HHS Region 1,1 wk ahead,0.7
 2011,40,2011/2012,40,HHS Region 1,2 wk ahead,0.6
@@ -2671,7 +2672,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,40,2011/2012,40,HHS Region 4,Season peak week,52
 2011,40,2011/2012,40,HHS Region 4,Season peak week,10
 2011,40,2011/2012,40,HHS Region 4,Season peak percentage,2.3
-2011,40,2011/2012,40,HHS Region 4,1 wk ahead,1.2
+2011,40,2011/2012,40,HHS Region 4,1 wk ahead,1.1
 2011,40,2011/2012,40,HHS Region 4,2 wk ahead,1.2
 2011,40,2011/2012,40,HHS Region 4,3 wk ahead,1.3
 2011,40,2011/2012,40,HHS Region 4,4 wk ahead,1.5
@@ -2679,19 +2680,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,40,2011/2012,40,HHS Region 5,Season peak week,11
 2011,40,2011/2012,40,HHS Region 5,Season peak percentage,2.4
 2011,40,2011/2012,40,HHS Region 5,1 wk ahead,0.9
-2011,40,2011/2012,40,HHS Region 5,2 wk ahead,1.1
+2011,40,2011/2012,40,HHS Region 5,2 wk ahead,1
 2011,40,2011/2012,40,HHS Region 5,3 wk ahead,1
 2011,40,2011/2012,40,HHS Region 5,4 wk ahead,1.1
 2011,40,2011/2012,40,HHS Region 6,Season onset,none
 2011,40,2011/2012,40,HHS Region 6,Season peak week,11
-2011,40,2011/2012,40,HHS Region 6,Season peak percentage,4.1
+2011,40,2011/2012,40,HHS Region 6,Season peak percentage,4.2
 2011,40,2011/2012,40,HHS Region 6,1 wk ahead,1.7
 2011,40,2011/2012,40,HHS Region 6,2 wk ahead,1.9
 2011,40,2011/2012,40,HHS Region 6,3 wk ahead,1.9
 2011,40,2011/2012,40,HHS Region 6,4 wk ahead,1.9
 2011,40,2011/2012,40,HHS Region 7,Season onset,5
 2011,40,2011/2012,40,HHS Region 7,Season peak week,9
-2011,40,2011/2012,40,HHS Region 7,Season peak percentage,3.4
+2011,40,2011/2012,40,HHS Region 7,Season peak percentage,3.5
 2011,40,2011/2012,40,HHS Region 7,1 wk ahead,0.9
 2011,40,2011/2012,40,HHS Region 7,2 wk ahead,0.8
 2011,40,2011/2012,40,HHS Region 7,3 wk ahead,1
@@ -2705,19 +2706,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,40,2011/2012,40,HHS Region 8,4 wk ahead,0.9
 2011,40,2011/2012,40,HHS Region 9,Season onset,none
 2011,40,2011/2012,40,HHS Region 9,Season peak week,52
-2011,40,2011/2012,40,HHS Region 9,Season peak week,8
 2011,40,2011/2012,40,HHS Region 9,Season peak percentage,3.7
-2011,40,2011/2012,40,HHS Region 9,1 wk ahead,1.7
-2011,40,2011/2012,40,HHS Region 9,2 wk ahead,2
-2011,40,2011/2012,40,HHS Region 9,3 wk ahead,2
-2011,40,2011/2012,40,HHS Region 9,4 wk ahead,2.2
-2011,40,2011/2012,40,HHS Region 10,Season onset,none
-2011,40,2011/2012,40,HHS Region 10,Season peak week,12
-2011,40,2011/2012,40,HHS Region 10,Season peak percentage,2.2
+2011,40,2011/2012,40,HHS Region 9,1 wk ahead,1.6
+2011,40,2011/2012,40,HHS Region 9,2 wk ahead,1.9
+2011,40,2011/2012,40,HHS Region 9,3 wk ahead,1.9
+2011,40,2011/2012,40,HHS Region 9,4 wk ahead,2.1
+2011,40,2011/2012,40,HHS Region 10,Season onset,10
+2011,40,2011/2012,40,HHS Region 10,Season peak week,11
+2011,40,2011/2012,40,HHS Region 10,Season peak percentage,2.7
 2011,40,2011/2012,40,HHS Region 10,1 wk ahead,0.7
-2011,40,2011/2012,40,HHS Region 10,2 wk ahead,0.6
+2011,40,2011/2012,40,HHS Region 10,2 wk ahead,0.5
 2011,40,2011/2012,40,HHS Region 10,3 wk ahead,0.7
-2011,40,2011/2012,40,HHS Region 10,4 wk ahead,0.8
+2011,40,2011/2012,40,HHS Region 10,4 wk ahead,1
 2011,41,2011/2012,41,US National,Season onset,none
 2011,41,2011/2012,41,US National,Season peak week,11
 2011,41,2011/2012,41,US National,Season peak percentage,2.4
@@ -2727,6 +2727,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,41,2011/2012,41,US National,4 wk ahead,1.4
 2011,41,2011/2012,41,HHS Region 1,Season onset,none
 2011,41,2011/2012,41,HHS Region 1,Season peak week,52
+2011,41,2011/2012,41,HHS Region 1,Season peak week,8
 2011,41,2011/2012,41,HHS Region 1,Season peak percentage,1
 2011,41,2011/2012,41,HHS Region 1,1 wk ahead,0.6
 2011,41,2011/2012,41,HHS Region 1,2 wk ahead,0.7
@@ -2757,20 +2758,20 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,41,2011/2012,41,HHS Region 5,Season onset,7
 2011,41,2011/2012,41,HHS Region 5,Season peak week,11
 2011,41,2011/2012,41,HHS Region 5,Season peak percentage,2.4
-2011,41,2011/2012,41,HHS Region 5,1 wk ahead,1.1
+2011,41,2011/2012,41,HHS Region 5,1 wk ahead,1
 2011,41,2011/2012,41,HHS Region 5,2 wk ahead,1
 2011,41,2011/2012,41,HHS Region 5,3 wk ahead,1.1
 2011,41,2011/2012,41,HHS Region 5,4 wk ahead,1.1
 2011,41,2011/2012,41,HHS Region 6,Season onset,none
 2011,41,2011/2012,41,HHS Region 6,Season peak week,11
-2011,41,2011/2012,41,HHS Region 6,Season peak percentage,4.1
+2011,41,2011/2012,41,HHS Region 6,Season peak percentage,4.2
 2011,41,2011/2012,41,HHS Region 6,1 wk ahead,1.9
 2011,41,2011/2012,41,HHS Region 6,2 wk ahead,1.9
 2011,41,2011/2012,41,HHS Region 6,3 wk ahead,1.9
 2011,41,2011/2012,41,HHS Region 6,4 wk ahead,2
 2011,41,2011/2012,41,HHS Region 7,Season onset,5
 2011,41,2011/2012,41,HHS Region 7,Season peak week,9
-2011,41,2011/2012,41,HHS Region 7,Season peak percentage,3.4
+2011,41,2011/2012,41,HHS Region 7,Season peak percentage,3.5
 2011,41,2011/2012,41,HHS Region 7,1 wk ahead,0.8
 2011,41,2011/2012,41,HHS Region 7,2 wk ahead,1
 2011,41,2011/2012,41,HHS Region 7,3 wk ahead,1.1
@@ -2784,28 +2785,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,41,2011/2012,41,HHS Region 8,4 wk ahead,1
 2011,41,2011/2012,41,HHS Region 9,Season onset,none
 2011,41,2011/2012,41,HHS Region 9,Season peak week,52
-2011,41,2011/2012,41,HHS Region 9,Season peak week,8
 2011,41,2011/2012,41,HHS Region 9,Season peak percentage,3.7
-2011,41,2011/2012,41,HHS Region 9,1 wk ahead,2
-2011,41,2011/2012,41,HHS Region 9,2 wk ahead,2
-2011,41,2011/2012,41,HHS Region 9,3 wk ahead,2.2
-2011,41,2011/2012,41,HHS Region 9,4 wk ahead,1.9
-2011,41,2011/2012,41,HHS Region 10,Season onset,none
-2011,41,2011/2012,41,HHS Region 10,Season peak week,12
-2011,41,2011/2012,41,HHS Region 10,Season peak percentage,2.2
-2011,41,2011/2012,41,HHS Region 10,1 wk ahead,0.6
+2011,41,2011/2012,41,HHS Region 9,1 wk ahead,1.9
+2011,41,2011/2012,41,HHS Region 9,2 wk ahead,1.9
+2011,41,2011/2012,41,HHS Region 9,3 wk ahead,2.1
+2011,41,2011/2012,41,HHS Region 9,4 wk ahead,1.8
+2011,41,2011/2012,41,HHS Region 10,Season onset,10
+2011,41,2011/2012,41,HHS Region 10,Season peak week,11
+2011,41,2011/2012,41,HHS Region 10,Season peak percentage,2.7
+2011,41,2011/2012,41,HHS Region 10,1 wk ahead,0.5
 2011,41,2011/2012,41,HHS Region 10,2 wk ahead,0.7
-2011,41,2011/2012,41,HHS Region 10,3 wk ahead,0.8
-2011,41,2011/2012,41,HHS Region 10,4 wk ahead,0.7
+2011,41,2011/2012,41,HHS Region 10,3 wk ahead,1
+2011,41,2011/2012,41,HHS Region 10,4 wk ahead,0.8
 2011,42,2011/2012,42,US National,Season onset,none
 2011,42,2011/2012,42,US National,Season peak week,11
 2011,42,2011/2012,42,US National,Season peak percentage,2.4
 2011,42,2011/2012,42,US National,1 wk ahead,1.3
 2011,42,2011/2012,42,US National,2 wk ahead,1.4
 2011,42,2011/2012,42,US National,3 wk ahead,1.4
-2011,42,2011/2012,42,US National,4 wk ahead,1.5
+2011,42,2011/2012,42,US National,4 wk ahead,1.4
 2011,42,2011/2012,42,HHS Region 1,Season onset,none
 2011,42,2011/2012,42,HHS Region 1,Season peak week,52
+2011,42,2011/2012,42,HHS Region 1,Season peak week,8
 2011,42,2011/2012,42,HHS Region 1,Season peak percentage,1
 2011,42,2011/2012,42,HHS Region 1,1 wk ahead,0.7
 2011,42,2011/2012,42,HHS Region 1,2 wk ahead,0.7
@@ -2842,14 +2843,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,42,2011/2012,42,HHS Region 5,4 wk ahead,1
 2011,42,2011/2012,42,HHS Region 6,Season onset,none
 2011,42,2011/2012,42,HHS Region 6,Season peak week,11
-2011,42,2011/2012,42,HHS Region 6,Season peak percentage,4.1
+2011,42,2011/2012,42,HHS Region 6,Season peak percentage,4.2
 2011,42,2011/2012,42,HHS Region 6,1 wk ahead,1.9
 2011,42,2011/2012,42,HHS Region 6,2 wk ahead,1.9
 2011,42,2011/2012,42,HHS Region 6,3 wk ahead,2
 2011,42,2011/2012,42,HHS Region 6,4 wk ahead,2.2
 2011,42,2011/2012,42,HHS Region 7,Season onset,5
 2011,42,2011/2012,42,HHS Region 7,Season peak week,9
-2011,42,2011/2012,42,HHS Region 7,Season peak percentage,3.4
+2011,42,2011/2012,42,HHS Region 7,Season peak percentage,3.5
 2011,42,2011/2012,42,HHS Region 7,1 wk ahead,1
 2011,42,2011/2012,42,HHS Region 7,2 wk ahead,1.1
 2011,42,2011/2012,42,HHS Region 7,3 wk ahead,0.9
@@ -2863,28 +2864,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,42,2011/2012,42,HHS Region 8,4 wk ahead,1
 2011,42,2011/2012,42,HHS Region 9,Season onset,none
 2011,42,2011/2012,42,HHS Region 9,Season peak week,52
-2011,42,2011/2012,42,HHS Region 9,Season peak week,8
 2011,42,2011/2012,42,HHS Region 9,Season peak percentage,3.7
-2011,42,2011/2012,42,HHS Region 9,1 wk ahead,2
-2011,42,2011/2012,42,HHS Region 9,2 wk ahead,2.2
-2011,42,2011/2012,42,HHS Region 9,3 wk ahead,1.9
-2011,42,2011/2012,42,HHS Region 9,4 wk ahead,2.3
-2011,42,2011/2012,42,HHS Region 10,Season onset,none
-2011,42,2011/2012,42,HHS Region 10,Season peak week,12
-2011,42,2011/2012,42,HHS Region 10,Season peak percentage,2.2
+2011,42,2011/2012,42,HHS Region 9,1 wk ahead,1.9
+2011,42,2011/2012,42,HHS Region 9,2 wk ahead,2.1
+2011,42,2011/2012,42,HHS Region 9,3 wk ahead,1.8
+2011,42,2011/2012,42,HHS Region 9,4 wk ahead,2.2
+2011,42,2011/2012,42,HHS Region 10,Season onset,10
+2011,42,2011/2012,42,HHS Region 10,Season peak week,11
+2011,42,2011/2012,42,HHS Region 10,Season peak percentage,2.7
 2011,42,2011/2012,42,HHS Region 10,1 wk ahead,0.7
-2011,42,2011/2012,42,HHS Region 10,2 wk ahead,0.8
-2011,42,2011/2012,42,HHS Region 10,3 wk ahead,0.7
+2011,42,2011/2012,42,HHS Region 10,2 wk ahead,1
+2011,42,2011/2012,42,HHS Region 10,3 wk ahead,0.8
 2011,42,2011/2012,42,HHS Region 10,4 wk ahead,0.9
 2011,43,2011/2012,43,US National,Season onset,none
 2011,43,2011/2012,43,US National,Season peak week,11
 2011,43,2011/2012,43,US National,Season peak percentage,2.4
 2011,43,2011/2012,43,US National,1 wk ahead,1.4
 2011,43,2011/2012,43,US National,2 wk ahead,1.4
-2011,43,2011/2012,43,US National,3 wk ahead,1.5
+2011,43,2011/2012,43,US National,3 wk ahead,1.4
 2011,43,2011/2012,43,US National,4 wk ahead,1.6
 2011,43,2011/2012,43,HHS Region 1,Season onset,none
 2011,43,2011/2012,43,HHS Region 1,Season peak week,52
+2011,43,2011/2012,43,HHS Region 1,Season peak week,8
 2011,43,2011/2012,43,HHS Region 1,Season peak percentage,1
 2011,43,2011/2012,43,HHS Region 1,1 wk ahead,0.7
 2011,43,2011/2012,43,HHS Region 1,2 wk ahead,0.7
@@ -2921,14 +2922,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,43,2011/2012,43,HHS Region 5,4 wk ahead,1.2
 2011,43,2011/2012,43,HHS Region 6,Season onset,none
 2011,43,2011/2012,43,HHS Region 6,Season peak week,11
-2011,43,2011/2012,43,HHS Region 6,Season peak percentage,4.1
+2011,43,2011/2012,43,HHS Region 6,Season peak percentage,4.2
 2011,43,2011/2012,43,HHS Region 6,1 wk ahead,1.9
 2011,43,2011/2012,43,HHS Region 6,2 wk ahead,2
 2011,43,2011/2012,43,HHS Region 6,3 wk ahead,2.2
 2011,43,2011/2012,43,HHS Region 6,4 wk ahead,2.1
 2011,43,2011/2012,43,HHS Region 7,Season onset,5
 2011,43,2011/2012,43,HHS Region 7,Season peak week,9
-2011,43,2011/2012,43,HHS Region 7,Season peak percentage,3.4
+2011,43,2011/2012,43,HHS Region 7,Season peak percentage,3.5
 2011,43,2011/2012,43,HHS Region 7,1 wk ahead,1.1
 2011,43,2011/2012,43,HHS Region 7,2 wk ahead,0.9
 2011,43,2011/2012,43,HHS Region 7,3 wk ahead,0.8
@@ -2942,28 +2943,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,43,2011/2012,43,HHS Region 8,4 wk ahead,1.1
 2011,43,2011/2012,43,HHS Region 9,Season onset,none
 2011,43,2011/2012,43,HHS Region 9,Season peak week,52
-2011,43,2011/2012,43,HHS Region 9,Season peak week,8
 2011,43,2011/2012,43,HHS Region 9,Season peak percentage,3.7
-2011,43,2011/2012,43,HHS Region 9,1 wk ahead,2.2
-2011,43,2011/2012,43,HHS Region 9,2 wk ahead,1.9
-2011,43,2011/2012,43,HHS Region 9,3 wk ahead,2.3
-2011,43,2011/2012,43,HHS Region 9,4 wk ahead,2.2
-2011,43,2011/2012,43,HHS Region 10,Season onset,none
-2011,43,2011/2012,43,HHS Region 10,Season peak week,12
-2011,43,2011/2012,43,HHS Region 10,Season peak percentage,2.2
-2011,43,2011/2012,43,HHS Region 10,1 wk ahead,0.8
-2011,43,2011/2012,43,HHS Region 10,2 wk ahead,0.7
+2011,43,2011/2012,43,HHS Region 9,1 wk ahead,2.1
+2011,43,2011/2012,43,HHS Region 9,2 wk ahead,1.8
+2011,43,2011/2012,43,HHS Region 9,3 wk ahead,2.2
+2011,43,2011/2012,43,HHS Region 9,4 wk ahead,2.1
+2011,43,2011/2012,43,HHS Region 10,Season onset,10
+2011,43,2011/2012,43,HHS Region 10,Season peak week,11
+2011,43,2011/2012,43,HHS Region 10,Season peak percentage,2.7
+2011,43,2011/2012,43,HHS Region 10,1 wk ahead,1
+2011,43,2011/2012,43,HHS Region 10,2 wk ahead,0.8
 2011,43,2011/2012,43,HHS Region 10,3 wk ahead,0.9
-2011,43,2011/2012,43,HHS Region 10,4 wk ahead,1.1
+2011,43,2011/2012,43,HHS Region 10,4 wk ahead,1.3
 2011,44,2011/2012,44,US National,Season onset,none
 2011,44,2011/2012,44,US National,Season peak week,11
 2011,44,2011/2012,44,US National,Season peak percentage,2.4
 2011,44,2011/2012,44,US National,1 wk ahead,1.4
-2011,44,2011/2012,44,US National,2 wk ahead,1.5
+2011,44,2011/2012,44,US National,2 wk ahead,1.4
 2011,44,2011/2012,44,US National,3 wk ahead,1.6
 2011,44,2011/2012,44,US National,4 wk ahead,1.3
 2011,44,2011/2012,44,HHS Region 1,Season onset,none
 2011,44,2011/2012,44,HHS Region 1,Season peak week,52
+2011,44,2011/2012,44,HHS Region 1,Season peak week,8
 2011,44,2011/2012,44,HHS Region 1,Season peak percentage,1
 2011,44,2011/2012,44,HHS Region 1,1 wk ahead,0.7
 2011,44,2011/2012,44,HHS Region 1,2 wk ahead,0.6
@@ -3000,14 +3001,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,44,2011/2012,44,HHS Region 5,4 wk ahead,1.1
 2011,44,2011/2012,44,HHS Region 6,Season onset,none
 2011,44,2011/2012,44,HHS Region 6,Season peak week,11
-2011,44,2011/2012,44,HHS Region 6,Season peak percentage,4.1
+2011,44,2011/2012,44,HHS Region 6,Season peak percentage,4.2
 2011,44,2011/2012,44,HHS Region 6,1 wk ahead,2
 2011,44,2011/2012,44,HHS Region 6,2 wk ahead,2.2
 2011,44,2011/2012,44,HHS Region 6,3 wk ahead,2.1
 2011,44,2011/2012,44,HHS Region 6,4 wk ahead,2.2
 2011,44,2011/2012,44,HHS Region 7,Season onset,5
 2011,44,2011/2012,44,HHS Region 7,Season peak week,9
-2011,44,2011/2012,44,HHS Region 7,Season peak percentage,3.4
+2011,44,2011/2012,44,HHS Region 7,Season peak percentage,3.5
 2011,44,2011/2012,44,HHS Region 7,1 wk ahead,0.9
 2011,44,2011/2012,44,HHS Region 7,2 wk ahead,0.8
 2011,44,2011/2012,44,HHS Region 7,3 wk ahead,0.9
@@ -3021,28 +3022,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,44,2011/2012,44,HHS Region 8,4 wk ahead,0.9
 2011,44,2011/2012,44,HHS Region 9,Season onset,none
 2011,44,2011/2012,44,HHS Region 9,Season peak week,52
-2011,44,2011/2012,44,HHS Region 9,Season peak week,8
 2011,44,2011/2012,44,HHS Region 9,Season peak percentage,3.7
-2011,44,2011/2012,44,HHS Region 9,1 wk ahead,1.9
-2011,44,2011/2012,44,HHS Region 9,2 wk ahead,2.3
-2011,44,2011/2012,44,HHS Region 9,3 wk ahead,2.2
-2011,44,2011/2012,44,HHS Region 9,4 wk ahead,1.5
-2011,44,2011/2012,44,HHS Region 10,Season onset,none
-2011,44,2011/2012,44,HHS Region 10,Season peak week,12
-2011,44,2011/2012,44,HHS Region 10,Season peak percentage,2.2
-2011,44,2011/2012,44,HHS Region 10,1 wk ahead,0.7
+2011,44,2011/2012,44,HHS Region 9,1 wk ahead,1.8
+2011,44,2011/2012,44,HHS Region 9,2 wk ahead,2.2
+2011,44,2011/2012,44,HHS Region 9,3 wk ahead,2.1
+2011,44,2011/2012,44,HHS Region 9,4 wk ahead,1.4
+2011,44,2011/2012,44,HHS Region 10,Season onset,10
+2011,44,2011/2012,44,HHS Region 10,Season peak week,11
+2011,44,2011/2012,44,HHS Region 10,Season peak percentage,2.7
+2011,44,2011/2012,44,HHS Region 10,1 wk ahead,0.8
 2011,44,2011/2012,44,HHS Region 10,2 wk ahead,0.9
-2011,44,2011/2012,44,HHS Region 10,3 wk ahead,1.1
+2011,44,2011/2012,44,HHS Region 10,3 wk ahead,1.3
 2011,44,2011/2012,44,HHS Region 10,4 wk ahead,0.8
 2011,45,2011/2012,45,US National,Season onset,none
 2011,45,2011/2012,45,US National,Season peak week,11
 2011,45,2011/2012,45,US National,Season peak percentage,2.4
-2011,45,2011/2012,45,US National,1 wk ahead,1.5
+2011,45,2011/2012,45,US National,1 wk ahead,1.4
 2011,45,2011/2012,45,US National,2 wk ahead,1.6
 2011,45,2011/2012,45,US National,3 wk ahead,1.3
 2011,45,2011/2012,45,US National,4 wk ahead,1.5
 2011,45,2011/2012,45,HHS Region 1,Season onset,none
 2011,45,2011/2012,45,HHS Region 1,Season peak week,52
+2011,45,2011/2012,45,HHS Region 1,Season peak week,8
 2011,45,2011/2012,45,HHS Region 1,Season peak percentage,1
 2011,45,2011/2012,45,HHS Region 1,1 wk ahead,0.6
 2011,45,2011/2012,45,HHS Region 1,2 wk ahead,0.7
@@ -3079,14 +3080,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,45,2011/2012,45,HHS Region 5,4 wk ahead,1
 2011,45,2011/2012,45,HHS Region 6,Season onset,none
 2011,45,2011/2012,45,HHS Region 6,Season peak week,11
-2011,45,2011/2012,45,HHS Region 6,Season peak percentage,4.1
+2011,45,2011/2012,45,HHS Region 6,Season peak percentage,4.2
 2011,45,2011/2012,45,HHS Region 6,1 wk ahead,2.2
 2011,45,2011/2012,45,HHS Region 6,2 wk ahead,2.1
 2011,45,2011/2012,45,HHS Region 6,3 wk ahead,2.2
 2011,45,2011/2012,45,HHS Region 6,4 wk ahead,2
 2011,45,2011/2012,45,HHS Region 7,Season onset,5
 2011,45,2011/2012,45,HHS Region 7,Season peak week,9
-2011,45,2011/2012,45,HHS Region 7,Season peak percentage,3.4
+2011,45,2011/2012,45,HHS Region 7,Season peak percentage,3.5
 2011,45,2011/2012,45,HHS Region 7,1 wk ahead,0.8
 2011,45,2011/2012,45,HHS Region 7,2 wk ahead,0.9
 2011,45,2011/2012,45,HHS Region 7,3 wk ahead,1
@@ -3100,17 +3101,16 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,45,2011/2012,45,HHS Region 8,4 wk ahead,0.9
 2011,45,2011/2012,45,HHS Region 9,Season onset,none
 2011,45,2011/2012,45,HHS Region 9,Season peak week,52
-2011,45,2011/2012,45,HHS Region 9,Season peak week,8
 2011,45,2011/2012,45,HHS Region 9,Season peak percentage,3.7
-2011,45,2011/2012,45,HHS Region 9,1 wk ahead,2.3
-2011,45,2011/2012,45,HHS Region 9,2 wk ahead,2.2
-2011,45,2011/2012,45,HHS Region 9,3 wk ahead,1.5
-2011,45,2011/2012,45,HHS Region 9,4 wk ahead,2.3
-2011,45,2011/2012,45,HHS Region 10,Season onset,none
-2011,45,2011/2012,45,HHS Region 10,Season peak week,12
-2011,45,2011/2012,45,HHS Region 10,Season peak percentage,2.2
+2011,45,2011/2012,45,HHS Region 9,1 wk ahead,2.2
+2011,45,2011/2012,45,HHS Region 9,2 wk ahead,2.1
+2011,45,2011/2012,45,HHS Region 9,3 wk ahead,1.4
+2011,45,2011/2012,45,HHS Region 9,4 wk ahead,2.2
+2011,45,2011/2012,45,HHS Region 10,Season onset,10
+2011,45,2011/2012,45,HHS Region 10,Season peak week,11
+2011,45,2011/2012,45,HHS Region 10,Season peak percentage,2.7
 2011,45,2011/2012,45,HHS Region 10,1 wk ahead,0.9
-2011,45,2011/2012,45,HHS Region 10,2 wk ahead,1.1
+2011,45,2011/2012,45,HHS Region 10,2 wk ahead,1.3
 2011,45,2011/2012,45,HHS Region 10,3 wk ahead,0.8
 2011,45,2011/2012,45,HHS Region 10,4 wk ahead,0.6
 2011,46,2011/2012,46,US National,Season onset,none
@@ -3122,6 +3122,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,46,2011/2012,46,US National,4 wk ahead,1.6
 2011,46,2011/2012,46,HHS Region 1,Season onset,none
 2011,46,2011/2012,46,HHS Region 1,Season peak week,52
+2011,46,2011/2012,46,HHS Region 1,Season peak week,8
 2011,46,2011/2012,46,HHS Region 1,Season peak percentage,1
 2011,46,2011/2012,46,HHS Region 1,1 wk ahead,0.7
 2011,46,2011/2012,46,HHS Region 1,2 wk ahead,0.6
@@ -3158,14 +3159,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,46,2011/2012,46,HHS Region 5,4 wk ahead,1.1
 2011,46,2011/2012,46,HHS Region 6,Season onset,none
 2011,46,2011/2012,46,HHS Region 6,Season peak week,11
-2011,46,2011/2012,46,HHS Region 6,Season peak percentage,4.1
+2011,46,2011/2012,46,HHS Region 6,Season peak percentage,4.2
 2011,46,2011/2012,46,HHS Region 6,1 wk ahead,2.1
 2011,46,2011/2012,46,HHS Region 6,2 wk ahead,2.2
 2011,46,2011/2012,46,HHS Region 6,3 wk ahead,2
 2011,46,2011/2012,46,HHS Region 6,4 wk ahead,2.1
 2011,46,2011/2012,46,HHS Region 7,Season onset,5
 2011,46,2011/2012,46,HHS Region 7,Season peak week,9
-2011,46,2011/2012,46,HHS Region 7,Season peak percentage,3.4
+2011,46,2011/2012,46,HHS Region 7,Season peak percentage,3.5
 2011,46,2011/2012,46,HHS Region 7,1 wk ahead,0.9
 2011,46,2011/2012,46,HHS Region 7,2 wk ahead,1
 2011,46,2011/2012,46,HHS Region 7,3 wk ahead,0.8
@@ -3179,19 +3180,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,46,2011/2012,46,HHS Region 8,4 wk ahead,1
 2011,46,2011/2012,46,HHS Region 9,Season onset,none
 2011,46,2011/2012,46,HHS Region 9,Season peak week,52
-2011,46,2011/2012,46,HHS Region 9,Season peak week,8
 2011,46,2011/2012,46,HHS Region 9,Season peak percentage,3.7
-2011,46,2011/2012,46,HHS Region 9,1 wk ahead,2.2
-2011,46,2011/2012,46,HHS Region 9,2 wk ahead,1.5
-2011,46,2011/2012,46,HHS Region 9,3 wk ahead,2.3
+2011,46,2011/2012,46,HHS Region 9,1 wk ahead,2.1
+2011,46,2011/2012,46,HHS Region 9,2 wk ahead,1.4
+2011,46,2011/2012,46,HHS Region 9,3 wk ahead,2.2
 2011,46,2011/2012,46,HHS Region 9,4 wk ahead,2.6
-2011,46,2011/2012,46,HHS Region 10,Season onset,none
-2011,46,2011/2012,46,HHS Region 10,Season peak week,12
-2011,46,2011/2012,46,HHS Region 10,Season peak percentage,2.2
-2011,46,2011/2012,46,HHS Region 10,1 wk ahead,1.1
+2011,46,2011/2012,46,HHS Region 10,Season onset,10
+2011,46,2011/2012,46,HHS Region 10,Season peak week,11
+2011,46,2011/2012,46,HHS Region 10,Season peak percentage,2.7
+2011,46,2011/2012,46,HHS Region 10,1 wk ahead,1.3
 2011,46,2011/2012,46,HHS Region 10,2 wk ahead,0.8
 2011,46,2011/2012,46,HHS Region 10,3 wk ahead,0.6
-2011,46,2011/2012,46,HHS Region 10,4 wk ahead,1
+2011,46,2011/2012,46,HHS Region 10,4 wk ahead,1.3
 2011,47,2011/2012,47,US National,Season onset,none
 2011,47,2011/2012,47,US National,Season peak week,11
 2011,47,2011/2012,47,US National,Season peak percentage,2.4
@@ -3201,6 +3201,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,47,2011/2012,47,US National,4 wk ahead,1.8
 2011,47,2011/2012,47,HHS Region 1,Season onset,none
 2011,47,2011/2012,47,HHS Region 1,Season peak week,52
+2011,47,2011/2012,47,HHS Region 1,Season peak week,8
 2011,47,2011/2012,47,HHS Region 1,Season peak percentage,1
 2011,47,2011/2012,47,HHS Region 1,1 wk ahead,0.6
 2011,47,2011/2012,47,HHS Region 1,2 wk ahead,0.6
@@ -3237,14 +3238,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,47,2011/2012,47,HHS Region 5,4 wk ahead,1.2
 2011,47,2011/2012,47,HHS Region 6,Season onset,none
 2011,47,2011/2012,47,HHS Region 6,Season peak week,11
-2011,47,2011/2012,47,HHS Region 6,Season peak percentage,4.1
+2011,47,2011/2012,47,HHS Region 6,Season peak percentage,4.2
 2011,47,2011/2012,47,HHS Region 6,1 wk ahead,2.2
 2011,47,2011/2012,47,HHS Region 6,2 wk ahead,2
 2011,47,2011/2012,47,HHS Region 6,3 wk ahead,2.1
 2011,47,2011/2012,47,HHS Region 6,4 wk ahead,2.2
 2011,47,2011/2012,47,HHS Region 7,Season onset,5
 2011,47,2011/2012,47,HHS Region 7,Season peak week,9
-2011,47,2011/2012,47,HHS Region 7,Season peak percentage,3.4
+2011,47,2011/2012,47,HHS Region 7,Season peak percentage,3.5
 2011,47,2011/2012,47,HHS Region 7,1 wk ahead,1
 2011,47,2011/2012,47,HHS Region 7,2 wk ahead,0.8
 2011,47,2011/2012,47,HHS Region 7,3 wk ahead,1.4
@@ -3258,19 +3259,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,47,2011/2012,47,HHS Region 8,4 wk ahead,1
 2011,47,2011/2012,47,HHS Region 9,Season onset,none
 2011,47,2011/2012,47,HHS Region 9,Season peak week,52
-2011,47,2011/2012,47,HHS Region 9,Season peak week,8
 2011,47,2011/2012,47,HHS Region 9,Season peak percentage,3.7
-2011,47,2011/2012,47,HHS Region 9,1 wk ahead,1.5
-2011,47,2011/2012,47,HHS Region 9,2 wk ahead,2.3
+2011,47,2011/2012,47,HHS Region 9,1 wk ahead,1.4
+2011,47,2011/2012,47,HHS Region 9,2 wk ahead,2.2
 2011,47,2011/2012,47,HHS Region 9,3 wk ahead,2.6
-2011,47,2011/2012,47,HHS Region 9,4 wk ahead,3.1
-2011,47,2011/2012,47,HHS Region 10,Season onset,none
-2011,47,2011/2012,47,HHS Region 10,Season peak week,12
-2011,47,2011/2012,47,HHS Region 10,Season peak percentage,2.2
+2011,47,2011/2012,47,HHS Region 9,4 wk ahead,3
+2011,47,2011/2012,47,HHS Region 10,Season onset,10
+2011,47,2011/2012,47,HHS Region 10,Season peak week,11
+2011,47,2011/2012,47,HHS Region 10,Season peak percentage,2.7
 2011,47,2011/2012,47,HHS Region 10,1 wk ahead,0.8
 2011,47,2011/2012,47,HHS Region 10,2 wk ahead,0.6
-2011,47,2011/2012,47,HHS Region 10,3 wk ahead,1
-2011,47,2011/2012,47,HHS Region 10,4 wk ahead,1.2
+2011,47,2011/2012,47,HHS Region 10,3 wk ahead,1.3
+2011,47,2011/2012,47,HHS Region 10,4 wk ahead,1.6
 2011,48,2011/2012,48,US National,Season onset,none
 2011,48,2011/2012,48,US National,Season peak week,11
 2011,48,2011/2012,48,US National,Season peak percentage,2.4
@@ -3280,6 +3280,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,48,2011/2012,48,US National,4 wk ahead,2.1
 2011,48,2011/2012,48,HHS Region 1,Season onset,none
 2011,48,2011/2012,48,HHS Region 1,Season peak week,52
+2011,48,2011/2012,48,HHS Region 1,Season peak week,8
 2011,48,2011/2012,48,HHS Region 1,Season peak percentage,1
 2011,48,2011/2012,48,HHS Region 1,1 wk ahead,0.6
 2011,48,2011/2012,48,HHS Region 1,2 wk ahead,0.8
@@ -3316,14 +3317,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,48,2011/2012,48,HHS Region 5,4 wk ahead,1.5
 2011,48,2011/2012,48,HHS Region 6,Season onset,none
 2011,48,2011/2012,48,HHS Region 6,Season peak week,11
-2011,48,2011/2012,48,HHS Region 6,Season peak percentage,4.1
+2011,48,2011/2012,48,HHS Region 6,Season peak percentage,4.2
 2011,48,2011/2012,48,HHS Region 6,1 wk ahead,2
 2011,48,2011/2012,48,HHS Region 6,2 wk ahead,2.1
 2011,48,2011/2012,48,HHS Region 6,3 wk ahead,2.2
 2011,48,2011/2012,48,HHS Region 6,4 wk ahead,2.3
 2011,48,2011/2012,48,HHS Region 7,Season onset,5
 2011,48,2011/2012,48,HHS Region 7,Season peak week,9
-2011,48,2011/2012,48,HHS Region 7,Season peak percentage,3.4
+2011,48,2011/2012,48,HHS Region 7,Season peak percentage,3.5
 2011,48,2011/2012,48,HHS Region 7,1 wk ahead,0.8
 2011,48,2011/2012,48,HHS Region 7,2 wk ahead,1.4
 2011,48,2011/2012,48,HHS Region 7,3 wk ahead,1.4
@@ -3337,28 +3338,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,48,2011/2012,48,HHS Region 8,4 wk ahead,1.1
 2011,48,2011/2012,48,HHS Region 9,Season onset,none
 2011,48,2011/2012,48,HHS Region 9,Season peak week,52
-2011,48,2011/2012,48,HHS Region 9,Season peak week,8
 2011,48,2011/2012,48,HHS Region 9,Season peak percentage,3.7
-2011,48,2011/2012,48,HHS Region 9,1 wk ahead,2.3
+2011,48,2011/2012,48,HHS Region 9,1 wk ahead,2.2
 2011,48,2011/2012,48,HHS Region 9,2 wk ahead,2.6
-2011,48,2011/2012,48,HHS Region 9,3 wk ahead,3.1
+2011,48,2011/2012,48,HHS Region 9,3 wk ahead,3
 2011,48,2011/2012,48,HHS Region 9,4 wk ahead,3.7
-2011,48,2011/2012,48,HHS Region 10,Season onset,none
-2011,48,2011/2012,48,HHS Region 10,Season peak week,12
-2011,48,2011/2012,48,HHS Region 10,Season peak percentage,2.2
+2011,48,2011/2012,48,HHS Region 10,Season onset,10
+2011,48,2011/2012,48,HHS Region 10,Season peak week,11
+2011,48,2011/2012,48,HHS Region 10,Season peak percentage,2.7
 2011,48,2011/2012,48,HHS Region 10,1 wk ahead,0.6
-2011,48,2011/2012,48,HHS Region 10,2 wk ahead,1
-2011,48,2011/2012,48,HHS Region 10,3 wk ahead,1.2
-2011,48,2011/2012,48,HHS Region 10,4 wk ahead,1.3
+2011,48,2011/2012,48,HHS Region 10,2 wk ahead,1.3
+2011,48,2011/2012,48,HHS Region 10,3 wk ahead,1.6
+2011,48,2011/2012,48,HHS Region 10,4 wk ahead,2
 2011,49,2011/2012,49,US National,Season onset,none
 2011,49,2011/2012,49,US National,Season peak week,11
 2011,49,2011/2012,49,US National,Season peak percentage,2.4
 2011,49,2011/2012,49,US National,1 wk ahead,1.6
 2011,49,2011/2012,49,US National,2 wk ahead,1.8
 2011,49,2011/2012,49,US National,3 wk ahead,2.1
-2011,49,2011/2012,49,US National,4 wk ahead,1.7
+2011,49,2011/2012,49,US National,4 wk ahead,1.8
 2011,49,2011/2012,49,HHS Region 1,Season onset,none
 2011,49,2011/2012,49,HHS Region 1,Season peak week,52
+2011,49,2011/2012,49,HHS Region 1,Season peak week,8
 2011,49,2011/2012,49,HHS Region 1,Season peak percentage,1
 2011,49,2011/2012,49,HHS Region 1,1 wk ahead,0.8
 2011,49,2011/2012,49,HHS Region 1,2 wk ahead,0.9
@@ -3395,14 +3396,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,49,2011/2012,49,HHS Region 5,4 wk ahead,1.2
 2011,49,2011/2012,49,HHS Region 6,Season onset,none
 2011,49,2011/2012,49,HHS Region 6,Season peak week,11
-2011,49,2011/2012,49,HHS Region 6,Season peak percentage,4.1
+2011,49,2011/2012,49,HHS Region 6,Season peak percentage,4.2
 2011,49,2011/2012,49,HHS Region 6,1 wk ahead,2.1
 2011,49,2011/2012,49,HHS Region 6,2 wk ahead,2.2
 2011,49,2011/2012,49,HHS Region 6,3 wk ahead,2.3
 2011,49,2011/2012,49,HHS Region 6,4 wk ahead,2.1
 2011,49,2011/2012,49,HHS Region 7,Season onset,5
 2011,49,2011/2012,49,HHS Region 7,Season peak week,9
-2011,49,2011/2012,49,HHS Region 7,Season peak percentage,3.4
+2011,49,2011/2012,49,HHS Region 7,Season peak percentage,3.5
 2011,49,2011/2012,49,HHS Region 7,1 wk ahead,1.4
 2011,49,2011/2012,49,HHS Region 7,2 wk ahead,1.4
 2011,49,2011/2012,49,HHS Region 7,3 wk ahead,1.9
@@ -3416,28 +3417,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,49,2011/2012,49,HHS Region 8,4 wk ahead,1.1
 2011,49,2011/2012,49,HHS Region 9,Season onset,none
 2011,49,2011/2012,49,HHS Region 9,Season peak week,52
-2011,49,2011/2012,49,HHS Region 9,Season peak week,8
 2011,49,2011/2012,49,HHS Region 9,Season peak percentage,3.7
 2011,49,2011/2012,49,HHS Region 9,1 wk ahead,2.6
-2011,49,2011/2012,49,HHS Region 9,2 wk ahead,3.1
+2011,49,2011/2012,49,HHS Region 9,2 wk ahead,3
 2011,49,2011/2012,49,HHS Region 9,3 wk ahead,3.7
 2011,49,2011/2012,49,HHS Region 9,4 wk ahead,3
-2011,49,2011/2012,49,HHS Region 10,Season onset,none
-2011,49,2011/2012,49,HHS Region 10,Season peak week,12
-2011,49,2011/2012,49,HHS Region 10,Season peak percentage,2.2
-2011,49,2011/2012,49,HHS Region 10,1 wk ahead,1
-2011,49,2011/2012,49,HHS Region 10,2 wk ahead,1.2
-2011,49,2011/2012,49,HHS Region 10,3 wk ahead,1.3
-2011,49,2011/2012,49,HHS Region 10,4 wk ahead,1.1
+2011,49,2011/2012,49,HHS Region 10,Season onset,10
+2011,49,2011/2012,49,HHS Region 10,Season peak week,11
+2011,49,2011/2012,49,HHS Region 10,Season peak percentage,2.7
+2011,49,2011/2012,49,HHS Region 10,1 wk ahead,1.3
+2011,49,2011/2012,49,HHS Region 10,2 wk ahead,1.6
+2011,49,2011/2012,49,HHS Region 10,3 wk ahead,2
+2011,49,2011/2012,49,HHS Region 10,4 wk ahead,1.6
 2011,50,2011/2012,50,US National,Season onset,none
 2011,50,2011/2012,50,US National,Season peak week,11
 2011,50,2011/2012,50,US National,Season peak percentage,2.4
 2011,50,2011/2012,50,US National,1 wk ahead,1.8
 2011,50,2011/2012,50,US National,2 wk ahead,2.1
-2011,50,2011/2012,50,US National,3 wk ahead,1.7
+2011,50,2011/2012,50,US National,3 wk ahead,1.8
 2011,50,2011/2012,50,US National,4 wk ahead,1.6
 2011,50,2011/2012,50,HHS Region 1,Season onset,none
 2011,50,2011/2012,50,HHS Region 1,Season peak week,52
+2011,50,2011/2012,50,HHS Region 1,Season peak week,8
 2011,50,2011/2012,50,HHS Region 1,Season peak percentage,1
 2011,50,2011/2012,50,HHS Region 1,1 wk ahead,0.9
 2011,50,2011/2012,50,HHS Region 1,2 wk ahead,1
@@ -3449,7 +3450,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,50,2011/2012,50,HHS Region 2,1 wk ahead,1.2
 2011,50,2011/2012,50,HHS Region 2,2 wk ahead,1.2
 2011,50,2011/2012,50,HHS Region 2,3 wk ahead,1.3
-2011,50,2011/2012,50,HHS Region 2,4 wk ahead,1
+2011,50,2011/2012,50,HHS Region 2,4 wk ahead,1.1
 2011,50,2011/2012,50,HHS Region 3,Season onset,none
 2011,50,2011/2012,50,HHS Region 3,Season peak week,52
 2011,50,2011/2012,50,HHS Region 3,Season peak percentage,2.1
@@ -3474,14 +3475,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,50,2011/2012,50,HHS Region 5,4 wk ahead,1.2
 2011,50,2011/2012,50,HHS Region 6,Season onset,none
 2011,50,2011/2012,50,HHS Region 6,Season peak week,11
-2011,50,2011/2012,50,HHS Region 6,Season peak percentage,4.1
+2011,50,2011/2012,50,HHS Region 6,Season peak percentage,4.2
 2011,50,2011/2012,50,HHS Region 6,1 wk ahead,2.2
 2011,50,2011/2012,50,HHS Region 6,2 wk ahead,2.3
 2011,50,2011/2012,50,HHS Region 6,3 wk ahead,2.1
 2011,50,2011/2012,50,HHS Region 6,4 wk ahead,2.1
 2011,50,2011/2012,50,HHS Region 7,Season onset,5
 2011,50,2011/2012,50,HHS Region 7,Season peak week,9
-2011,50,2011/2012,50,HHS Region 7,Season peak percentage,3.4
+2011,50,2011/2012,50,HHS Region 7,Season peak percentage,3.5
 2011,50,2011/2012,50,HHS Region 7,1 wk ahead,1.4
 2011,50,2011/2012,50,HHS Region 7,2 wk ahead,1.9
 2011,50,2011/2012,50,HHS Region 7,3 wk ahead,1.5
@@ -3495,28 +3496,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,50,2011/2012,50,HHS Region 8,4 wk ahead,1.1
 2011,50,2011/2012,50,HHS Region 9,Season onset,none
 2011,50,2011/2012,50,HHS Region 9,Season peak week,52
-2011,50,2011/2012,50,HHS Region 9,Season peak week,8
 2011,50,2011/2012,50,HHS Region 9,Season peak percentage,3.7
-2011,50,2011/2012,50,HHS Region 9,1 wk ahead,3.1
+2011,50,2011/2012,50,HHS Region 9,1 wk ahead,3
 2011,50,2011/2012,50,HHS Region 9,2 wk ahead,3.7
 2011,50,2011/2012,50,HHS Region 9,3 wk ahead,3
 2011,50,2011/2012,50,HHS Region 9,4 wk ahead,2.5
-2011,50,2011/2012,50,HHS Region 10,Season onset,none
-2011,50,2011/2012,50,HHS Region 10,Season peak week,12
-2011,50,2011/2012,50,HHS Region 10,Season peak percentage,2.2
-2011,50,2011/2012,50,HHS Region 10,1 wk ahead,1.2
-2011,50,2011/2012,50,HHS Region 10,2 wk ahead,1.3
-2011,50,2011/2012,50,HHS Region 10,3 wk ahead,1.1
-2011,50,2011/2012,50,HHS Region 10,4 wk ahead,0.7
+2011,50,2011/2012,50,HHS Region 10,Season onset,10
+2011,50,2011/2012,50,HHS Region 10,Season peak week,11
+2011,50,2011/2012,50,HHS Region 10,Season peak percentage,2.7
+2011,50,2011/2012,50,HHS Region 10,1 wk ahead,1.6
+2011,50,2011/2012,50,HHS Region 10,2 wk ahead,2
+2011,50,2011/2012,50,HHS Region 10,3 wk ahead,1.6
+2011,50,2011/2012,50,HHS Region 10,4 wk ahead,1
 2011,51,2011/2012,51,US National,Season onset,none
 2011,51,2011/2012,51,US National,Season peak week,11
 2011,51,2011/2012,51,US National,Season peak percentage,2.4
 2011,51,2011/2012,51,US National,1 wk ahead,2.1
-2011,51,2011/2012,51,US National,2 wk ahead,1.7
+2011,51,2011/2012,51,US National,2 wk ahead,1.8
 2011,51,2011/2012,51,US National,3 wk ahead,1.6
 2011,51,2011/2012,51,US National,4 wk ahead,1.6
 2011,51,2011/2012,51,HHS Region 1,Season onset,none
 2011,51,2011/2012,51,HHS Region 1,Season peak week,52
+2011,51,2011/2012,51,HHS Region 1,Season peak week,8
 2011,51,2011/2012,51,HHS Region 1,Season peak percentage,1
 2011,51,2011/2012,51,HHS Region 1,1 wk ahead,1
 2011,51,2011/2012,51,HHS Region 1,2 wk ahead,0.9
@@ -3527,8 +3528,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,51,2011/2012,51,HHS Region 2,Season peak percentage,1.4
 2011,51,2011/2012,51,HHS Region 2,1 wk ahead,1.2
 2011,51,2011/2012,51,HHS Region 2,2 wk ahead,1.3
-2011,51,2011/2012,51,HHS Region 2,3 wk ahead,1
-2011,51,2011/2012,51,HHS Region 2,4 wk ahead,1.1
+2011,51,2011/2012,51,HHS Region 2,3 wk ahead,1.1
+2011,51,2011/2012,51,HHS Region 2,4 wk ahead,1.2
 2011,51,2011/2012,51,HHS Region 3,Season onset,none
 2011,51,2011/2012,51,HHS Region 3,Season peak week,52
 2011,51,2011/2012,51,HHS Region 3,Season peak percentage,2.1
@@ -3553,14 +3554,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,51,2011/2012,51,HHS Region 5,4 wk ahead,1.2
 2011,51,2011/2012,51,HHS Region 6,Season onset,none
 2011,51,2011/2012,51,HHS Region 6,Season peak week,11
-2011,51,2011/2012,51,HHS Region 6,Season peak percentage,4.1
+2011,51,2011/2012,51,HHS Region 6,Season peak percentage,4.2
 2011,51,2011/2012,51,HHS Region 6,1 wk ahead,2.3
 2011,51,2011/2012,51,HHS Region 6,2 wk ahead,2.1
 2011,51,2011/2012,51,HHS Region 6,3 wk ahead,2.1
 2011,51,2011/2012,51,HHS Region 6,4 wk ahead,2.2
 2011,51,2011/2012,51,HHS Region 7,Season onset,5
 2011,51,2011/2012,51,HHS Region 7,Season peak week,9
-2011,51,2011/2012,51,HHS Region 7,Season peak percentage,3.4
+2011,51,2011/2012,51,HHS Region 7,Season peak percentage,3.5
 2011,51,2011/2012,51,HHS Region 7,1 wk ahead,1.9
 2011,51,2011/2012,51,HHS Region 7,2 wk ahead,1.5
 2011,51,2011/2012,51,HHS Region 7,3 wk ahead,1.5
@@ -3574,28 +3575,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,51,2011/2012,51,HHS Region 8,4 wk ahead,1.1
 2011,51,2011/2012,51,HHS Region 9,Season onset,none
 2011,51,2011/2012,51,HHS Region 9,Season peak week,52
-2011,51,2011/2012,51,HHS Region 9,Season peak week,8
 2011,51,2011/2012,51,HHS Region 9,Season peak percentage,3.7
 2011,51,2011/2012,51,HHS Region 9,1 wk ahead,3.7
 2011,51,2011/2012,51,HHS Region 9,2 wk ahead,3
 2011,51,2011/2012,51,HHS Region 9,3 wk ahead,2.5
-2011,51,2011/2012,51,HHS Region 9,4 wk ahead,2.4
-2011,51,2011/2012,51,HHS Region 10,Season onset,none
-2011,51,2011/2012,51,HHS Region 10,Season peak week,12
-2011,51,2011/2012,51,HHS Region 10,Season peak percentage,2.2
-2011,51,2011/2012,51,HHS Region 10,1 wk ahead,1.3
-2011,51,2011/2012,51,HHS Region 10,2 wk ahead,1.1
-2011,51,2011/2012,51,HHS Region 10,3 wk ahead,0.7
-2011,51,2011/2012,51,HHS Region 10,4 wk ahead,1.1
+2011,51,2011/2012,51,HHS Region 9,4 wk ahead,2.3
+2011,51,2011/2012,51,HHS Region 10,Season onset,10
+2011,51,2011/2012,51,HHS Region 10,Season peak week,11
+2011,51,2011/2012,51,HHS Region 10,Season peak percentage,2.7
+2011,51,2011/2012,51,HHS Region 10,1 wk ahead,2
+2011,51,2011/2012,51,HHS Region 10,2 wk ahead,1.6
+2011,51,2011/2012,51,HHS Region 10,3 wk ahead,1
+2011,51,2011/2012,51,HHS Region 10,4 wk ahead,1.5
 2011,52,2011/2012,52,US National,Season onset,none
 2011,52,2011/2012,52,US National,Season peak week,11
 2011,52,2011/2012,52,US National,Season peak percentage,2.4
-2011,52,2011/2012,52,US National,1 wk ahead,1.7
+2011,52,2011/2012,52,US National,1 wk ahead,1.8
 2011,52,2011/2012,52,US National,2 wk ahead,1.6
 2011,52,2011/2012,52,US National,3 wk ahead,1.6
 2011,52,2011/2012,52,US National,4 wk ahead,1.8
 2011,52,2011/2012,52,HHS Region 1,Season onset,none
 2011,52,2011/2012,52,HHS Region 1,Season peak week,52
+2011,52,2011/2012,52,HHS Region 1,Season peak week,8
 2011,52,2011/2012,52,HHS Region 1,Season peak percentage,1
 2011,52,2011/2012,52,HHS Region 1,1 wk ahead,0.9
 2011,52,2011/2012,52,HHS Region 1,2 wk ahead,0.8
@@ -3605,8 +3606,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,52,2011/2012,52,HHS Region 2,Season peak week,49
 2011,52,2011/2012,52,HHS Region 2,Season peak percentage,1.4
 2011,52,2011/2012,52,HHS Region 2,1 wk ahead,1.3
-2011,52,2011/2012,52,HHS Region 2,2 wk ahead,1
-2011,52,2011/2012,52,HHS Region 2,3 wk ahead,1.1
+2011,52,2011/2012,52,HHS Region 2,2 wk ahead,1.1
+2011,52,2011/2012,52,HHS Region 2,3 wk ahead,1.2
 2011,52,2011/2012,52,HHS Region 2,4 wk ahead,1
 2011,52,2011/2012,52,HHS Region 3,Season onset,none
 2011,52,2011/2012,52,HHS Region 3,Season peak week,52
@@ -3622,7 +3623,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,52,2011/2012,52,HHS Region 4,1 wk ahead,1.6
 2011,52,2011/2012,52,HHS Region 4,2 wk ahead,1.5
 2011,52,2011/2012,52,HHS Region 4,3 wk ahead,1.7
-2011,52,2011/2012,52,HHS Region 4,4 wk ahead,1.7
+2011,52,2011/2012,52,HHS Region 4,4 wk ahead,1.8
 2011,52,2011/2012,52,HHS Region 5,Season onset,7
 2011,52,2011/2012,52,HHS Region 5,Season peak week,11
 2011,52,2011/2012,52,HHS Region 5,Season peak percentage,2.4
@@ -3632,14 +3633,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,52,2011/2012,52,HHS Region 5,4 wk ahead,1.3
 2011,52,2011/2012,52,HHS Region 6,Season onset,none
 2011,52,2011/2012,52,HHS Region 6,Season peak week,11
-2011,52,2011/2012,52,HHS Region 6,Season peak percentage,4.1
+2011,52,2011/2012,52,HHS Region 6,Season peak percentage,4.2
 2011,52,2011/2012,52,HHS Region 6,1 wk ahead,2.1
 2011,52,2011/2012,52,HHS Region 6,2 wk ahead,2.1
 2011,52,2011/2012,52,HHS Region 6,3 wk ahead,2.2
-2011,52,2011/2012,52,HHS Region 6,4 wk ahead,2.4
+2011,52,2011/2012,52,HHS Region 6,4 wk ahead,2.3
 2011,52,2011/2012,52,HHS Region 7,Season onset,5
 2011,52,2011/2012,52,HHS Region 7,Season peak week,9
-2011,52,2011/2012,52,HHS Region 7,Season peak percentage,3.4
+2011,52,2011/2012,52,HHS Region 7,Season peak percentage,3.5
 2011,52,2011/2012,52,HHS Region 7,1 wk ahead,1.5
 2011,52,2011/2012,52,HHS Region 7,2 wk ahead,1.5
 2011,52,2011/2012,52,HHS Region 7,3 wk ahead,1.6
@@ -3653,28 +3654,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,52,2011/2012,52,HHS Region 8,4 wk ahead,1.3
 2011,52,2011/2012,52,HHS Region 9,Season onset,none
 2011,52,2011/2012,52,HHS Region 9,Season peak week,52
-2011,52,2011/2012,52,HHS Region 9,Season peak week,8
 2011,52,2011/2012,52,HHS Region 9,Season peak percentage,3.7
 2011,52,2011/2012,52,HHS Region 9,1 wk ahead,3
 2011,52,2011/2012,52,HHS Region 9,2 wk ahead,2.5
-2011,52,2011/2012,52,HHS Region 9,3 wk ahead,2.4
-2011,52,2011/2012,52,HHS Region 9,4 wk ahead,3
-2011,52,2011/2012,52,HHS Region 10,Season onset,none
-2011,52,2011/2012,52,HHS Region 10,Season peak week,12
-2011,52,2011/2012,52,HHS Region 10,Season peak percentage,2.2
-2011,52,2011/2012,52,HHS Region 10,1 wk ahead,1.1
-2011,52,2011/2012,52,HHS Region 10,2 wk ahead,0.7
-2011,52,2011/2012,52,HHS Region 10,3 wk ahead,1.1
-2011,52,2011/2012,52,HHS Region 10,4 wk ahead,1.1
+2011,52,2011/2012,52,HHS Region 9,3 wk ahead,2.3
+2011,52,2011/2012,52,HHS Region 9,4 wk ahead,2.9
+2011,52,2011/2012,52,HHS Region 10,Season onset,10
+2011,52,2011/2012,52,HHS Region 10,Season peak week,11
+2011,52,2011/2012,52,HHS Region 10,Season peak percentage,2.7
+2011,52,2011/2012,52,HHS Region 10,1 wk ahead,1.6
+2011,52,2011/2012,52,HHS Region 10,2 wk ahead,1
+2011,52,2011/2012,52,HHS Region 10,3 wk ahead,1.5
+2011,52,2011/2012,52,HHS Region 10,4 wk ahead,1.3
 2012,1,2011/2012,53,US National,Season onset,none
 2012,1,2011/2012,53,US National,Season peak week,11
 2012,1,2011/2012,53,US National,Season peak percentage,2.4
 2012,1,2011/2012,53,US National,1 wk ahead,1.6
 2012,1,2011/2012,53,US National,2 wk ahead,1.6
 2012,1,2011/2012,53,US National,3 wk ahead,1.8
-2012,1,2011/2012,53,US National,4 wk ahead,1.9
+2012,1,2011/2012,53,US National,4 wk ahead,2
 2012,1,2011/2012,53,HHS Region 1,Season onset,none
 2012,1,2011/2012,53,HHS Region 1,Season peak week,52
+2012,1,2011/2012,53,HHS Region 1,Season peak week,8
 2012,1,2011/2012,53,HHS Region 1,Season peak percentage,1
 2012,1,2011/2012,53,HHS Region 1,1 wk ahead,0.8
 2012,1,2011/2012,53,HHS Region 1,2 wk ahead,0.8
@@ -3683,8 +3684,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,1,2011/2012,53,HHS Region 2,Season onset,none
 2012,1,2011/2012,53,HHS Region 2,Season peak week,49
 2012,1,2011/2012,53,HHS Region 2,Season peak percentage,1.4
-2012,1,2011/2012,53,HHS Region 2,1 wk ahead,1
-2012,1,2011/2012,53,HHS Region 2,2 wk ahead,1.1
+2012,1,2011/2012,53,HHS Region 2,1 wk ahead,1.1
+2012,1,2011/2012,53,HHS Region 2,2 wk ahead,1.2
 2012,1,2011/2012,53,HHS Region 2,3 wk ahead,1
 2012,1,2011/2012,53,HHS Region 2,4 wk ahead,1.1
 2012,1,2011/2012,53,HHS Region 3,Season onset,none
@@ -3700,8 +3701,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,1,2011/2012,53,HHS Region 4,Season peak percentage,2.3
 2012,1,2011/2012,53,HHS Region 4,1 wk ahead,1.5
 2012,1,2011/2012,53,HHS Region 4,2 wk ahead,1.7
-2012,1,2011/2012,53,HHS Region 4,3 wk ahead,1.7
-2012,1,2011/2012,53,HHS Region 4,4 wk ahead,1.8
+2012,1,2011/2012,53,HHS Region 4,3 wk ahead,1.8
+2012,1,2011/2012,53,HHS Region 4,4 wk ahead,1.9
 2012,1,2011/2012,53,HHS Region 5,Season onset,7
 2012,1,2011/2012,53,HHS Region 5,Season peak week,11
 2012,1,2011/2012,53,HHS Region 5,Season peak percentage,2.4
@@ -3711,14 +3712,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,1,2011/2012,53,HHS Region 5,4 wk ahead,1.5
 2012,1,2011/2012,53,HHS Region 6,Season onset,none
 2012,1,2011/2012,53,HHS Region 6,Season peak week,11
-2012,1,2011/2012,53,HHS Region 6,Season peak percentage,4.1
+2012,1,2011/2012,53,HHS Region 6,Season peak percentage,4.2
 2012,1,2011/2012,53,HHS Region 6,1 wk ahead,2.1
 2012,1,2011/2012,53,HHS Region 6,2 wk ahead,2.2
-2012,1,2011/2012,53,HHS Region 6,3 wk ahead,2.4
-2012,1,2011/2012,53,HHS Region 6,4 wk ahead,2.5
+2012,1,2011/2012,53,HHS Region 6,3 wk ahead,2.3
+2012,1,2011/2012,53,HHS Region 6,4 wk ahead,2.6
 2012,1,2011/2012,53,HHS Region 7,Season onset,5
 2012,1,2011/2012,53,HHS Region 7,Season peak week,9
-2012,1,2011/2012,53,HHS Region 7,Season peak percentage,3.4
+2012,1,2011/2012,53,HHS Region 7,Season peak percentage,3.5
 2012,1,2011/2012,53,HHS Region 7,1 wk ahead,1.5
 2012,1,2011/2012,53,HHS Region 7,2 wk ahead,1.6
 2012,1,2011/2012,53,HHS Region 7,3 wk ahead,1.8
@@ -3732,28 +3733,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,1,2011/2012,53,HHS Region 8,4 wk ahead,1.5
 2012,1,2011/2012,53,HHS Region 9,Season onset,none
 2012,1,2011/2012,53,HHS Region 9,Season peak week,52
-2012,1,2011/2012,53,HHS Region 9,Season peak week,8
 2012,1,2011/2012,53,HHS Region 9,Season peak percentage,3.7
 2012,1,2011/2012,53,HHS Region 9,1 wk ahead,2.5
-2012,1,2011/2012,53,HHS Region 9,2 wk ahead,2.4
-2012,1,2011/2012,53,HHS Region 9,3 wk ahead,3
-2012,1,2011/2012,53,HHS Region 9,4 wk ahead,3.3
-2012,1,2011/2012,53,HHS Region 10,Season onset,none
-2012,1,2011/2012,53,HHS Region 10,Season peak week,12
-2012,1,2011/2012,53,HHS Region 10,Season peak percentage,2.2
-2012,1,2011/2012,53,HHS Region 10,1 wk ahead,0.7
-2012,1,2011/2012,53,HHS Region 10,2 wk ahead,1.1
-2012,1,2011/2012,53,HHS Region 10,3 wk ahead,1.1
-2012,1,2011/2012,53,HHS Region 10,4 wk ahead,1.2
+2012,1,2011/2012,53,HHS Region 9,2 wk ahead,2.3
+2012,1,2011/2012,53,HHS Region 9,3 wk ahead,2.9
+2012,1,2011/2012,53,HHS Region 9,4 wk ahead,3.2
+2012,1,2011/2012,53,HHS Region 10,Season onset,10
+2012,1,2011/2012,53,HHS Region 10,Season peak week,11
+2012,1,2011/2012,53,HHS Region 10,Season peak percentage,2.7
+2012,1,2011/2012,53,HHS Region 10,1 wk ahead,1
+2012,1,2011/2012,53,HHS Region 10,2 wk ahead,1.5
+2012,1,2011/2012,53,HHS Region 10,3 wk ahead,1.3
+2012,1,2011/2012,53,HHS Region 10,4 wk ahead,1.8
 2012,2,2011/2012,54,US National,Season onset,none
 2012,2,2011/2012,54,US National,Season peak week,11
 2012,2,2011/2012,54,US National,Season peak percentage,2.4
 2012,2,2011/2012,54,US National,1 wk ahead,1.6
 2012,2,2011/2012,54,US National,2 wk ahead,1.8
-2012,2,2011/2012,54,US National,3 wk ahead,1.9
+2012,2,2011/2012,54,US National,3 wk ahead,2
 2012,2,2011/2012,54,US National,4 wk ahead,1.9
 2012,2,2011/2012,54,HHS Region 1,Season onset,none
 2012,2,2011/2012,54,HHS Region 1,Season peak week,52
+2012,2,2011/2012,54,HHS Region 1,Season peak week,8
 2012,2,2011/2012,54,HHS Region 1,Season peak percentage,1
 2012,2,2011/2012,54,HHS Region 1,1 wk ahead,0.8
 2012,2,2011/2012,54,HHS Region 1,2 wk ahead,0.8
@@ -3762,7 +3763,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,2,2011/2012,54,HHS Region 2,Season onset,none
 2012,2,2011/2012,54,HHS Region 2,Season peak week,49
 2012,2,2011/2012,54,HHS Region 2,Season peak percentage,1.4
-2012,2,2011/2012,54,HHS Region 2,1 wk ahead,1.1
+2012,2,2011/2012,54,HHS Region 2,1 wk ahead,1.2
 2012,2,2011/2012,54,HHS Region 2,2 wk ahead,1
 2012,2,2011/2012,54,HHS Region 2,3 wk ahead,1.1
 2012,2,2011/2012,54,HHS Region 2,4 wk ahead,1
@@ -3778,8 +3779,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,2,2011/2012,54,HHS Region 4,Season peak week,10
 2012,2,2011/2012,54,HHS Region 4,Season peak percentage,2.3
 2012,2,2011/2012,54,HHS Region 4,1 wk ahead,1.7
-2012,2,2011/2012,54,HHS Region 4,2 wk ahead,1.7
-2012,2,2011/2012,54,HHS Region 4,3 wk ahead,1.8
+2012,2,2011/2012,54,HHS Region 4,2 wk ahead,1.8
+2012,2,2011/2012,54,HHS Region 4,3 wk ahead,1.9
 2012,2,2011/2012,54,HHS Region 4,4 wk ahead,1.9
 2012,2,2011/2012,54,HHS Region 5,Season onset,7
 2012,2,2011/2012,54,HHS Region 5,Season peak week,11
@@ -3790,14 +3791,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,2,2011/2012,54,HHS Region 5,4 wk ahead,1.4
 2012,2,2011/2012,54,HHS Region 6,Season onset,none
 2012,2,2011/2012,54,HHS Region 6,Season peak week,11
-2012,2,2011/2012,54,HHS Region 6,Season peak percentage,4.1
+2012,2,2011/2012,54,HHS Region 6,Season peak percentage,4.2
 2012,2,2011/2012,54,HHS Region 6,1 wk ahead,2.2
-2012,2,2011/2012,54,HHS Region 6,2 wk ahead,2.4
-2012,2,2011/2012,54,HHS Region 6,3 wk ahead,2.5
-2012,2,2011/2012,54,HHS Region 6,4 wk ahead,2.7
+2012,2,2011/2012,54,HHS Region 6,2 wk ahead,2.3
+2012,2,2011/2012,54,HHS Region 6,3 wk ahead,2.6
+2012,2,2011/2012,54,HHS Region 6,4 wk ahead,2.6
 2012,2,2011/2012,54,HHS Region 7,Season onset,5
 2012,2,2011/2012,54,HHS Region 7,Season peak week,9
-2012,2,2011/2012,54,HHS Region 7,Season peak percentage,3.4
+2012,2,2011/2012,54,HHS Region 7,Season peak percentage,3.5
 2012,2,2011/2012,54,HHS Region 7,1 wk ahead,1.6
 2012,2,2011/2012,54,HHS Region 7,2 wk ahead,1.8
 2012,2,2011/2012,54,HHS Region 7,3 wk ahead,2.6
@@ -3811,28 +3812,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,2,2011/2012,54,HHS Region 8,4 wk ahead,1.6
 2012,2,2011/2012,54,HHS Region 9,Season onset,none
 2012,2,2011/2012,54,HHS Region 9,Season peak week,52
-2012,2,2011/2012,54,HHS Region 9,Season peak week,8
 2012,2,2011/2012,54,HHS Region 9,Season peak percentage,3.7
-2012,2,2011/2012,54,HHS Region 9,1 wk ahead,2.4
-2012,2,2011/2012,54,HHS Region 9,2 wk ahead,3
-2012,2,2011/2012,54,HHS Region 9,3 wk ahead,3.3
-2012,2,2011/2012,54,HHS Region 9,4 wk ahead,2.9
-2012,2,2011/2012,54,HHS Region 10,Season onset,none
-2012,2,2011/2012,54,HHS Region 10,Season peak week,12
-2012,2,2011/2012,54,HHS Region 10,Season peak percentage,2.2
-2012,2,2011/2012,54,HHS Region 10,1 wk ahead,1.1
-2012,2,2011/2012,54,HHS Region 10,2 wk ahead,1.1
-2012,2,2011/2012,54,HHS Region 10,3 wk ahead,1.2
-2012,2,2011/2012,54,HHS Region 10,4 wk ahead,1.2
+2012,2,2011/2012,54,HHS Region 9,1 wk ahead,2.3
+2012,2,2011/2012,54,HHS Region 9,2 wk ahead,2.9
+2012,2,2011/2012,54,HHS Region 9,3 wk ahead,3.2
+2012,2,2011/2012,54,HHS Region 9,4 wk ahead,2.8
+2012,2,2011/2012,54,HHS Region 10,Season onset,10
+2012,2,2011/2012,54,HHS Region 10,Season peak week,11
+2012,2,2011/2012,54,HHS Region 10,Season peak percentage,2.7
+2012,2,2011/2012,54,HHS Region 10,1 wk ahead,1.5
+2012,2,2011/2012,54,HHS Region 10,2 wk ahead,1.3
+2012,2,2011/2012,54,HHS Region 10,3 wk ahead,1.8
+2012,2,2011/2012,54,HHS Region 10,4 wk ahead,1.7
 2012,3,2011/2012,55,US National,Season onset,none
 2012,3,2011/2012,55,US National,Season peak week,11
 2012,3,2011/2012,55,US National,Season peak percentage,2.4
 2012,3,2011/2012,55,US National,1 wk ahead,1.8
-2012,3,2011/2012,55,US National,2 wk ahead,1.9
+2012,3,2011/2012,55,US National,2 wk ahead,2
 2012,3,2011/2012,55,US National,3 wk ahead,1.9
 2012,3,2011/2012,55,US National,4 wk ahead,2.1
 2012,3,2011/2012,55,HHS Region 1,Season onset,none
 2012,3,2011/2012,55,HHS Region 1,Season peak week,52
+2012,3,2011/2012,55,HHS Region 1,Season peak week,8
 2012,3,2011/2012,55,HHS Region 1,Season peak percentage,1
 2012,3,2011/2012,55,HHS Region 1,1 wk ahead,0.8
 2012,3,2011/2012,55,HHS Region 1,2 wk ahead,0.8
@@ -3856,10 +3857,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,3,2011/2012,55,HHS Region 4,Season peak week,52
 2012,3,2011/2012,55,HHS Region 4,Season peak week,10
 2012,3,2011/2012,55,HHS Region 4,Season peak percentage,2.3
-2012,3,2011/2012,55,HHS Region 4,1 wk ahead,1.7
-2012,3,2011/2012,55,HHS Region 4,2 wk ahead,1.8
+2012,3,2011/2012,55,HHS Region 4,1 wk ahead,1.8
+2012,3,2011/2012,55,HHS Region 4,2 wk ahead,1.9
 2012,3,2011/2012,55,HHS Region 4,3 wk ahead,1.9
-2012,3,2011/2012,55,HHS Region 4,4 wk ahead,2
+2012,3,2011/2012,55,HHS Region 4,4 wk ahead,2.1
 2012,3,2011/2012,55,HHS Region 5,Season onset,7
 2012,3,2011/2012,55,HHS Region 5,Season peak week,11
 2012,3,2011/2012,55,HHS Region 5,Season peak percentage,2.4
@@ -3869,18 +3870,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,3,2011/2012,55,HHS Region 5,4 wk ahead,1.6
 2012,3,2011/2012,55,HHS Region 6,Season onset,none
 2012,3,2011/2012,55,HHS Region 6,Season peak week,11
-2012,3,2011/2012,55,HHS Region 6,Season peak percentage,4.1
-2012,3,2011/2012,55,HHS Region 6,1 wk ahead,2.4
-2012,3,2011/2012,55,HHS Region 6,2 wk ahead,2.5
-2012,3,2011/2012,55,HHS Region 6,3 wk ahead,2.7
+2012,3,2011/2012,55,HHS Region 6,Season peak percentage,4.2
+2012,3,2011/2012,55,HHS Region 6,1 wk ahead,2.3
+2012,3,2011/2012,55,HHS Region 6,2 wk ahead,2.6
+2012,3,2011/2012,55,HHS Region 6,3 wk ahead,2.6
 2012,3,2011/2012,55,HHS Region 6,4 wk ahead,3
 2012,3,2011/2012,55,HHS Region 7,Season onset,5
 2012,3,2011/2012,55,HHS Region 7,Season peak week,9
-2012,3,2011/2012,55,HHS Region 7,Season peak percentage,3.4
+2012,3,2011/2012,55,HHS Region 7,Season peak percentage,3.5
 2012,3,2011/2012,55,HHS Region 7,1 wk ahead,1.8
 2012,3,2011/2012,55,HHS Region 7,2 wk ahead,2.6
 2012,3,2011/2012,55,HHS Region 7,3 wk ahead,2.8
-2012,3,2011/2012,55,HHS Region 7,4 wk ahead,3.1
+2012,3,2011/2012,55,HHS Region 7,4 wk ahead,3.2
 2012,3,2011/2012,55,HHS Region 8,Season onset,none
 2012,3,2011/2012,55,HHS Region 8,Season peak week,11
 2012,3,2011/2012,55,HHS Region 8,Season peak percentage,2.2
@@ -3890,33 +3891,33 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,3,2011/2012,55,HHS Region 8,4 wk ahead,1.6
 2012,3,2011/2012,55,HHS Region 9,Season onset,none
 2012,3,2011/2012,55,HHS Region 9,Season peak week,52
-2012,3,2011/2012,55,HHS Region 9,Season peak week,8
 2012,3,2011/2012,55,HHS Region 9,Season peak percentage,3.7
-2012,3,2011/2012,55,HHS Region 9,1 wk ahead,3
-2012,3,2011/2012,55,HHS Region 9,2 wk ahead,3.3
-2012,3,2011/2012,55,HHS Region 9,3 wk ahead,2.9
-2012,3,2011/2012,55,HHS Region 9,4 wk ahead,3.2
-2012,3,2011/2012,55,HHS Region 10,Season onset,none
-2012,3,2011/2012,55,HHS Region 10,Season peak week,12
-2012,3,2011/2012,55,HHS Region 10,Season peak percentage,2.2
-2012,3,2011/2012,55,HHS Region 10,1 wk ahead,1.1
-2012,3,2011/2012,55,HHS Region 10,2 wk ahead,1.2
-2012,3,2011/2012,55,HHS Region 10,3 wk ahead,1.2
-2012,3,2011/2012,55,HHS Region 10,4 wk ahead,1.5
+2012,3,2011/2012,55,HHS Region 9,1 wk ahead,2.9
+2012,3,2011/2012,55,HHS Region 9,2 wk ahead,3.2
+2012,3,2011/2012,55,HHS Region 9,3 wk ahead,2.8
+2012,3,2011/2012,55,HHS Region 9,4 wk ahead,3.1
+2012,3,2011/2012,55,HHS Region 10,Season onset,10
+2012,3,2011/2012,55,HHS Region 10,Season peak week,11
+2012,3,2011/2012,55,HHS Region 10,Season peak percentage,2.7
+2012,3,2011/2012,55,HHS Region 10,1 wk ahead,1.3
+2012,3,2011/2012,55,HHS Region 10,2 wk ahead,1.8
+2012,3,2011/2012,55,HHS Region 10,3 wk ahead,1.7
+2012,3,2011/2012,55,HHS Region 10,4 wk ahead,2
 2012,4,2011/2012,56,US National,Season onset,none
 2012,4,2011/2012,56,US National,Season peak week,11
 2012,4,2011/2012,56,US National,Season peak percentage,2.4
-2012,4,2011/2012,56,US National,1 wk ahead,1.9
+2012,4,2011/2012,56,US National,1 wk ahead,2
 2012,4,2011/2012,56,US National,2 wk ahead,1.9
 2012,4,2011/2012,56,US National,3 wk ahead,2.1
 2012,4,2011/2012,56,US National,4 wk ahead,2.2
 2012,4,2011/2012,56,HHS Region 1,Season onset,none
 2012,4,2011/2012,56,HHS Region 1,Season peak week,52
+2012,4,2011/2012,56,HHS Region 1,Season peak week,8
 2012,4,2011/2012,56,HHS Region 1,Season peak percentage,1
 2012,4,2011/2012,56,HHS Region 1,1 wk ahead,0.8
 2012,4,2011/2012,56,HHS Region 1,2 wk ahead,0.8
 2012,4,2011/2012,56,HHS Region 1,3 wk ahead,0.9
-2012,4,2011/2012,56,HHS Region 1,4 wk ahead,0.9
+2012,4,2011/2012,56,HHS Region 1,4 wk ahead,1
 2012,4,2011/2012,56,HHS Region 2,Season onset,none
 2012,4,2011/2012,56,HHS Region 2,Season peak week,49
 2012,4,2011/2012,56,HHS Region 2,Season peak percentage,1.4
@@ -3935,9 +3936,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,4,2011/2012,56,HHS Region 4,Season peak week,52
 2012,4,2011/2012,56,HHS Region 4,Season peak week,10
 2012,4,2011/2012,56,HHS Region 4,Season peak percentage,2.3
-2012,4,2011/2012,56,HHS Region 4,1 wk ahead,1.8
+2012,4,2011/2012,56,HHS Region 4,1 wk ahead,1.9
 2012,4,2011/2012,56,HHS Region 4,2 wk ahead,1.9
-2012,4,2011/2012,56,HHS Region 4,3 wk ahead,2
+2012,4,2011/2012,56,HHS Region 4,3 wk ahead,2.1
 2012,4,2011/2012,56,HHS Region 4,4 wk ahead,2
 2012,4,2011/2012,56,HHS Region 5,Season onset,7
 2012,4,2011/2012,56,HHS Region 5,Season peak week,11
@@ -3948,17 +3949,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,4,2011/2012,56,HHS Region 5,4 wk ahead,1.8
 2012,4,2011/2012,56,HHS Region 6,Season onset,none
 2012,4,2011/2012,56,HHS Region 6,Season peak week,11
-2012,4,2011/2012,56,HHS Region 6,Season peak percentage,4.1
-2012,4,2011/2012,56,HHS Region 6,1 wk ahead,2.5
-2012,4,2011/2012,56,HHS Region 6,2 wk ahead,2.7
+2012,4,2011/2012,56,HHS Region 6,Season peak percentage,4.2
+2012,4,2011/2012,56,HHS Region 6,1 wk ahead,2.6
+2012,4,2011/2012,56,HHS Region 6,2 wk ahead,2.6
 2012,4,2011/2012,56,HHS Region 6,3 wk ahead,3
 2012,4,2011/2012,56,HHS Region 6,4 wk ahead,3.3
 2012,4,2011/2012,56,HHS Region 7,Season onset,5
 2012,4,2011/2012,56,HHS Region 7,Season peak week,9
-2012,4,2011/2012,56,HHS Region 7,Season peak percentage,3.4
+2012,4,2011/2012,56,HHS Region 7,Season peak percentage,3.5
 2012,4,2011/2012,56,HHS Region 7,1 wk ahead,2.6
 2012,4,2011/2012,56,HHS Region 7,2 wk ahead,2.8
-2012,4,2011/2012,56,HHS Region 7,3 wk ahead,3.1
+2012,4,2011/2012,56,HHS Region 7,3 wk ahead,3.2
 2012,4,2011/2012,56,HHS Region 7,4 wk ahead,3
 2012,4,2011/2012,56,HHS Region 8,Season onset,none
 2012,4,2011/2012,56,HHS Region 8,Season peak week,11
@@ -3969,19 +3970,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,4,2011/2012,56,HHS Region 8,4 wk ahead,1.9
 2012,4,2011/2012,56,HHS Region 9,Season onset,none
 2012,4,2011/2012,56,HHS Region 9,Season peak week,52
-2012,4,2011/2012,56,HHS Region 9,Season peak week,8
 2012,4,2011/2012,56,HHS Region 9,Season peak percentage,3.7
-2012,4,2011/2012,56,HHS Region 9,1 wk ahead,3.3
-2012,4,2011/2012,56,HHS Region 9,2 wk ahead,2.9
-2012,4,2011/2012,56,HHS Region 9,3 wk ahead,3.2
-2012,4,2011/2012,56,HHS Region 9,4 wk ahead,3.7
-2012,4,2011/2012,56,HHS Region 10,Season onset,none
-2012,4,2011/2012,56,HHS Region 10,Season peak week,12
-2012,4,2011/2012,56,HHS Region 10,Season peak percentage,2.2
-2012,4,2011/2012,56,HHS Region 10,1 wk ahead,1.2
-2012,4,2011/2012,56,HHS Region 10,2 wk ahead,1.2
-2012,4,2011/2012,56,HHS Region 10,3 wk ahead,1.5
-2012,4,2011/2012,56,HHS Region 10,4 wk ahead,1.4
+2012,4,2011/2012,56,HHS Region 9,1 wk ahead,3.2
+2012,4,2011/2012,56,HHS Region 9,2 wk ahead,2.8
+2012,4,2011/2012,56,HHS Region 9,3 wk ahead,3.1
+2012,4,2011/2012,56,HHS Region 9,4 wk ahead,3.6
+2012,4,2011/2012,56,HHS Region 10,Season onset,10
+2012,4,2011/2012,56,HHS Region 10,Season peak week,11
+2012,4,2011/2012,56,HHS Region 10,Season peak percentage,2.7
+2012,4,2011/2012,56,HHS Region 10,1 wk ahead,1.8
+2012,4,2011/2012,56,HHS Region 10,2 wk ahead,1.7
+2012,4,2011/2012,56,HHS Region 10,3 wk ahead,2
+2012,4,2011/2012,56,HHS Region 10,4 wk ahead,1.8
 2012,5,2011/2012,57,US National,Season onset,none
 2012,5,2011/2012,57,US National,Season peak week,11
 2012,5,2011/2012,57,US National,Season peak percentage,2.4
@@ -3991,10 +3991,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,5,2011/2012,57,US National,4 wk ahead,2.2
 2012,5,2011/2012,57,HHS Region 1,Season onset,none
 2012,5,2011/2012,57,HHS Region 1,Season peak week,52
+2012,5,2011/2012,57,HHS Region 1,Season peak week,8
 2012,5,2011/2012,57,HHS Region 1,Season peak percentage,1
 2012,5,2011/2012,57,HHS Region 1,1 wk ahead,0.8
 2012,5,2011/2012,57,HHS Region 1,2 wk ahead,0.9
-2012,5,2011/2012,57,HHS Region 1,3 wk ahead,0.9
+2012,5,2011/2012,57,HHS Region 1,3 wk ahead,1
 2012,5,2011/2012,57,HHS Region 1,4 wk ahead,0.8
 2012,5,2011/2012,57,HHS Region 2,Season onset,none
 2012,5,2011/2012,57,HHS Region 2,Season peak week,49
@@ -4015,7 +4016,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,5,2011/2012,57,HHS Region 4,Season peak week,10
 2012,5,2011/2012,57,HHS Region 4,Season peak percentage,2.3
 2012,5,2011/2012,57,HHS Region 4,1 wk ahead,1.9
-2012,5,2011/2012,57,HHS Region 4,2 wk ahead,2
+2012,5,2011/2012,57,HHS Region 4,2 wk ahead,2.1
 2012,5,2011/2012,57,HHS Region 4,3 wk ahead,2
 2012,5,2011/2012,57,HHS Region 4,4 wk ahead,2.1
 2012,5,2011/2012,57,HHS Region 5,Season onset,7
@@ -4027,18 +4028,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,5,2011/2012,57,HHS Region 5,4 wk ahead,1.8
 2012,5,2011/2012,57,HHS Region 6,Season onset,none
 2012,5,2011/2012,57,HHS Region 6,Season peak week,11
-2012,5,2011/2012,57,HHS Region 6,Season peak percentage,4.1
-2012,5,2011/2012,57,HHS Region 6,1 wk ahead,2.7
+2012,5,2011/2012,57,HHS Region 6,Season peak percentage,4.2
+2012,5,2011/2012,57,HHS Region 6,1 wk ahead,2.6
 2012,5,2011/2012,57,HHS Region 6,2 wk ahead,3
 2012,5,2011/2012,57,HHS Region 6,3 wk ahead,3.3
 2012,5,2011/2012,57,HHS Region 6,4 wk ahead,3.5
 2012,5,2011/2012,57,HHS Region 7,Season onset,5
 2012,5,2011/2012,57,HHS Region 7,Season peak week,9
-2012,5,2011/2012,57,HHS Region 7,Season peak percentage,3.4
+2012,5,2011/2012,57,HHS Region 7,Season peak percentage,3.5
 2012,5,2011/2012,57,HHS Region 7,1 wk ahead,2.8
-2012,5,2011/2012,57,HHS Region 7,2 wk ahead,3.1
+2012,5,2011/2012,57,HHS Region 7,2 wk ahead,3.2
 2012,5,2011/2012,57,HHS Region 7,3 wk ahead,3
-2012,5,2011/2012,57,HHS Region 7,4 wk ahead,3.4
+2012,5,2011/2012,57,HHS Region 7,4 wk ahead,3.5
 2012,5,2011/2012,57,HHS Region 8,Season onset,none
 2012,5,2011/2012,57,HHS Region 8,Season peak week,11
 2012,5,2011/2012,57,HHS Region 8,Season peak percentage,2.2
@@ -4048,19 +4049,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,5,2011/2012,57,HHS Region 8,4 wk ahead,1.7
 2012,5,2011/2012,57,HHS Region 9,Season onset,none
 2012,5,2011/2012,57,HHS Region 9,Season peak week,52
-2012,5,2011/2012,57,HHS Region 9,Season peak week,8
 2012,5,2011/2012,57,HHS Region 9,Season peak percentage,3.7
-2012,5,2011/2012,57,HHS Region 9,1 wk ahead,2.9
-2012,5,2011/2012,57,HHS Region 9,2 wk ahead,3.2
-2012,5,2011/2012,57,HHS Region 9,3 wk ahead,3.7
+2012,5,2011/2012,57,HHS Region 9,1 wk ahead,2.8
+2012,5,2011/2012,57,HHS Region 9,2 wk ahead,3.1
+2012,5,2011/2012,57,HHS Region 9,3 wk ahead,3.6
 2012,5,2011/2012,57,HHS Region 9,4 wk ahead,3.1
-2012,5,2011/2012,57,HHS Region 10,Season onset,none
-2012,5,2011/2012,57,HHS Region 10,Season peak week,12
-2012,5,2011/2012,57,HHS Region 10,Season peak percentage,2.2
-2012,5,2011/2012,57,HHS Region 10,1 wk ahead,1.2
-2012,5,2011/2012,57,HHS Region 10,2 wk ahead,1.5
-2012,5,2011/2012,57,HHS Region 10,3 wk ahead,1.4
-2012,5,2011/2012,57,HHS Region 10,4 wk ahead,1.5
+2012,5,2011/2012,57,HHS Region 10,Season onset,10
+2012,5,2011/2012,57,HHS Region 10,Season peak week,11
+2012,5,2011/2012,57,HHS Region 10,Season peak percentage,2.7
+2012,5,2011/2012,57,HHS Region 10,1 wk ahead,1.7
+2012,5,2011/2012,57,HHS Region 10,2 wk ahead,2
+2012,5,2011/2012,57,HHS Region 10,3 wk ahead,1.8
+2012,5,2011/2012,57,HHS Region 10,4 wk ahead,1.9
 2012,6,2011/2012,58,US National,Season onset,none
 2012,6,2011/2012,58,US National,Season peak week,11
 2012,6,2011/2012,58,US National,Season peak percentage,2.4
@@ -4070,9 +4070,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,6,2011/2012,58,US National,4 wk ahead,2.2
 2012,6,2011/2012,58,HHS Region 1,Season onset,none
 2012,6,2011/2012,58,HHS Region 1,Season peak week,52
+2012,6,2011/2012,58,HHS Region 1,Season peak week,8
 2012,6,2011/2012,58,HHS Region 1,Season peak percentage,1
 2012,6,2011/2012,58,HHS Region 1,1 wk ahead,0.9
-2012,6,2011/2012,58,HHS Region 1,2 wk ahead,0.9
+2012,6,2011/2012,58,HHS Region 1,2 wk ahead,1
 2012,6,2011/2012,58,HHS Region 1,3 wk ahead,0.8
 2012,6,2011/2012,58,HHS Region 1,4 wk ahead,0.8
 2012,6,2011/2012,58,HHS Region 2,Season onset,none
@@ -4093,7 +4094,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,6,2011/2012,58,HHS Region 4,Season peak week,52
 2012,6,2011/2012,58,HHS Region 4,Season peak week,10
 2012,6,2011/2012,58,HHS Region 4,Season peak percentage,2.3
-2012,6,2011/2012,58,HHS Region 4,1 wk ahead,2
+2012,6,2011/2012,58,HHS Region 4,1 wk ahead,2.1
 2012,6,2011/2012,58,HHS Region 4,2 wk ahead,2
 2012,6,2011/2012,58,HHS Region 4,3 wk ahead,2.1
 2012,6,2011/2012,58,HHS Region 4,4 wk ahead,2.3
@@ -4103,20 +4104,20 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,6,2011/2012,58,HHS Region 5,1 wk ahead,1.6
 2012,6,2011/2012,58,HHS Region 5,2 wk ahead,1.8
 2012,6,2011/2012,58,HHS Region 5,3 wk ahead,1.8
-2012,6,2011/2012,58,HHS Region 5,4 wk ahead,2
+2012,6,2011/2012,58,HHS Region 5,4 wk ahead,2.1
 2012,6,2011/2012,58,HHS Region 6,Season onset,none
 2012,6,2011/2012,58,HHS Region 6,Season peak week,11
-2012,6,2011/2012,58,HHS Region 6,Season peak percentage,4.1
+2012,6,2011/2012,58,HHS Region 6,Season peak percentage,4.2
 2012,6,2011/2012,58,HHS Region 6,1 wk ahead,3
 2012,6,2011/2012,58,HHS Region 6,2 wk ahead,3.3
 2012,6,2011/2012,58,HHS Region 6,3 wk ahead,3.5
 2012,6,2011/2012,58,HHS Region 6,4 wk ahead,3.4
 2012,6,2011/2012,58,HHS Region 7,Season onset,5
 2012,6,2011/2012,58,HHS Region 7,Season peak week,9
-2012,6,2011/2012,58,HHS Region 7,Season peak percentage,3.4
-2012,6,2011/2012,58,HHS Region 7,1 wk ahead,3.1
+2012,6,2011/2012,58,HHS Region 7,Season peak percentage,3.5
+2012,6,2011/2012,58,HHS Region 7,1 wk ahead,3.2
 2012,6,2011/2012,58,HHS Region 7,2 wk ahead,3
-2012,6,2011/2012,58,HHS Region 7,3 wk ahead,3.4
+2012,6,2011/2012,58,HHS Region 7,3 wk ahead,3.5
 2012,6,2011/2012,58,HHS Region 7,4 wk ahead,3.1
 2012,6,2011/2012,58,HHS Region 8,Season onset,none
 2012,6,2011/2012,58,HHS Region 8,Season peak week,11
@@ -4127,19 +4128,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,6,2011/2012,58,HHS Region 8,4 wk ahead,1.8
 2012,6,2011/2012,58,HHS Region 9,Season onset,none
 2012,6,2011/2012,58,HHS Region 9,Season peak week,52
-2012,6,2011/2012,58,HHS Region 9,Season peak week,8
 2012,6,2011/2012,58,HHS Region 9,Season peak percentage,3.7
-2012,6,2011/2012,58,HHS Region 9,1 wk ahead,3.2
-2012,6,2011/2012,58,HHS Region 9,2 wk ahead,3.7
+2012,6,2011/2012,58,HHS Region 9,1 wk ahead,3.1
+2012,6,2011/2012,58,HHS Region 9,2 wk ahead,3.6
 2012,6,2011/2012,58,HHS Region 9,3 wk ahead,3.1
-2012,6,2011/2012,58,HHS Region 9,4 wk ahead,2.5
-2012,6,2011/2012,58,HHS Region 10,Season onset,none
-2012,6,2011/2012,58,HHS Region 10,Season peak week,12
-2012,6,2011/2012,58,HHS Region 10,Season peak percentage,2.2
-2012,6,2011/2012,58,HHS Region 10,1 wk ahead,1.5
-2012,6,2011/2012,58,HHS Region 10,2 wk ahead,1.4
-2012,6,2011/2012,58,HHS Region 10,3 wk ahead,1.5
-2012,6,2011/2012,58,HHS Region 10,4 wk ahead,1.6
+2012,6,2011/2012,58,HHS Region 9,4 wk ahead,2.4
+2012,6,2011/2012,58,HHS Region 10,Season onset,10
+2012,6,2011/2012,58,HHS Region 10,Season peak week,11
+2012,6,2011/2012,58,HHS Region 10,Season peak percentage,2.7
+2012,6,2011/2012,58,HHS Region 10,1 wk ahead,2
+2012,6,2011/2012,58,HHS Region 10,2 wk ahead,1.8
+2012,6,2011/2012,58,HHS Region 10,3 wk ahead,1.9
+2012,6,2011/2012,58,HHS Region 10,4 wk ahead,2.2
 2012,7,2011/2012,59,US National,Season onset,none
 2012,7,2011/2012,59,US National,Season peak week,11
 2012,7,2011/2012,59,US National,Season peak percentage,2.4
@@ -4149,8 +4149,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,7,2011/2012,59,US National,4 wk ahead,2.4
 2012,7,2011/2012,59,HHS Region 1,Season onset,none
 2012,7,2011/2012,59,HHS Region 1,Season peak week,52
+2012,7,2011/2012,59,HHS Region 1,Season peak week,8
 2012,7,2011/2012,59,HHS Region 1,Season peak percentage,1
-2012,7,2011/2012,59,HHS Region 1,1 wk ahead,0.9
+2012,7,2011/2012,59,HHS Region 1,1 wk ahead,1
 2012,7,2011/2012,59,HHS Region 1,2 wk ahead,0.8
 2012,7,2011/2012,59,HHS Region 1,3 wk ahead,0.8
 2012,7,2011/2012,59,HHS Region 1,4 wk ahead,0.9
@@ -4181,20 +4182,20 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,7,2011/2012,59,HHS Region 5,Season peak percentage,2.4
 2012,7,2011/2012,59,HHS Region 5,1 wk ahead,1.8
 2012,7,2011/2012,59,HHS Region 5,2 wk ahead,1.8
-2012,7,2011/2012,59,HHS Region 5,3 wk ahead,2
+2012,7,2011/2012,59,HHS Region 5,3 wk ahead,2.1
 2012,7,2011/2012,59,HHS Region 5,4 wk ahead,2.4
 2012,7,2011/2012,59,HHS Region 6,Season onset,none
 2012,7,2011/2012,59,HHS Region 6,Season peak week,11
-2012,7,2011/2012,59,HHS Region 6,Season peak percentage,4.1
+2012,7,2011/2012,59,HHS Region 6,Season peak percentage,4.2
 2012,7,2011/2012,59,HHS Region 6,1 wk ahead,3.3
 2012,7,2011/2012,59,HHS Region 6,2 wk ahead,3.5
 2012,7,2011/2012,59,HHS Region 6,3 wk ahead,3.4
-2012,7,2011/2012,59,HHS Region 6,4 wk ahead,4.1
+2012,7,2011/2012,59,HHS Region 6,4 wk ahead,4.2
 2012,7,2011/2012,59,HHS Region 7,Season onset,5
 2012,7,2011/2012,59,HHS Region 7,Season peak week,9
-2012,7,2011/2012,59,HHS Region 7,Season peak percentage,3.4
+2012,7,2011/2012,59,HHS Region 7,Season peak percentage,3.5
 2012,7,2011/2012,59,HHS Region 7,1 wk ahead,3
-2012,7,2011/2012,59,HHS Region 7,2 wk ahead,3.4
+2012,7,2011/2012,59,HHS Region 7,2 wk ahead,3.5
 2012,7,2011/2012,59,HHS Region 7,3 wk ahead,3.1
 2012,7,2011/2012,59,HHS Region 7,4 wk ahead,2.6
 2012,7,2011/2012,59,HHS Region 8,Season onset,none
@@ -4206,19 +4207,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,7,2011/2012,59,HHS Region 8,4 wk ahead,2.2
 2012,7,2011/2012,59,HHS Region 9,Season onset,none
 2012,7,2011/2012,59,HHS Region 9,Season peak week,52
-2012,7,2011/2012,59,HHS Region 9,Season peak week,8
 2012,7,2011/2012,59,HHS Region 9,Season peak percentage,3.7
-2012,7,2011/2012,59,HHS Region 9,1 wk ahead,3.7
+2012,7,2011/2012,59,HHS Region 9,1 wk ahead,3.6
 2012,7,2011/2012,59,HHS Region 9,2 wk ahead,3.1
-2012,7,2011/2012,59,HHS Region 9,3 wk ahead,2.5
-2012,7,2011/2012,59,HHS Region 9,4 wk ahead,2.8
-2012,7,2011/2012,59,HHS Region 10,Season onset,none
-2012,7,2011/2012,59,HHS Region 10,Season peak week,12
-2012,7,2011/2012,59,HHS Region 10,Season peak percentage,2.2
-2012,7,2011/2012,59,HHS Region 10,1 wk ahead,1.4
-2012,7,2011/2012,59,HHS Region 10,2 wk ahead,1.5
-2012,7,2011/2012,59,HHS Region 10,3 wk ahead,1.6
-2012,7,2011/2012,59,HHS Region 10,4 wk ahead,1.9
+2012,7,2011/2012,59,HHS Region 9,3 wk ahead,2.4
+2012,7,2011/2012,59,HHS Region 9,4 wk ahead,2.7
+2012,7,2011/2012,59,HHS Region 10,Season onset,10
+2012,7,2011/2012,59,HHS Region 10,Season peak week,11
+2012,7,2011/2012,59,HHS Region 10,Season peak percentage,2.7
+2012,7,2011/2012,59,HHS Region 10,1 wk ahead,1.8
+2012,7,2011/2012,59,HHS Region 10,2 wk ahead,1.9
+2012,7,2011/2012,59,HHS Region 10,3 wk ahead,2.2
+2012,7,2011/2012,59,HHS Region 10,4 wk ahead,2.7
 2012,8,2011/2012,60,US National,Season onset,none
 2012,8,2011/2012,60,US National,Season peak week,11
 2012,8,2011/2012,60,US National,Season peak percentage,2.4
@@ -4228,11 +4228,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,8,2011/2012,60,US National,4 wk ahead,2
 2012,8,2011/2012,60,HHS Region 1,Season onset,none
 2012,8,2011/2012,60,HHS Region 1,Season peak week,52
+2012,8,2011/2012,60,HHS Region 1,Season peak week,8
 2012,8,2011/2012,60,HHS Region 1,Season peak percentage,1
 2012,8,2011/2012,60,HHS Region 1,1 wk ahead,0.8
 2012,8,2011/2012,60,HHS Region 1,2 wk ahead,0.8
 2012,8,2011/2012,60,HHS Region 1,3 wk ahead,0.9
-2012,8,2011/2012,60,HHS Region 1,4 wk ahead,0.8
+2012,8,2011/2012,60,HHS Region 1,4 wk ahead,0.9
 2012,8,2011/2012,60,HHS Region 2,Season onset,none
 2012,8,2011/2012,60,HHS Region 2,Season peak week,49
 2012,8,2011/2012,60,HHS Region 2,Season peak percentage,1.4
@@ -4246,7 +4247,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,8,2011/2012,60,HHS Region 3,1 wk ahead,1.7
 2012,8,2011/2012,60,HHS Region 3,2 wk ahead,1.6
 2012,8,2011/2012,60,HHS Region 3,3 wk ahead,1.9
-2012,8,2011/2012,60,HHS Region 3,4 wk ahead,1.4
+2012,8,2011/2012,60,HHS Region 3,4 wk ahead,1.5
 2012,8,2011/2012,60,HHS Region 4,Season onset,none
 2012,8,2011/2012,60,HHS Region 4,Season peak week,52
 2012,8,2011/2012,60,HHS Region 4,Season peak week,10
@@ -4259,20 +4260,20 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,8,2011/2012,60,HHS Region 5,Season peak week,11
 2012,8,2011/2012,60,HHS Region 5,Season peak percentage,2.4
 2012,8,2011/2012,60,HHS Region 5,1 wk ahead,1.8
-2012,8,2011/2012,60,HHS Region 5,2 wk ahead,2
+2012,8,2011/2012,60,HHS Region 5,2 wk ahead,2.1
 2012,8,2011/2012,60,HHS Region 5,3 wk ahead,2.4
 2012,8,2011/2012,60,HHS Region 5,4 wk ahead,1.9
 2012,8,2011/2012,60,HHS Region 6,Season onset,none
 2012,8,2011/2012,60,HHS Region 6,Season peak week,11
-2012,8,2011/2012,60,HHS Region 6,Season peak percentage,4.1
+2012,8,2011/2012,60,HHS Region 6,Season peak percentage,4.2
 2012,8,2011/2012,60,HHS Region 6,1 wk ahead,3.5
 2012,8,2011/2012,60,HHS Region 6,2 wk ahead,3.4
-2012,8,2011/2012,60,HHS Region 6,3 wk ahead,4.1
-2012,8,2011/2012,60,HHS Region 6,4 wk ahead,2.9
+2012,8,2011/2012,60,HHS Region 6,3 wk ahead,4.2
+2012,8,2011/2012,60,HHS Region 6,4 wk ahead,3
 2012,8,2011/2012,60,HHS Region 7,Season onset,5
 2012,8,2011/2012,60,HHS Region 7,Season peak week,9
-2012,8,2011/2012,60,HHS Region 7,Season peak percentage,3.4
-2012,8,2011/2012,60,HHS Region 7,1 wk ahead,3.4
+2012,8,2011/2012,60,HHS Region 7,Season peak percentage,3.5
+2012,8,2011/2012,60,HHS Region 7,1 wk ahead,3.5
 2012,8,2011/2012,60,HHS Region 7,2 wk ahead,3.1
 2012,8,2011/2012,60,HHS Region 7,3 wk ahead,2.6
 2012,8,2011/2012,60,HHS Region 7,4 wk ahead,1.7
@@ -4285,32 +4286,32 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,8,2011/2012,60,HHS Region 8,4 wk ahead,1.6
 2012,8,2011/2012,60,HHS Region 9,Season onset,none
 2012,8,2011/2012,60,HHS Region 9,Season peak week,52
-2012,8,2011/2012,60,HHS Region 9,Season peak week,8
 2012,8,2011/2012,60,HHS Region 9,Season peak percentage,3.7
 2012,8,2011/2012,60,HHS Region 9,1 wk ahead,3.1
-2012,8,2011/2012,60,HHS Region 9,2 wk ahead,2.5
-2012,8,2011/2012,60,HHS Region 9,3 wk ahead,2.8
-2012,8,2011/2012,60,HHS Region 9,4 wk ahead,2.6
-2012,8,2011/2012,60,HHS Region 10,Season onset,none
-2012,8,2011/2012,60,HHS Region 10,Season peak week,12
-2012,8,2011/2012,60,HHS Region 10,Season peak percentage,2.2
-2012,8,2011/2012,60,HHS Region 10,1 wk ahead,1.5
-2012,8,2011/2012,60,HHS Region 10,2 wk ahead,1.6
-2012,8,2011/2012,60,HHS Region 10,3 wk ahead,1.9
-2012,8,2011/2012,60,HHS Region 10,4 wk ahead,2.2
+2012,8,2011/2012,60,HHS Region 9,2 wk ahead,2.4
+2012,8,2011/2012,60,HHS Region 9,3 wk ahead,2.7
+2012,8,2011/2012,60,HHS Region 9,4 wk ahead,2.5
+2012,8,2011/2012,60,HHS Region 10,Season onset,10
+2012,8,2011/2012,60,HHS Region 10,Season peak week,11
+2012,8,2011/2012,60,HHS Region 10,Season peak percentage,2.7
+2012,8,2011/2012,60,HHS Region 10,1 wk ahead,1.9
+2012,8,2011/2012,60,HHS Region 10,2 wk ahead,2.2
+2012,8,2011/2012,60,HHS Region 10,3 wk ahead,2.7
+2012,8,2011/2012,60,HHS Region 10,4 wk ahead,2.4
 2012,9,2011/2012,61,US National,Season onset,none
 2012,9,2011/2012,61,US National,Season peak week,11
 2012,9,2011/2012,61,US National,Season peak percentage,2.4
 2012,9,2011/2012,61,US National,1 wk ahead,2.2
 2012,9,2011/2012,61,US National,2 wk ahead,2.4
 2012,9,2011/2012,61,US National,3 wk ahead,2
-2012,9,2011/2012,61,US National,4 wk ahead,1.8
+2012,9,2011/2012,61,US National,4 wk ahead,1.9
 2012,9,2011/2012,61,HHS Region 1,Season onset,none
 2012,9,2011/2012,61,HHS Region 1,Season peak week,52
+2012,9,2011/2012,61,HHS Region 1,Season peak week,8
 2012,9,2011/2012,61,HHS Region 1,Season peak percentage,1
 2012,9,2011/2012,61,HHS Region 1,1 wk ahead,0.8
 2012,9,2011/2012,61,HHS Region 1,2 wk ahead,0.9
-2012,9,2011/2012,61,HHS Region 1,3 wk ahead,0.8
+2012,9,2011/2012,61,HHS Region 1,3 wk ahead,0.9
 2012,9,2011/2012,61,HHS Region 1,4 wk ahead,0.6
 2012,9,2011/2012,61,HHS Region 2,Season onset,none
 2012,9,2011/2012,61,HHS Region 2,Season peak week,49
@@ -4324,7 +4325,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,9,2011/2012,61,HHS Region 3,Season peak percentage,2.1
 2012,9,2011/2012,61,HHS Region 3,1 wk ahead,1.6
 2012,9,2011/2012,61,HHS Region 3,2 wk ahead,1.9
-2012,9,2011/2012,61,HHS Region 3,3 wk ahead,1.4
+2012,9,2011/2012,61,HHS Region 3,3 wk ahead,1.5
 2012,9,2011/2012,61,HHS Region 3,4 wk ahead,1.4
 2012,9,2011/2012,61,HHS Region 4,Season onset,none
 2012,9,2011/2012,61,HHS Region 4,Season peak week,52
@@ -4337,20 +4338,20 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,9,2011/2012,61,HHS Region 5,Season onset,7
 2012,9,2011/2012,61,HHS Region 5,Season peak week,11
 2012,9,2011/2012,61,HHS Region 5,Season peak percentage,2.4
-2012,9,2011/2012,61,HHS Region 5,1 wk ahead,2
+2012,9,2011/2012,61,HHS Region 5,1 wk ahead,2.1
 2012,9,2011/2012,61,HHS Region 5,2 wk ahead,2.4
 2012,9,2011/2012,61,HHS Region 5,3 wk ahead,1.9
-2012,9,2011/2012,61,HHS Region 5,4 wk ahead,1.3
+2012,9,2011/2012,61,HHS Region 5,4 wk ahead,1.4
 2012,9,2011/2012,61,HHS Region 6,Season onset,none
 2012,9,2011/2012,61,HHS Region 6,Season peak week,11
-2012,9,2011/2012,61,HHS Region 6,Season peak percentage,4.1
+2012,9,2011/2012,61,HHS Region 6,Season peak percentage,4.2
 2012,9,2011/2012,61,HHS Region 6,1 wk ahead,3.4
-2012,9,2011/2012,61,HHS Region 6,2 wk ahead,4.1
-2012,9,2011/2012,61,HHS Region 6,3 wk ahead,2.9
+2012,9,2011/2012,61,HHS Region 6,2 wk ahead,4.2
+2012,9,2011/2012,61,HHS Region 6,3 wk ahead,3
 2012,9,2011/2012,61,HHS Region 6,4 wk ahead,2.6
 2012,9,2011/2012,61,HHS Region 7,Season onset,5
 2012,9,2011/2012,61,HHS Region 7,Season peak week,9
-2012,9,2011/2012,61,HHS Region 7,Season peak percentage,3.4
+2012,9,2011/2012,61,HHS Region 7,Season peak percentage,3.5
 2012,9,2011/2012,61,HHS Region 7,1 wk ahead,3.1
 2012,9,2011/2012,61,HHS Region 7,2 wk ahead,2.6
 2012,9,2011/2012,61,HHS Region 7,3 wk ahead,1.7
@@ -4364,31 +4365,31 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,9,2011/2012,61,HHS Region 8,4 wk ahead,1.5
 2012,9,2011/2012,61,HHS Region 9,Season onset,none
 2012,9,2011/2012,61,HHS Region 9,Season peak week,52
-2012,9,2011/2012,61,HHS Region 9,Season peak week,8
 2012,9,2011/2012,61,HHS Region 9,Season peak percentage,3.7
-2012,9,2011/2012,61,HHS Region 9,1 wk ahead,2.5
-2012,9,2011/2012,61,HHS Region 9,2 wk ahead,2.8
-2012,9,2011/2012,61,HHS Region 9,3 wk ahead,2.6
-2012,9,2011/2012,61,HHS Region 9,4 wk ahead,3.4
-2012,9,2011/2012,61,HHS Region 10,Season onset,none
-2012,9,2011/2012,61,HHS Region 10,Season peak week,12
-2012,9,2011/2012,61,HHS Region 10,Season peak percentage,2.2
-2012,9,2011/2012,61,HHS Region 10,1 wk ahead,1.6
-2012,9,2011/2012,61,HHS Region 10,2 wk ahead,1.9
-2012,9,2011/2012,61,HHS Region 10,3 wk ahead,2.2
-2012,9,2011/2012,61,HHS Region 10,4 wk ahead,1.8
+2012,9,2011/2012,61,HHS Region 9,1 wk ahead,2.4
+2012,9,2011/2012,61,HHS Region 9,2 wk ahead,2.7
+2012,9,2011/2012,61,HHS Region 9,3 wk ahead,2.5
+2012,9,2011/2012,61,HHS Region 9,4 wk ahead,3.3
+2012,9,2011/2012,61,HHS Region 10,Season onset,10
+2012,9,2011/2012,61,HHS Region 10,Season peak week,11
+2012,9,2011/2012,61,HHS Region 10,Season peak percentage,2.7
+2012,9,2011/2012,61,HHS Region 10,1 wk ahead,2.2
+2012,9,2011/2012,61,HHS Region 10,2 wk ahead,2.7
+2012,9,2011/2012,61,HHS Region 10,3 wk ahead,2.4
+2012,9,2011/2012,61,HHS Region 10,4 wk ahead,1.9
 2012,10,2011/2012,62,US National,Season onset,none
 2012,10,2011/2012,62,US National,Season peak week,11
 2012,10,2011/2012,62,US National,Season peak percentage,2.4
 2012,10,2011/2012,62,US National,1 wk ahead,2.4
 2012,10,2011/2012,62,US National,2 wk ahead,2
-2012,10,2011/2012,62,US National,3 wk ahead,1.8
+2012,10,2011/2012,62,US National,3 wk ahead,1.9
 2012,10,2011/2012,62,US National,4 wk ahead,1.7
 2012,10,2011/2012,62,HHS Region 1,Season onset,none
 2012,10,2011/2012,62,HHS Region 1,Season peak week,52
+2012,10,2011/2012,62,HHS Region 1,Season peak week,8
 2012,10,2011/2012,62,HHS Region 1,Season peak percentage,1
 2012,10,2011/2012,62,HHS Region 1,1 wk ahead,0.9
-2012,10,2011/2012,62,HHS Region 1,2 wk ahead,0.8
+2012,10,2011/2012,62,HHS Region 1,2 wk ahead,0.9
 2012,10,2011/2012,62,HHS Region 1,3 wk ahead,0.6
 2012,10,2011/2012,62,HHS Region 1,4 wk ahead,0.8
 2012,10,2011/2012,62,HHS Region 2,Season onset,none
@@ -4402,7 +4403,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,10,2011/2012,62,HHS Region 3,Season peak week,52
 2012,10,2011/2012,62,HHS Region 3,Season peak percentage,2.1
 2012,10,2011/2012,62,HHS Region 3,1 wk ahead,1.9
-2012,10,2011/2012,62,HHS Region 3,2 wk ahead,1.4
+2012,10,2011/2012,62,HHS Region 3,2 wk ahead,1.5
 2012,10,2011/2012,62,HHS Region 3,3 wk ahead,1.4
 2012,10,2011/2012,62,HHS Region 3,4 wk ahead,1.3
 2012,10,2011/2012,62,HHS Region 4,Season onset,none
@@ -4418,18 +4419,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,10,2011/2012,62,HHS Region 5,Season peak percentage,2.4
 2012,10,2011/2012,62,HHS Region 5,1 wk ahead,2.4
 2012,10,2011/2012,62,HHS Region 5,2 wk ahead,1.9
-2012,10,2011/2012,62,HHS Region 5,3 wk ahead,1.3
+2012,10,2011/2012,62,HHS Region 5,3 wk ahead,1.4
 2012,10,2011/2012,62,HHS Region 5,4 wk ahead,1.4
 2012,10,2011/2012,62,HHS Region 6,Season onset,none
 2012,10,2011/2012,62,HHS Region 6,Season peak week,11
-2012,10,2011/2012,62,HHS Region 6,Season peak percentage,4.1
-2012,10,2011/2012,62,HHS Region 6,1 wk ahead,4.1
-2012,10,2011/2012,62,HHS Region 6,2 wk ahead,2.9
+2012,10,2011/2012,62,HHS Region 6,Season peak percentage,4.2
+2012,10,2011/2012,62,HHS Region 6,1 wk ahead,4.2
+2012,10,2011/2012,62,HHS Region 6,2 wk ahead,3
 2012,10,2011/2012,62,HHS Region 6,3 wk ahead,2.6
-2012,10,2011/2012,62,HHS Region 6,4 wk ahead,2.4
+2012,10,2011/2012,62,HHS Region 6,4 wk ahead,2.3
 2012,10,2011/2012,62,HHS Region 7,Season onset,5
 2012,10,2011/2012,62,HHS Region 7,Season peak week,9
-2012,10,2011/2012,62,HHS Region 7,Season peak percentage,3.4
+2012,10,2011/2012,62,HHS Region 7,Season peak percentage,3.5
 2012,10,2011/2012,62,HHS Region 7,1 wk ahead,2.6
 2012,10,2011/2012,62,HHS Region 7,2 wk ahead,1.7
 2012,10,2011/2012,62,HHS Region 7,3 wk ahead,1.2
@@ -4443,30 +4444,30 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,10,2011/2012,62,HHS Region 8,4 wk ahead,1.2
 2012,10,2011/2012,62,HHS Region 9,Season onset,none
 2012,10,2011/2012,62,HHS Region 9,Season peak week,52
-2012,10,2011/2012,62,HHS Region 9,Season peak week,8
 2012,10,2011/2012,62,HHS Region 9,Season peak percentage,3.7
-2012,10,2011/2012,62,HHS Region 9,1 wk ahead,2.8
-2012,10,2011/2012,62,HHS Region 9,2 wk ahead,2.6
-2012,10,2011/2012,62,HHS Region 9,3 wk ahead,3.4
-2012,10,2011/2012,62,HHS Region 9,4 wk ahead,2.7
-2012,10,2011/2012,62,HHS Region 10,Season onset,none
-2012,10,2011/2012,62,HHS Region 10,Season peak week,12
-2012,10,2011/2012,62,HHS Region 10,Season peak percentage,2.2
-2012,10,2011/2012,62,HHS Region 10,1 wk ahead,1.9
-2012,10,2011/2012,62,HHS Region 10,2 wk ahead,2.2
-2012,10,2011/2012,62,HHS Region 10,3 wk ahead,1.8
-2012,10,2011/2012,62,HHS Region 10,4 wk ahead,1.6
+2012,10,2011/2012,62,HHS Region 9,1 wk ahead,2.7
+2012,10,2011/2012,62,HHS Region 9,2 wk ahead,2.5
+2012,10,2011/2012,62,HHS Region 9,3 wk ahead,3.3
+2012,10,2011/2012,62,HHS Region 9,4 wk ahead,2.6
+2012,10,2011/2012,62,HHS Region 10,Season onset,10
+2012,10,2011/2012,62,HHS Region 10,Season peak week,11
+2012,10,2011/2012,62,HHS Region 10,Season peak percentage,2.7
+2012,10,2011/2012,62,HHS Region 10,1 wk ahead,2.7
+2012,10,2011/2012,62,HHS Region 10,2 wk ahead,2.4
+2012,10,2011/2012,62,HHS Region 10,3 wk ahead,1.9
+2012,10,2011/2012,62,HHS Region 10,4 wk ahead,1.8
 2012,11,2011/2012,63,US National,Season onset,none
 2012,11,2011/2012,63,US National,Season peak week,11
 2012,11,2011/2012,63,US National,Season peak percentage,2.4
 2012,11,2011/2012,63,US National,1 wk ahead,2
-2012,11,2011/2012,63,US National,2 wk ahead,1.8
+2012,11,2011/2012,63,US National,2 wk ahead,1.9
 2012,11,2011/2012,63,US National,3 wk ahead,1.7
 2012,11,2011/2012,63,US National,4 wk ahead,1.5
 2012,11,2011/2012,63,HHS Region 1,Season onset,none
 2012,11,2011/2012,63,HHS Region 1,Season peak week,52
+2012,11,2011/2012,63,HHS Region 1,Season peak week,8
 2012,11,2011/2012,63,HHS Region 1,Season peak percentage,1
-2012,11,2011/2012,63,HHS Region 1,1 wk ahead,0.8
+2012,11,2011/2012,63,HHS Region 1,1 wk ahead,0.9
 2012,11,2011/2012,63,HHS Region 1,2 wk ahead,0.6
 2012,11,2011/2012,63,HHS Region 1,3 wk ahead,0.8
 2012,11,2011/2012,63,HHS Region 1,4 wk ahead,0.9
@@ -4476,11 +4477,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,11,2011/2012,63,HHS Region 2,1 wk ahead,1.2
 2012,11,2011/2012,63,HHS Region 2,2 wk ahead,1.1
 2012,11,2011/2012,63,HHS Region 2,3 wk ahead,1.3
-2012,11,2011/2012,63,HHS Region 2,4 wk ahead,1.1
+2012,11,2011/2012,63,HHS Region 2,4 wk ahead,1.2
 2012,11,2011/2012,63,HHS Region 3,Season onset,none
 2012,11,2011/2012,63,HHS Region 3,Season peak week,52
 2012,11,2011/2012,63,HHS Region 3,Season peak percentage,2.1
-2012,11,2011/2012,63,HHS Region 3,1 wk ahead,1.4
+2012,11,2011/2012,63,HHS Region 3,1 wk ahead,1.5
 2012,11,2011/2012,63,HHS Region 3,2 wk ahead,1.4
 2012,11,2011/2012,63,HHS Region 3,3 wk ahead,1.3
 2012,11,2011/2012,63,HHS Region 3,4 wk ahead,1.2
@@ -4491,24 +4492,24 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,11,2011/2012,63,HHS Region 4,1 wk ahead,1.9
 2012,11,2011/2012,63,HHS Region 4,2 wk ahead,1.7
 2012,11,2011/2012,63,HHS Region 4,3 wk ahead,1.6
-2012,11,2011/2012,63,HHS Region 4,4 wk ahead,1.4
+2012,11,2011/2012,63,HHS Region 4,4 wk ahead,1.5
 2012,11,2011/2012,63,HHS Region 5,Season onset,7
 2012,11,2011/2012,63,HHS Region 5,Season peak week,11
 2012,11,2011/2012,63,HHS Region 5,Season peak percentage,2.4
 2012,11,2011/2012,63,HHS Region 5,1 wk ahead,1.9
-2012,11,2011/2012,63,HHS Region 5,2 wk ahead,1.3
+2012,11,2011/2012,63,HHS Region 5,2 wk ahead,1.4
 2012,11,2011/2012,63,HHS Region 5,3 wk ahead,1.4
 2012,11,2011/2012,63,HHS Region 5,4 wk ahead,1.2
 2012,11,2011/2012,63,HHS Region 6,Season onset,none
 2012,11,2011/2012,63,HHS Region 6,Season peak week,11
-2012,11,2011/2012,63,HHS Region 6,Season peak percentage,4.1
-2012,11,2011/2012,63,HHS Region 6,1 wk ahead,2.9
+2012,11,2011/2012,63,HHS Region 6,Season peak percentage,4.2
+2012,11,2011/2012,63,HHS Region 6,1 wk ahead,3
 2012,11,2011/2012,63,HHS Region 6,2 wk ahead,2.6
-2012,11,2011/2012,63,HHS Region 6,3 wk ahead,2.4
+2012,11,2011/2012,63,HHS Region 6,3 wk ahead,2.3
 2012,11,2011/2012,63,HHS Region 6,4 wk ahead,1.9
 2012,11,2011/2012,63,HHS Region 7,Season onset,5
 2012,11,2011/2012,63,HHS Region 7,Season peak week,9
-2012,11,2011/2012,63,HHS Region 7,Season peak percentage,3.4
+2012,11,2011/2012,63,HHS Region 7,Season peak percentage,3.5
 2012,11,2011/2012,63,HHS Region 7,1 wk ahead,1.7
 2012,11,2011/2012,63,HHS Region 7,2 wk ahead,1.2
 2012,11,2011/2012,63,HHS Region 7,3 wk ahead,0.9
@@ -4522,28 +4523,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,11,2011/2012,63,HHS Region 8,4 wk ahead,1.1
 2012,11,2011/2012,63,HHS Region 9,Season onset,none
 2012,11,2011/2012,63,HHS Region 9,Season peak week,52
-2012,11,2011/2012,63,HHS Region 9,Season peak week,8
 2012,11,2011/2012,63,HHS Region 9,Season peak percentage,3.7
-2012,11,2011/2012,63,HHS Region 9,1 wk ahead,2.6
-2012,11,2011/2012,63,HHS Region 9,2 wk ahead,3.4
-2012,11,2011/2012,63,HHS Region 9,3 wk ahead,2.7
+2012,11,2011/2012,63,HHS Region 9,1 wk ahead,2.5
+2012,11,2011/2012,63,HHS Region 9,2 wk ahead,3.3
+2012,11,2011/2012,63,HHS Region 9,3 wk ahead,2.6
 2012,11,2011/2012,63,HHS Region 9,4 wk ahead,2.6
-2012,11,2011/2012,63,HHS Region 10,Season onset,none
-2012,11,2011/2012,63,HHS Region 10,Season peak week,12
-2012,11,2011/2012,63,HHS Region 10,Season peak percentage,2.2
-2012,11,2011/2012,63,HHS Region 10,1 wk ahead,2.2
-2012,11,2011/2012,63,HHS Region 10,2 wk ahead,1.8
-2012,11,2011/2012,63,HHS Region 10,3 wk ahead,1.6
-2012,11,2011/2012,63,HHS Region 10,4 wk ahead,1.9
+2012,11,2011/2012,63,HHS Region 10,Season onset,10
+2012,11,2011/2012,63,HHS Region 10,Season peak week,11
+2012,11,2011/2012,63,HHS Region 10,Season peak percentage,2.7
+2012,11,2011/2012,63,HHS Region 10,1 wk ahead,2.4
+2012,11,2011/2012,63,HHS Region 10,2 wk ahead,1.9
+2012,11,2011/2012,63,HHS Region 10,3 wk ahead,1.8
+2012,11,2011/2012,63,HHS Region 10,4 wk ahead,2.1
 2012,12,2011/2012,64,US National,Season onset,none
 2012,12,2011/2012,64,US National,Season peak week,11
 2012,12,2011/2012,64,US National,Season peak percentage,2.4
-2012,12,2011/2012,64,US National,1 wk ahead,1.8
+2012,12,2011/2012,64,US National,1 wk ahead,1.9
 2012,12,2011/2012,64,US National,2 wk ahead,1.7
 2012,12,2011/2012,64,US National,3 wk ahead,1.5
 2012,12,2011/2012,64,US National,4 wk ahead,1.4
 2012,12,2011/2012,64,HHS Region 1,Season onset,none
 2012,12,2011/2012,64,HHS Region 1,Season peak week,52
+2012,12,2011/2012,64,HHS Region 1,Season peak week,8
 2012,12,2011/2012,64,HHS Region 1,Season peak percentage,1
 2012,12,2011/2012,64,HHS Region 1,1 wk ahead,0.6
 2012,12,2011/2012,64,HHS Region 1,2 wk ahead,0.8
@@ -4554,7 +4555,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,12,2011/2012,64,HHS Region 2,Season peak percentage,1.4
 2012,12,2011/2012,64,HHS Region 2,1 wk ahead,1.1
 2012,12,2011/2012,64,HHS Region 2,2 wk ahead,1.3
-2012,12,2011/2012,64,HHS Region 2,3 wk ahead,1.1
+2012,12,2011/2012,64,HHS Region 2,3 wk ahead,1.2
 2012,12,2011/2012,64,HHS Region 2,4 wk ahead,1.1
 2012,12,2011/2012,64,HHS Region 3,Season onset,none
 2012,12,2011/2012,64,HHS Region 3,Season peak week,52
@@ -4569,29 +4570,29 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,12,2011/2012,64,HHS Region 4,Season peak percentage,2.3
 2012,12,2011/2012,64,HHS Region 4,1 wk ahead,1.7
 2012,12,2011/2012,64,HHS Region 4,2 wk ahead,1.6
-2012,12,2011/2012,64,HHS Region 4,3 wk ahead,1.4
+2012,12,2011/2012,64,HHS Region 4,3 wk ahead,1.5
 2012,12,2011/2012,64,HHS Region 4,4 wk ahead,1.4
 2012,12,2011/2012,64,HHS Region 5,Season onset,7
 2012,12,2011/2012,64,HHS Region 5,Season peak week,11
 2012,12,2011/2012,64,HHS Region 5,Season peak percentage,2.4
-2012,12,2011/2012,64,HHS Region 5,1 wk ahead,1.3
+2012,12,2011/2012,64,HHS Region 5,1 wk ahead,1.4
 2012,12,2011/2012,64,HHS Region 5,2 wk ahead,1.4
 2012,12,2011/2012,64,HHS Region 5,3 wk ahead,1.2
 2012,12,2011/2012,64,HHS Region 5,4 wk ahead,1
 2012,12,2011/2012,64,HHS Region 6,Season onset,none
 2012,12,2011/2012,64,HHS Region 6,Season peak week,11
-2012,12,2011/2012,64,HHS Region 6,Season peak percentage,4.1
+2012,12,2011/2012,64,HHS Region 6,Season peak percentage,4.2
 2012,12,2011/2012,64,HHS Region 6,1 wk ahead,2.6
-2012,12,2011/2012,64,HHS Region 6,2 wk ahead,2.4
+2012,12,2011/2012,64,HHS Region 6,2 wk ahead,2.3
 2012,12,2011/2012,64,HHS Region 6,3 wk ahead,1.9
 2012,12,2011/2012,64,HHS Region 6,4 wk ahead,2
 2012,12,2011/2012,64,HHS Region 7,Season onset,5
 2012,12,2011/2012,64,HHS Region 7,Season peak week,9
-2012,12,2011/2012,64,HHS Region 7,Season peak percentage,3.4
+2012,12,2011/2012,64,HHS Region 7,Season peak percentage,3.5
 2012,12,2011/2012,64,HHS Region 7,1 wk ahead,1.2
 2012,12,2011/2012,64,HHS Region 7,2 wk ahead,0.9
 2012,12,2011/2012,64,HHS Region 7,3 wk ahead,0.8
-2012,12,2011/2012,64,HHS Region 7,4 wk ahead,0.8
+2012,12,2011/2012,64,HHS Region 7,4 wk ahead,0.7
 2012,12,2011/2012,64,HHS Region 8,Season onset,none
 2012,12,2011/2012,64,HHS Region 8,Season peak week,11
 2012,12,2011/2012,64,HHS Region 8,Season peak percentage,2.2
@@ -4601,19 +4602,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,12,2011/2012,64,HHS Region 8,4 wk ahead,0.9
 2012,12,2011/2012,64,HHS Region 9,Season onset,none
 2012,12,2011/2012,64,HHS Region 9,Season peak week,52
-2012,12,2011/2012,64,HHS Region 9,Season peak week,8
 2012,12,2011/2012,64,HHS Region 9,Season peak percentage,3.7
-2012,12,2011/2012,64,HHS Region 9,1 wk ahead,3.4
-2012,12,2011/2012,64,HHS Region 9,2 wk ahead,2.7
+2012,12,2011/2012,64,HHS Region 9,1 wk ahead,3.3
+2012,12,2011/2012,64,HHS Region 9,2 wk ahead,2.6
 2012,12,2011/2012,64,HHS Region 9,3 wk ahead,2.6
 2012,12,2011/2012,64,HHS Region 9,4 wk ahead,2
-2012,12,2011/2012,64,HHS Region 10,Season onset,none
-2012,12,2011/2012,64,HHS Region 10,Season peak week,12
-2012,12,2011/2012,64,HHS Region 10,Season peak percentage,2.2
-2012,12,2011/2012,64,HHS Region 10,1 wk ahead,1.8
-2012,12,2011/2012,64,HHS Region 10,2 wk ahead,1.6
-2012,12,2011/2012,64,HHS Region 10,3 wk ahead,1.9
-2012,12,2011/2012,64,HHS Region 10,4 wk ahead,1.6
+2012,12,2011/2012,64,HHS Region 10,Season onset,10
+2012,12,2011/2012,64,HHS Region 10,Season peak week,11
+2012,12,2011/2012,64,HHS Region 10,Season peak percentage,2.7
+2012,12,2011/2012,64,HHS Region 10,1 wk ahead,1.9
+2012,12,2011/2012,64,HHS Region 10,2 wk ahead,1.8
+2012,12,2011/2012,64,HHS Region 10,3 wk ahead,2.1
+2012,12,2011/2012,64,HHS Region 10,4 wk ahead,2.1
 2012,13,2011/2012,65,US National,Season onset,none
 2012,13,2011/2012,65,US National,Season peak week,11
 2012,13,2011/2012,65,US National,Season peak percentage,2.4
@@ -4623,6 +4623,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,13,2011/2012,65,US National,4 wk ahead,1.3
 2012,13,2011/2012,65,HHS Region 1,Season onset,none
 2012,13,2011/2012,65,HHS Region 1,Season peak week,52
+2012,13,2011/2012,65,HHS Region 1,Season peak week,8
 2012,13,2011/2012,65,HHS Region 1,Season peak percentage,1
 2012,13,2011/2012,65,HHS Region 1,1 wk ahead,0.8
 2012,13,2011/2012,65,HHS Region 1,2 wk ahead,0.9
@@ -4632,22 +4633,22 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,13,2011/2012,65,HHS Region 2,Season peak week,49
 2012,13,2011/2012,65,HHS Region 2,Season peak percentage,1.4
 2012,13,2011/2012,65,HHS Region 2,1 wk ahead,1.3
-2012,13,2011/2012,65,HHS Region 2,2 wk ahead,1.1
+2012,13,2011/2012,65,HHS Region 2,2 wk ahead,1.2
 2012,13,2011/2012,65,HHS Region 2,3 wk ahead,1.1
-2012,13,2011/2012,65,HHS Region 2,4 wk ahead,0.9
+2012,13,2011/2012,65,HHS Region 2,4 wk ahead,1
 2012,13,2011/2012,65,HHS Region 3,Season onset,none
 2012,13,2011/2012,65,HHS Region 3,Season peak week,52
 2012,13,2011/2012,65,HHS Region 3,Season peak percentage,2.1
 2012,13,2011/2012,65,HHS Region 3,1 wk ahead,1.3
 2012,13,2011/2012,65,HHS Region 3,2 wk ahead,1.2
 2012,13,2011/2012,65,HHS Region 3,3 wk ahead,1.1
-2012,13,2011/2012,65,HHS Region 3,4 wk ahead,1.1
+2012,13,2011/2012,65,HHS Region 3,4 wk ahead,1
 2012,13,2011/2012,65,HHS Region 4,Season onset,none
 2012,13,2011/2012,65,HHS Region 4,Season peak week,52
 2012,13,2011/2012,65,HHS Region 4,Season peak week,10
 2012,13,2011/2012,65,HHS Region 4,Season peak percentage,2.3
 2012,13,2011/2012,65,HHS Region 4,1 wk ahead,1.6
-2012,13,2011/2012,65,HHS Region 4,2 wk ahead,1.4
+2012,13,2011/2012,65,HHS Region 4,2 wk ahead,1.5
 2012,13,2011/2012,65,HHS Region 4,3 wk ahead,1.4
 2012,13,2011/2012,65,HHS Region 4,4 wk ahead,1.3
 2012,13,2011/2012,65,HHS Region 5,Season onset,7
@@ -4659,17 +4660,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,13,2011/2012,65,HHS Region 5,4 wk ahead,0.9
 2012,13,2011/2012,65,HHS Region 6,Season onset,none
 2012,13,2011/2012,65,HHS Region 6,Season peak week,11
-2012,13,2011/2012,65,HHS Region 6,Season peak percentage,4.1
-2012,13,2011/2012,65,HHS Region 6,1 wk ahead,2.4
+2012,13,2011/2012,65,HHS Region 6,Season peak percentage,4.2
+2012,13,2011/2012,65,HHS Region 6,1 wk ahead,2.3
 2012,13,2011/2012,65,HHS Region 6,2 wk ahead,1.9
 2012,13,2011/2012,65,HHS Region 6,3 wk ahead,2
 2012,13,2011/2012,65,HHS Region 6,4 wk ahead,1.9
 2012,13,2011/2012,65,HHS Region 7,Season onset,5
 2012,13,2011/2012,65,HHS Region 7,Season peak week,9
-2012,13,2011/2012,65,HHS Region 7,Season peak percentage,3.4
+2012,13,2011/2012,65,HHS Region 7,Season peak percentage,3.5
 2012,13,2011/2012,65,HHS Region 7,1 wk ahead,0.9
 2012,13,2011/2012,65,HHS Region 7,2 wk ahead,0.8
-2012,13,2011/2012,65,HHS Region 7,3 wk ahead,0.8
+2012,13,2011/2012,65,HHS Region 7,3 wk ahead,0.7
 2012,13,2011/2012,65,HHS Region 7,4 wk ahead,0.7
 2012,13,2011/2012,65,HHS Region 8,Season onset,none
 2012,13,2011/2012,65,HHS Region 8,Season peak week,11
@@ -4680,28 +4681,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,13,2011/2012,65,HHS Region 8,4 wk ahead,0.9
 2012,13,2011/2012,65,HHS Region 9,Season onset,none
 2012,13,2011/2012,65,HHS Region 9,Season peak week,52
-2012,13,2011/2012,65,HHS Region 9,Season peak week,8
 2012,13,2011/2012,65,HHS Region 9,Season peak percentage,3.7
-2012,13,2011/2012,65,HHS Region 9,1 wk ahead,2.7
+2012,13,2011/2012,65,HHS Region 9,1 wk ahead,2.6
 2012,13,2011/2012,65,HHS Region 9,2 wk ahead,2.6
 2012,13,2011/2012,65,HHS Region 9,3 wk ahead,2
-2012,13,2011/2012,65,HHS Region 9,4 wk ahead,1.9
-2012,13,2011/2012,65,HHS Region 10,Season onset,none
-2012,13,2011/2012,65,HHS Region 10,Season peak week,12
-2012,13,2011/2012,65,HHS Region 10,Season peak percentage,2.2
-2012,13,2011/2012,65,HHS Region 10,1 wk ahead,1.6
-2012,13,2011/2012,65,HHS Region 10,2 wk ahead,1.9
-2012,13,2011/2012,65,HHS Region 10,3 wk ahead,1.6
-2012,13,2011/2012,65,HHS Region 10,4 wk ahead,1.4
+2012,13,2011/2012,65,HHS Region 9,4 wk ahead,2
+2012,13,2011/2012,65,HHS Region 10,Season onset,10
+2012,13,2011/2012,65,HHS Region 10,Season peak week,11
+2012,13,2011/2012,65,HHS Region 10,Season peak percentage,2.7
+2012,13,2011/2012,65,HHS Region 10,1 wk ahead,1.8
+2012,13,2011/2012,65,HHS Region 10,2 wk ahead,2.1
+2012,13,2011/2012,65,HHS Region 10,3 wk ahead,2.1
+2012,13,2011/2012,65,HHS Region 10,4 wk ahead,1.8
 2012,14,2011/2012,66,US National,Season onset,none
 2012,14,2011/2012,66,US National,Season peak week,11
 2012,14,2011/2012,66,US National,Season peak percentage,2.4
 2012,14,2011/2012,66,US National,1 wk ahead,1.5
 2012,14,2011/2012,66,US National,2 wk ahead,1.4
 2012,14,2011/2012,66,US National,3 wk ahead,1.3
-2012,14,2011/2012,66,US National,4 wk ahead,1.4
+2012,14,2011/2012,66,US National,4 wk ahead,1.5
 2012,14,2011/2012,66,HHS Region 1,Season onset,none
 2012,14,2011/2012,66,HHS Region 1,Season peak week,52
+2012,14,2011/2012,66,HHS Region 1,Season peak week,8
 2012,14,2011/2012,66,HHS Region 1,Season peak percentage,1
 2012,14,2011/2012,66,HHS Region 1,1 wk ahead,0.9
 2012,14,2011/2012,66,HHS Region 1,2 wk ahead,0.8
@@ -4710,22 +4711,22 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,14,2011/2012,66,HHS Region 2,Season onset,none
 2012,14,2011/2012,66,HHS Region 2,Season peak week,49
 2012,14,2011/2012,66,HHS Region 2,Season peak percentage,1.4
-2012,14,2011/2012,66,HHS Region 2,1 wk ahead,1.1
+2012,14,2011/2012,66,HHS Region 2,1 wk ahead,1.2
 2012,14,2011/2012,66,HHS Region 2,2 wk ahead,1.1
-2012,14,2011/2012,66,HHS Region 2,3 wk ahead,0.9
+2012,14,2011/2012,66,HHS Region 2,3 wk ahead,1
 2012,14,2011/2012,66,HHS Region 2,4 wk ahead,1
 2012,14,2011/2012,66,HHS Region 3,Season onset,none
 2012,14,2011/2012,66,HHS Region 3,Season peak week,52
 2012,14,2011/2012,66,HHS Region 3,Season peak percentage,2.1
 2012,14,2011/2012,66,HHS Region 3,1 wk ahead,1.2
 2012,14,2011/2012,66,HHS Region 3,2 wk ahead,1.1
-2012,14,2011/2012,66,HHS Region 3,3 wk ahead,1.1
+2012,14,2011/2012,66,HHS Region 3,3 wk ahead,1
 2012,14,2011/2012,66,HHS Region 3,4 wk ahead,1.3
 2012,14,2011/2012,66,HHS Region 4,Season onset,none
 2012,14,2011/2012,66,HHS Region 4,Season peak week,52
 2012,14,2011/2012,66,HHS Region 4,Season peak week,10
 2012,14,2011/2012,66,HHS Region 4,Season peak percentage,2.3
-2012,14,2011/2012,66,HHS Region 4,1 wk ahead,1.4
+2012,14,2011/2012,66,HHS Region 4,1 wk ahead,1.5
 2012,14,2011/2012,66,HHS Region 4,2 wk ahead,1.4
 2012,14,2011/2012,66,HHS Region 4,3 wk ahead,1.3
 2012,14,2011/2012,66,HHS Region 4,4 wk ahead,1.5
@@ -4735,19 +4736,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,14,2011/2012,66,HHS Region 5,1 wk ahead,1.2
 2012,14,2011/2012,66,HHS Region 5,2 wk ahead,1
 2012,14,2011/2012,66,HHS Region 5,3 wk ahead,0.9
-2012,14,2011/2012,66,HHS Region 5,4 wk ahead,1
+2012,14,2011/2012,66,HHS Region 5,4 wk ahead,1.1
 2012,14,2011/2012,66,HHS Region 6,Season onset,none
 2012,14,2011/2012,66,HHS Region 6,Season peak week,11
-2012,14,2011/2012,66,HHS Region 6,Season peak percentage,4.1
+2012,14,2011/2012,66,HHS Region 6,Season peak percentage,4.2
 2012,14,2011/2012,66,HHS Region 6,1 wk ahead,1.9
 2012,14,2011/2012,66,HHS Region 6,2 wk ahead,2
 2012,14,2011/2012,66,HHS Region 6,3 wk ahead,1.9
 2012,14,2011/2012,66,HHS Region 6,4 wk ahead,1.9
 2012,14,2011/2012,66,HHS Region 7,Season onset,5
 2012,14,2011/2012,66,HHS Region 7,Season peak week,9
-2012,14,2011/2012,66,HHS Region 7,Season peak percentage,3.4
+2012,14,2011/2012,66,HHS Region 7,Season peak percentage,3.5
 2012,14,2011/2012,66,HHS Region 7,1 wk ahead,0.8
-2012,14,2011/2012,66,HHS Region 7,2 wk ahead,0.8
+2012,14,2011/2012,66,HHS Region 7,2 wk ahead,0.7
 2012,14,2011/2012,66,HHS Region 7,3 wk ahead,0.7
 2012,14,2011/2012,66,HHS Region 7,4 wk ahead,0.8
 2012,14,2011/2012,66,HHS Region 8,Season onset,none
@@ -4759,28 +4760,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,14,2011/2012,66,HHS Region 8,4 wk ahead,0.9
 2012,14,2011/2012,66,HHS Region 9,Season onset,none
 2012,14,2011/2012,66,HHS Region 9,Season peak week,52
-2012,14,2011/2012,66,HHS Region 9,Season peak week,8
 2012,14,2011/2012,66,HHS Region 9,Season peak percentage,3.7
 2012,14,2011/2012,66,HHS Region 9,1 wk ahead,2.6
 2012,14,2011/2012,66,HHS Region 9,2 wk ahead,2
-2012,14,2011/2012,66,HHS Region 9,3 wk ahead,1.9
-2012,14,2011/2012,66,HHS Region 9,4 wk ahead,2.1
-2012,14,2011/2012,66,HHS Region 10,Season onset,none
-2012,14,2011/2012,66,HHS Region 10,Season peak week,12
-2012,14,2011/2012,66,HHS Region 10,Season peak percentage,2.2
-2012,14,2011/2012,66,HHS Region 10,1 wk ahead,1.9
-2012,14,2011/2012,66,HHS Region 10,2 wk ahead,1.6
-2012,14,2011/2012,66,HHS Region 10,3 wk ahead,1.4
-2012,14,2011/2012,66,HHS Region 10,4 wk ahead,1.4
+2012,14,2011/2012,66,HHS Region 9,3 wk ahead,2
+2012,14,2011/2012,66,HHS Region 9,4 wk ahead,2.4
+2012,14,2011/2012,66,HHS Region 10,Season onset,10
+2012,14,2011/2012,66,HHS Region 10,Season peak week,11
+2012,14,2011/2012,66,HHS Region 10,Season peak percentage,2.7
+2012,14,2011/2012,66,HHS Region 10,1 wk ahead,2.1
+2012,14,2011/2012,66,HHS Region 10,2 wk ahead,2.1
+2012,14,2011/2012,66,HHS Region 10,3 wk ahead,1.8
+2012,14,2011/2012,66,HHS Region 10,4 wk ahead,2.1
 2012,15,2011/2012,67,US National,Season onset,none
 2012,15,2011/2012,67,US National,Season peak week,11
 2012,15,2011/2012,67,US National,Season peak percentage,2.4
 2012,15,2011/2012,67,US National,1 wk ahead,1.4
 2012,15,2011/2012,67,US National,2 wk ahead,1.3
-2012,15,2011/2012,67,US National,3 wk ahead,1.4
-2012,15,2011/2012,67,US National,4 wk ahead,1.3
+2012,15,2011/2012,67,US National,3 wk ahead,1.5
+2012,15,2011/2012,67,US National,4 wk ahead,1.4
 2012,15,2011/2012,67,HHS Region 1,Season onset,none
 2012,15,2011/2012,67,HHS Region 1,Season peak week,52
+2012,15,2011/2012,67,HHS Region 1,Season peak week,8
 2012,15,2011/2012,67,HHS Region 1,Season peak percentage,1
 2012,15,2011/2012,67,HHS Region 1,1 wk ahead,0.8
 2012,15,2011/2012,67,HHS Region 1,2 wk ahead,0.6
@@ -4790,14 +4791,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,15,2011/2012,67,HHS Region 2,Season peak week,49
 2012,15,2011/2012,67,HHS Region 2,Season peak percentage,1.4
 2012,15,2011/2012,67,HHS Region 2,1 wk ahead,1.1
-2012,15,2011/2012,67,HHS Region 2,2 wk ahead,0.9
+2012,15,2011/2012,67,HHS Region 2,2 wk ahead,1
 2012,15,2011/2012,67,HHS Region 2,3 wk ahead,1
 2012,15,2011/2012,67,HHS Region 2,4 wk ahead,0.9
 2012,15,2011/2012,67,HHS Region 3,Season onset,none
 2012,15,2011/2012,67,HHS Region 3,Season peak week,52
 2012,15,2011/2012,67,HHS Region 3,Season peak percentage,2.1
 2012,15,2011/2012,67,HHS Region 3,1 wk ahead,1.1
-2012,15,2011/2012,67,HHS Region 3,2 wk ahead,1.1
+2012,15,2011/2012,67,HHS Region 3,2 wk ahead,1
 2012,15,2011/2012,67,HHS Region 3,3 wk ahead,1.3
 2012,15,2011/2012,67,HHS Region 3,4 wk ahead,1.5
 2012,15,2011/2012,67,HHS Region 4,Season onset,none
@@ -4813,22 +4814,22 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,15,2011/2012,67,HHS Region 5,Season peak percentage,2.4
 2012,15,2011/2012,67,HHS Region 5,1 wk ahead,1
 2012,15,2011/2012,67,HHS Region 5,2 wk ahead,0.9
-2012,15,2011/2012,67,HHS Region 5,3 wk ahead,1
+2012,15,2011/2012,67,HHS Region 5,3 wk ahead,1.1
 2012,15,2011/2012,67,HHS Region 5,4 wk ahead,1
 2012,15,2011/2012,67,HHS Region 6,Season onset,none
 2012,15,2011/2012,67,HHS Region 6,Season peak week,11
-2012,15,2011/2012,67,HHS Region 6,Season peak percentage,4.1
+2012,15,2011/2012,67,HHS Region 6,Season peak percentage,4.2
 2012,15,2011/2012,67,HHS Region 6,1 wk ahead,2
 2012,15,2011/2012,67,HHS Region 6,2 wk ahead,1.9
 2012,15,2011/2012,67,HHS Region 6,3 wk ahead,1.9
 2012,15,2011/2012,67,HHS Region 6,4 wk ahead,1.9
 2012,15,2011/2012,67,HHS Region 7,Season onset,5
 2012,15,2011/2012,67,HHS Region 7,Season peak week,9
-2012,15,2011/2012,67,HHS Region 7,Season peak percentage,3.4
-2012,15,2011/2012,67,HHS Region 7,1 wk ahead,0.8
+2012,15,2011/2012,67,HHS Region 7,Season peak percentage,3.5
+2012,15,2011/2012,67,HHS Region 7,1 wk ahead,0.7
 2012,15,2011/2012,67,HHS Region 7,2 wk ahead,0.7
 2012,15,2011/2012,67,HHS Region 7,3 wk ahead,0.8
-2012,15,2011/2012,67,HHS Region 7,4 wk ahead,0.7
+2012,15,2011/2012,67,HHS Region 7,4 wk ahead,0.2
 2012,15,2011/2012,67,HHS Region 8,Season onset,none
 2012,15,2011/2012,67,HHS Region 8,Season peak week,11
 2012,15,2011/2012,67,HHS Region 8,Season peak percentage,2.2
@@ -4838,28 +4839,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,15,2011/2012,67,HHS Region 8,4 wk ahead,0.8
 2012,15,2011/2012,67,HHS Region 9,Season onset,none
 2012,15,2011/2012,67,HHS Region 9,Season peak week,52
-2012,15,2011/2012,67,HHS Region 9,Season peak week,8
 2012,15,2011/2012,67,HHS Region 9,Season peak percentage,3.7
 2012,15,2011/2012,67,HHS Region 9,1 wk ahead,2
-2012,15,2011/2012,67,HHS Region 9,2 wk ahead,1.9
-2012,15,2011/2012,67,HHS Region 9,3 wk ahead,2.1
-2012,15,2011/2012,67,HHS Region 9,4 wk ahead,2
-2012,15,2011/2012,67,HHS Region 10,Season onset,none
-2012,15,2011/2012,67,HHS Region 10,Season peak week,12
-2012,15,2011/2012,67,HHS Region 10,Season peak percentage,2.2
-2012,15,2011/2012,67,HHS Region 10,1 wk ahead,1.6
-2012,15,2011/2012,67,HHS Region 10,2 wk ahead,1.4
-2012,15,2011/2012,67,HHS Region 10,3 wk ahead,1.4
-2012,15,2011/2012,67,HHS Region 10,4 wk ahead,1.1
+2012,15,2011/2012,67,HHS Region 9,2 wk ahead,2
+2012,15,2011/2012,67,HHS Region 9,3 wk ahead,2.4
+2012,15,2011/2012,67,HHS Region 9,4 wk ahead,2.4
+2012,15,2011/2012,67,HHS Region 10,Season onset,10
+2012,15,2011/2012,67,HHS Region 10,Season peak week,11
+2012,15,2011/2012,67,HHS Region 10,Season peak percentage,2.7
+2012,15,2011/2012,67,HHS Region 10,1 wk ahead,2.1
+2012,15,2011/2012,67,HHS Region 10,2 wk ahead,1.8
+2012,15,2011/2012,67,HHS Region 10,3 wk ahead,2.1
+2012,15,2011/2012,67,HHS Region 10,4 wk ahead,1.9
 2012,16,2011/2012,68,US National,Season onset,none
 2012,16,2011/2012,68,US National,Season peak week,11
 2012,16,2011/2012,68,US National,Season peak percentage,2.4
 2012,16,2011/2012,68,US National,1 wk ahead,1.3
-2012,16,2011/2012,68,US National,2 wk ahead,1.4
-2012,16,2011/2012,68,US National,3 wk ahead,1.3
-2012,16,2011/2012,68,US National,4 wk ahead,1.2
+2012,16,2011/2012,68,US National,2 wk ahead,1.5
+2012,16,2011/2012,68,US National,3 wk ahead,1.4
+2012,16,2011/2012,68,US National,4 wk ahead,1.3
 2012,16,2011/2012,68,HHS Region 1,Season onset,none
 2012,16,2011/2012,68,HHS Region 1,Season peak week,52
+2012,16,2011/2012,68,HHS Region 1,Season peak week,8
 2012,16,2011/2012,68,HHS Region 1,Season peak percentage,1
 2012,16,2011/2012,68,HHS Region 1,1 wk ahead,0.6
 2012,16,2011/2012,68,HHS Region 1,2 wk ahead,0.5
@@ -4868,17 +4869,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,16,2011/2012,68,HHS Region 2,Season onset,none
 2012,16,2011/2012,68,HHS Region 2,Season peak week,49
 2012,16,2011/2012,68,HHS Region 2,Season peak percentage,1.4
-2012,16,2011/2012,68,HHS Region 2,1 wk ahead,0.9
+2012,16,2011/2012,68,HHS Region 2,1 wk ahead,1
 2012,16,2011/2012,68,HHS Region 2,2 wk ahead,1
 2012,16,2011/2012,68,HHS Region 2,3 wk ahead,0.9
 2012,16,2011/2012,68,HHS Region 2,4 wk ahead,0.9
 2012,16,2011/2012,68,HHS Region 3,Season onset,none
 2012,16,2011/2012,68,HHS Region 3,Season peak week,52
 2012,16,2011/2012,68,HHS Region 3,Season peak percentage,2.1
-2012,16,2011/2012,68,HHS Region 3,1 wk ahead,1.1
+2012,16,2011/2012,68,HHS Region 3,1 wk ahead,1
 2012,16,2011/2012,68,HHS Region 3,2 wk ahead,1.3
 2012,16,2011/2012,68,HHS Region 3,3 wk ahead,1.5
-2012,16,2011/2012,68,HHS Region 3,4 wk ahead,1
+2012,16,2011/2012,68,HHS Region 3,4 wk ahead,1.2
 2012,16,2011/2012,68,HHS Region 4,Season onset,none
 2012,16,2011/2012,68,HHS Region 4,Season peak week,52
 2012,16,2011/2012,68,HHS Region 4,Season peak week,10
@@ -4886,28 +4887,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,16,2011/2012,68,HHS Region 4,1 wk ahead,1.3
 2012,16,2011/2012,68,HHS Region 4,2 wk ahead,1.5
 2012,16,2011/2012,68,HHS Region 4,3 wk ahead,1.4
-2012,16,2011/2012,68,HHS Region 4,4 wk ahead,1.4
+2012,16,2011/2012,68,HHS Region 4,4 wk ahead,1.1
 2012,16,2011/2012,68,HHS Region 5,Season onset,7
 2012,16,2011/2012,68,HHS Region 5,Season peak week,11
 2012,16,2011/2012,68,HHS Region 5,Season peak percentage,2.4
 2012,16,2011/2012,68,HHS Region 5,1 wk ahead,0.9
-2012,16,2011/2012,68,HHS Region 5,2 wk ahead,1
+2012,16,2011/2012,68,HHS Region 5,2 wk ahead,1.1
 2012,16,2011/2012,68,HHS Region 5,3 wk ahead,1
 2012,16,2011/2012,68,HHS Region 5,4 wk ahead,0.8
 2012,16,2011/2012,68,HHS Region 6,Season onset,none
 2012,16,2011/2012,68,HHS Region 6,Season peak week,11
-2012,16,2011/2012,68,HHS Region 6,Season peak percentage,4.1
+2012,16,2011/2012,68,HHS Region 6,Season peak percentage,4.2
 2012,16,2011/2012,68,HHS Region 6,1 wk ahead,1.9
 2012,16,2011/2012,68,HHS Region 6,2 wk ahead,1.9
 2012,16,2011/2012,68,HHS Region 6,3 wk ahead,1.9
 2012,16,2011/2012,68,HHS Region 6,4 wk ahead,1.9
 2012,16,2011/2012,68,HHS Region 7,Season onset,5
 2012,16,2011/2012,68,HHS Region 7,Season peak week,9
-2012,16,2011/2012,68,HHS Region 7,Season peak percentage,3.4
+2012,16,2011/2012,68,HHS Region 7,Season peak percentage,3.5
 2012,16,2011/2012,68,HHS Region 7,1 wk ahead,0.7
 2012,16,2011/2012,68,HHS Region 7,2 wk ahead,0.8
-2012,16,2011/2012,68,HHS Region 7,3 wk ahead,0.7
-2012,16,2011/2012,68,HHS Region 7,4 wk ahead,0.5
+2012,16,2011/2012,68,HHS Region 7,3 wk ahead,0.2
+2012,16,2011/2012,68,HHS Region 7,4 wk ahead,0.2
 2012,16,2011/2012,68,HHS Region 8,Season onset,none
 2012,16,2011/2012,68,HHS Region 8,Season peak week,11
 2012,16,2011/2012,68,HHS Region 8,Season peak percentage,2.2
@@ -4917,28 +4918,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,16,2011/2012,68,HHS Region 8,4 wk ahead,0.8
 2012,16,2011/2012,68,HHS Region 9,Season onset,none
 2012,16,2011/2012,68,HHS Region 9,Season peak week,52
-2012,16,2011/2012,68,HHS Region 9,Season peak week,8
 2012,16,2011/2012,68,HHS Region 9,Season peak percentage,3.7
-2012,16,2011/2012,68,HHS Region 9,1 wk ahead,1.9
-2012,16,2011/2012,68,HHS Region 9,2 wk ahead,2.1
-2012,16,2011/2012,68,HHS Region 9,3 wk ahead,2
-2012,16,2011/2012,68,HHS Region 9,4 wk ahead,1.9
-2012,16,2011/2012,68,HHS Region 10,Season onset,none
-2012,16,2011/2012,68,HHS Region 10,Season peak week,12
-2012,16,2011/2012,68,HHS Region 10,Season peak percentage,2.2
-2012,16,2011/2012,68,HHS Region 10,1 wk ahead,1.4
-2012,16,2011/2012,68,HHS Region 10,2 wk ahead,1.4
-2012,16,2011/2012,68,HHS Region 10,3 wk ahead,1.1
-2012,16,2011/2012,68,HHS Region 10,4 wk ahead,0.9
+2012,16,2011/2012,68,HHS Region 9,1 wk ahead,2
+2012,16,2011/2012,68,HHS Region 9,2 wk ahead,2.4
+2012,16,2011/2012,68,HHS Region 9,3 wk ahead,2.4
+2012,16,2011/2012,68,HHS Region 9,4 wk ahead,0.6
+2012,16,2011/2012,68,HHS Region 10,Season onset,10
+2012,16,2011/2012,68,HHS Region 10,Season peak week,11
+2012,16,2011/2012,68,HHS Region 10,Season peak percentage,2.7
+2012,16,2011/2012,68,HHS Region 10,1 wk ahead,1.8
+2012,16,2011/2012,68,HHS Region 10,2 wk ahead,2.1
+2012,16,2011/2012,68,HHS Region 10,3 wk ahead,1.9
+2012,16,2011/2012,68,HHS Region 10,4 wk ahead,1.6
 2012,17,2011/2012,69,US National,Season onset,none
 2012,17,2011/2012,69,US National,Season peak week,11
 2012,17,2011/2012,69,US National,Season peak percentage,2.4
-2012,17,2011/2012,69,US National,1 wk ahead,1.4
-2012,17,2011/2012,69,US National,2 wk ahead,1.3
-2012,17,2011/2012,69,US National,3 wk ahead,1.2
-2012,17,2011/2012,69,US National,4 wk ahead,1.2
+2012,17,2011/2012,69,US National,1 wk ahead,1.5
+2012,17,2011/2012,69,US National,2 wk ahead,1.4
+2012,17,2011/2012,69,US National,3 wk ahead,1.3
+2012,17,2011/2012,69,US National,4 wk ahead,1.3
 2012,17,2011/2012,69,HHS Region 1,Season onset,none
 2012,17,2011/2012,69,HHS Region 1,Season peak week,52
+2012,17,2011/2012,69,HHS Region 1,Season peak week,8
 2012,17,2011/2012,69,HHS Region 1,Season peak percentage,1
 2012,17,2011/2012,69,HHS Region 1,1 wk ahead,0.5
 2012,17,2011/2012,69,HHS Region 1,2 wk ahead,0.6
@@ -4956,7 +4957,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,17,2011/2012,69,HHS Region 3,Season peak percentage,2.1
 2012,17,2011/2012,69,HHS Region 3,1 wk ahead,1.3
 2012,17,2011/2012,69,HHS Region 3,2 wk ahead,1.5
-2012,17,2011/2012,69,HHS Region 3,3 wk ahead,1
+2012,17,2011/2012,69,HHS Region 3,3 wk ahead,1.2
 2012,17,2011/2012,69,HHS Region 3,4 wk ahead,1.1
 2012,17,2011/2012,69,HHS Region 4,Season onset,none
 2012,17,2011/2012,69,HHS Region 4,Season peak week,52
@@ -4964,28 +4965,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,17,2011/2012,69,HHS Region 4,Season peak percentage,2.3
 2012,17,2011/2012,69,HHS Region 4,1 wk ahead,1.5
 2012,17,2011/2012,69,HHS Region 4,2 wk ahead,1.4
-2012,17,2011/2012,69,HHS Region 4,3 wk ahead,1.4
+2012,17,2011/2012,69,HHS Region 4,3 wk ahead,1.1
 2012,17,2011/2012,69,HHS Region 4,4 wk ahead,1.5
 2012,17,2011/2012,69,HHS Region 5,Season onset,7
 2012,17,2011/2012,69,HHS Region 5,Season peak week,11
 2012,17,2011/2012,69,HHS Region 5,Season peak percentage,2.4
-2012,17,2011/2012,69,HHS Region 5,1 wk ahead,1
+2012,17,2011/2012,69,HHS Region 5,1 wk ahead,1.1
 2012,17,2011/2012,69,HHS Region 5,2 wk ahead,1
 2012,17,2011/2012,69,HHS Region 5,3 wk ahead,0.8
 2012,17,2011/2012,69,HHS Region 5,4 wk ahead,0.7
 2012,17,2011/2012,69,HHS Region 6,Season onset,none
 2012,17,2011/2012,69,HHS Region 6,Season peak week,11
-2012,17,2011/2012,69,HHS Region 6,Season peak percentage,4.1
+2012,17,2011/2012,69,HHS Region 6,Season peak percentage,4.2
 2012,17,2011/2012,69,HHS Region 6,1 wk ahead,1.9
 2012,17,2011/2012,69,HHS Region 6,2 wk ahead,1.9
 2012,17,2011/2012,69,HHS Region 6,3 wk ahead,1.9
 2012,17,2011/2012,69,HHS Region 6,4 wk ahead,1.9
 2012,17,2011/2012,69,HHS Region 7,Season onset,5
 2012,17,2011/2012,69,HHS Region 7,Season peak week,9
-2012,17,2011/2012,69,HHS Region 7,Season peak percentage,3.4
+2012,17,2011/2012,69,HHS Region 7,Season peak percentage,3.5
 2012,17,2011/2012,69,HHS Region 7,1 wk ahead,0.8
-2012,17,2011/2012,69,HHS Region 7,2 wk ahead,0.7
-2012,17,2011/2012,69,HHS Region 7,3 wk ahead,0.5
+2012,17,2011/2012,69,HHS Region 7,2 wk ahead,0.2
+2012,17,2011/2012,69,HHS Region 7,3 wk ahead,0.2
 2012,17,2011/2012,69,HHS Region 7,4 wk ahead,0.4
 2012,17,2011/2012,69,HHS Region 8,Season onset,none
 2012,17,2011/2012,69,HHS Region 8,Season peak week,11
@@ -4996,28 +4997,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,17,2011/2012,69,HHS Region 8,4 wk ahead,0.6
 2012,17,2011/2012,69,HHS Region 9,Season onset,none
 2012,17,2011/2012,69,HHS Region 9,Season peak week,52
-2012,17,2011/2012,69,HHS Region 9,Season peak week,8
 2012,17,2011/2012,69,HHS Region 9,Season peak percentage,3.7
-2012,17,2011/2012,69,HHS Region 9,1 wk ahead,2.1
-2012,17,2011/2012,69,HHS Region 9,2 wk ahead,2
-2012,17,2011/2012,69,HHS Region 9,3 wk ahead,1.9
+2012,17,2011/2012,69,HHS Region 9,1 wk ahead,2.4
+2012,17,2011/2012,69,HHS Region 9,2 wk ahead,2.4
+2012,17,2011/2012,69,HHS Region 9,3 wk ahead,0.6
 2012,17,2011/2012,69,HHS Region 9,4 wk ahead,2
-2012,17,2011/2012,69,HHS Region 10,Season onset,none
-2012,17,2011/2012,69,HHS Region 10,Season peak week,12
-2012,17,2011/2012,69,HHS Region 10,Season peak percentage,2.2
-2012,17,2011/2012,69,HHS Region 10,1 wk ahead,1.4
-2012,17,2011/2012,69,HHS Region 10,2 wk ahead,1.1
-2012,17,2011/2012,69,HHS Region 10,3 wk ahead,0.9
+2012,17,2011/2012,69,HHS Region 10,Season onset,10
+2012,17,2011/2012,69,HHS Region 10,Season peak week,11
+2012,17,2011/2012,69,HHS Region 10,Season peak percentage,2.7
+2012,17,2011/2012,69,HHS Region 10,1 wk ahead,2.1
+2012,17,2011/2012,69,HHS Region 10,2 wk ahead,1.9
+2012,17,2011/2012,69,HHS Region 10,3 wk ahead,1.6
 2012,17,2011/2012,69,HHS Region 10,4 wk ahead,0.7
 2012,18,2011/2012,70,US National,Season onset,none
 2012,18,2011/2012,70,US National,Season peak week,11
 2012,18,2011/2012,70,US National,Season peak percentage,2.4
-2012,18,2011/2012,70,US National,1 wk ahead,1.3
-2012,18,2011/2012,70,US National,2 wk ahead,1.2
-2012,18,2011/2012,70,US National,3 wk ahead,1.2
+2012,18,2011/2012,70,US National,1 wk ahead,1.4
+2012,18,2011/2012,70,US National,2 wk ahead,1.3
+2012,18,2011/2012,70,US National,3 wk ahead,1.3
 2012,18,2011/2012,70,US National,4 wk ahead,1.3
 2012,18,2011/2012,70,HHS Region 1,Season onset,none
 2012,18,2011/2012,70,HHS Region 1,Season peak week,52
+2012,18,2011/2012,70,HHS Region 1,Season peak week,8
 2012,18,2011/2012,70,HHS Region 1,Season peak percentage,1
 2012,18,2011/2012,70,HHS Region 1,1 wk ahead,0.6
 2012,18,2011/2012,70,HHS Region 1,2 wk ahead,0.5
@@ -5034,7 +5035,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,18,2011/2012,70,HHS Region 3,Season peak week,52
 2012,18,2011/2012,70,HHS Region 3,Season peak percentage,2.1
 2012,18,2011/2012,70,HHS Region 3,1 wk ahead,1.5
-2012,18,2011/2012,70,HHS Region 3,2 wk ahead,1
+2012,18,2011/2012,70,HHS Region 3,2 wk ahead,1.2
 2012,18,2011/2012,70,HHS Region 3,3 wk ahead,1.1
 2012,18,2011/2012,70,HHS Region 3,4 wk ahead,0.7
 2012,18,2011/2012,70,HHS Region 4,Season onset,none
@@ -5042,7 +5043,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,18,2011/2012,70,HHS Region 4,Season peak week,10
 2012,18,2011/2012,70,HHS Region 4,Season peak percentage,2.3
 2012,18,2011/2012,70,HHS Region 4,1 wk ahead,1.4
-2012,18,2011/2012,70,HHS Region 4,2 wk ahead,1.4
+2012,18,2011/2012,70,HHS Region 4,2 wk ahead,1.1
 2012,18,2011/2012,70,HHS Region 4,3 wk ahead,1.5
 2012,18,2011/2012,70,HHS Region 4,4 wk ahead,1.7
 2012,18,2011/2012,70,HHS Region 5,Season onset,7
@@ -5054,16 +5055,16 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,18,2011/2012,70,HHS Region 5,4 wk ahead,0.8
 2012,18,2011/2012,70,HHS Region 6,Season onset,none
 2012,18,2011/2012,70,HHS Region 6,Season peak week,11
-2012,18,2011/2012,70,HHS Region 6,Season peak percentage,4.1
+2012,18,2011/2012,70,HHS Region 6,Season peak percentage,4.2
 2012,18,2011/2012,70,HHS Region 6,1 wk ahead,1.9
 2012,18,2011/2012,70,HHS Region 6,2 wk ahead,1.9
 2012,18,2011/2012,70,HHS Region 6,3 wk ahead,1.9
 2012,18,2011/2012,70,HHS Region 6,4 wk ahead,2.2
 2012,18,2011/2012,70,HHS Region 7,Season onset,5
 2012,18,2011/2012,70,HHS Region 7,Season peak week,9
-2012,18,2011/2012,70,HHS Region 7,Season peak percentage,3.4
-2012,18,2011/2012,70,HHS Region 7,1 wk ahead,0.7
-2012,18,2011/2012,70,HHS Region 7,2 wk ahead,0.5
+2012,18,2011/2012,70,HHS Region 7,Season peak percentage,3.5
+2012,18,2011/2012,70,HHS Region 7,1 wk ahead,0.2
+2012,18,2011/2012,70,HHS Region 7,2 wk ahead,0.2
 2012,18,2011/2012,70,HHS Region 7,3 wk ahead,0.4
 2012,18,2011/2012,70,HHS Region 7,4 wk ahead,0.3
 2012,18,2011/2012,70,HHS Region 8,Season onset,none
@@ -5075,28 +5076,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,18,2011/2012,70,HHS Region 8,4 wk ahead,0.8
 2012,18,2011/2012,70,HHS Region 9,Season onset,none
 2012,18,2011/2012,70,HHS Region 9,Season peak week,52
-2012,18,2011/2012,70,HHS Region 9,Season peak week,8
 2012,18,2011/2012,70,HHS Region 9,Season peak percentage,3.7
-2012,18,2011/2012,70,HHS Region 9,1 wk ahead,2
-2012,18,2011/2012,70,HHS Region 9,2 wk ahead,1.9
+2012,18,2011/2012,70,HHS Region 9,1 wk ahead,2.4
+2012,18,2011/2012,70,HHS Region 9,2 wk ahead,0.6
 2012,18,2011/2012,70,HHS Region 9,3 wk ahead,2
 2012,18,2011/2012,70,HHS Region 9,4 wk ahead,2
-2012,18,2011/2012,70,HHS Region 10,Season onset,none
-2012,18,2011/2012,70,HHS Region 10,Season peak week,12
-2012,18,2011/2012,70,HHS Region 10,Season peak percentage,2.2
-2012,18,2011/2012,70,HHS Region 10,1 wk ahead,1.1
-2012,18,2011/2012,70,HHS Region 10,2 wk ahead,0.9
+2012,18,2011/2012,70,HHS Region 10,Season onset,10
+2012,18,2011/2012,70,HHS Region 10,Season peak week,11
+2012,18,2011/2012,70,HHS Region 10,Season peak percentage,2.7
+2012,18,2011/2012,70,HHS Region 10,1 wk ahead,1.9
+2012,18,2011/2012,70,HHS Region 10,2 wk ahead,1.6
 2012,18,2011/2012,70,HHS Region 10,3 wk ahead,0.7
 2012,18,2011/2012,70,HHS Region 10,4 wk ahead,0.7
 2012,19,2011/2012,71,US National,Season onset,none
 2012,19,2011/2012,71,US National,Season peak week,11
 2012,19,2011/2012,71,US National,Season peak percentage,2.4
-2012,19,2011/2012,71,US National,1 wk ahead,1.2
-2012,19,2011/2012,71,US National,2 wk ahead,1.2
+2012,19,2011/2012,71,US National,1 wk ahead,1.3
+2012,19,2011/2012,71,US National,2 wk ahead,1.3
 2012,19,2011/2012,71,US National,3 wk ahead,1.3
-2012,19,2011/2012,71,US National,4 wk ahead,1.1
+2012,19,2011/2012,71,US National,4 wk ahead,1.2
 2012,19,2011/2012,71,HHS Region 1,Season onset,none
 2012,19,2011/2012,71,HHS Region 1,Season peak week,52
+2012,19,2011/2012,71,HHS Region 1,Season peak week,8
 2012,19,2011/2012,71,HHS Region 1,Season peak percentage,1
 2012,19,2011/2012,71,HHS Region 1,1 wk ahead,0.5
 2012,19,2011/2012,71,HHS Region 1,2 wk ahead,0.6
@@ -5112,7 +5113,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,19,2011/2012,71,HHS Region 3,Season onset,none
 2012,19,2011/2012,71,HHS Region 3,Season peak week,52
 2012,19,2011/2012,71,HHS Region 3,Season peak percentage,2.1
-2012,19,2011/2012,71,HHS Region 3,1 wk ahead,1
+2012,19,2011/2012,71,HHS Region 3,1 wk ahead,1.2
 2012,19,2011/2012,71,HHS Region 3,2 wk ahead,1.1
 2012,19,2011/2012,71,HHS Region 3,3 wk ahead,0.7
 2012,19,2011/2012,71,HHS Region 3,4 wk ahead,1.3
@@ -5120,7 +5121,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,19,2011/2012,71,HHS Region 4,Season peak week,52
 2012,19,2011/2012,71,HHS Region 4,Season peak week,10
 2012,19,2011/2012,71,HHS Region 4,Season peak percentage,2.3
-2012,19,2011/2012,71,HHS Region 4,1 wk ahead,1.4
+2012,19,2011/2012,71,HHS Region 4,1 wk ahead,1.1
 2012,19,2011/2012,71,HHS Region 4,2 wk ahead,1.5
 2012,19,2011/2012,71,HHS Region 4,3 wk ahead,1.7
 2012,19,2011/2012,71,HHS Region 4,4 wk ahead,1.5
@@ -5133,15 +5134,15 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,19,2011/2012,71,HHS Region 5,4 wk ahead,0.6
 2012,19,2011/2012,71,HHS Region 6,Season onset,none
 2012,19,2011/2012,71,HHS Region 6,Season peak week,11
-2012,19,2011/2012,71,HHS Region 6,Season peak percentage,4.1
+2012,19,2011/2012,71,HHS Region 6,Season peak percentage,4.2
 2012,19,2011/2012,71,HHS Region 6,1 wk ahead,1.9
 2012,19,2011/2012,71,HHS Region 6,2 wk ahead,1.9
 2012,19,2011/2012,71,HHS Region 6,3 wk ahead,2.2
 2012,19,2011/2012,71,HHS Region 6,4 wk ahead,1.5
 2012,19,2011/2012,71,HHS Region 7,Season onset,5
 2012,19,2011/2012,71,HHS Region 7,Season peak week,9
-2012,19,2011/2012,71,HHS Region 7,Season peak percentage,3.4
-2012,19,2011/2012,71,HHS Region 7,1 wk ahead,0.5
+2012,19,2011/2012,71,HHS Region 7,Season peak percentage,3.5
+2012,19,2011/2012,71,HHS Region 7,1 wk ahead,0.2
 2012,19,2011/2012,71,HHS Region 7,2 wk ahead,0.4
 2012,19,2011/2012,71,HHS Region 7,3 wk ahead,0.3
 2012,19,2011/2012,71,HHS Region 7,4 wk ahead,0.1
@@ -5154,28 +5155,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,19,2011/2012,71,HHS Region 8,4 wk ahead,0.7
 2012,19,2011/2012,71,HHS Region 9,Season onset,none
 2012,19,2011/2012,71,HHS Region 9,Season peak week,52
-2012,19,2011/2012,71,HHS Region 9,Season peak week,8
 2012,19,2011/2012,71,HHS Region 9,Season peak percentage,3.7
-2012,19,2011/2012,71,HHS Region 9,1 wk ahead,1.9
+2012,19,2011/2012,71,HHS Region 9,1 wk ahead,0.6
 2012,19,2011/2012,71,HHS Region 9,2 wk ahead,2
 2012,19,2011/2012,71,HHS Region 9,3 wk ahead,2
 2012,19,2011/2012,71,HHS Region 9,4 wk ahead,1.7
-2012,19,2011/2012,71,HHS Region 10,Season onset,none
-2012,19,2011/2012,71,HHS Region 10,Season peak week,12
-2012,19,2011/2012,71,HHS Region 10,Season peak percentage,2.2
-2012,19,2011/2012,71,HHS Region 10,1 wk ahead,0.9
+2012,19,2011/2012,71,HHS Region 10,Season onset,10
+2012,19,2011/2012,71,HHS Region 10,Season peak week,11
+2012,19,2011/2012,71,HHS Region 10,Season peak percentage,2.7
+2012,19,2011/2012,71,HHS Region 10,1 wk ahead,1.6
 2012,19,2011/2012,71,HHS Region 10,2 wk ahead,0.7
 2012,19,2011/2012,71,HHS Region 10,3 wk ahead,0.7
 2012,19,2011/2012,71,HHS Region 10,4 wk ahead,0.6
 2012,20,2011/2012,72,US National,Season onset,none
 2012,20,2011/2012,72,US National,Season peak week,11
 2012,20,2011/2012,72,US National,Season peak percentage,2.4
-2012,20,2011/2012,72,US National,1 wk ahead,1.2
+2012,20,2011/2012,72,US National,1 wk ahead,1.3
 2012,20,2011/2012,72,US National,2 wk ahead,1.3
-2012,20,2011/2012,72,US National,3 wk ahead,1.1
+2012,20,2011/2012,72,US National,3 wk ahead,1.2
 2012,20,2011/2012,72,US National,4 wk ahead,1.1
 2012,20,2011/2012,72,HHS Region 1,Season onset,none
 2012,20,2011/2012,72,HHS Region 1,Season peak week,52
+2012,20,2011/2012,72,HHS Region 1,Season peak week,8
 2012,20,2011/2012,72,HHS Region 1,Season peak percentage,1
 2012,20,2011/2012,72,HHS Region 1,1 wk ahead,0.6
 2012,20,2011/2012,72,HHS Region 1,2 wk ahead,0.6
@@ -5212,14 +5213,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,20,2011/2012,72,HHS Region 5,4 wk ahead,0.5
 2012,20,2011/2012,72,HHS Region 6,Season onset,none
 2012,20,2011/2012,72,HHS Region 6,Season peak week,11
-2012,20,2011/2012,72,HHS Region 6,Season peak percentage,4.1
+2012,20,2011/2012,72,HHS Region 6,Season peak percentage,4.2
 2012,20,2011/2012,72,HHS Region 6,1 wk ahead,1.9
 2012,20,2011/2012,72,HHS Region 6,2 wk ahead,2.2
 2012,20,2011/2012,72,HHS Region 6,3 wk ahead,1.5
 2012,20,2011/2012,72,HHS Region 6,4 wk ahead,1.3
 2012,20,2011/2012,72,HHS Region 7,Season onset,5
 2012,20,2011/2012,72,HHS Region 7,Season peak week,9
-2012,20,2011/2012,72,HHS Region 7,Season peak percentage,3.4
+2012,20,2011/2012,72,HHS Region 7,Season peak percentage,3.5
 2012,20,2011/2012,72,HHS Region 7,1 wk ahead,0.4
 2012,20,2011/2012,72,HHS Region 7,2 wk ahead,0.3
 2012,20,2011/2012,72,HHS Region 7,3 wk ahead,0.1
@@ -5233,15 +5234,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,20,2011/2012,72,HHS Region 8,4 wk ahead,0.6
 2012,20,2011/2012,72,HHS Region 9,Season onset,none
 2012,20,2011/2012,72,HHS Region 9,Season peak week,52
-2012,20,2011/2012,72,HHS Region 9,Season peak week,8
 2012,20,2011/2012,72,HHS Region 9,Season peak percentage,3.7
 2012,20,2011/2012,72,HHS Region 9,1 wk ahead,2
 2012,20,2011/2012,72,HHS Region 9,2 wk ahead,2
 2012,20,2011/2012,72,HHS Region 9,3 wk ahead,1.7
 2012,20,2011/2012,72,HHS Region 9,4 wk ahead,1.6
-2012,20,2011/2012,72,HHS Region 10,Season onset,none
-2012,20,2011/2012,72,HHS Region 10,Season peak week,12
-2012,20,2011/2012,72,HHS Region 10,Season peak percentage,2.2
+2012,20,2011/2012,72,HHS Region 10,Season onset,10
+2012,20,2011/2012,72,HHS Region 10,Season peak week,11
+2012,20,2011/2012,72,HHS Region 10,Season peak percentage,2.7
 2012,20,2011/2012,72,HHS Region 10,1 wk ahead,0.7
 2012,20,2011/2012,72,HHS Region 10,2 wk ahead,0.7
 2012,20,2011/2012,72,HHS Region 10,3 wk ahead,0.6
@@ -5270,7 +5270,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,40,2012/2013,40,HHS Region 3,Season onset,49
 2012,40,2012/2013,40,HHS Region 3,Season peak week,52
 2012,40,2012/2013,40,HHS Region 3,Season peak percentage,7.1
-2012,40,2012/2013,40,HHS Region 3,1 wk ahead,1.1
+2012,40,2012/2013,40,HHS Region 3,1 wk ahead,1.3
 2012,40,2012/2013,40,HHS Region 3,2 wk ahead,1.1
 2012,40,2012/2013,40,HHS Region 3,3 wk ahead,1.1
 2012,40,2012/2013,40,HHS Region 3,4 wk ahead,1.3
@@ -5284,10 +5284,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,40,2012/2013,40,HHS Region 5,Season onset,47
 2012,40,2012/2013,40,HHS Region 5,Season peak week,52
 2012,40,2012/2013,40,HHS Region 5,Season peak percentage,5.7
-2012,40,2012/2013,40,HHS Region 5,1 wk ahead,1
+2012,40,2012/2013,40,HHS Region 5,1 wk ahead,0.9
 2012,40,2012/2013,40,HHS Region 5,2 wk ahead,1
-2012,40,2012/2013,40,HHS Region 5,3 wk ahead,1
-2012,40,2012/2013,40,HHS Region 5,4 wk ahead,1.1
+2012,40,2012/2013,40,HHS Region 5,3 wk ahead,0.9
+2012,40,2012/2013,40,HHS Region 5,4 wk ahead,1
 2012,40,2012/2013,40,HHS Region 6,Season onset,47
 2012,40,2012/2013,40,HHS Region 6,Season peak week,52
 2012,40,2012/2013,40,HHS Region 6,Season peak percentage,9.3
@@ -5297,9 +5297,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,40,2012/2013,40,HHS Region 6,4 wk ahead,2.5
 2012,40,2012/2013,40,HHS Region 7,Season onset,47
 2012,40,2012/2013,40,HHS Region 7,Season peak week,52
-2012,40,2012/2013,40,HHS Region 7,Season peak percentage,6.7
+2012,40,2012/2013,40,HHS Region 7,Season peak percentage,6.8
 2012,40,2012/2013,40,HHS Region 7,1 wk ahead,1.1
-2012,40,2012/2013,40,HHS Region 7,2 wk ahead,1.4
+2012,40,2012/2013,40,HHS Region 7,2 wk ahead,1.3
 2012,40,2012/2013,40,HHS Region 7,3 wk ahead,1.3
 2012,40,2012/2013,40,HHS Region 7,4 wk ahead,1.5
 2012,40,2012/2013,40,HHS Region 8,Season onset,50
@@ -5330,7 +5330,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,41,2012/2013,41,US National,1 wk ahead,1.3
 2012,41,2012/2013,41,US National,2 wk ahead,1.4
 2012,41,2012/2013,41,US National,3 wk ahead,1.5
-2012,41,2012/2013,41,US National,4 wk ahead,1.7
+2012,41,2012/2013,41,US National,4 wk ahead,1.6
 2012,41,2012/2013,41,HHS Region 1,Season onset,49
 2012,41,2012/2013,41,HHS Region 1,Season peak week,52
 2012,41,2012/2013,41,HHS Region 1,Season peak percentage,3.9
@@ -5363,8 +5363,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,41,2012/2013,41,HHS Region 5,Season peak week,52
 2012,41,2012/2013,41,HHS Region 5,Season peak percentage,5.7
 2012,41,2012/2013,41,HHS Region 5,1 wk ahead,1
-2012,41,2012/2013,41,HHS Region 5,2 wk ahead,1
-2012,41,2012/2013,41,HHS Region 5,3 wk ahead,1.1
+2012,41,2012/2013,41,HHS Region 5,2 wk ahead,0.9
+2012,41,2012/2013,41,HHS Region 5,3 wk ahead,1
 2012,41,2012/2013,41,HHS Region 5,4 wk ahead,1.1
 2012,41,2012/2013,41,HHS Region 6,Season onset,47
 2012,41,2012/2013,41,HHS Region 6,Season peak week,52
@@ -5375,8 +5375,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,41,2012/2013,41,HHS Region 6,4 wk ahead,2.9
 2012,41,2012/2013,41,HHS Region 7,Season onset,47
 2012,41,2012/2013,41,HHS Region 7,Season peak week,52
-2012,41,2012/2013,41,HHS Region 7,Season peak percentage,6.7
-2012,41,2012/2013,41,HHS Region 7,1 wk ahead,1.4
+2012,41,2012/2013,41,HHS Region 7,Season peak percentage,6.8
+2012,41,2012/2013,41,HHS Region 7,1 wk ahead,1.3
 2012,41,2012/2013,41,HHS Region 7,2 wk ahead,1.3
 2012,41,2012/2013,41,HHS Region 7,3 wk ahead,1.5
 2012,41,2012/2013,41,HHS Region 7,4 wk ahead,1.6
@@ -5407,7 +5407,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,42,2012/2013,42,US National,Season peak percentage,6.1
 2012,42,2012/2013,42,US National,1 wk ahead,1.4
 2012,42,2012/2013,42,US National,2 wk ahead,1.5
-2012,42,2012/2013,42,US National,3 wk ahead,1.7
+2012,42,2012/2013,42,US National,3 wk ahead,1.6
 2012,42,2012/2013,42,US National,4 wk ahead,1.8
 2012,42,2012/2013,42,HHS Region 1,Season onset,49
 2012,42,2012/2013,42,HHS Region 1,Season peak week,52
@@ -5440,8 +5440,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,42,2012/2013,42,HHS Region 5,Season onset,47
 2012,42,2012/2013,42,HHS Region 5,Season peak week,52
 2012,42,2012/2013,42,HHS Region 5,Season peak percentage,5.7
-2012,42,2012/2013,42,HHS Region 5,1 wk ahead,1
-2012,42,2012/2013,42,HHS Region 5,2 wk ahead,1.1
+2012,42,2012/2013,42,HHS Region 5,1 wk ahead,0.9
+2012,42,2012/2013,42,HHS Region 5,2 wk ahead,1
 2012,42,2012/2013,42,HHS Region 5,3 wk ahead,1.1
 2012,42,2012/2013,42,HHS Region 5,4 wk ahead,1.2
 2012,42,2012/2013,42,HHS Region 6,Season onset,47
@@ -5453,7 +5453,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,42,2012/2013,42,HHS Region 6,4 wk ahead,2.9
 2012,42,2012/2013,42,HHS Region 7,Season onset,47
 2012,42,2012/2013,42,HHS Region 7,Season peak week,52
-2012,42,2012/2013,42,HHS Region 7,Season peak percentage,6.7
+2012,42,2012/2013,42,HHS Region 7,Season peak percentage,6.8
 2012,42,2012/2013,42,HHS Region 7,1 wk ahead,1.3
 2012,42,2012/2013,42,HHS Region 7,2 wk ahead,1.5
 2012,42,2012/2013,42,HHS Region 7,3 wk ahead,1.6
@@ -5484,7 +5484,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,43,2012/2013,43,US National,Season peak week,52
 2012,43,2012/2013,43,US National,Season peak percentage,6.1
 2012,43,2012/2013,43,US National,1 wk ahead,1.5
-2012,43,2012/2013,43,US National,2 wk ahead,1.7
+2012,43,2012/2013,43,US National,2 wk ahead,1.6
 2012,43,2012/2013,43,US National,3 wk ahead,1.8
 2012,43,2012/2013,43,US National,4 wk ahead,2.3
 2012,43,2012/2013,43,HHS Region 1,Season onset,49
@@ -5507,7 +5507,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,43,2012/2013,43,HHS Region 3,1 wk ahead,1.3
 2012,43,2012/2013,43,HHS Region 3,2 wk ahead,1.3
 2012,43,2012/2013,43,HHS Region 3,3 wk ahead,1.3
-2012,43,2012/2013,43,HHS Region 3,4 wk ahead,1.7
+2012,43,2012/2013,43,HHS Region 3,4 wk ahead,1.8
 2012,43,2012/2013,43,HHS Region 4,Season onset,47
 2012,43,2012/2013,43,HHS Region 4,Season peak week,52
 2012,43,2012/2013,43,HHS Region 4,Season peak percentage,6.3
@@ -5518,7 +5518,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,43,2012/2013,43,HHS Region 5,Season onset,47
 2012,43,2012/2013,43,HHS Region 5,Season peak week,52
 2012,43,2012/2013,43,HHS Region 5,Season peak percentage,5.7
-2012,43,2012/2013,43,HHS Region 5,1 wk ahead,1.1
+2012,43,2012/2013,43,HHS Region 5,1 wk ahead,1
 2012,43,2012/2013,43,HHS Region 5,2 wk ahead,1.1
 2012,43,2012/2013,43,HHS Region 5,3 wk ahead,1.2
 2012,43,2012/2013,43,HHS Region 5,4 wk ahead,1.6
@@ -5531,7 +5531,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,43,2012/2013,43,HHS Region 6,4 wk ahead,4.4
 2012,43,2012/2013,43,HHS Region 7,Season onset,47
 2012,43,2012/2013,43,HHS Region 7,Season peak week,52
-2012,43,2012/2013,43,HHS Region 7,Season peak percentage,6.7
+2012,43,2012/2013,43,HHS Region 7,Season peak percentage,6.8
 2012,43,2012/2013,43,HHS Region 7,1 wk ahead,1.5
 2012,43,2012/2013,43,HHS Region 7,2 wk ahead,1.6
 2012,43,2012/2013,43,HHS Region 7,3 wk ahead,2
@@ -5550,7 +5550,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,43,2012/2013,43,HHS Region 9,1 wk ahead,2.1
 2012,43,2012/2013,43,HHS Region 9,2 wk ahead,2.2
 2012,43,2012/2013,43,HHS Region 9,3 wk ahead,2.2
-2012,43,2012/2013,43,HHS Region 9,4 wk ahead,2.4
+2012,43,2012/2013,43,HHS Region 9,4 wk ahead,2.3
 2012,43,2012/2013,43,HHS Region 10,Season onset,50
 2012,43,2012/2013,43,HHS Region 10,Season peak week,4
 2012,43,2012/2013,43,HHS Region 10,Season peak percentage,3.7
@@ -5561,7 +5561,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,44,2012/2013,44,US National,Season onset,47
 2012,44,2012/2013,44,US National,Season peak week,52
 2012,44,2012/2013,44,US National,Season peak percentage,6.1
-2012,44,2012/2013,44,US National,1 wk ahead,1.7
+2012,44,2012/2013,44,US National,1 wk ahead,1.6
 2012,44,2012/2013,44,US National,2 wk ahead,1.8
 2012,44,2012/2013,44,US National,3 wk ahead,2.3
 2012,44,2012/2013,44,US National,4 wk ahead,2.2
@@ -5584,7 +5584,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,44,2012/2013,44,HHS Region 3,Season peak percentage,7.1
 2012,44,2012/2013,44,HHS Region 3,1 wk ahead,1.3
 2012,44,2012/2013,44,HHS Region 3,2 wk ahead,1.3
-2012,44,2012/2013,44,HHS Region 3,3 wk ahead,1.7
+2012,44,2012/2013,44,HHS Region 3,3 wk ahead,1.8
 2012,44,2012/2013,44,HHS Region 3,4 wk ahead,1.6
 2012,44,2012/2013,44,HHS Region 4,Season onset,47
 2012,44,2012/2013,44,HHS Region 4,Season peak week,52
@@ -5609,7 +5609,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,44,2012/2013,44,HHS Region 6,4 wk ahead,3.7
 2012,44,2012/2013,44,HHS Region 7,Season onset,47
 2012,44,2012/2013,44,HHS Region 7,Season peak week,52
-2012,44,2012/2013,44,HHS Region 7,Season peak percentage,6.7
+2012,44,2012/2013,44,HHS Region 7,Season peak percentage,6.8
 2012,44,2012/2013,44,HHS Region 7,1 wk ahead,1.6
 2012,44,2012/2013,44,HHS Region 7,2 wk ahead,2
 2012,44,2012/2013,44,HHS Region 7,3 wk ahead,2.3
@@ -5627,8 +5627,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,44,2012/2013,44,HHS Region 9,Season peak percentage,5.6
 2012,44,2012/2013,44,HHS Region 9,1 wk ahead,2.2
 2012,44,2012/2013,44,HHS Region 9,2 wk ahead,2.2
-2012,44,2012/2013,44,HHS Region 9,3 wk ahead,2.4
-2012,44,2012/2013,44,HHS Region 9,4 wk ahead,2.2
+2012,44,2012/2013,44,HHS Region 9,3 wk ahead,2.3
+2012,44,2012/2013,44,HHS Region 9,4 wk ahead,2.1
 2012,44,2012/2013,44,HHS Region 10,Season onset,50
 2012,44,2012/2013,44,HHS Region 10,Season peak week,4
 2012,44,2012/2013,44,HHS Region 10,Season peak percentage,3.7
@@ -5661,7 +5661,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,45,2012/2013,45,HHS Region 3,Season peak week,52
 2012,45,2012/2013,45,HHS Region 3,Season peak percentage,7.1
 2012,45,2012/2013,45,HHS Region 3,1 wk ahead,1.3
-2012,45,2012/2013,45,HHS Region 3,2 wk ahead,1.7
+2012,45,2012/2013,45,HHS Region 3,2 wk ahead,1.8
 2012,45,2012/2013,45,HHS Region 3,3 wk ahead,1.6
 2012,45,2012/2013,45,HHS Region 3,4 wk ahead,2.5
 2012,45,2012/2013,45,HHS Region 4,Season onset,47
@@ -5684,10 +5684,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,45,2012/2013,45,HHS Region 6,1 wk ahead,2.9
 2012,45,2012/2013,45,HHS Region 6,2 wk ahead,4.4
 2012,45,2012/2013,45,HHS Region 6,3 wk ahead,3.7
-2012,45,2012/2013,45,HHS Region 6,4 wk ahead,4.6
+2012,45,2012/2013,45,HHS Region 6,4 wk ahead,4.7
 2012,45,2012/2013,45,HHS Region 7,Season onset,47
 2012,45,2012/2013,45,HHS Region 7,Season peak week,52
-2012,45,2012/2013,45,HHS Region 7,Season peak percentage,6.7
+2012,45,2012/2013,45,HHS Region 7,Season peak percentage,6.8
 2012,45,2012/2013,45,HHS Region 7,1 wk ahead,2
 2012,45,2012/2013,45,HHS Region 7,2 wk ahead,2.3
 2012,45,2012/2013,45,HHS Region 7,3 wk ahead,2.2
@@ -5704,9 +5704,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,45,2012/2013,45,HHS Region 9,Season peak week,4
 2012,45,2012/2013,45,HHS Region 9,Season peak percentage,5.6
 2012,45,2012/2013,45,HHS Region 9,1 wk ahead,2.2
-2012,45,2012/2013,45,HHS Region 9,2 wk ahead,2.4
-2012,45,2012/2013,45,HHS Region 9,3 wk ahead,2.2
-2012,45,2012/2013,45,HHS Region 9,4 wk ahead,2.2
+2012,45,2012/2013,45,HHS Region 9,2 wk ahead,2.3
+2012,45,2012/2013,45,HHS Region 9,3 wk ahead,2.1
+2012,45,2012/2013,45,HHS Region 9,4 wk ahead,2.1
 2012,45,2012/2013,45,HHS Region 10,Season onset,50
 2012,45,2012/2013,45,HHS Region 10,Season peak week,4
 2012,45,2012/2013,45,HHS Region 10,Season peak percentage,3.7
@@ -5738,7 +5738,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,46,2012/2013,46,HHS Region 3,Season onset,49
 2012,46,2012/2013,46,HHS Region 3,Season peak week,52
 2012,46,2012/2013,46,HHS Region 3,Season peak percentage,7.1
-2012,46,2012/2013,46,HHS Region 3,1 wk ahead,1.7
+2012,46,2012/2013,46,HHS Region 3,1 wk ahead,1.8
 2012,46,2012/2013,46,HHS Region 3,2 wk ahead,1.6
 2012,46,2012/2013,46,HHS Region 3,3 wk ahead,2.5
 2012,46,2012/2013,46,HHS Region 3,4 wk ahead,3.4
@@ -5748,7 +5748,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,46,2012/2013,46,HHS Region 4,1 wk ahead,2.8
 2012,46,2012/2013,46,HHS Region 4,2 wk ahead,2.7
 2012,46,2012/2013,46,HHS Region 4,3 wk ahead,4.2
-2012,46,2012/2013,46,HHS Region 4,4 wk ahead,4.7
+2012,46,2012/2013,46,HHS Region 4,4 wk ahead,4.6
 2012,46,2012/2013,46,HHS Region 5,Season onset,47
 2012,46,2012/2013,46,HHS Region 5,Season peak week,52
 2012,46,2012/2013,46,HHS Region 5,Season peak percentage,5.7
@@ -5761,11 +5761,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,46,2012/2013,46,HHS Region 6,Season peak percentage,9.3
 2012,46,2012/2013,46,HHS Region 6,1 wk ahead,4.4
 2012,46,2012/2013,46,HHS Region 6,2 wk ahead,3.7
-2012,46,2012/2013,46,HHS Region 6,3 wk ahead,4.6
+2012,46,2012/2013,46,HHS Region 6,3 wk ahead,4.7
 2012,46,2012/2013,46,HHS Region 6,4 wk ahead,5.6
 2012,46,2012/2013,46,HHS Region 7,Season onset,47
 2012,46,2012/2013,46,HHS Region 7,Season peak week,52
-2012,46,2012/2013,46,HHS Region 7,Season peak percentage,6.7
+2012,46,2012/2013,46,HHS Region 7,Season peak percentage,6.8
 2012,46,2012/2013,46,HHS Region 7,1 wk ahead,2.3
 2012,46,2012/2013,46,HHS Region 7,2 wk ahead,2.2
 2012,46,2012/2013,46,HHS Region 7,3 wk ahead,2.3
@@ -5781,10 +5781,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,46,2012/2013,46,HHS Region 9,Season onset,2
 2012,46,2012/2013,46,HHS Region 9,Season peak week,4
 2012,46,2012/2013,46,HHS Region 9,Season peak percentage,5.6
-2012,46,2012/2013,46,HHS Region 9,1 wk ahead,2.4
-2012,46,2012/2013,46,HHS Region 9,2 wk ahead,2.2
-2012,46,2012/2013,46,HHS Region 9,3 wk ahead,2.2
-2012,46,2012/2013,46,HHS Region 9,4 wk ahead,2.5
+2012,46,2012/2013,46,HHS Region 9,1 wk ahead,2.3
+2012,46,2012/2013,46,HHS Region 9,2 wk ahead,2.1
+2012,46,2012/2013,46,HHS Region 9,3 wk ahead,2.1
+2012,46,2012/2013,46,HHS Region 9,4 wk ahead,2.4
 2012,46,2012/2013,46,HHS Region 10,Season onset,50
 2012,46,2012/2013,46,HHS Region 10,Season peak week,4
 2012,46,2012/2013,46,HHS Region 10,Season peak percentage,3.7
@@ -5825,7 +5825,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,47,2012/2013,47,HHS Region 4,Season peak percentage,6.3
 2012,47,2012/2013,47,HHS Region 4,1 wk ahead,2.7
 2012,47,2012/2013,47,HHS Region 4,2 wk ahead,4.2
-2012,47,2012/2013,47,HHS Region 4,3 wk ahead,4.7
+2012,47,2012/2013,47,HHS Region 4,3 wk ahead,4.6
 2012,47,2012/2013,47,HHS Region 4,4 wk ahead,5
 2012,47,2012/2013,47,HHS Region 5,Season onset,47
 2012,47,2012/2013,47,HHS Region 5,Season peak week,52
@@ -5838,16 +5838,16 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,47,2012/2013,47,HHS Region 6,Season peak week,52
 2012,47,2012/2013,47,HHS Region 6,Season peak percentage,9.3
 2012,47,2012/2013,47,HHS Region 6,1 wk ahead,3.7
-2012,47,2012/2013,47,HHS Region 6,2 wk ahead,4.6
+2012,47,2012/2013,47,HHS Region 6,2 wk ahead,4.7
 2012,47,2012/2013,47,HHS Region 6,3 wk ahead,5.6
 2012,47,2012/2013,47,HHS Region 6,4 wk ahead,7.2
 2012,47,2012/2013,47,HHS Region 7,Season onset,47
 2012,47,2012/2013,47,HHS Region 7,Season peak week,52
-2012,47,2012/2013,47,HHS Region 7,Season peak percentage,6.7
+2012,47,2012/2013,47,HHS Region 7,Season peak percentage,6.8
 2012,47,2012/2013,47,HHS Region 7,1 wk ahead,2.2
 2012,47,2012/2013,47,HHS Region 7,2 wk ahead,2.3
 2012,47,2012/2013,47,HHS Region 7,3 wk ahead,2.8
-2012,47,2012/2013,47,HHS Region 7,4 wk ahead,4.1
+2012,47,2012/2013,47,HHS Region 7,4 wk ahead,4
 2012,47,2012/2013,47,HHS Region 8,Season onset,50
 2012,47,2012/2013,47,HHS Region 8,Season peak week,52
 2012,47,2012/2013,47,HHS Region 8,Season peak week,3
@@ -5859,10 +5859,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,47,2012/2013,47,HHS Region 9,Season onset,2
 2012,47,2012/2013,47,HHS Region 9,Season peak week,4
 2012,47,2012/2013,47,HHS Region 9,Season peak percentage,5.6
-2012,47,2012/2013,47,HHS Region 9,1 wk ahead,2.2
-2012,47,2012/2013,47,HHS Region 9,2 wk ahead,2.2
-2012,47,2012/2013,47,HHS Region 9,3 wk ahead,2.5
-2012,47,2012/2013,47,HHS Region 9,4 wk ahead,3.1
+2012,47,2012/2013,47,HHS Region 9,1 wk ahead,2.1
+2012,47,2012/2013,47,HHS Region 9,2 wk ahead,2.1
+2012,47,2012/2013,47,HHS Region 9,3 wk ahead,2.4
+2012,47,2012/2013,47,HHS Region 9,4 wk ahead,3
 2012,47,2012/2013,47,HHS Region 10,Season onset,50
 2012,47,2012/2013,47,HHS Region 10,Season peak week,4
 2012,47,2012/2013,47,HHS Region 10,Season peak percentage,3.7
@@ -5902,7 +5902,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,48,2012/2013,48,HHS Region 4,Season peak week,52
 2012,48,2012/2013,48,HHS Region 4,Season peak percentage,6.3
 2012,48,2012/2013,48,HHS Region 4,1 wk ahead,4.2
-2012,48,2012/2013,48,HHS Region 4,2 wk ahead,4.7
+2012,48,2012/2013,48,HHS Region 4,2 wk ahead,4.6
 2012,48,2012/2013,48,HHS Region 4,3 wk ahead,5
 2012,48,2012/2013,48,HHS Region 4,4 wk ahead,6.3
 2012,48,2012/2013,48,HHS Region 5,Season onset,47
@@ -5915,17 +5915,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,48,2012/2013,48,HHS Region 6,Season onset,47
 2012,48,2012/2013,48,HHS Region 6,Season peak week,52
 2012,48,2012/2013,48,HHS Region 6,Season peak percentage,9.3
-2012,48,2012/2013,48,HHS Region 6,1 wk ahead,4.6
+2012,48,2012/2013,48,HHS Region 6,1 wk ahead,4.7
 2012,48,2012/2013,48,HHS Region 6,2 wk ahead,5.6
 2012,48,2012/2013,48,HHS Region 6,3 wk ahead,7.2
 2012,48,2012/2013,48,HHS Region 6,4 wk ahead,9.3
 2012,48,2012/2013,48,HHS Region 7,Season onset,47
 2012,48,2012/2013,48,HHS Region 7,Season peak week,52
-2012,48,2012/2013,48,HHS Region 7,Season peak percentage,6.7
+2012,48,2012/2013,48,HHS Region 7,Season peak percentage,6.8
 2012,48,2012/2013,48,HHS Region 7,1 wk ahead,2.3
 2012,48,2012/2013,48,HHS Region 7,2 wk ahead,2.8
-2012,48,2012/2013,48,HHS Region 7,3 wk ahead,4.1
-2012,48,2012/2013,48,HHS Region 7,4 wk ahead,6.7
+2012,48,2012/2013,48,HHS Region 7,3 wk ahead,4
+2012,48,2012/2013,48,HHS Region 7,4 wk ahead,6.8
 2012,48,2012/2013,48,HHS Region 8,Season onset,50
 2012,48,2012/2013,48,HHS Region 8,Season peak week,52
 2012,48,2012/2013,48,HHS Region 8,Season peak week,3
@@ -5937,9 +5937,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,48,2012/2013,48,HHS Region 9,Season onset,2
 2012,48,2012/2013,48,HHS Region 9,Season peak week,4
 2012,48,2012/2013,48,HHS Region 9,Season peak percentage,5.6
-2012,48,2012/2013,48,HHS Region 9,1 wk ahead,2.2
-2012,48,2012/2013,48,HHS Region 9,2 wk ahead,2.5
-2012,48,2012/2013,48,HHS Region 9,3 wk ahead,3.1
+2012,48,2012/2013,48,HHS Region 9,1 wk ahead,2.1
+2012,48,2012/2013,48,HHS Region 9,2 wk ahead,2.4
+2012,48,2012/2013,48,HHS Region 9,3 wk ahead,3
 2012,48,2012/2013,48,HHS Region 9,4 wk ahead,4.8
 2012,48,2012/2013,48,HHS Region 10,Season onset,50
 2012,48,2012/2013,48,HHS Region 10,Season peak week,4
@@ -5954,7 +5954,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,49,2012/2013,49,US National,1 wk ahead,3.4
 2012,49,2012/2013,49,US National,2 wk ahead,4.3
 2012,49,2012/2013,49,US National,3 wk ahead,6.1
-2012,49,2012/2013,49,US National,4 wk ahead,4.6
+2012,49,2012/2013,49,US National,4 wk ahead,4.7
 2012,49,2012/2013,49,HHS Region 1,Season onset,49
 2012,49,2012/2013,49,HHS Region 1,Season peak week,52
 2012,49,2012/2013,49,HHS Region 1,Season peak percentage,3.9
@@ -5979,10 +5979,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,49,2012/2013,49,HHS Region 4,Season onset,47
 2012,49,2012/2013,49,HHS Region 4,Season peak week,52
 2012,49,2012/2013,49,HHS Region 4,Season peak percentage,6.3
-2012,49,2012/2013,49,HHS Region 4,1 wk ahead,4.7
+2012,49,2012/2013,49,HHS Region 4,1 wk ahead,4.6
 2012,49,2012/2013,49,HHS Region 4,2 wk ahead,5
 2012,49,2012/2013,49,HHS Region 4,3 wk ahead,6.3
-2012,49,2012/2013,49,HHS Region 4,4 wk ahead,4.4
+2012,49,2012/2013,49,HHS Region 4,4 wk ahead,4.5
 2012,49,2012/2013,49,HHS Region 5,Season onset,47
 2012,49,2012/2013,49,HHS Region 5,Season peak week,52
 2012,49,2012/2013,49,HHS Region 5,Season peak percentage,5.7
@@ -5999,10 +5999,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,49,2012/2013,49,HHS Region 6,4 wk ahead,7.7
 2012,49,2012/2013,49,HHS Region 7,Season onset,47
 2012,49,2012/2013,49,HHS Region 7,Season peak week,52
-2012,49,2012/2013,49,HHS Region 7,Season peak percentage,6.7
+2012,49,2012/2013,49,HHS Region 7,Season peak percentage,6.8
 2012,49,2012/2013,49,HHS Region 7,1 wk ahead,2.8
-2012,49,2012/2013,49,HHS Region 7,2 wk ahead,4.1
-2012,49,2012/2013,49,HHS Region 7,3 wk ahead,6.7
+2012,49,2012/2013,49,HHS Region 7,2 wk ahead,4
+2012,49,2012/2013,49,HHS Region 7,3 wk ahead,6.8
 2012,49,2012/2013,49,HHS Region 7,4 wk ahead,5.8
 2012,49,2012/2013,49,HHS Region 8,Season onset,50
 2012,49,2012/2013,49,HHS Region 8,Season peak week,52
@@ -6015,8 +6015,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,49,2012/2013,49,HHS Region 9,Season onset,2
 2012,49,2012/2013,49,HHS Region 9,Season peak week,4
 2012,49,2012/2013,49,HHS Region 9,Season peak percentage,5.6
-2012,49,2012/2013,49,HHS Region 9,1 wk ahead,2.5
-2012,49,2012/2013,49,HHS Region 9,2 wk ahead,3.1
+2012,49,2012/2013,49,HHS Region 9,1 wk ahead,2.4
+2012,49,2012/2013,49,HHS Region 9,2 wk ahead,3
 2012,49,2012/2013,49,HHS Region 9,3 wk ahead,4.8
 2012,49,2012/2013,49,HHS Region 9,4 wk ahead,3.4
 2012,49,2012/2013,49,HHS Region 10,Season onset,50
@@ -6031,7 +6031,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,50,2012/2013,50,US National,Season peak percentage,6.1
 2012,50,2012/2013,50,US National,1 wk ahead,4.3
 2012,50,2012/2013,50,US National,2 wk ahead,6.1
-2012,50,2012/2013,50,US National,3 wk ahead,4.6
+2012,50,2012/2013,50,US National,3 wk ahead,4.7
 2012,50,2012/2013,50,US National,4 wk ahead,4.3
 2012,50,2012/2013,50,HHS Region 1,Season onset,49
 2012,50,2012/2013,50,HHS Region 1,Season peak week,52
@@ -6059,7 +6059,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,50,2012/2013,50,HHS Region 4,Season peak percentage,6.3
 2012,50,2012/2013,50,HHS Region 4,1 wk ahead,5
 2012,50,2012/2013,50,HHS Region 4,2 wk ahead,6.3
-2012,50,2012/2013,50,HHS Region 4,3 wk ahead,4.4
+2012,50,2012/2013,50,HHS Region 4,3 wk ahead,4.5
 2012,50,2012/2013,50,HHS Region 4,4 wk ahead,3.5
 2012,50,2012/2013,50,HHS Region 5,Season onset,47
 2012,50,2012/2013,50,HHS Region 5,Season peak week,52
@@ -6077,9 +6077,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,50,2012/2013,50,HHS Region 6,4 wk ahead,7.3
 2012,50,2012/2013,50,HHS Region 7,Season onset,47
 2012,50,2012/2013,50,HHS Region 7,Season peak week,52
-2012,50,2012/2013,50,HHS Region 7,Season peak percentage,6.7
-2012,50,2012/2013,50,HHS Region 7,1 wk ahead,4.1
-2012,50,2012/2013,50,HHS Region 7,2 wk ahead,6.7
+2012,50,2012/2013,50,HHS Region 7,Season peak percentage,6.8
+2012,50,2012/2013,50,HHS Region 7,1 wk ahead,4
+2012,50,2012/2013,50,HHS Region 7,2 wk ahead,6.8
 2012,50,2012/2013,50,HHS Region 7,3 wk ahead,5.8
 2012,50,2012/2013,50,HHS Region 7,4 wk ahead,5.1
 2012,50,2012/2013,50,HHS Region 8,Season onset,50
@@ -6093,7 +6093,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,50,2012/2013,50,HHS Region 9,Season onset,2
 2012,50,2012/2013,50,HHS Region 9,Season peak week,4
 2012,50,2012/2013,50,HHS Region 9,Season peak percentage,5.6
-2012,50,2012/2013,50,HHS Region 9,1 wk ahead,3.1
+2012,50,2012/2013,50,HHS Region 9,1 wk ahead,3
 2012,50,2012/2013,50,HHS Region 9,2 wk ahead,4.8
 2012,50,2012/2013,50,HHS Region 9,3 wk ahead,3.4
 2012,50,2012/2013,50,HHS Region 9,4 wk ahead,3.5
@@ -6108,7 +6108,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,51,2012/2013,51,US National,Season peak week,52
 2012,51,2012/2013,51,US National,Season peak percentage,6.1
 2012,51,2012/2013,51,US National,1 wk ahead,6.1
-2012,51,2012/2013,51,US National,2 wk ahead,4.6
+2012,51,2012/2013,51,US National,2 wk ahead,4.7
 2012,51,2012/2013,51,US National,3 wk ahead,4.3
 2012,51,2012/2013,51,US National,4 wk ahead,4.5
 2012,51,2012/2013,51,HHS Region 1,Season onset,49
@@ -6136,7 +6136,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,51,2012/2013,51,HHS Region 4,Season peak week,52
 2012,51,2012/2013,51,HHS Region 4,Season peak percentage,6.3
 2012,51,2012/2013,51,HHS Region 4,1 wk ahead,6.3
-2012,51,2012/2013,51,HHS Region 4,2 wk ahead,4.4
+2012,51,2012/2013,51,HHS Region 4,2 wk ahead,4.5
 2012,51,2012/2013,51,HHS Region 4,3 wk ahead,3.5
 2012,51,2012/2013,51,HHS Region 4,4 wk ahead,3.1
 2012,51,2012/2013,51,HHS Region 5,Season onset,47
@@ -6155,8 +6155,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,51,2012/2013,51,HHS Region 6,4 wk ahead,7.4
 2012,51,2012/2013,51,HHS Region 7,Season onset,47
 2012,51,2012/2013,51,HHS Region 7,Season peak week,52
-2012,51,2012/2013,51,HHS Region 7,Season peak percentage,6.7
-2012,51,2012/2013,51,HHS Region 7,1 wk ahead,6.7
+2012,51,2012/2013,51,HHS Region 7,Season peak percentage,6.8
+2012,51,2012/2013,51,HHS Region 7,1 wk ahead,6.8
 2012,51,2012/2013,51,HHS Region 7,2 wk ahead,5.8
 2012,51,2012/2013,51,HHS Region 7,3 wk ahead,5.1
 2012,51,2012/2013,51,HHS Region 7,4 wk ahead,5.2
@@ -6185,7 +6185,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,52,2012/2013,52,US National,Season onset,47
 2012,52,2012/2013,52,US National,Season peak week,52
 2012,52,2012/2013,52,US National,Season peak percentage,6.1
-2012,52,2012/2013,52,US National,1 wk ahead,4.6
+2012,52,2012/2013,52,US National,1 wk ahead,4.7
 2012,52,2012/2013,52,US National,2 wk ahead,4.3
 2012,52,2012/2013,52,US National,3 wk ahead,4.5
 2012,52,2012/2013,52,US National,4 wk ahead,4.2
@@ -6213,7 +6213,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,52,2012/2013,52,HHS Region 4,Season onset,47
 2012,52,2012/2013,52,HHS Region 4,Season peak week,52
 2012,52,2012/2013,52,HHS Region 4,Season peak percentage,6.3
-2012,52,2012/2013,52,HHS Region 4,1 wk ahead,4.4
+2012,52,2012/2013,52,HHS Region 4,1 wk ahead,4.5
 2012,52,2012/2013,52,HHS Region 4,2 wk ahead,3.5
 2012,52,2012/2013,52,HHS Region 4,3 wk ahead,3.1
 2012,52,2012/2013,52,HHS Region 4,4 wk ahead,2.5
@@ -6233,7 +6233,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,52,2012/2013,52,HHS Region 6,4 wk ahead,7.1
 2012,52,2012/2013,52,HHS Region 7,Season onset,47
 2012,52,2012/2013,52,HHS Region 7,Season peak week,52
-2012,52,2012/2013,52,HHS Region 7,Season peak percentage,6.7
+2012,52,2012/2013,52,HHS Region 7,Season peak percentage,6.8
 2012,52,2012/2013,52,HHS Region 7,1 wk ahead,5.8
 2012,52,2012/2013,52,HHS Region 7,2 wk ahead,5.1
 2012,52,2012/2013,52,HHS Region 7,3 wk ahead,5.2
@@ -6311,11 +6311,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,1,2012/2013,53,HHS Region 6,4 wk ahead,5.8
 2013,1,2012/2013,53,HHS Region 7,Season onset,47
 2013,1,2012/2013,53,HHS Region 7,Season peak week,52
-2013,1,2012/2013,53,HHS Region 7,Season peak percentage,6.7
+2013,1,2012/2013,53,HHS Region 7,Season peak percentage,6.8
 2013,1,2012/2013,53,HHS Region 7,1 wk ahead,5.1
 2013,1,2012/2013,53,HHS Region 7,2 wk ahead,5.2
 2013,1,2012/2013,53,HHS Region 7,3 wk ahead,5.3
-2013,1,2012/2013,53,HHS Region 7,4 wk ahead,5.2
+2013,1,2012/2013,53,HHS Region 7,4 wk ahead,5.1
 2013,1,2012/2013,53,HHS Region 8,Season onset,50
 2013,1,2012/2013,53,HHS Region 8,Season peak week,52
 2013,1,2012/2013,53,HHS Region 8,Season peak week,3
@@ -6389,10 +6389,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,2,2012/2013,54,HHS Region 6,4 wk ahead,4.5
 2013,2,2012/2013,54,HHS Region 7,Season onset,47
 2013,2,2012/2013,54,HHS Region 7,Season peak week,52
-2013,2,2012/2013,54,HHS Region 7,Season peak percentage,6.7
+2013,2,2012/2013,54,HHS Region 7,Season peak percentage,6.8
 2013,2,2012/2013,54,HHS Region 7,1 wk ahead,5.2
 2013,2,2012/2013,54,HHS Region 7,2 wk ahead,5.3
-2013,2,2012/2013,54,HHS Region 7,3 wk ahead,5.2
+2013,2,2012/2013,54,HHS Region 7,3 wk ahead,5.1
 2013,2,2012/2013,54,HHS Region 7,4 wk ahead,4.3
 2013,2,2012/2013,54,HHS Region 8,Season onset,50
 2013,2,2012/2013,54,HHS Region 8,Season peak week,52
@@ -6408,7 +6408,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,2,2012/2013,54,HHS Region 9,1 wk ahead,4.7
 2013,2,2012/2013,54,HHS Region 9,2 wk ahead,5.6
 2013,2,2012/2013,54,HHS Region 9,3 wk ahead,5.5
-2013,2,2012/2013,54,HHS Region 9,4 wk ahead,5
+2013,2,2012/2013,54,HHS Region 9,4 wk ahead,4.8
 2013,2,2012/2013,54,HHS Region 10,Season onset,50
 2013,2,2012/2013,54,HHS Region 10,Season peak week,4
 2013,2,2012/2013,54,HHS Region 10,Season peak percentage,3.7
@@ -6467,9 +6467,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,3,2012/2013,55,HHS Region 6,4 wk ahead,3.9
 2013,3,2012/2013,55,HHS Region 7,Season onset,47
 2013,3,2012/2013,55,HHS Region 7,Season peak week,52
-2013,3,2012/2013,55,HHS Region 7,Season peak percentage,6.7
+2013,3,2012/2013,55,HHS Region 7,Season peak percentage,6.8
 2013,3,2012/2013,55,HHS Region 7,1 wk ahead,5.3
-2013,3,2012/2013,55,HHS Region 7,2 wk ahead,5.2
+2013,3,2012/2013,55,HHS Region 7,2 wk ahead,5.1
 2013,3,2012/2013,55,HHS Region 7,3 wk ahead,4.3
 2013,3,2012/2013,55,HHS Region 7,4 wk ahead,3.4
 2013,3,2012/2013,55,HHS Region 8,Season onset,50
@@ -6485,7 +6485,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,3,2012/2013,55,HHS Region 9,Season peak percentage,5.6
 2013,3,2012/2013,55,HHS Region 9,1 wk ahead,5.6
 2013,3,2012/2013,55,HHS Region 9,2 wk ahead,5.5
-2013,3,2012/2013,55,HHS Region 9,3 wk ahead,5
+2013,3,2012/2013,55,HHS Region 9,3 wk ahead,4.8
 2013,3,2012/2013,55,HHS Region 9,4 wk ahead,4.5
 2013,3,2012/2013,55,HHS Region 10,Season onset,50
 2013,3,2012/2013,55,HHS Region 10,Season peak week,4
@@ -6545,8 +6545,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,4,2012/2013,56,HHS Region 6,4 wk ahead,3.3
 2013,4,2012/2013,56,HHS Region 7,Season onset,47
 2013,4,2012/2013,56,HHS Region 7,Season peak week,52
-2013,4,2012/2013,56,HHS Region 7,Season peak percentage,6.7
-2013,4,2012/2013,56,HHS Region 7,1 wk ahead,5.2
+2013,4,2012/2013,56,HHS Region 7,Season peak percentage,6.8
+2013,4,2012/2013,56,HHS Region 7,1 wk ahead,5.1
 2013,4,2012/2013,56,HHS Region 7,2 wk ahead,4.3
 2013,4,2012/2013,56,HHS Region 7,3 wk ahead,3.4
 2013,4,2012/2013,56,HHS Region 7,4 wk ahead,3.1
@@ -6562,9 +6562,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,4,2012/2013,56,HHS Region 9,Season peak week,4
 2013,4,2012/2013,56,HHS Region 9,Season peak percentage,5.6
 2013,4,2012/2013,56,HHS Region 9,1 wk ahead,5.5
-2013,4,2012/2013,56,HHS Region 9,2 wk ahead,5
+2013,4,2012/2013,56,HHS Region 9,2 wk ahead,4.8
 2013,4,2012/2013,56,HHS Region 9,3 wk ahead,4.5
-2013,4,2012/2013,56,HHS Region 9,4 wk ahead,3.8
+2013,4,2012/2013,56,HHS Region 9,4 wk ahead,3.9
 2013,4,2012/2013,56,HHS Region 10,Season onset,50
 2013,4,2012/2013,56,HHS Region 10,Season peak week,4
 2013,4,2012/2013,56,HHS Region 10,Season peak percentage,3.7
@@ -6623,7 +6623,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,5,2012/2013,57,HHS Region 6,4 wk ahead,3.2
 2013,5,2012/2013,57,HHS Region 7,Season onset,47
 2013,5,2012/2013,57,HHS Region 7,Season peak week,52
-2013,5,2012/2013,57,HHS Region 7,Season peak percentage,6.7
+2013,5,2012/2013,57,HHS Region 7,Season peak percentage,6.8
 2013,5,2012/2013,57,HHS Region 7,1 wk ahead,4.3
 2013,5,2012/2013,57,HHS Region 7,2 wk ahead,3.4
 2013,5,2012/2013,57,HHS Region 7,3 wk ahead,3.1
@@ -6639,9 +6639,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,5,2012/2013,57,HHS Region 9,Season onset,2
 2013,5,2012/2013,57,HHS Region 9,Season peak week,4
 2013,5,2012/2013,57,HHS Region 9,Season peak percentage,5.6
-2013,5,2012/2013,57,HHS Region 9,1 wk ahead,5
+2013,5,2012/2013,57,HHS Region 9,1 wk ahead,4.8
 2013,5,2012/2013,57,HHS Region 9,2 wk ahead,4.5
-2013,5,2012/2013,57,HHS Region 9,3 wk ahead,3.8
+2013,5,2012/2013,57,HHS Region 9,3 wk ahead,3.9
 2013,5,2012/2013,57,HHS Region 9,4 wk ahead,3.5
 2013,5,2012/2013,57,HHS Region 10,Season onset,50
 2013,5,2012/2013,57,HHS Region 10,Season peak week,4
@@ -6656,7 +6656,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,6,2012/2013,58,US National,1 wk ahead,3
 2013,6,2012/2013,58,US National,2 wk ahead,2.7
 2013,6,2012/2013,58,US National,3 wk ahead,2.5
-2013,6,2012/2013,58,US National,4 wk ahead,2.6
+2013,6,2012/2013,58,US National,4 wk ahead,2.5
 2013,6,2012/2013,58,HHS Region 1,Season onset,49
 2013,6,2012/2013,58,HHS Region 1,Season peak week,52
 2013,6,2012/2013,58,HHS Region 1,Season peak percentage,3.9
@@ -6677,7 +6677,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,6,2012/2013,58,HHS Region 3,1 wk ahead,2.8
 2013,6,2012/2013,58,HHS Region 3,2 wk ahead,2.6
 2013,6,2012/2013,58,HHS Region 3,3 wk ahead,2.6
-2013,6,2012/2013,58,HHS Region 3,4 wk ahead,3.3
+2013,6,2012/2013,58,HHS Region 3,4 wk ahead,2.7
 2013,6,2012/2013,58,HHS Region 4,Season onset,47
 2013,6,2012/2013,58,HHS Region 4,Season peak week,52
 2013,6,2012/2013,58,HHS Region 4,Season peak percentage,6.3
@@ -6698,10 +6698,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,6,2012/2013,58,HHS Region 6,1 wk ahead,3.9
 2013,6,2012/2013,58,HHS Region 6,2 wk ahead,3.3
 2013,6,2012/2013,58,HHS Region 6,3 wk ahead,3.2
-2013,6,2012/2013,58,HHS Region 6,4 wk ahead,3.1
+2013,6,2012/2013,58,HHS Region 6,4 wk ahead,3.2
 2013,6,2012/2013,58,HHS Region 7,Season onset,47
 2013,6,2012/2013,58,HHS Region 7,Season peak week,52
-2013,6,2012/2013,58,HHS Region 7,Season peak percentage,6.7
+2013,6,2012/2013,58,HHS Region 7,Season peak percentage,6.8
 2013,6,2012/2013,58,HHS Region 7,1 wk ahead,3.4
 2013,6,2012/2013,58,HHS Region 7,2 wk ahead,3.1
 2013,6,2012/2013,58,HHS Region 7,3 wk ahead,2.4
@@ -6718,7 +6718,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,6,2012/2013,58,HHS Region 9,Season peak week,4
 2013,6,2012/2013,58,HHS Region 9,Season peak percentage,5.6
 2013,6,2012/2013,58,HHS Region 9,1 wk ahead,4.5
-2013,6,2012/2013,58,HHS Region 9,2 wk ahead,3.8
+2013,6,2012/2013,58,HHS Region 9,2 wk ahead,3.9
 2013,6,2012/2013,58,HHS Region 9,3 wk ahead,3.5
 2013,6,2012/2013,58,HHS Region 9,4 wk ahead,3.6
 2013,6,2012/2013,58,HHS Region 10,Season onset,50
@@ -6733,7 +6733,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,7,2012/2013,59,US National,Season peak percentage,6.1
 2013,7,2012/2013,59,US National,1 wk ahead,2.7
 2013,7,2012/2013,59,US National,2 wk ahead,2.5
-2013,7,2012/2013,59,US National,3 wk ahead,2.6
+2013,7,2012/2013,59,US National,3 wk ahead,2.5
 2013,7,2012/2013,59,US National,4 wk ahead,2.4
 2013,7,2012/2013,59,HHS Region 1,Season onset,49
 2013,7,2012/2013,59,HHS Region 1,Season peak week,52
@@ -6754,15 +6754,15 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,7,2012/2013,59,HHS Region 3,Season peak percentage,7.1
 2013,7,2012/2013,59,HHS Region 3,1 wk ahead,2.6
 2013,7,2012/2013,59,HHS Region 3,2 wk ahead,2.6
-2013,7,2012/2013,59,HHS Region 3,3 wk ahead,3.3
-2013,7,2012/2013,59,HHS Region 3,4 wk ahead,2.6
+2013,7,2012/2013,59,HHS Region 3,3 wk ahead,2.7
+2013,7,2012/2013,59,HHS Region 3,4 wk ahead,2.7
 2013,7,2012/2013,59,HHS Region 4,Season onset,47
 2013,7,2012/2013,59,HHS Region 4,Season peak week,52
 2013,7,2012/2013,59,HHS Region 4,Season peak percentage,6.3
 2013,7,2012/2013,59,HHS Region 4,1 wk ahead,2
 2013,7,2012/2013,59,HHS Region 4,2 wk ahead,1.9
 2013,7,2012/2013,59,HHS Region 4,3 wk ahead,2.2
-2013,7,2012/2013,59,HHS Region 4,4 wk ahead,2
+2013,7,2012/2013,59,HHS Region 4,4 wk ahead,2.1
 2013,7,2012/2013,59,HHS Region 5,Season onset,47
 2013,7,2012/2013,59,HHS Region 5,Season peak week,52
 2013,7,2012/2013,59,HHS Region 5,Season peak percentage,5.7
@@ -6775,11 +6775,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,7,2012/2013,59,HHS Region 6,Season peak percentage,9.3
 2013,7,2012/2013,59,HHS Region 6,1 wk ahead,3.3
 2013,7,2012/2013,59,HHS Region 6,2 wk ahead,3.2
-2013,7,2012/2013,59,HHS Region 6,3 wk ahead,3.1
+2013,7,2012/2013,59,HHS Region 6,3 wk ahead,3.2
 2013,7,2012/2013,59,HHS Region 6,4 wk ahead,3
 2013,7,2012/2013,59,HHS Region 7,Season onset,47
 2013,7,2012/2013,59,HHS Region 7,Season peak week,52
-2013,7,2012/2013,59,HHS Region 7,Season peak percentage,6.7
+2013,7,2012/2013,59,HHS Region 7,Season peak percentage,6.8
 2013,7,2012/2013,59,HHS Region 7,1 wk ahead,3.1
 2013,7,2012/2013,59,HHS Region 7,2 wk ahead,2.4
 2013,7,2012/2013,59,HHS Region 7,3 wk ahead,2.3
@@ -6795,7 +6795,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,7,2012/2013,59,HHS Region 9,Season onset,2
 2013,7,2012/2013,59,HHS Region 9,Season peak week,4
 2013,7,2012/2013,59,HHS Region 9,Season peak percentage,5.6
-2013,7,2012/2013,59,HHS Region 9,1 wk ahead,3.8
+2013,7,2012/2013,59,HHS Region 9,1 wk ahead,3.9
 2013,7,2012/2013,59,HHS Region 9,2 wk ahead,3.5
 2013,7,2012/2013,59,HHS Region 9,3 wk ahead,3.6
 2013,7,2012/2013,59,HHS Region 9,4 wk ahead,3.1
@@ -6810,7 +6810,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,8,2012/2013,60,US National,Season peak week,52
 2013,8,2012/2013,60,US National,Season peak percentage,6.1
 2013,8,2012/2013,60,US National,1 wk ahead,2.5
-2013,8,2012/2013,60,US National,2 wk ahead,2.6
+2013,8,2012/2013,60,US National,2 wk ahead,2.5
 2013,8,2012/2013,60,US National,3 wk ahead,2.4
 2013,8,2012/2013,60,US National,4 wk ahead,2.1
 2013,8,2012/2013,60,HHS Region 1,Season onset,49
@@ -6826,20 +6826,20 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,8,2012/2013,60,HHS Region 2,1 wk ahead,2.8
 2013,8,2012/2013,60,HHS Region 2,2 wk ahead,3
 2013,8,2012/2013,60,HHS Region 2,3 wk ahead,2.9
-2013,8,2012/2013,60,HHS Region 2,4 wk ahead,2.5
+2013,8,2012/2013,60,HHS Region 2,4 wk ahead,2.6
 2013,8,2012/2013,60,HHS Region 3,Season onset,49
 2013,8,2012/2013,60,HHS Region 3,Season peak week,52
 2013,8,2012/2013,60,HHS Region 3,Season peak percentage,7.1
 2013,8,2012/2013,60,HHS Region 3,1 wk ahead,2.6
-2013,8,2012/2013,60,HHS Region 3,2 wk ahead,3.3
-2013,8,2012/2013,60,HHS Region 3,3 wk ahead,2.6
-2013,8,2012/2013,60,HHS Region 3,4 wk ahead,2.2
+2013,8,2012/2013,60,HHS Region 3,2 wk ahead,2.7
+2013,8,2012/2013,60,HHS Region 3,3 wk ahead,2.7
+2013,8,2012/2013,60,HHS Region 3,4 wk ahead,2.3
 2013,8,2012/2013,60,HHS Region 4,Season onset,47
 2013,8,2012/2013,60,HHS Region 4,Season peak week,52
 2013,8,2012/2013,60,HHS Region 4,Season peak percentage,6.3
 2013,8,2012/2013,60,HHS Region 4,1 wk ahead,1.9
 2013,8,2012/2013,60,HHS Region 4,2 wk ahead,2.2
-2013,8,2012/2013,60,HHS Region 4,3 wk ahead,2
+2013,8,2012/2013,60,HHS Region 4,3 wk ahead,2.1
 2013,8,2012/2013,60,HHS Region 4,4 wk ahead,1.8
 2013,8,2012/2013,60,HHS Region 5,Season onset,47
 2013,8,2012/2013,60,HHS Region 5,Season peak week,52
@@ -6852,12 +6852,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,8,2012/2013,60,HHS Region 6,Season peak week,52
 2013,8,2012/2013,60,HHS Region 6,Season peak percentage,9.3
 2013,8,2012/2013,60,HHS Region 6,1 wk ahead,3.2
-2013,8,2012/2013,60,HHS Region 6,2 wk ahead,3.1
+2013,8,2012/2013,60,HHS Region 6,2 wk ahead,3.2
 2013,8,2012/2013,60,HHS Region 6,3 wk ahead,3
 2013,8,2012/2013,60,HHS Region 6,4 wk ahead,2.6
 2013,8,2012/2013,60,HHS Region 7,Season onset,47
 2013,8,2012/2013,60,HHS Region 7,Season peak week,52
-2013,8,2012/2013,60,HHS Region 7,Season peak percentage,6.7
+2013,8,2012/2013,60,HHS Region 7,Season peak percentage,6.8
 2013,8,2012/2013,60,HHS Region 7,1 wk ahead,2.4
 2013,8,2012/2013,60,HHS Region 7,2 wk ahead,2.3
 2013,8,2012/2013,60,HHS Region 7,3 wk ahead,1.9
@@ -6887,7 +6887,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,9,2012/2013,61,US National,Season onset,47
 2013,9,2012/2013,61,US National,Season peak week,52
 2013,9,2012/2013,61,US National,Season peak percentage,6.1
-2013,9,2012/2013,61,US National,1 wk ahead,2.6
+2013,9,2012/2013,61,US National,1 wk ahead,2.5
 2013,9,2012/2013,61,US National,2 wk ahead,2.4
 2013,9,2012/2013,61,US National,3 wk ahead,2.1
 2013,9,2012/2013,61,US National,4 wk ahead,1.9
@@ -6903,20 +6903,20 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,9,2012/2013,61,HHS Region 2,Season peak percentage,5.5
 2013,9,2012/2013,61,HHS Region 2,1 wk ahead,3
 2013,9,2012/2013,61,HHS Region 2,2 wk ahead,2.9
-2013,9,2012/2013,61,HHS Region 2,3 wk ahead,2.5
+2013,9,2012/2013,61,HHS Region 2,3 wk ahead,2.6
 2013,9,2012/2013,61,HHS Region 2,4 wk ahead,2.2
 2013,9,2012/2013,61,HHS Region 3,Season onset,49
 2013,9,2012/2013,61,HHS Region 3,Season peak week,52
 2013,9,2012/2013,61,HHS Region 3,Season peak percentage,7.1
-2013,9,2012/2013,61,HHS Region 3,1 wk ahead,3.3
-2013,9,2012/2013,61,HHS Region 3,2 wk ahead,2.6
-2013,9,2012/2013,61,HHS Region 3,3 wk ahead,2.2
+2013,9,2012/2013,61,HHS Region 3,1 wk ahead,2.7
+2013,9,2012/2013,61,HHS Region 3,2 wk ahead,2.7
+2013,9,2012/2013,61,HHS Region 3,3 wk ahead,2.3
 2013,9,2012/2013,61,HHS Region 3,4 wk ahead,2.1
 2013,9,2012/2013,61,HHS Region 4,Season onset,47
 2013,9,2012/2013,61,HHS Region 4,Season peak week,52
 2013,9,2012/2013,61,HHS Region 4,Season peak percentage,6.3
 2013,9,2012/2013,61,HHS Region 4,1 wk ahead,2.2
-2013,9,2012/2013,61,HHS Region 4,2 wk ahead,2
+2013,9,2012/2013,61,HHS Region 4,2 wk ahead,2.1
 2013,9,2012/2013,61,HHS Region 4,3 wk ahead,1.8
 2013,9,2012/2013,61,HHS Region 4,4 wk ahead,1.7
 2013,9,2012/2013,61,HHS Region 5,Season onset,47
@@ -6929,13 +6929,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,9,2012/2013,61,HHS Region 6,Season onset,47
 2013,9,2012/2013,61,HHS Region 6,Season peak week,52
 2013,9,2012/2013,61,HHS Region 6,Season peak percentage,9.3
-2013,9,2012/2013,61,HHS Region 6,1 wk ahead,3.1
+2013,9,2012/2013,61,HHS Region 6,1 wk ahead,3.2
 2013,9,2012/2013,61,HHS Region 6,2 wk ahead,3
 2013,9,2012/2013,61,HHS Region 6,3 wk ahead,2.6
 2013,9,2012/2013,61,HHS Region 6,4 wk ahead,2.3
 2013,9,2012/2013,61,HHS Region 7,Season onset,47
 2013,9,2012/2013,61,HHS Region 7,Season peak week,52
-2013,9,2012/2013,61,HHS Region 7,Season peak percentage,6.7
+2013,9,2012/2013,61,HHS Region 7,Season peak percentage,6.8
 2013,9,2012/2013,61,HHS Region 7,1 wk ahead,2.3
 2013,9,2012/2013,61,HHS Region 7,2 wk ahead,1.9
 2013,9,2012/2013,61,HHS Region 7,3 wk ahead,1.5
@@ -6947,14 +6947,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,9,2012/2013,61,HHS Region 8,1 wk ahead,1.8
 2013,9,2012/2013,61,HHS Region 8,2 wk ahead,1.8
 2013,9,2012/2013,61,HHS Region 8,3 wk ahead,1.2
-2013,9,2012/2013,61,HHS Region 8,4 wk ahead,1.2
+2013,9,2012/2013,61,HHS Region 8,4 wk ahead,1.3
 2013,9,2012/2013,61,HHS Region 9,Season onset,2
 2013,9,2012/2013,61,HHS Region 9,Season peak week,4
 2013,9,2012/2013,61,HHS Region 9,Season peak percentage,5.6
 2013,9,2012/2013,61,HHS Region 9,1 wk ahead,3.6
 2013,9,2012/2013,61,HHS Region 9,2 wk ahead,3.1
 2013,9,2012/2013,61,HHS Region 9,3 wk ahead,2.9
-2013,9,2012/2013,61,HHS Region 9,4 wk ahead,2.6
+2013,9,2012/2013,61,HHS Region 9,4 wk ahead,2.9
 2013,9,2012/2013,61,HHS Region 10,Season onset,50
 2013,9,2012/2013,61,HHS Region 10,Season peak week,4
 2013,9,2012/2013,61,HHS Region 10,Season peak percentage,3.7
@@ -6980,20 +6980,20 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,10,2012/2013,62,HHS Region 2,Season peak week,52
 2013,10,2012/2013,62,HHS Region 2,Season peak percentage,5.5
 2013,10,2012/2013,62,HHS Region 2,1 wk ahead,2.9
-2013,10,2012/2013,62,HHS Region 2,2 wk ahead,2.5
+2013,10,2012/2013,62,HHS Region 2,2 wk ahead,2.6
 2013,10,2012/2013,62,HHS Region 2,3 wk ahead,2.2
-2013,10,2012/2013,62,HHS Region 2,4 wk ahead,1.9
+2013,10,2012/2013,62,HHS Region 2,4 wk ahead,2
 2013,10,2012/2013,62,HHS Region 3,Season onset,49
 2013,10,2012/2013,62,HHS Region 3,Season peak week,52
 2013,10,2012/2013,62,HHS Region 3,Season peak percentage,7.1
-2013,10,2012/2013,62,HHS Region 3,1 wk ahead,2.6
-2013,10,2012/2013,62,HHS Region 3,2 wk ahead,2.2
+2013,10,2012/2013,62,HHS Region 3,1 wk ahead,2.7
+2013,10,2012/2013,62,HHS Region 3,2 wk ahead,2.3
 2013,10,2012/2013,62,HHS Region 3,3 wk ahead,2.1
 2013,10,2012/2013,62,HHS Region 3,4 wk ahead,1.7
 2013,10,2012/2013,62,HHS Region 4,Season onset,47
 2013,10,2012/2013,62,HHS Region 4,Season peak week,52
 2013,10,2012/2013,62,HHS Region 4,Season peak percentage,6.3
-2013,10,2012/2013,62,HHS Region 4,1 wk ahead,2
+2013,10,2012/2013,62,HHS Region 4,1 wk ahead,2.1
 2013,10,2012/2013,62,HHS Region 4,2 wk ahead,1.8
 2013,10,2012/2013,62,HHS Region 4,3 wk ahead,1.7
 2013,10,2012/2013,62,HHS Region 4,4 wk ahead,1.4
@@ -7003,7 +7003,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,10,2012/2013,62,HHS Region 5,1 wk ahead,2.1
 2013,10,2012/2013,62,HHS Region 5,2 wk ahead,1.8
 2013,10,2012/2013,62,HHS Region 5,3 wk ahead,1.6
-2013,10,2012/2013,62,HHS Region 5,4 wk ahead,1.4
+2013,10,2012/2013,62,HHS Region 5,4 wk ahead,1.3
 2013,10,2012/2013,62,HHS Region 6,Season onset,47
 2013,10,2012/2013,62,HHS Region 6,Season peak week,52
 2013,10,2012/2013,62,HHS Region 6,Season peak percentage,9.3
@@ -7013,7 +7013,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,10,2012/2013,62,HHS Region 6,4 wk ahead,2.2
 2013,10,2012/2013,62,HHS Region 7,Season onset,47
 2013,10,2012/2013,62,HHS Region 7,Season peak week,52
-2013,10,2012/2013,62,HHS Region 7,Season peak percentage,6.7
+2013,10,2012/2013,62,HHS Region 7,Season peak percentage,6.8
 2013,10,2012/2013,62,HHS Region 7,1 wk ahead,1.9
 2013,10,2012/2013,62,HHS Region 7,2 wk ahead,1.5
 2013,10,2012/2013,62,HHS Region 7,3 wk ahead,1.5
@@ -7024,15 +7024,15 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,10,2012/2013,62,HHS Region 8,Season peak percentage,4.1
 2013,10,2012/2013,62,HHS Region 8,1 wk ahead,1.8
 2013,10,2012/2013,62,HHS Region 8,2 wk ahead,1.2
-2013,10,2012/2013,62,HHS Region 8,3 wk ahead,1.2
+2013,10,2012/2013,62,HHS Region 8,3 wk ahead,1.3
 2013,10,2012/2013,62,HHS Region 8,4 wk ahead,1.2
 2013,10,2012/2013,62,HHS Region 9,Season onset,2
 2013,10,2012/2013,62,HHS Region 9,Season peak week,4
 2013,10,2012/2013,62,HHS Region 9,Season peak percentage,5.6
 2013,10,2012/2013,62,HHS Region 9,1 wk ahead,3.1
 2013,10,2012/2013,62,HHS Region 9,2 wk ahead,2.9
-2013,10,2012/2013,62,HHS Region 9,3 wk ahead,2.6
-2013,10,2012/2013,62,HHS Region 9,4 wk ahead,2.2
+2013,10,2012/2013,62,HHS Region 9,3 wk ahead,2.9
+2013,10,2012/2013,62,HHS Region 9,4 wk ahead,2.4
 2013,10,2012/2013,62,HHS Region 10,Season onset,50
 2013,10,2012/2013,62,HHS Region 10,Season peak week,4
 2013,10,2012/2013,62,HHS Region 10,Season peak percentage,3.7
@@ -7046,7 +7046,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,11,2012/2013,63,US National,1 wk ahead,2.1
 2013,11,2012/2013,63,US National,2 wk ahead,1.9
 2013,11,2012/2013,63,US National,3 wk ahead,1.7
-2013,11,2012/2013,63,US National,4 wk ahead,1.4
+2013,11,2012/2013,63,US National,4 wk ahead,1.5
 2013,11,2012/2013,63,HHS Region 1,Season onset,49
 2013,11,2012/2013,63,HHS Region 1,Season peak week,52
 2013,11,2012/2013,63,HHS Region 1,Season peak percentage,3.9
@@ -7057,14 +7057,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,11,2012/2013,63,HHS Region 2,Season onset,48
 2013,11,2012/2013,63,HHS Region 2,Season peak week,52
 2013,11,2012/2013,63,HHS Region 2,Season peak percentage,5.5
-2013,11,2012/2013,63,HHS Region 2,1 wk ahead,2.5
+2013,11,2012/2013,63,HHS Region 2,1 wk ahead,2.6
 2013,11,2012/2013,63,HHS Region 2,2 wk ahead,2.2
-2013,11,2012/2013,63,HHS Region 2,3 wk ahead,1.9
+2013,11,2012/2013,63,HHS Region 2,3 wk ahead,2
 2013,11,2012/2013,63,HHS Region 2,4 wk ahead,1.6
 2013,11,2012/2013,63,HHS Region 3,Season onset,49
 2013,11,2012/2013,63,HHS Region 3,Season peak week,52
 2013,11,2012/2013,63,HHS Region 3,Season peak percentage,7.1
-2013,11,2012/2013,63,HHS Region 3,1 wk ahead,2.2
+2013,11,2012/2013,63,HHS Region 3,1 wk ahead,2.3
 2013,11,2012/2013,63,HHS Region 3,2 wk ahead,2.1
 2013,11,2012/2013,63,HHS Region 3,3 wk ahead,1.7
 2013,11,2012/2013,63,HHS Region 3,4 wk ahead,1.5
@@ -7080,18 +7080,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,11,2012/2013,63,HHS Region 5,Season peak percentage,5.7
 2013,11,2012/2013,63,HHS Region 5,1 wk ahead,1.8
 2013,11,2012/2013,63,HHS Region 5,2 wk ahead,1.6
-2013,11,2012/2013,63,HHS Region 5,3 wk ahead,1.4
-2013,11,2012/2013,63,HHS Region 5,4 wk ahead,1.2
+2013,11,2012/2013,63,HHS Region 5,3 wk ahead,1.3
+2013,11,2012/2013,63,HHS Region 5,4 wk ahead,1.1
 2013,11,2012/2013,63,HHS Region 6,Season onset,47
 2013,11,2012/2013,63,HHS Region 6,Season peak week,52
 2013,11,2012/2013,63,HHS Region 6,Season peak percentage,9.3
 2013,11,2012/2013,63,HHS Region 6,1 wk ahead,2.6
 2013,11,2012/2013,63,HHS Region 6,2 wk ahead,2.3
 2013,11,2012/2013,63,HHS Region 6,3 wk ahead,2.2
-2013,11,2012/2013,63,HHS Region 6,4 wk ahead,2
+2013,11,2012/2013,63,HHS Region 6,4 wk ahead,2.1
 2013,11,2012/2013,63,HHS Region 7,Season onset,47
 2013,11,2012/2013,63,HHS Region 7,Season peak week,52
-2013,11,2012/2013,63,HHS Region 7,Season peak percentage,6.7
+2013,11,2012/2013,63,HHS Region 7,Season peak percentage,6.8
 2013,11,2012/2013,63,HHS Region 7,1 wk ahead,1.5
 2013,11,2012/2013,63,HHS Region 7,2 wk ahead,1.5
 2013,11,2012/2013,63,HHS Region 7,3 wk ahead,1.1
@@ -7101,16 +7101,16 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,11,2012/2013,63,HHS Region 8,Season peak week,3
 2013,11,2012/2013,63,HHS Region 8,Season peak percentage,4.1
 2013,11,2012/2013,63,HHS Region 8,1 wk ahead,1.2
-2013,11,2012/2013,63,HHS Region 8,2 wk ahead,1.2
+2013,11,2012/2013,63,HHS Region 8,2 wk ahead,1.3
 2013,11,2012/2013,63,HHS Region 8,3 wk ahead,1.2
 2013,11,2012/2013,63,HHS Region 8,4 wk ahead,1
 2013,11,2012/2013,63,HHS Region 9,Season onset,2
 2013,11,2012/2013,63,HHS Region 9,Season peak week,4
 2013,11,2012/2013,63,HHS Region 9,Season peak percentage,5.6
 2013,11,2012/2013,63,HHS Region 9,1 wk ahead,2.9
-2013,11,2012/2013,63,HHS Region 9,2 wk ahead,2.6
-2013,11,2012/2013,63,HHS Region 9,3 wk ahead,2.2
-2013,11,2012/2013,63,HHS Region 9,4 wk ahead,1.9
+2013,11,2012/2013,63,HHS Region 9,2 wk ahead,2.9
+2013,11,2012/2013,63,HHS Region 9,3 wk ahead,2.4
+2013,11,2012/2013,63,HHS Region 9,4 wk ahead,2
 2013,11,2012/2013,63,HHS Region 10,Season onset,50
 2013,11,2012/2013,63,HHS Region 10,Season peak week,4
 2013,11,2012/2013,63,HHS Region 10,Season peak percentage,3.7
@@ -7123,7 +7123,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,12,2012/2013,64,US National,Season peak percentage,6.1
 2013,12,2012/2013,64,US National,1 wk ahead,1.9
 2013,12,2012/2013,64,US National,2 wk ahead,1.7
-2013,12,2012/2013,64,US National,3 wk ahead,1.4
+2013,12,2012/2013,64,US National,3 wk ahead,1.5
 2013,12,2012/2013,64,US National,4 wk ahead,1.3
 2013,12,2012/2013,64,HHS Region 1,Season onset,49
 2013,12,2012/2013,64,HHS Region 1,Season peak week,52
@@ -7136,7 +7136,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,12,2012/2013,64,HHS Region 2,Season peak week,52
 2013,12,2012/2013,64,HHS Region 2,Season peak percentage,5.5
 2013,12,2012/2013,64,HHS Region 2,1 wk ahead,2.2
-2013,12,2012/2013,64,HHS Region 2,2 wk ahead,1.9
+2013,12,2012/2013,64,HHS Region 2,2 wk ahead,2
 2013,12,2012/2013,64,HHS Region 2,3 wk ahead,1.6
 2013,12,2012/2013,64,HHS Region 2,4 wk ahead,1.4
 2013,12,2012/2013,64,HHS Region 3,Season onset,49
@@ -7157,19 +7157,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,12,2012/2013,64,HHS Region 5,Season peak week,52
 2013,12,2012/2013,64,HHS Region 5,Season peak percentage,5.7
 2013,12,2012/2013,64,HHS Region 5,1 wk ahead,1.6
-2013,12,2012/2013,64,HHS Region 5,2 wk ahead,1.4
-2013,12,2012/2013,64,HHS Region 5,3 wk ahead,1.2
-2013,12,2012/2013,64,HHS Region 5,4 wk ahead,1.1
+2013,12,2012/2013,64,HHS Region 5,2 wk ahead,1.3
+2013,12,2012/2013,64,HHS Region 5,3 wk ahead,1.1
+2013,12,2012/2013,64,HHS Region 5,4 wk ahead,1
 2013,12,2012/2013,64,HHS Region 6,Season onset,47
 2013,12,2012/2013,64,HHS Region 6,Season peak week,52
 2013,12,2012/2013,64,HHS Region 6,Season peak percentage,9.3
 2013,12,2012/2013,64,HHS Region 6,1 wk ahead,2.3
 2013,12,2012/2013,64,HHS Region 6,2 wk ahead,2.2
-2013,12,2012/2013,64,HHS Region 6,3 wk ahead,2
-2013,12,2012/2013,64,HHS Region 6,4 wk ahead,2
+2013,12,2012/2013,64,HHS Region 6,3 wk ahead,2.1
+2013,12,2012/2013,64,HHS Region 6,4 wk ahead,1.9
 2013,12,2012/2013,64,HHS Region 7,Season onset,47
 2013,12,2012/2013,64,HHS Region 7,Season peak week,52
-2013,12,2012/2013,64,HHS Region 7,Season peak percentage,6.7
+2013,12,2012/2013,64,HHS Region 7,Season peak percentage,6.8
 2013,12,2012/2013,64,HHS Region 7,1 wk ahead,1.5
 2013,12,2012/2013,64,HHS Region 7,2 wk ahead,1.1
 2013,12,2012/2013,64,HHS Region 7,3 wk ahead,1
@@ -7178,17 +7178,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,12,2012/2013,64,HHS Region 8,Season peak week,52
 2013,12,2012/2013,64,HHS Region 8,Season peak week,3
 2013,12,2012/2013,64,HHS Region 8,Season peak percentage,4.1
-2013,12,2012/2013,64,HHS Region 8,1 wk ahead,1.2
+2013,12,2012/2013,64,HHS Region 8,1 wk ahead,1.3
 2013,12,2012/2013,64,HHS Region 8,2 wk ahead,1.2
 2013,12,2012/2013,64,HHS Region 8,3 wk ahead,1
 2013,12,2012/2013,64,HHS Region 8,4 wk ahead,1
 2013,12,2012/2013,64,HHS Region 9,Season onset,2
 2013,12,2012/2013,64,HHS Region 9,Season peak week,4
 2013,12,2012/2013,64,HHS Region 9,Season peak percentage,5.6
-2013,12,2012/2013,64,HHS Region 9,1 wk ahead,2.6
-2013,12,2012/2013,64,HHS Region 9,2 wk ahead,2.2
-2013,12,2012/2013,64,HHS Region 9,3 wk ahead,1.9
-2013,12,2012/2013,64,HHS Region 9,4 wk ahead,1.7
+2013,12,2012/2013,64,HHS Region 9,1 wk ahead,2.9
+2013,12,2012/2013,64,HHS Region 9,2 wk ahead,2.4
+2013,12,2012/2013,64,HHS Region 9,3 wk ahead,2
+2013,12,2012/2013,64,HHS Region 9,4 wk ahead,1.8
 2013,12,2012/2013,64,HHS Region 10,Season onset,50
 2013,12,2012/2013,64,HHS Region 10,Season peak week,4
 2013,12,2012/2013,64,HHS Region 10,Season peak percentage,3.7
@@ -7200,7 +7200,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,13,2012/2013,65,US National,Season peak week,52
 2013,13,2012/2013,65,US National,Season peak percentage,6.1
 2013,13,2012/2013,65,US National,1 wk ahead,1.7
-2013,13,2012/2013,65,US National,2 wk ahead,1.4
+2013,13,2012/2013,65,US National,2 wk ahead,1.5
 2013,13,2012/2013,65,US National,3 wk ahead,1.3
 2013,13,2012/2013,65,US National,4 wk ahead,1.2
 2013,13,2012/2013,65,HHS Region 1,Season onset,49
@@ -7213,7 +7213,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,13,2012/2013,65,HHS Region 2,Season onset,48
 2013,13,2012/2013,65,HHS Region 2,Season peak week,52
 2013,13,2012/2013,65,HHS Region 2,Season peak percentage,5.5
-2013,13,2012/2013,65,HHS Region 2,1 wk ahead,1.9
+2013,13,2012/2013,65,HHS Region 2,1 wk ahead,2
 2013,13,2012/2013,65,HHS Region 2,2 wk ahead,1.6
 2013,13,2012/2013,65,HHS Region 2,3 wk ahead,1.4
 2013,13,2012/2013,65,HHS Region 2,4 wk ahead,1.5
@@ -7230,28 +7230,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,13,2012/2013,65,HHS Region 4,1 wk ahead,1.4
 2013,13,2012/2013,65,HHS Region 4,2 wk ahead,1.2
 2013,13,2012/2013,65,HHS Region 4,3 wk ahead,1
-2013,13,2012/2013,65,HHS Region 4,4 wk ahead,0.9
+2013,13,2012/2013,65,HHS Region 4,4 wk ahead,0.8
 2013,13,2012/2013,65,HHS Region 5,Season onset,47
 2013,13,2012/2013,65,HHS Region 5,Season peak week,52
 2013,13,2012/2013,65,HHS Region 5,Season peak percentage,5.7
-2013,13,2012/2013,65,HHS Region 5,1 wk ahead,1.4
-2013,13,2012/2013,65,HHS Region 5,2 wk ahead,1.2
-2013,13,2012/2013,65,HHS Region 5,3 wk ahead,1.1
-2013,13,2012/2013,65,HHS Region 5,4 wk ahead,1
+2013,13,2012/2013,65,HHS Region 5,1 wk ahead,1.3
+2013,13,2012/2013,65,HHS Region 5,2 wk ahead,1.1
+2013,13,2012/2013,65,HHS Region 5,3 wk ahead,1
+2013,13,2012/2013,65,HHS Region 5,4 wk ahead,0.9
 2013,13,2012/2013,65,HHS Region 6,Season onset,47
 2013,13,2012/2013,65,HHS Region 6,Season peak week,52
 2013,13,2012/2013,65,HHS Region 6,Season peak percentage,9.3
 2013,13,2012/2013,65,HHS Region 6,1 wk ahead,2.2
-2013,13,2012/2013,65,HHS Region 6,2 wk ahead,2
-2013,13,2012/2013,65,HHS Region 6,3 wk ahead,2
-2013,13,2012/2013,65,HHS Region 6,4 wk ahead,1.9
+2013,13,2012/2013,65,HHS Region 6,2 wk ahead,2.1
+2013,13,2012/2013,65,HHS Region 6,3 wk ahead,1.9
+2013,13,2012/2013,65,HHS Region 6,4 wk ahead,1.8
 2013,13,2012/2013,65,HHS Region 7,Season onset,47
 2013,13,2012/2013,65,HHS Region 7,Season peak week,52
-2013,13,2012/2013,65,HHS Region 7,Season peak percentage,6.7
+2013,13,2012/2013,65,HHS Region 7,Season peak percentage,6.8
 2013,13,2012/2013,65,HHS Region 7,1 wk ahead,1.1
 2013,13,2012/2013,65,HHS Region 7,2 wk ahead,1
 2013,13,2012/2013,65,HHS Region 7,3 wk ahead,0.9
-2013,13,2012/2013,65,HHS Region 7,4 wk ahead,0.9
+2013,13,2012/2013,65,HHS Region 7,4 wk ahead,0.7
 2013,13,2012/2013,65,HHS Region 8,Season onset,50
 2013,13,2012/2013,65,HHS Region 8,Season peak week,52
 2013,13,2012/2013,65,HHS Region 8,Season peak week,3
@@ -7263,10 +7263,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,13,2012/2013,65,HHS Region 9,Season onset,2
 2013,13,2012/2013,65,HHS Region 9,Season peak week,4
 2013,13,2012/2013,65,HHS Region 9,Season peak percentage,5.6
-2013,13,2012/2013,65,HHS Region 9,1 wk ahead,2.2
-2013,13,2012/2013,65,HHS Region 9,2 wk ahead,1.9
-2013,13,2012/2013,65,HHS Region 9,3 wk ahead,1.7
-2013,13,2012/2013,65,HHS Region 9,4 wk ahead,1.6
+2013,13,2012/2013,65,HHS Region 9,1 wk ahead,2.4
+2013,13,2012/2013,65,HHS Region 9,2 wk ahead,2
+2013,13,2012/2013,65,HHS Region 9,3 wk ahead,1.8
+2013,13,2012/2013,65,HHS Region 9,4 wk ahead,1.8
 2013,13,2012/2013,65,HHS Region 10,Season onset,50
 2013,13,2012/2013,65,HHS Region 10,Season peak week,4
 2013,13,2012/2013,65,HHS Region 10,Season peak percentage,3.7
@@ -7277,7 +7277,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,14,2012/2013,66,US National,Season onset,47
 2013,14,2012/2013,66,US National,Season peak week,52
 2013,14,2012/2013,66,US National,Season peak percentage,6.1
-2013,14,2012/2013,66,US National,1 wk ahead,1.4
+2013,14,2012/2013,66,US National,1 wk ahead,1.5
 2013,14,2012/2013,66,US National,2 wk ahead,1.3
 2013,14,2012/2013,66,US National,3 wk ahead,1.2
 2013,14,2012/2013,66,US National,4 wk ahead,1.1
@@ -7301,35 +7301,35 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,14,2012/2013,66,HHS Region 3,1 wk ahead,1.5
 2013,14,2012/2013,66,HHS Region 3,2 wk ahead,1.1
 2013,14,2012/2013,66,HHS Region 3,3 wk ahead,1.1
-2013,14,2012/2013,66,HHS Region 3,4 wk ahead,1.1
+2013,14,2012/2013,66,HHS Region 3,4 wk ahead,1.3
 2013,14,2012/2013,66,HHS Region 4,Season onset,47
 2013,14,2012/2013,66,HHS Region 4,Season peak week,52
 2013,14,2012/2013,66,HHS Region 4,Season peak percentage,6.3
 2013,14,2012/2013,66,HHS Region 4,1 wk ahead,1.2
 2013,14,2012/2013,66,HHS Region 4,2 wk ahead,1
-2013,14,2012/2013,66,HHS Region 4,3 wk ahead,0.9
+2013,14,2012/2013,66,HHS Region 4,3 wk ahead,0.8
 2013,14,2012/2013,66,HHS Region 4,4 wk ahead,0.7
 2013,14,2012/2013,66,HHS Region 5,Season onset,47
 2013,14,2012/2013,66,HHS Region 5,Season peak week,52
 2013,14,2012/2013,66,HHS Region 5,Season peak percentage,5.7
-2013,14,2012/2013,66,HHS Region 5,1 wk ahead,1.2
-2013,14,2012/2013,66,HHS Region 5,2 wk ahead,1.1
-2013,14,2012/2013,66,HHS Region 5,3 wk ahead,1
+2013,14,2012/2013,66,HHS Region 5,1 wk ahead,1.1
+2013,14,2012/2013,66,HHS Region 5,2 wk ahead,1
+2013,14,2012/2013,66,HHS Region 5,3 wk ahead,0.9
 2013,14,2012/2013,66,HHS Region 5,4 wk ahead,0.8
 2013,14,2012/2013,66,HHS Region 6,Season onset,47
 2013,14,2012/2013,66,HHS Region 6,Season peak week,52
 2013,14,2012/2013,66,HHS Region 6,Season peak percentage,9.3
-2013,14,2012/2013,66,HHS Region 6,1 wk ahead,2
-2013,14,2012/2013,66,HHS Region 6,2 wk ahead,2
-2013,14,2012/2013,66,HHS Region 6,3 wk ahead,1.9
-2013,14,2012/2013,66,HHS Region 6,4 wk ahead,1.7
+2013,14,2012/2013,66,HHS Region 6,1 wk ahead,2.1
+2013,14,2012/2013,66,HHS Region 6,2 wk ahead,1.9
+2013,14,2012/2013,66,HHS Region 6,3 wk ahead,1.8
+2013,14,2012/2013,66,HHS Region 6,4 wk ahead,1.6
 2013,14,2012/2013,66,HHS Region 7,Season onset,47
 2013,14,2012/2013,66,HHS Region 7,Season peak week,52
-2013,14,2012/2013,66,HHS Region 7,Season peak percentage,6.7
+2013,14,2012/2013,66,HHS Region 7,Season peak percentage,6.8
 2013,14,2012/2013,66,HHS Region 7,1 wk ahead,1
 2013,14,2012/2013,66,HHS Region 7,2 wk ahead,0.9
-2013,14,2012/2013,66,HHS Region 7,3 wk ahead,0.9
-2013,14,2012/2013,66,HHS Region 7,4 wk ahead,0.8
+2013,14,2012/2013,66,HHS Region 7,3 wk ahead,0.7
+2013,14,2012/2013,66,HHS Region 7,4 wk ahead,0.6
 2013,14,2012/2013,66,HHS Region 8,Season onset,50
 2013,14,2012/2013,66,HHS Region 8,Season peak week,52
 2013,14,2012/2013,66,HHS Region 8,Season peak week,3
@@ -7341,17 +7341,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,14,2012/2013,66,HHS Region 9,Season onset,2
 2013,14,2012/2013,66,HHS Region 9,Season peak week,4
 2013,14,2012/2013,66,HHS Region 9,Season peak percentage,5.6
-2013,14,2012/2013,66,HHS Region 9,1 wk ahead,1.9
-2013,14,2012/2013,66,HHS Region 9,2 wk ahead,1.7
-2013,14,2012/2013,66,HHS Region 9,3 wk ahead,1.6
-2013,14,2012/2013,66,HHS Region 9,4 wk ahead,1.6
+2013,14,2012/2013,66,HHS Region 9,1 wk ahead,2
+2013,14,2012/2013,66,HHS Region 9,2 wk ahead,1.8
+2013,14,2012/2013,66,HHS Region 9,3 wk ahead,1.8
+2013,14,2012/2013,66,HHS Region 9,4 wk ahead,1.5
 2013,14,2012/2013,66,HHS Region 10,Season onset,50
 2013,14,2012/2013,66,HHS Region 10,Season peak week,4
 2013,14,2012/2013,66,HHS Region 10,Season peak percentage,3.7
 2013,14,2012/2013,66,HHS Region 10,1 wk ahead,0.4
 2013,14,2012/2013,66,HHS Region 10,2 wk ahead,0.4
 2013,14,2012/2013,66,HHS Region 10,3 wk ahead,0.4
-2013,14,2012/2013,66,HHS Region 10,4 wk ahead,0.4
+2013,14,2012/2013,66,HHS Region 10,4 wk ahead,0.5
 2013,15,2012/2013,67,US National,Season onset,47
 2013,15,2012/2013,67,US National,Season peak week,52
 2013,15,2012/2013,67,US National,Season peak percentage,6.1
@@ -7378,36 +7378,36 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,15,2012/2013,67,HHS Region 3,Season peak percentage,7.1
 2013,15,2012/2013,67,HHS Region 3,1 wk ahead,1.1
 2013,15,2012/2013,67,HHS Region 3,2 wk ahead,1.1
-2013,15,2012/2013,67,HHS Region 3,3 wk ahead,1.1
-2013,15,2012/2013,67,HHS Region 3,4 wk ahead,1.3
+2013,15,2012/2013,67,HHS Region 3,3 wk ahead,1.3
+2013,15,2012/2013,67,HHS Region 3,4 wk ahead,1.1
 2013,15,2012/2013,67,HHS Region 4,Season onset,47
 2013,15,2012/2013,67,HHS Region 4,Season peak week,52
 2013,15,2012/2013,67,HHS Region 4,Season peak percentage,6.3
 2013,15,2012/2013,67,HHS Region 4,1 wk ahead,1
-2013,15,2012/2013,67,HHS Region 4,2 wk ahead,0.9
+2013,15,2012/2013,67,HHS Region 4,2 wk ahead,0.8
 2013,15,2012/2013,67,HHS Region 4,3 wk ahead,0.7
-2013,15,2012/2013,67,HHS Region 4,4 wk ahead,0.7
+2013,15,2012/2013,67,HHS Region 4,4 wk ahead,0.6
 2013,15,2012/2013,67,HHS Region 5,Season onset,47
 2013,15,2012/2013,67,HHS Region 5,Season peak week,52
 2013,15,2012/2013,67,HHS Region 5,Season peak percentage,5.7
-2013,15,2012/2013,67,HHS Region 5,1 wk ahead,1.1
-2013,15,2012/2013,67,HHS Region 5,2 wk ahead,1
+2013,15,2012/2013,67,HHS Region 5,1 wk ahead,1
+2013,15,2012/2013,67,HHS Region 5,2 wk ahead,0.9
 2013,15,2012/2013,67,HHS Region 5,3 wk ahead,0.8
-2013,15,2012/2013,67,HHS Region 5,4 wk ahead,0.9
+2013,15,2012/2013,67,HHS Region 5,4 wk ahead,0.8
 2013,15,2012/2013,67,HHS Region 6,Season onset,47
 2013,15,2012/2013,67,HHS Region 6,Season peak week,52
 2013,15,2012/2013,67,HHS Region 6,Season peak percentage,9.3
-2013,15,2012/2013,67,HHS Region 6,1 wk ahead,2
-2013,15,2012/2013,67,HHS Region 6,2 wk ahead,1.9
-2013,15,2012/2013,67,HHS Region 6,3 wk ahead,1.7
+2013,15,2012/2013,67,HHS Region 6,1 wk ahead,1.9
+2013,15,2012/2013,67,HHS Region 6,2 wk ahead,1.8
+2013,15,2012/2013,67,HHS Region 6,3 wk ahead,1.6
 2013,15,2012/2013,67,HHS Region 6,4 wk ahead,1.7
 2013,15,2012/2013,67,HHS Region 7,Season onset,47
 2013,15,2012/2013,67,HHS Region 7,Season peak week,52
-2013,15,2012/2013,67,HHS Region 7,Season peak percentage,6.7
+2013,15,2012/2013,67,HHS Region 7,Season peak percentage,6.8
 2013,15,2012/2013,67,HHS Region 7,1 wk ahead,0.9
-2013,15,2012/2013,67,HHS Region 7,2 wk ahead,0.9
-2013,15,2012/2013,67,HHS Region 7,3 wk ahead,0.8
-2013,15,2012/2013,67,HHS Region 7,4 wk ahead,0.8
+2013,15,2012/2013,67,HHS Region 7,2 wk ahead,0.7
+2013,15,2012/2013,67,HHS Region 7,3 wk ahead,0.6
+2013,15,2012/2013,67,HHS Region 7,4 wk ahead,0.5
 2013,15,2012/2013,67,HHS Region 8,Season onset,50
 2013,15,2012/2013,67,HHS Region 8,Season peak week,52
 2013,15,2012/2013,67,HHS Region 8,Season peak week,3
@@ -7419,16 +7419,16 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,15,2012/2013,67,HHS Region 9,Season onset,2
 2013,15,2012/2013,67,HHS Region 9,Season peak week,4
 2013,15,2012/2013,67,HHS Region 9,Season peak percentage,5.6
-2013,15,2012/2013,67,HHS Region 9,1 wk ahead,1.7
-2013,15,2012/2013,67,HHS Region 9,2 wk ahead,1.6
-2013,15,2012/2013,67,HHS Region 9,3 wk ahead,1.6
-2013,15,2012/2013,67,HHS Region 9,4 wk ahead,1.5
+2013,15,2012/2013,67,HHS Region 9,1 wk ahead,1.8
+2013,15,2012/2013,67,HHS Region 9,2 wk ahead,1.8
+2013,15,2012/2013,67,HHS Region 9,3 wk ahead,1.5
+2013,15,2012/2013,67,HHS Region 9,4 wk ahead,0.9
 2013,15,2012/2013,67,HHS Region 10,Season onset,50
 2013,15,2012/2013,67,HHS Region 10,Season peak week,4
 2013,15,2012/2013,67,HHS Region 10,Season peak percentage,3.7
 2013,15,2012/2013,67,HHS Region 10,1 wk ahead,0.4
 2013,15,2012/2013,67,HHS Region 10,2 wk ahead,0.4
-2013,15,2012/2013,67,HHS Region 10,3 wk ahead,0.4
+2013,15,2012/2013,67,HHS Region 10,3 wk ahead,0.5
 2013,15,2012/2013,67,HHS Region 10,4 wk ahead,0.2
 2013,16,2012/2013,68,US National,Season onset,47
 2013,16,2012/2013,68,US National,Season peak week,52
@@ -7450,42 +7450,42 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,16,2012/2013,68,HHS Region 2,1 wk ahead,1.5
 2013,16,2012/2013,68,HHS Region 2,2 wk ahead,1.4
 2013,16,2012/2013,68,HHS Region 2,3 wk ahead,1.3
-2013,16,2012/2013,68,HHS Region 2,4 wk ahead,1.3
+2013,16,2012/2013,68,HHS Region 2,4 wk ahead,0.9
 2013,16,2012/2013,68,HHS Region 3,Season onset,49
 2013,16,2012/2013,68,HHS Region 3,Season peak week,52
 2013,16,2012/2013,68,HHS Region 3,Season peak percentage,7.1
 2013,16,2012/2013,68,HHS Region 3,1 wk ahead,1.1
-2013,16,2012/2013,68,HHS Region 3,2 wk ahead,1.1
-2013,16,2012/2013,68,HHS Region 3,3 wk ahead,1.3
-2013,16,2012/2013,68,HHS Region 3,4 wk ahead,1.1
+2013,16,2012/2013,68,HHS Region 3,2 wk ahead,1.3
+2013,16,2012/2013,68,HHS Region 3,3 wk ahead,1.1
+2013,16,2012/2013,68,HHS Region 3,4 wk ahead,1
 2013,16,2012/2013,68,HHS Region 4,Season onset,47
 2013,16,2012/2013,68,HHS Region 4,Season peak week,52
 2013,16,2012/2013,68,HHS Region 4,Season peak percentage,6.3
-2013,16,2012/2013,68,HHS Region 4,1 wk ahead,0.9
+2013,16,2012/2013,68,HHS Region 4,1 wk ahead,0.8
 2013,16,2012/2013,68,HHS Region 4,2 wk ahead,0.7
-2013,16,2012/2013,68,HHS Region 4,3 wk ahead,0.7
+2013,16,2012/2013,68,HHS Region 4,3 wk ahead,0.6
 2013,16,2012/2013,68,HHS Region 4,4 wk ahead,0.8
 2013,16,2012/2013,68,HHS Region 5,Season onset,47
 2013,16,2012/2013,68,HHS Region 5,Season peak week,52
 2013,16,2012/2013,68,HHS Region 5,Season peak percentage,5.7
-2013,16,2012/2013,68,HHS Region 5,1 wk ahead,1
+2013,16,2012/2013,68,HHS Region 5,1 wk ahead,0.9
 2013,16,2012/2013,68,HHS Region 5,2 wk ahead,0.8
-2013,16,2012/2013,68,HHS Region 5,3 wk ahead,0.9
-2013,16,2012/2013,68,HHS Region 5,4 wk ahead,0.9
+2013,16,2012/2013,68,HHS Region 5,3 wk ahead,0.8
+2013,16,2012/2013,68,HHS Region 5,4 wk ahead,0.8
 2013,16,2012/2013,68,HHS Region 6,Season onset,47
 2013,16,2012/2013,68,HHS Region 6,Season peak week,52
 2013,16,2012/2013,68,HHS Region 6,Season peak percentage,9.3
-2013,16,2012/2013,68,HHS Region 6,1 wk ahead,1.9
-2013,16,2012/2013,68,HHS Region 6,2 wk ahead,1.7
+2013,16,2012/2013,68,HHS Region 6,1 wk ahead,1.8
+2013,16,2012/2013,68,HHS Region 6,2 wk ahead,1.6
 2013,16,2012/2013,68,HHS Region 6,3 wk ahead,1.7
 2013,16,2012/2013,68,HHS Region 6,4 wk ahead,1.6
 2013,16,2012/2013,68,HHS Region 7,Season onset,47
 2013,16,2012/2013,68,HHS Region 7,Season peak week,52
-2013,16,2012/2013,68,HHS Region 7,Season peak percentage,6.7
-2013,16,2012/2013,68,HHS Region 7,1 wk ahead,0.9
-2013,16,2012/2013,68,HHS Region 7,2 wk ahead,0.8
-2013,16,2012/2013,68,HHS Region 7,3 wk ahead,0.8
-2013,16,2012/2013,68,HHS Region 7,4 wk ahead,0.6
+2013,16,2012/2013,68,HHS Region 7,Season peak percentage,6.8
+2013,16,2012/2013,68,HHS Region 7,1 wk ahead,0.7
+2013,16,2012/2013,68,HHS Region 7,2 wk ahead,0.6
+2013,16,2012/2013,68,HHS Region 7,3 wk ahead,0.5
+2013,16,2012/2013,68,HHS Region 7,4 wk ahead,0.3
 2013,16,2012/2013,68,HHS Region 8,Season onset,50
 2013,16,2012/2013,68,HHS Region 8,Season peak week,52
 2013,16,2012/2013,68,HHS Region 8,Season peak week,3
@@ -7493,19 +7493,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,16,2012/2013,68,HHS Region 8,1 wk ahead,1
 2013,16,2012/2013,68,HHS Region 8,2 wk ahead,1
 2013,16,2012/2013,68,HHS Region 8,3 wk ahead,0.9
-2013,16,2012/2013,68,HHS Region 8,4 wk ahead,0.7
+2013,16,2012/2013,68,HHS Region 8,4 wk ahead,0.8
 2013,16,2012/2013,68,HHS Region 9,Season onset,2
 2013,16,2012/2013,68,HHS Region 9,Season peak week,4
 2013,16,2012/2013,68,HHS Region 9,Season peak percentage,5.6
-2013,16,2012/2013,68,HHS Region 9,1 wk ahead,1.6
-2013,16,2012/2013,68,HHS Region 9,2 wk ahead,1.6
-2013,16,2012/2013,68,HHS Region 9,3 wk ahead,1.5
-2013,16,2012/2013,68,HHS Region 9,4 wk ahead,1.6
+2013,16,2012/2013,68,HHS Region 9,1 wk ahead,1.8
+2013,16,2012/2013,68,HHS Region 9,2 wk ahead,1.5
+2013,16,2012/2013,68,HHS Region 9,3 wk ahead,0.9
+2013,16,2012/2013,68,HHS Region 9,4 wk ahead,0.6
 2013,16,2012/2013,68,HHS Region 10,Season onset,50
 2013,16,2012/2013,68,HHS Region 10,Season peak week,4
 2013,16,2012/2013,68,HHS Region 10,Season peak percentage,3.7
 2013,16,2012/2013,68,HHS Region 10,1 wk ahead,0.4
-2013,16,2012/2013,68,HHS Region 10,2 wk ahead,0.4
+2013,16,2012/2013,68,HHS Region 10,2 wk ahead,0.5
 2013,16,2012/2013,68,HHS Region 10,3 wk ahead,0.2
 2013,16,2012/2013,68,HHS Region 10,4 wk ahead,0.3
 2013,17,2012/2013,69,US National,Season onset,47
@@ -7527,42 +7527,42 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,17,2012/2013,69,HHS Region 2,Season peak percentage,5.5
 2013,17,2012/2013,69,HHS Region 2,1 wk ahead,1.4
 2013,17,2012/2013,69,HHS Region 2,2 wk ahead,1.3
-2013,17,2012/2013,69,HHS Region 2,3 wk ahead,1.3
-2013,17,2012/2013,69,HHS Region 2,4 wk ahead,1.2
+2013,17,2012/2013,69,HHS Region 2,3 wk ahead,0.9
+2013,17,2012/2013,69,HHS Region 2,4 wk ahead,1
 2013,17,2012/2013,69,HHS Region 3,Season onset,49
 2013,17,2012/2013,69,HHS Region 3,Season peak week,52
 2013,17,2012/2013,69,HHS Region 3,Season peak percentage,7.1
-2013,17,2012/2013,69,HHS Region 3,1 wk ahead,1.1
-2013,17,2012/2013,69,HHS Region 3,2 wk ahead,1.3
-2013,17,2012/2013,69,HHS Region 3,3 wk ahead,1.1
+2013,17,2012/2013,69,HHS Region 3,1 wk ahead,1.3
+2013,17,2012/2013,69,HHS Region 3,2 wk ahead,1.1
+2013,17,2012/2013,69,HHS Region 3,3 wk ahead,1
 2013,17,2012/2013,69,HHS Region 3,4 wk ahead,1.1
 2013,17,2012/2013,69,HHS Region 4,Season onset,47
 2013,17,2012/2013,69,HHS Region 4,Season peak week,52
 2013,17,2012/2013,69,HHS Region 4,Season peak percentage,6.3
 2013,17,2012/2013,69,HHS Region 4,1 wk ahead,0.7
-2013,17,2012/2013,69,HHS Region 4,2 wk ahead,0.7
+2013,17,2012/2013,69,HHS Region 4,2 wk ahead,0.6
 2013,17,2012/2013,69,HHS Region 4,3 wk ahead,0.8
 2013,17,2012/2013,69,HHS Region 4,4 wk ahead,0.8
 2013,17,2012/2013,69,HHS Region 5,Season onset,47
 2013,17,2012/2013,69,HHS Region 5,Season peak week,52
 2013,17,2012/2013,69,HHS Region 5,Season peak percentage,5.7
 2013,17,2012/2013,69,HHS Region 5,1 wk ahead,0.8
-2013,17,2012/2013,69,HHS Region 5,2 wk ahead,0.9
-2013,17,2012/2013,69,HHS Region 5,3 wk ahead,0.9
+2013,17,2012/2013,69,HHS Region 5,2 wk ahead,0.8
+2013,17,2012/2013,69,HHS Region 5,3 wk ahead,0.8
 2013,17,2012/2013,69,HHS Region 5,4 wk ahead,0.8
 2013,17,2012/2013,69,HHS Region 6,Season onset,47
 2013,17,2012/2013,69,HHS Region 6,Season peak week,52
 2013,17,2012/2013,69,HHS Region 6,Season peak percentage,9.3
-2013,17,2012/2013,69,HHS Region 6,1 wk ahead,1.7
+2013,17,2012/2013,69,HHS Region 6,1 wk ahead,1.6
 2013,17,2012/2013,69,HHS Region 6,2 wk ahead,1.7
 2013,17,2012/2013,69,HHS Region 6,3 wk ahead,1.6
 2013,17,2012/2013,69,HHS Region 6,4 wk ahead,1.5
 2013,17,2012/2013,69,HHS Region 7,Season onset,47
 2013,17,2012/2013,69,HHS Region 7,Season peak week,52
-2013,17,2012/2013,69,HHS Region 7,Season peak percentage,6.7
-2013,17,2012/2013,69,HHS Region 7,1 wk ahead,0.8
-2013,17,2012/2013,69,HHS Region 7,2 wk ahead,0.8
-2013,17,2012/2013,69,HHS Region 7,3 wk ahead,0.6
+2013,17,2012/2013,69,HHS Region 7,Season peak percentage,6.8
+2013,17,2012/2013,69,HHS Region 7,1 wk ahead,0.6
+2013,17,2012/2013,69,HHS Region 7,2 wk ahead,0.5
+2013,17,2012/2013,69,HHS Region 7,3 wk ahead,0.3
 2013,17,2012/2013,69,HHS Region 7,4 wk ahead,0.7
 2013,17,2012/2013,69,HHS Region 8,Season onset,50
 2013,17,2012/2013,69,HHS Region 8,Season peak week,52
@@ -7570,19 +7570,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,17,2012/2013,69,HHS Region 8,Season peak percentage,4.1
 2013,17,2012/2013,69,HHS Region 8,1 wk ahead,1
 2013,17,2012/2013,69,HHS Region 8,2 wk ahead,0.9
-2013,17,2012/2013,69,HHS Region 8,3 wk ahead,0.7
+2013,17,2012/2013,69,HHS Region 8,3 wk ahead,0.8
 2013,17,2012/2013,69,HHS Region 8,4 wk ahead,0.8
 2013,17,2012/2013,69,HHS Region 9,Season onset,2
 2013,17,2012/2013,69,HHS Region 9,Season peak week,4
 2013,17,2012/2013,69,HHS Region 9,Season peak percentage,5.6
-2013,17,2012/2013,69,HHS Region 9,1 wk ahead,1.6
-2013,17,2012/2013,69,HHS Region 9,2 wk ahead,1.5
-2013,17,2012/2013,69,HHS Region 9,3 wk ahead,1.6
+2013,17,2012/2013,69,HHS Region 9,1 wk ahead,1.5
+2013,17,2012/2013,69,HHS Region 9,2 wk ahead,0.9
+2013,17,2012/2013,69,HHS Region 9,3 wk ahead,0.6
 2013,17,2012/2013,69,HHS Region 9,4 wk ahead,1.4
 2013,17,2012/2013,69,HHS Region 10,Season onset,50
 2013,17,2012/2013,69,HHS Region 10,Season peak week,4
 2013,17,2012/2013,69,HHS Region 10,Season peak percentage,3.7
-2013,17,2012/2013,69,HHS Region 10,1 wk ahead,0.4
+2013,17,2012/2013,69,HHS Region 10,1 wk ahead,0.5
 2013,17,2012/2013,69,HHS Region 10,2 wk ahead,0.2
 2013,17,2012/2013,69,HHS Region 10,3 wk ahead,0.3
 2013,17,2012/2013,69,HHS Region 10,4 wk ahead,0.3
@@ -7592,7 +7592,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,18,2012/2013,70,US National,1 wk ahead,1.1
 2013,18,2012/2013,70,US National,2 wk ahead,1.1
 2013,18,2012/2013,70,US National,3 wk ahead,1
-2013,18,2012/2013,70,US National,4 wk ahead,1
+2013,18,2012/2013,70,US National,4 wk ahead,1.1
 2013,18,2012/2013,70,HHS Region 1,Season onset,49
 2013,18,2012/2013,70,HHS Region 1,Season peak week,52
 2013,18,2012/2013,70,HHS Region 1,Season peak percentage,3.9
@@ -7604,28 +7604,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,18,2012/2013,70,HHS Region 2,Season peak week,52
 2013,18,2012/2013,70,HHS Region 2,Season peak percentage,5.5
 2013,18,2012/2013,70,HHS Region 2,1 wk ahead,1.3
-2013,18,2012/2013,70,HHS Region 2,2 wk ahead,1.3
-2013,18,2012/2013,70,HHS Region 2,3 wk ahead,1.2
+2013,18,2012/2013,70,HHS Region 2,2 wk ahead,0.9
+2013,18,2012/2013,70,HHS Region 2,3 wk ahead,1
 2013,18,2012/2013,70,HHS Region 2,4 wk ahead,1.4
 2013,18,2012/2013,70,HHS Region 3,Season onset,49
 2013,18,2012/2013,70,HHS Region 3,Season peak week,52
 2013,18,2012/2013,70,HHS Region 3,Season peak percentage,7.1
-2013,18,2012/2013,70,HHS Region 3,1 wk ahead,1.3
-2013,18,2012/2013,70,HHS Region 3,2 wk ahead,1.1
+2013,18,2012/2013,70,HHS Region 3,1 wk ahead,1.1
+2013,18,2012/2013,70,HHS Region 3,2 wk ahead,1
 2013,18,2012/2013,70,HHS Region 3,3 wk ahead,1.1
 2013,18,2012/2013,70,HHS Region 3,4 wk ahead,1.3
 2013,18,2012/2013,70,HHS Region 4,Season onset,47
 2013,18,2012/2013,70,HHS Region 4,Season peak week,52
 2013,18,2012/2013,70,HHS Region 4,Season peak percentage,6.3
-2013,18,2012/2013,70,HHS Region 4,1 wk ahead,0.7
+2013,18,2012/2013,70,HHS Region 4,1 wk ahead,0.6
 2013,18,2012/2013,70,HHS Region 4,2 wk ahead,0.8
 2013,18,2012/2013,70,HHS Region 4,3 wk ahead,0.8
 2013,18,2012/2013,70,HHS Region 4,4 wk ahead,0.6
 2013,18,2012/2013,70,HHS Region 5,Season onset,47
 2013,18,2012/2013,70,HHS Region 5,Season peak week,52
 2013,18,2012/2013,70,HHS Region 5,Season peak percentage,5.7
-2013,18,2012/2013,70,HHS Region 5,1 wk ahead,0.9
-2013,18,2012/2013,70,HHS Region 5,2 wk ahead,0.9
+2013,18,2012/2013,70,HHS Region 5,1 wk ahead,0.8
+2013,18,2012/2013,70,HHS Region 5,2 wk ahead,0.8
 2013,18,2012/2013,70,HHS Region 5,3 wk ahead,0.8
 2013,18,2012/2013,70,HHS Region 5,4 wk ahead,1
 2013,18,2012/2013,70,HHS Region 6,Season onset,47
@@ -7637,9 +7637,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,18,2012/2013,70,HHS Region 6,4 wk ahead,1.5
 2013,18,2012/2013,70,HHS Region 7,Season onset,47
 2013,18,2012/2013,70,HHS Region 7,Season peak week,52
-2013,18,2012/2013,70,HHS Region 7,Season peak percentage,6.7
-2013,18,2012/2013,70,HHS Region 7,1 wk ahead,0.8
-2013,18,2012/2013,70,HHS Region 7,2 wk ahead,0.6
+2013,18,2012/2013,70,HHS Region 7,Season peak percentage,6.8
+2013,18,2012/2013,70,HHS Region 7,1 wk ahead,0.5
+2013,18,2012/2013,70,HHS Region 7,2 wk ahead,0.3
 2013,18,2012/2013,70,HHS Region 7,3 wk ahead,0.7
 2013,18,2012/2013,70,HHS Region 7,4 wk ahead,0.8
 2013,18,2012/2013,70,HHS Region 8,Season onset,50
@@ -7647,14 +7647,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,18,2012/2013,70,HHS Region 8,Season peak week,3
 2013,18,2012/2013,70,HHS Region 8,Season peak percentage,4.1
 2013,18,2012/2013,70,HHS Region 8,1 wk ahead,0.9
-2013,18,2012/2013,70,HHS Region 8,2 wk ahead,0.7
+2013,18,2012/2013,70,HHS Region 8,2 wk ahead,0.8
 2013,18,2012/2013,70,HHS Region 8,3 wk ahead,0.8
 2013,18,2012/2013,70,HHS Region 8,4 wk ahead,0.8
 2013,18,2012/2013,70,HHS Region 9,Season onset,2
 2013,18,2012/2013,70,HHS Region 9,Season peak week,4
 2013,18,2012/2013,70,HHS Region 9,Season peak percentage,5.6
-2013,18,2012/2013,70,HHS Region 9,1 wk ahead,1.5
-2013,18,2012/2013,70,HHS Region 9,2 wk ahead,1.6
+2013,18,2012/2013,70,HHS Region 9,1 wk ahead,0.9
+2013,18,2012/2013,70,HHS Region 9,2 wk ahead,0.6
 2013,18,2012/2013,70,HHS Region 9,3 wk ahead,1.4
 2013,18,2012/2013,70,HHS Region 9,4 wk ahead,1.4
 2013,18,2012/2013,70,HHS Region 10,Season onset,50
@@ -7669,7 +7669,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,19,2012/2013,71,US National,Season peak percentage,6.1
 2013,19,2012/2013,71,US National,1 wk ahead,1.1
 2013,19,2012/2013,71,US National,2 wk ahead,1
-2013,19,2012/2013,71,US National,3 wk ahead,1
+2013,19,2012/2013,71,US National,3 wk ahead,1.1
 2013,19,2012/2013,71,US National,4 wk ahead,0.9
 2013,19,2012/2013,71,HHS Region 1,Season onset,49
 2013,19,2012/2013,71,HHS Region 1,Season peak week,52
@@ -7681,14 +7681,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,19,2012/2013,71,HHS Region 2,Season onset,48
 2013,19,2012/2013,71,HHS Region 2,Season peak week,52
 2013,19,2012/2013,71,HHS Region 2,Season peak percentage,5.5
-2013,19,2012/2013,71,HHS Region 2,1 wk ahead,1.3
-2013,19,2012/2013,71,HHS Region 2,2 wk ahead,1.2
+2013,19,2012/2013,71,HHS Region 2,1 wk ahead,0.9
+2013,19,2012/2013,71,HHS Region 2,2 wk ahead,1
 2013,19,2012/2013,71,HHS Region 2,3 wk ahead,1.4
 2013,19,2012/2013,71,HHS Region 2,4 wk ahead,1.1
 2013,19,2012/2013,71,HHS Region 3,Season onset,49
 2013,19,2012/2013,71,HHS Region 3,Season peak week,52
 2013,19,2012/2013,71,HHS Region 3,Season peak percentage,7.1
-2013,19,2012/2013,71,HHS Region 3,1 wk ahead,1.1
+2013,19,2012/2013,71,HHS Region 3,1 wk ahead,1
 2013,19,2012/2013,71,HHS Region 3,2 wk ahead,1.1
 2013,19,2012/2013,71,HHS Region 3,3 wk ahead,1.3
 2013,19,2012/2013,71,HHS Region 3,4 wk ahead,1
@@ -7702,7 +7702,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,19,2012/2013,71,HHS Region 5,Season onset,47
 2013,19,2012/2013,71,HHS Region 5,Season peak week,52
 2013,19,2012/2013,71,HHS Region 5,Season peak percentage,5.7
-2013,19,2012/2013,71,HHS Region 5,1 wk ahead,0.9
+2013,19,2012/2013,71,HHS Region 5,1 wk ahead,0.8
 2013,19,2012/2013,71,HHS Region 5,2 wk ahead,0.8
 2013,19,2012/2013,71,HHS Region 5,3 wk ahead,1
 2013,19,2012/2013,71,HHS Region 5,4 wk ahead,0.9
@@ -7715,8 +7715,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,19,2012/2013,71,HHS Region 6,4 wk ahead,1.3
 2013,19,2012/2013,71,HHS Region 7,Season onset,47
 2013,19,2012/2013,71,HHS Region 7,Season peak week,52
-2013,19,2012/2013,71,HHS Region 7,Season peak percentage,6.7
-2013,19,2012/2013,71,HHS Region 7,1 wk ahead,0.6
+2013,19,2012/2013,71,HHS Region 7,Season peak percentage,6.8
+2013,19,2012/2013,71,HHS Region 7,1 wk ahead,0.3
 2013,19,2012/2013,71,HHS Region 7,2 wk ahead,0.7
 2013,19,2012/2013,71,HHS Region 7,3 wk ahead,0.8
 2013,19,2012/2013,71,HHS Region 7,4 wk ahead,0.2
@@ -7724,14 +7724,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,19,2012/2013,71,HHS Region 8,Season peak week,52
 2013,19,2012/2013,71,HHS Region 8,Season peak week,3
 2013,19,2012/2013,71,HHS Region 8,Season peak percentage,4.1
-2013,19,2012/2013,71,HHS Region 8,1 wk ahead,0.7
+2013,19,2012/2013,71,HHS Region 8,1 wk ahead,0.8
 2013,19,2012/2013,71,HHS Region 8,2 wk ahead,0.8
 2013,19,2012/2013,71,HHS Region 8,3 wk ahead,0.8
 2013,19,2012/2013,71,HHS Region 8,4 wk ahead,0.7
 2013,19,2012/2013,71,HHS Region 9,Season onset,2
 2013,19,2012/2013,71,HHS Region 9,Season peak week,4
 2013,19,2012/2013,71,HHS Region 9,Season peak percentage,5.6
-2013,19,2012/2013,71,HHS Region 9,1 wk ahead,1.6
+2013,19,2012/2013,71,HHS Region 9,1 wk ahead,0.6
 2013,19,2012/2013,71,HHS Region 9,2 wk ahead,1.4
 2013,19,2012/2013,71,HHS Region 9,3 wk ahead,1.4
 2013,19,2012/2013,71,HHS Region 9,4 wk ahead,1.4
@@ -7746,7 +7746,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,20,2012/2013,72,US National,Season peak week,52
 2013,20,2012/2013,72,US National,Season peak percentage,6.1
 2013,20,2012/2013,72,US National,1 wk ahead,1
-2013,20,2012/2013,72,US National,2 wk ahead,1
+2013,20,2012/2013,72,US National,2 wk ahead,1.1
 2013,20,2012/2013,72,US National,3 wk ahead,0.9
 2013,20,2012/2013,72,US National,4 wk ahead,0.9
 2013,20,2012/2013,72,HHS Region 1,Season onset,49
@@ -7759,7 +7759,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,20,2012/2013,72,HHS Region 2,Season onset,48
 2013,20,2012/2013,72,HHS Region 2,Season peak week,52
 2013,20,2012/2013,72,HHS Region 2,Season peak percentage,5.5
-2013,20,2012/2013,72,HHS Region 2,1 wk ahead,1.2
+2013,20,2012/2013,72,HHS Region 2,1 wk ahead,1
 2013,20,2012/2013,72,HHS Region 2,2 wk ahead,1.4
 2013,20,2012/2013,72,HHS Region 2,3 wk ahead,1.1
 2013,20,2012/2013,72,HHS Region 2,4 wk ahead,1.2
@@ -7793,7 +7793,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,20,2012/2013,72,HHS Region 6,4 wk ahead,1.2
 2013,20,2012/2013,72,HHS Region 7,Season onset,47
 2013,20,2012/2013,72,HHS Region 7,Season peak week,52
-2013,20,2012/2013,72,HHS Region 7,Season peak percentage,6.7
+2013,20,2012/2013,72,HHS Region 7,Season peak percentage,6.8
 2013,20,2012/2013,72,HHS Region 7,1 wk ahead,0.7
 2013,20,2012/2013,72,HHS Region 7,2 wk ahead,0.8
 2013,20,2012/2013,72,HHS Region 7,3 wk ahead,0.2
@@ -7839,7 +7839,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,40,2013/2014,40,HHS Region 2,Season peak week,13
 2013,40,2013/2014,40,HHS Region 2,Season peak percentage,3.4
 2013,40,2013/2014,40,HHS Region 2,1 wk ahead,1.7
-2013,40,2013/2014,40,HHS Region 2,2 wk ahead,2
+2013,40,2013/2014,40,HHS Region 2,2 wk ahead,1.9
 2013,40,2013/2014,40,HHS Region 2,3 wk ahead,1.7
 2013,40,2013/2014,40,HHS Region 2,4 wk ahead,2
 2013,40,2013/2014,40,HHS Region 3,Season onset,51
@@ -7885,9 +7885,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,40,2013/2014,40,HHS Region 8,3 wk ahead,0.8
 2013,40,2013/2014,40,HHS Region 8,4 wk ahead,0.7
 2013,40,2013/2014,40,HHS Region 9,Season onset,51
-2013,40,2013/2014,40,HHS Region 9,Season peak week,1
 2013,40,2013/2014,40,HHS Region 9,Season peak week,4
-2013,40,2013/2014,40,HHS Region 9,Season peak percentage,4.6
+2013,40,2013/2014,40,HHS Region 9,Season peak percentage,4.7
 2013,40,2013/2014,40,HHS Region 9,1 wk ahead,1.6
 2013,40,2013/2014,40,HHS Region 9,2 wk ahead,1.6
 2013,40,2013/2014,40,HHS Region 9,3 wk ahead,1.6
@@ -7917,7 +7916,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,41,2013/2014,41,HHS Region 2,Season peak week,6
 2013,41,2013/2014,41,HHS Region 2,Season peak week,13
 2013,41,2013/2014,41,HHS Region 2,Season peak percentage,3.4
-2013,41,2013/2014,41,HHS Region 2,1 wk ahead,2
+2013,41,2013/2014,41,HHS Region 2,1 wk ahead,1.9
 2013,41,2013/2014,41,HHS Region 2,2 wk ahead,1.7
 2013,41,2013/2014,41,HHS Region 2,3 wk ahead,2
 2013,41,2013/2014,41,HHS Region 2,4 wk ahead,1.8
@@ -7964,9 +7963,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,41,2013/2014,41,HHS Region 8,3 wk ahead,0.7
 2013,41,2013/2014,41,HHS Region 8,4 wk ahead,0.8
 2013,41,2013/2014,41,HHS Region 9,Season onset,51
-2013,41,2013/2014,41,HHS Region 9,Season peak week,1
 2013,41,2013/2014,41,HHS Region 9,Season peak week,4
-2013,41,2013/2014,41,HHS Region 9,Season peak percentage,4.6
+2013,41,2013/2014,41,HHS Region 9,Season peak percentage,4.7
 2013,41,2013/2014,41,HHS Region 9,1 wk ahead,1.6
 2013,41,2013/2014,41,HHS Region 9,2 wk ahead,1.6
 2013,41,2013/2014,41,HHS Region 9,3 wk ahead,1.8
@@ -8043,13 +8041,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,42,2013/2014,42,HHS Region 8,3 wk ahead,0.8
 2013,42,2013/2014,42,HHS Region 8,4 wk ahead,0.7
 2013,42,2013/2014,42,HHS Region 9,Season onset,51
-2013,42,2013/2014,42,HHS Region 9,Season peak week,1
 2013,42,2013/2014,42,HHS Region 9,Season peak week,4
-2013,42,2013/2014,42,HHS Region 9,Season peak percentage,4.6
+2013,42,2013/2014,42,HHS Region 9,Season peak percentage,4.7
 2013,42,2013/2014,42,HHS Region 9,1 wk ahead,1.6
 2013,42,2013/2014,42,HHS Region 9,2 wk ahead,1.8
 2013,42,2013/2014,42,HHS Region 9,3 wk ahead,2.1
-2013,42,2013/2014,42,HHS Region 9,4 wk ahead,2
+2013,42,2013/2014,42,HHS Region 9,4 wk ahead,2.1
 2013,42,2013/2014,42,HHS Region 10,Season onset,51
 2013,42,2013/2014,42,HHS Region 10,Season peak week,1
 2013,42,2013/2014,42,HHS Region 10,Season peak percentage,4
@@ -8078,7 +8075,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,43,2013/2014,43,HHS Region 2,1 wk ahead,2
 2013,43,2013/2014,43,HHS Region 2,2 wk ahead,1.8
 2013,43,2013/2014,43,HHS Region 2,3 wk ahead,1.5
-2013,43,2013/2014,43,HHS Region 2,4 wk ahead,1.9
+2013,43,2013/2014,43,HHS Region 2,4 wk ahead,1.8
 2013,43,2013/2014,43,HHS Region 3,Season onset,51
 2013,43,2013/2014,43,HHS Region 3,Season peak week,1
 2013,43,2013/2014,43,HHS Region 3,Season peak percentage,3.6
@@ -8122,12 +8119,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,43,2013/2014,43,HHS Region 8,3 wk ahead,0.7
 2013,43,2013/2014,43,HHS Region 8,4 wk ahead,1
 2013,43,2013/2014,43,HHS Region 9,Season onset,51
-2013,43,2013/2014,43,HHS Region 9,Season peak week,1
 2013,43,2013/2014,43,HHS Region 9,Season peak week,4
-2013,43,2013/2014,43,HHS Region 9,Season peak percentage,4.6
+2013,43,2013/2014,43,HHS Region 9,Season peak percentage,4.7
 2013,43,2013/2014,43,HHS Region 9,1 wk ahead,1.8
 2013,43,2013/2014,43,HHS Region 9,2 wk ahead,2.1
-2013,43,2013/2014,43,HHS Region 9,3 wk ahead,2
+2013,43,2013/2014,43,HHS Region 9,3 wk ahead,2.1
 2013,43,2013/2014,43,HHS Region 9,4 wk ahead,2
 2013,43,2013/2014,43,HHS Region 10,Season onset,51
 2013,43,2013/2014,43,HHS Region 10,Season peak week,1
@@ -8156,7 +8152,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,44,2013/2014,44,HHS Region 2,Season peak percentage,3.4
 2013,44,2013/2014,44,HHS Region 2,1 wk ahead,1.8
 2013,44,2013/2014,44,HHS Region 2,2 wk ahead,1.5
-2013,44,2013/2014,44,HHS Region 2,3 wk ahead,1.9
+2013,44,2013/2014,44,HHS Region 2,3 wk ahead,1.8
 2013,44,2013/2014,44,HHS Region 2,4 wk ahead,2
 2013,44,2013/2014,44,HHS Region 3,Season onset,51
 2013,44,2013/2014,44,HHS Region 3,Season peak week,1
@@ -8201,13 +8197,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,44,2013/2014,44,HHS Region 8,3 wk ahead,1
 2013,44,2013/2014,44,HHS Region 8,4 wk ahead,1
 2013,44,2013/2014,44,HHS Region 9,Season onset,51
-2013,44,2013/2014,44,HHS Region 9,Season peak week,1
 2013,44,2013/2014,44,HHS Region 9,Season peak week,4
-2013,44,2013/2014,44,HHS Region 9,Season peak percentage,4.6
+2013,44,2013/2014,44,HHS Region 9,Season peak percentage,4.7
 2013,44,2013/2014,44,HHS Region 9,1 wk ahead,2.1
-2013,44,2013/2014,44,HHS Region 9,2 wk ahead,2
+2013,44,2013/2014,44,HHS Region 9,2 wk ahead,2.1
 2013,44,2013/2014,44,HHS Region 9,3 wk ahead,2
-2013,44,2013/2014,44,HHS Region 9,4 wk ahead,2.3
+2013,44,2013/2014,44,HHS Region 9,4 wk ahead,2.4
 2013,44,2013/2014,44,HHS Region 10,Season onset,51
 2013,44,2013/2014,44,HHS Region 10,Season peak week,1
 2013,44,2013/2014,44,HHS Region 10,Season peak percentage,4
@@ -8234,7 +8229,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,45,2013/2014,45,HHS Region 2,Season peak week,13
 2013,45,2013/2014,45,HHS Region 2,Season peak percentage,3.4
 2013,45,2013/2014,45,HHS Region 2,1 wk ahead,1.5
-2013,45,2013/2014,45,HHS Region 2,2 wk ahead,1.9
+2013,45,2013/2014,45,HHS Region 2,2 wk ahead,1.8
 2013,45,2013/2014,45,HHS Region 2,3 wk ahead,2
 2013,45,2013/2014,45,HHS Region 2,4 wk ahead,2
 2013,45,2013/2014,45,HHS Region 3,Season onset,51
@@ -8280,13 +8275,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,45,2013/2014,45,HHS Region 8,3 wk ahead,1
 2013,45,2013/2014,45,HHS Region 8,4 wk ahead,1.5
 2013,45,2013/2014,45,HHS Region 9,Season onset,51
-2013,45,2013/2014,45,HHS Region 9,Season peak week,1
 2013,45,2013/2014,45,HHS Region 9,Season peak week,4
-2013,45,2013/2014,45,HHS Region 9,Season peak percentage,4.6
-2013,45,2013/2014,45,HHS Region 9,1 wk ahead,2
+2013,45,2013/2014,45,HHS Region 9,Season peak percentage,4.7
+2013,45,2013/2014,45,HHS Region 9,1 wk ahead,2.1
 2013,45,2013/2014,45,HHS Region 9,2 wk ahead,2
-2013,45,2013/2014,45,HHS Region 9,3 wk ahead,2.3
-2013,45,2013/2014,45,HHS Region 9,4 wk ahead,2.1
+2013,45,2013/2014,45,HHS Region 9,3 wk ahead,2.4
+2013,45,2013/2014,45,HHS Region 9,4 wk ahead,2.2
 2013,45,2013/2014,45,HHS Region 10,Season onset,51
 2013,45,2013/2014,45,HHS Region 10,Season peak week,1
 2013,45,2013/2014,45,HHS Region 10,Season peak percentage,4
@@ -8312,7 +8306,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,46,2013/2014,46,HHS Region 2,Season peak week,6
 2013,46,2013/2014,46,HHS Region 2,Season peak week,13
 2013,46,2013/2014,46,HHS Region 2,Season peak percentage,3.4
-2013,46,2013/2014,46,HHS Region 2,1 wk ahead,1.9
+2013,46,2013/2014,46,HHS Region 2,1 wk ahead,1.8
 2013,46,2013/2014,46,HHS Region 2,2 wk ahead,2
 2013,46,2013/2014,46,HHS Region 2,3 wk ahead,2
 2013,46,2013/2014,46,HHS Region 2,4 wk ahead,1.8
@@ -8359,13 +8353,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,46,2013/2014,46,HHS Region 8,3 wk ahead,1.5
 2013,46,2013/2014,46,HHS Region 8,4 wk ahead,1.6
 2013,46,2013/2014,46,HHS Region 9,Season onset,51
-2013,46,2013/2014,46,HHS Region 9,Season peak week,1
 2013,46,2013/2014,46,HHS Region 9,Season peak week,4
-2013,46,2013/2014,46,HHS Region 9,Season peak percentage,4.6
+2013,46,2013/2014,46,HHS Region 9,Season peak percentage,4.7
 2013,46,2013/2014,46,HHS Region 9,1 wk ahead,2
-2013,46,2013/2014,46,HHS Region 9,2 wk ahead,2.3
-2013,46,2013/2014,46,HHS Region 9,3 wk ahead,2.1
-2013,46,2013/2014,46,HHS Region 9,4 wk ahead,2.5
+2013,46,2013/2014,46,HHS Region 9,2 wk ahead,2.4
+2013,46,2013/2014,46,HHS Region 9,3 wk ahead,2.2
+2013,46,2013/2014,46,HHS Region 9,4 wk ahead,2.6
 2013,46,2013/2014,46,HHS Region 10,Season onset,51
 2013,46,2013/2014,46,HHS Region 10,Season peak week,1
 2013,46,2013/2014,46,HHS Region 10,Season peak percentage,4
@@ -8401,7 +8394,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,47,2013/2014,47,HHS Region 3,1 wk ahead,1.5
 2013,47,2013/2014,47,HHS Region 3,2 wk ahead,1.5
 2013,47,2013/2014,47,HHS Region 3,3 wk ahead,1.6
-2013,47,2013/2014,47,HHS Region 3,4 wk ahead,2
+2013,47,2013/2014,47,HHS Region 3,4 wk ahead,2.2
 2013,47,2013/2014,47,HHS Region 4,Season onset,48
 2013,47,2013/2014,47,HHS Region 4,Season peak week,52
 2013,47,2013/2014,47,HHS Region 4,Season peak percentage,4.6
@@ -8438,13 +8431,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,47,2013/2014,47,HHS Region 8,3 wk ahead,1.6
 2013,47,2013/2014,47,HHS Region 8,4 wk ahead,2
 2013,47,2013/2014,47,HHS Region 9,Season onset,51
-2013,47,2013/2014,47,HHS Region 9,Season peak week,1
 2013,47,2013/2014,47,HHS Region 9,Season peak week,4
-2013,47,2013/2014,47,HHS Region 9,Season peak percentage,4.6
-2013,47,2013/2014,47,HHS Region 9,1 wk ahead,2.3
-2013,47,2013/2014,47,HHS Region 9,2 wk ahead,2.1
-2013,47,2013/2014,47,HHS Region 9,3 wk ahead,2.5
-2013,47,2013/2014,47,HHS Region 9,4 wk ahead,2.9
+2013,47,2013/2014,47,HHS Region 9,Season peak percentage,4.7
+2013,47,2013/2014,47,HHS Region 9,1 wk ahead,2.4
+2013,47,2013/2014,47,HHS Region 9,2 wk ahead,2.2
+2013,47,2013/2014,47,HHS Region 9,3 wk ahead,2.6
+2013,47,2013/2014,47,HHS Region 9,4 wk ahead,3
 2013,47,2013/2014,47,HHS Region 10,Season onset,51
 2013,47,2013/2014,47,HHS Region 10,Season peak week,1
 2013,47,2013/2014,47,HHS Region 10,Season peak percentage,4
@@ -8479,7 +8471,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,48,2013/2014,48,HHS Region 3,Season peak percentage,3.6
 2013,48,2013/2014,48,HHS Region 3,1 wk ahead,1.5
 2013,48,2013/2014,48,HHS Region 3,2 wk ahead,1.6
-2013,48,2013/2014,48,HHS Region 3,3 wk ahead,2
+2013,48,2013/2014,48,HHS Region 3,3 wk ahead,2.2
 2013,48,2013/2014,48,HHS Region 3,4 wk ahead,3.3
 2013,48,2013/2014,48,HHS Region 4,Season onset,48
 2013,48,2013/2014,48,HHS Region 4,Season peak week,52
@@ -8517,13 +8509,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,48,2013/2014,48,HHS Region 8,3 wk ahead,2
 2013,48,2013/2014,48,HHS Region 8,4 wk ahead,3.7
 2013,48,2013/2014,48,HHS Region 9,Season onset,51
-2013,48,2013/2014,48,HHS Region 9,Season peak week,1
 2013,48,2013/2014,48,HHS Region 9,Season peak week,4
-2013,48,2013/2014,48,HHS Region 9,Season peak percentage,4.6
-2013,48,2013/2014,48,HHS Region 9,1 wk ahead,2.1
-2013,48,2013/2014,48,HHS Region 9,2 wk ahead,2.5
-2013,48,2013/2014,48,HHS Region 9,3 wk ahead,2.9
-2013,48,2013/2014,48,HHS Region 9,4 wk ahead,4.5
+2013,48,2013/2014,48,HHS Region 9,Season peak percentage,4.7
+2013,48,2013/2014,48,HHS Region 9,1 wk ahead,2.2
+2013,48,2013/2014,48,HHS Region 9,2 wk ahead,2.6
+2013,48,2013/2014,48,HHS Region 9,3 wk ahead,3
+2013,48,2013/2014,48,HHS Region 9,4 wk ahead,4.6
 2013,48,2013/2014,48,HHS Region 10,Season onset,51
 2013,48,2013/2014,48,HHS Region 10,Season peak week,1
 2013,48,2013/2014,48,HHS Region 10,Season peak percentage,4
@@ -8557,7 +8548,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,49,2013/2014,49,HHS Region 3,Season peak week,1
 2013,49,2013/2014,49,HHS Region 3,Season peak percentage,3.6
 2013,49,2013/2014,49,HHS Region 3,1 wk ahead,1.6
-2013,49,2013/2014,49,HHS Region 3,2 wk ahead,2
+2013,49,2013/2014,49,HHS Region 3,2 wk ahead,2.2
 2013,49,2013/2014,49,HHS Region 3,3 wk ahead,3.3
 2013,49,2013/2014,49,HHS Region 3,4 wk ahead,3.6
 2013,49,2013/2014,49,HHS Region 4,Season onset,48
@@ -8580,7 +8571,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,49,2013/2014,49,HHS Region 6,1 wk ahead,5.6
 2013,49,2013/2014,49,HHS Region 6,2 wk ahead,8
 2013,49,2013/2014,49,HHS Region 6,3 wk ahead,9.9
-2013,49,2013/2014,49,HHS Region 6,4 wk ahead,8.6
+2013,49,2013/2014,49,HHS Region 6,4 wk ahead,8.7
 2013,49,2013/2014,49,HHS Region 7,Season onset,51
 2013,49,2013/2014,49,HHS Region 7,Season peak week,52
 2013,49,2013/2014,49,HHS Region 7,Season peak percentage,4.5
@@ -8596,12 +8587,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,49,2013/2014,49,HHS Region 8,3 wk ahead,3.7
 2013,49,2013/2014,49,HHS Region 8,4 wk ahead,3
 2013,49,2013/2014,49,HHS Region 9,Season onset,51
-2013,49,2013/2014,49,HHS Region 9,Season peak week,1
 2013,49,2013/2014,49,HHS Region 9,Season peak week,4
-2013,49,2013/2014,49,HHS Region 9,Season peak percentage,4.6
-2013,49,2013/2014,49,HHS Region 9,1 wk ahead,2.5
-2013,49,2013/2014,49,HHS Region 9,2 wk ahead,2.9
-2013,49,2013/2014,49,HHS Region 9,3 wk ahead,4.5
+2013,49,2013/2014,49,HHS Region 9,Season peak percentage,4.7
+2013,49,2013/2014,49,HHS Region 9,1 wk ahead,2.6
+2013,49,2013/2014,49,HHS Region 9,2 wk ahead,3
+2013,49,2013/2014,49,HHS Region 9,3 wk ahead,4.6
 2013,49,2013/2014,49,HHS Region 9,4 wk ahead,4.6
 2013,49,2013/2014,49,HHS Region 10,Season onset,51
 2013,49,2013/2014,49,HHS Region 10,Season peak week,1
@@ -8635,7 +8625,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,50,2013/2014,50,HHS Region 3,Season onset,51
 2013,50,2013/2014,50,HHS Region 3,Season peak week,1
 2013,50,2013/2014,50,HHS Region 3,Season peak percentage,3.6
-2013,50,2013/2014,50,HHS Region 3,1 wk ahead,2
+2013,50,2013/2014,50,HHS Region 3,1 wk ahead,2.2
 2013,50,2013/2014,50,HHS Region 3,2 wk ahead,3.3
 2013,50,2013/2014,50,HHS Region 3,3 wk ahead,3.6
 2013,50,2013/2014,50,HHS Region 3,4 wk ahead,3.2
@@ -8645,7 +8635,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,50,2013/2014,50,HHS Region 4,1 wk ahead,3.2
 2013,50,2013/2014,50,HHS Region 4,2 wk ahead,4.6
 2013,50,2013/2014,50,HHS Region 4,3 wk ahead,3.9
-2013,50,2013/2014,50,HHS Region 4,4 wk ahead,3
+2013,50,2013/2014,50,HHS Region 4,4 wk ahead,3.1
 2013,50,2013/2014,50,HHS Region 5,Season onset,48
 2013,50,2013/2014,50,HHS Region 5,Season peak week,52
 2013,50,2013/2014,50,HHS Region 5,Season peak percentage,3.6
@@ -8658,7 +8648,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,50,2013/2014,50,HHS Region 6,Season peak percentage,9.9
 2013,50,2013/2014,50,HHS Region 6,1 wk ahead,8
 2013,50,2013/2014,50,HHS Region 6,2 wk ahead,9.9
-2013,50,2013/2014,50,HHS Region 6,3 wk ahead,8.6
+2013,50,2013/2014,50,HHS Region 6,3 wk ahead,8.7
 2013,50,2013/2014,50,HHS Region 6,4 wk ahead,6.9
 2013,50,2013/2014,50,HHS Region 7,Season onset,51
 2013,50,2013/2014,50,HHS Region 7,Season peak week,52
@@ -8675,11 +8665,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,50,2013/2014,50,HHS Region 8,3 wk ahead,3
 2013,50,2013/2014,50,HHS Region 8,4 wk ahead,2.6
 2013,50,2013/2014,50,HHS Region 9,Season onset,51
-2013,50,2013/2014,50,HHS Region 9,Season peak week,1
 2013,50,2013/2014,50,HHS Region 9,Season peak week,4
-2013,50,2013/2014,50,HHS Region 9,Season peak percentage,4.6
-2013,50,2013/2014,50,HHS Region 9,1 wk ahead,2.9
-2013,50,2013/2014,50,HHS Region 9,2 wk ahead,4.5
+2013,50,2013/2014,50,HHS Region 9,Season peak percentage,4.7
+2013,50,2013/2014,50,HHS Region 9,1 wk ahead,3
+2013,50,2013/2014,50,HHS Region 9,2 wk ahead,4.6
 2013,50,2013/2014,50,HHS Region 9,3 wk ahead,4.6
 2013,50,2013/2014,50,HHS Region 9,4 wk ahead,4.2
 2013,50,2013/2014,50,HHS Region 10,Season onset,51
@@ -8723,7 +8712,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,51,2013/2014,51,HHS Region 4,Season peak percentage,4.6
 2013,51,2013/2014,51,HHS Region 4,1 wk ahead,4.6
 2013,51,2013/2014,51,HHS Region 4,2 wk ahead,3.9
-2013,51,2013/2014,51,HHS Region 4,3 wk ahead,3
+2013,51,2013/2014,51,HHS Region 4,3 wk ahead,3.1
 2013,51,2013/2014,51,HHS Region 4,4 wk ahead,2.8
 2013,51,2013/2014,51,HHS Region 5,Season onset,48
 2013,51,2013/2014,51,HHS Region 5,Season peak week,52
@@ -8736,7 +8725,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,51,2013/2014,51,HHS Region 6,Season peak week,52
 2013,51,2013/2014,51,HHS Region 6,Season peak percentage,9.9
 2013,51,2013/2014,51,HHS Region 6,1 wk ahead,9.9
-2013,51,2013/2014,51,HHS Region 6,2 wk ahead,8.6
+2013,51,2013/2014,51,HHS Region 6,2 wk ahead,8.7
 2013,51,2013/2014,51,HHS Region 6,3 wk ahead,6.9
 2013,51,2013/2014,51,HHS Region 6,4 wk ahead,5.8
 2013,51,2013/2014,51,HHS Region 7,Season onset,51
@@ -8754,13 +8743,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,51,2013/2014,51,HHS Region 8,3 wk ahead,2.6
 2013,51,2013/2014,51,HHS Region 8,4 wk ahead,2.3
 2013,51,2013/2014,51,HHS Region 9,Season onset,51
-2013,51,2013/2014,51,HHS Region 9,Season peak week,1
 2013,51,2013/2014,51,HHS Region 9,Season peak week,4
-2013,51,2013/2014,51,HHS Region 9,Season peak percentage,4.6
-2013,51,2013/2014,51,HHS Region 9,1 wk ahead,4.5
+2013,51,2013/2014,51,HHS Region 9,Season peak percentage,4.7
+2013,51,2013/2014,51,HHS Region 9,1 wk ahead,4.6
 2013,51,2013/2014,51,HHS Region 9,2 wk ahead,4.6
 2013,51,2013/2014,51,HHS Region 9,3 wk ahead,4.2
-2013,51,2013/2014,51,HHS Region 9,4 wk ahead,4.2
+2013,51,2013/2014,51,HHS Region 9,4 wk ahead,4.3
 2013,51,2013/2014,51,HHS Region 10,Season onset,51
 2013,51,2013/2014,51,HHS Region 10,Season peak week,1
 2013,51,2013/2014,51,HHS Region 10,Season peak percentage,4
@@ -8801,7 +8789,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,52,2013/2014,52,HHS Region 4,Season peak week,52
 2013,52,2013/2014,52,HHS Region 4,Season peak percentage,4.6
 2013,52,2013/2014,52,HHS Region 4,1 wk ahead,3.9
-2013,52,2013/2014,52,HHS Region 4,2 wk ahead,3
+2013,52,2013/2014,52,HHS Region 4,2 wk ahead,3.1
 2013,52,2013/2014,52,HHS Region 4,3 wk ahead,2.8
 2013,52,2013/2014,52,HHS Region 4,4 wk ahead,2.9
 2013,52,2013/2014,52,HHS Region 5,Season onset,48
@@ -8814,7 +8802,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,52,2013/2014,52,HHS Region 6,Season onset,45
 2013,52,2013/2014,52,HHS Region 6,Season peak week,52
 2013,52,2013/2014,52,HHS Region 6,Season peak percentage,9.9
-2013,52,2013/2014,52,HHS Region 6,1 wk ahead,8.6
+2013,52,2013/2014,52,HHS Region 6,1 wk ahead,8.7
 2013,52,2013/2014,52,HHS Region 6,2 wk ahead,6.9
 2013,52,2013/2014,52,HHS Region 6,3 wk ahead,5.8
 2013,52,2013/2014,52,HHS Region 6,4 wk ahead,5.3
@@ -8833,13 +8821,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,52,2013/2014,52,HHS Region 8,3 wk ahead,2.3
 2013,52,2013/2014,52,HHS Region 8,4 wk ahead,2.1
 2013,52,2013/2014,52,HHS Region 9,Season onset,51
-2013,52,2013/2014,52,HHS Region 9,Season peak week,1
 2013,52,2013/2014,52,HHS Region 9,Season peak week,4
-2013,52,2013/2014,52,HHS Region 9,Season peak percentage,4.6
+2013,52,2013/2014,52,HHS Region 9,Season peak percentage,4.7
 2013,52,2013/2014,52,HHS Region 9,1 wk ahead,4.6
 2013,52,2013/2014,52,HHS Region 9,2 wk ahead,4.2
-2013,52,2013/2014,52,HHS Region 9,3 wk ahead,4.2
-2013,52,2013/2014,52,HHS Region 9,4 wk ahead,4.6
+2013,52,2013/2014,52,HHS Region 9,3 wk ahead,4.3
+2013,52,2013/2014,52,HHS Region 9,4 wk ahead,4.7
 2013,52,2013/2014,52,HHS Region 10,Season onset,51
 2013,52,2013/2014,52,HHS Region 10,Season peak week,1
 2013,52,2013/2014,52,HHS Region 10,Season peak percentage,4
@@ -8879,7 +8866,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,1,2013/2014,53,HHS Region 4,Season onset,48
 2014,1,2013/2014,53,HHS Region 4,Season peak week,52
 2014,1,2013/2014,53,HHS Region 4,Season peak percentage,4.6
-2014,1,2013/2014,53,HHS Region 4,1 wk ahead,3
+2014,1,2013/2014,53,HHS Region 4,1 wk ahead,3.1
 2014,1,2013/2014,53,HHS Region 4,2 wk ahead,2.8
 2014,1,2013/2014,53,HHS Region 4,3 wk ahead,2.9
 2014,1,2013/2014,53,HHS Region 4,4 wk ahead,2.7
@@ -8912,13 +8899,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,1,2013/2014,53,HHS Region 8,3 wk ahead,2.1
 2014,1,2013/2014,53,HHS Region 8,4 wk ahead,1.8
 2014,1,2013/2014,53,HHS Region 9,Season onset,51
-2014,1,2013/2014,53,HHS Region 9,Season peak week,1
 2014,1,2013/2014,53,HHS Region 9,Season peak week,4
-2014,1,2013/2014,53,HHS Region 9,Season peak percentage,4.6
+2014,1,2013/2014,53,HHS Region 9,Season peak percentage,4.7
 2014,1,2013/2014,53,HHS Region 9,1 wk ahead,4.2
-2014,1,2013/2014,53,HHS Region 9,2 wk ahead,4.2
-2014,1,2013/2014,53,HHS Region 9,3 wk ahead,4.6
-2014,1,2013/2014,53,HHS Region 9,4 wk ahead,4
+2014,1,2013/2014,53,HHS Region 9,2 wk ahead,4.3
+2014,1,2013/2014,53,HHS Region 9,3 wk ahead,4.7
+2014,1,2013/2014,53,HHS Region 9,4 wk ahead,4.1
 2014,1,2013/2014,53,HHS Region 10,Season onset,51
 2014,1,2013/2014,53,HHS Region 10,Season peak week,1
 2014,1,2013/2014,53,HHS Region 10,Season peak percentage,4
@@ -8961,7 +8947,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,2,2013/2014,54,HHS Region 4,1 wk ahead,2.8
 2014,2,2013/2014,54,HHS Region 4,2 wk ahead,2.9
 2014,2,2013/2014,54,HHS Region 4,3 wk ahead,2.7
-2014,2,2013/2014,54,HHS Region 4,4 wk ahead,2.3
+2014,2,2013/2014,54,HHS Region 4,4 wk ahead,2.2
 2014,2,2013/2014,54,HHS Region 5,Season onset,48
 2014,2,2013/2014,54,HHS Region 5,Season peak week,52
 2014,2,2013/2014,54,HHS Region 5,Season peak percentage,3.6
@@ -8991,13 +8977,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,2,2013/2014,54,HHS Region 8,3 wk ahead,1.8
 2014,2,2013/2014,54,HHS Region 8,4 wk ahead,1.8
 2014,2,2013/2014,54,HHS Region 9,Season onset,51
-2014,2,2013/2014,54,HHS Region 9,Season peak week,1
 2014,2,2013/2014,54,HHS Region 9,Season peak week,4
-2014,2,2013/2014,54,HHS Region 9,Season peak percentage,4.6
-2014,2,2013/2014,54,HHS Region 9,1 wk ahead,4.2
-2014,2,2013/2014,54,HHS Region 9,2 wk ahead,4.6
-2014,2,2013/2014,54,HHS Region 9,3 wk ahead,4
-2014,2,2013/2014,54,HHS Region 9,4 wk ahead,3.6
+2014,2,2013/2014,54,HHS Region 9,Season peak percentage,4.7
+2014,2,2013/2014,54,HHS Region 9,1 wk ahead,4.3
+2014,2,2013/2014,54,HHS Region 9,2 wk ahead,4.7
+2014,2,2013/2014,54,HHS Region 9,3 wk ahead,4.1
+2014,2,2013/2014,54,HHS Region 9,4 wk ahead,3.7
 2014,2,2013/2014,54,HHS Region 10,Season onset,51
 2014,2,2013/2014,54,HHS Region 10,Season peak week,1
 2014,2,2013/2014,54,HHS Region 10,Season peak percentage,4
@@ -9039,7 +9024,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,3,2013/2014,55,HHS Region 4,Season peak percentage,4.6
 2014,3,2013/2014,55,HHS Region 4,1 wk ahead,2.9
 2014,3,2013/2014,55,HHS Region 4,2 wk ahead,2.7
-2014,3,2013/2014,55,HHS Region 4,3 wk ahead,2.3
+2014,3,2013/2014,55,HHS Region 4,3 wk ahead,2.2
 2014,3,2013/2014,55,HHS Region 4,4 wk ahead,2
 2014,3,2013/2014,55,HHS Region 5,Season onset,48
 2014,3,2013/2014,55,HHS Region 5,Season peak week,52
@@ -9054,7 +9039,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,3,2013/2014,55,HHS Region 6,1 wk ahead,5.3
 2014,3,2013/2014,55,HHS Region 6,2 wk ahead,5.2
 2014,3,2013/2014,55,HHS Region 6,3 wk ahead,4.6
-2014,3,2013/2014,55,HHS Region 6,4 wk ahead,3.9
+2014,3,2013/2014,55,HHS Region 6,4 wk ahead,3.8
 2014,3,2013/2014,55,HHS Region 7,Season onset,51
 2014,3,2013/2014,55,HHS Region 7,Season peak week,52
 2014,3,2013/2014,55,HHS Region 7,Season peak percentage,4.5
@@ -9070,12 +9055,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,3,2013/2014,55,HHS Region 8,3 wk ahead,1.8
 2014,3,2013/2014,55,HHS Region 8,4 wk ahead,1.5
 2014,3,2013/2014,55,HHS Region 9,Season onset,51
-2014,3,2013/2014,55,HHS Region 9,Season peak week,1
 2014,3,2013/2014,55,HHS Region 9,Season peak week,4
-2014,3,2013/2014,55,HHS Region 9,Season peak percentage,4.6
-2014,3,2013/2014,55,HHS Region 9,1 wk ahead,4.6
-2014,3,2013/2014,55,HHS Region 9,2 wk ahead,4
-2014,3,2013/2014,55,HHS Region 9,3 wk ahead,3.6
+2014,3,2013/2014,55,HHS Region 9,Season peak percentage,4.7
+2014,3,2013/2014,55,HHS Region 9,1 wk ahead,4.7
+2014,3,2013/2014,55,HHS Region 9,2 wk ahead,4.1
+2014,3,2013/2014,55,HHS Region 9,3 wk ahead,3.7
 2014,3,2013/2014,55,HHS Region 9,4 wk ahead,3.3
 2014,3,2013/2014,55,HHS Region 10,Season onset,51
 2014,3,2013/2014,55,HHS Region 10,Season peak week,1
@@ -9112,12 +9096,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,4,2013/2014,56,HHS Region 3,1 wk ahead,3
 2014,4,2013/2014,56,HHS Region 3,2 wk ahead,2.8
 2014,4,2013/2014,56,HHS Region 3,3 wk ahead,2.4
-2014,4,2013/2014,56,HHS Region 3,4 wk ahead,2.1
+2014,4,2013/2014,56,HHS Region 3,4 wk ahead,2
 2014,4,2013/2014,56,HHS Region 4,Season onset,48
 2014,4,2013/2014,56,HHS Region 4,Season peak week,52
 2014,4,2013/2014,56,HHS Region 4,Season peak percentage,4.6
 2014,4,2013/2014,56,HHS Region 4,1 wk ahead,2.7
-2014,4,2013/2014,56,HHS Region 4,2 wk ahead,2.3
+2014,4,2013/2014,56,HHS Region 4,2 wk ahead,2.2
 2014,4,2013/2014,56,HHS Region 4,3 wk ahead,2
 2014,4,2013/2014,56,HHS Region 4,4 wk ahead,1.5
 2014,4,2013/2014,56,HHS Region 5,Season onset,48
@@ -9132,7 +9116,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,4,2013/2014,56,HHS Region 6,Season peak percentage,9.9
 2014,4,2013/2014,56,HHS Region 6,1 wk ahead,5.2
 2014,4,2013/2014,56,HHS Region 6,2 wk ahead,4.6
-2014,4,2013/2014,56,HHS Region 6,3 wk ahead,3.9
+2014,4,2013/2014,56,HHS Region 6,3 wk ahead,3.8
 2014,4,2013/2014,56,HHS Region 6,4 wk ahead,3.8
 2014,4,2013/2014,56,HHS Region 7,Season onset,51
 2014,4,2013/2014,56,HHS Region 7,Season peak week,52
@@ -9149,11 +9133,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,4,2013/2014,56,HHS Region 8,3 wk ahead,1.5
 2014,4,2013/2014,56,HHS Region 8,4 wk ahead,1.5
 2014,4,2013/2014,56,HHS Region 9,Season onset,51
-2014,4,2013/2014,56,HHS Region 9,Season peak week,1
 2014,4,2013/2014,56,HHS Region 9,Season peak week,4
-2014,4,2013/2014,56,HHS Region 9,Season peak percentage,4.6
-2014,4,2013/2014,56,HHS Region 9,1 wk ahead,4
-2014,4,2013/2014,56,HHS Region 9,2 wk ahead,3.6
+2014,4,2013/2014,56,HHS Region 9,Season peak percentage,4.7
+2014,4,2013/2014,56,HHS Region 9,1 wk ahead,4.1
+2014,4,2013/2014,56,HHS Region 9,2 wk ahead,3.7
 2014,4,2013/2014,56,HHS Region 9,3 wk ahead,3.3
 2014,4,2013/2014,56,HHS Region 9,4 wk ahead,3.2
 2014,4,2013/2014,56,HHS Region 10,Season onset,51
@@ -9190,12 +9173,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,5,2013/2014,57,HHS Region 3,Season peak percentage,3.6
 2014,5,2013/2014,57,HHS Region 3,1 wk ahead,2.8
 2014,5,2013/2014,57,HHS Region 3,2 wk ahead,2.4
-2014,5,2013/2014,57,HHS Region 3,3 wk ahead,2.1
+2014,5,2013/2014,57,HHS Region 3,3 wk ahead,2
 2014,5,2013/2014,57,HHS Region 3,4 wk ahead,2
 2014,5,2013/2014,57,HHS Region 4,Season onset,48
 2014,5,2013/2014,57,HHS Region 4,Season peak week,52
 2014,5,2013/2014,57,HHS Region 4,Season peak percentage,4.6
-2014,5,2013/2014,57,HHS Region 4,1 wk ahead,2.3
+2014,5,2013/2014,57,HHS Region 4,1 wk ahead,2.2
 2014,5,2013/2014,57,HHS Region 4,2 wk ahead,2
 2014,5,2013/2014,57,HHS Region 4,3 wk ahead,1.5
 2014,5,2013/2014,57,HHS Region 4,4 wk ahead,1.4
@@ -9210,7 +9193,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,5,2013/2014,57,HHS Region 6,Season peak week,52
 2014,5,2013/2014,57,HHS Region 6,Season peak percentage,9.9
 2014,5,2013/2014,57,HHS Region 6,1 wk ahead,4.6
-2014,5,2013/2014,57,HHS Region 6,2 wk ahead,3.9
+2014,5,2013/2014,57,HHS Region 6,2 wk ahead,3.8
 2014,5,2013/2014,57,HHS Region 6,3 wk ahead,3.8
 2014,5,2013/2014,57,HHS Region 6,4 wk ahead,3.6
 2014,5,2013/2014,57,HHS Region 7,Season onset,51
@@ -9219,7 +9202,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,5,2013/2014,57,HHS Region 7,1 wk ahead,2.1
 2014,5,2013/2014,57,HHS Region 7,2 wk ahead,1.6
 2014,5,2013/2014,57,HHS Region 7,3 wk ahead,1.4
-2014,5,2013/2014,57,HHS Region 7,4 wk ahead,1.3
+2014,5,2013/2014,57,HHS Region 7,4 wk ahead,1.2
 2014,5,2013/2014,57,HHS Region 8,Season onset,49
 2014,5,2013/2014,57,HHS Region 8,Season peak week,52
 2014,5,2013/2014,57,HHS Region 8,Season peak percentage,3.7
@@ -9228,13 +9211,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,5,2013/2014,57,HHS Region 8,3 wk ahead,1.5
 2014,5,2013/2014,57,HHS Region 8,4 wk ahead,1.2
 2014,5,2013/2014,57,HHS Region 9,Season onset,51
-2014,5,2013/2014,57,HHS Region 9,Season peak week,1
 2014,5,2013/2014,57,HHS Region 9,Season peak week,4
-2014,5,2013/2014,57,HHS Region 9,Season peak percentage,4.6
-2014,5,2013/2014,57,HHS Region 9,1 wk ahead,3.6
+2014,5,2013/2014,57,HHS Region 9,Season peak percentage,4.7
+2014,5,2013/2014,57,HHS Region 9,1 wk ahead,3.7
 2014,5,2013/2014,57,HHS Region 9,2 wk ahead,3.3
 2014,5,2013/2014,57,HHS Region 9,3 wk ahead,3.2
-2014,5,2013/2014,57,HHS Region 9,4 wk ahead,2.9
+2014,5,2013/2014,57,HHS Region 9,4 wk ahead,3
 2014,5,2013/2014,57,HHS Region 10,Season onset,51
 2014,5,2013/2014,57,HHS Region 10,Season peak week,1
 2014,5,2013/2014,57,HHS Region 10,Season peak percentage,4
@@ -9268,7 +9250,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,6,2013/2014,58,HHS Region 3,Season peak week,1
 2014,6,2013/2014,58,HHS Region 3,Season peak percentage,3.6
 2014,6,2013/2014,58,HHS Region 3,1 wk ahead,2.4
-2014,6,2013/2014,58,HHS Region 3,2 wk ahead,2.1
+2014,6,2013/2014,58,HHS Region 3,2 wk ahead,2
 2014,6,2013/2014,58,HHS Region 3,3 wk ahead,2
 2014,6,2013/2014,58,HHS Region 3,4 wk ahead,1.8
 2014,6,2013/2014,58,HHS Region 4,Season onset,48
@@ -9277,7 +9259,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,6,2013/2014,58,HHS Region 4,1 wk ahead,2
 2014,6,2013/2014,58,HHS Region 4,2 wk ahead,1.5
 2014,6,2013/2014,58,HHS Region 4,3 wk ahead,1.4
-2014,6,2013/2014,58,HHS Region 4,4 wk ahead,1.3
+2014,6,2013/2014,58,HHS Region 4,4 wk ahead,1.4
 2014,6,2013/2014,58,HHS Region 5,Season onset,48
 2014,6,2013/2014,58,HHS Region 5,Season peak week,52
 2014,6,2013/2014,58,HHS Region 5,Season peak percentage,3.6
@@ -9288,7 +9270,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,6,2013/2014,58,HHS Region 6,Season onset,45
 2014,6,2013/2014,58,HHS Region 6,Season peak week,52
 2014,6,2013/2014,58,HHS Region 6,Season peak percentage,9.9
-2014,6,2013/2014,58,HHS Region 6,1 wk ahead,3.9
+2014,6,2013/2014,58,HHS Region 6,1 wk ahead,3.8
 2014,6,2013/2014,58,HHS Region 6,2 wk ahead,3.8
 2014,6,2013/2014,58,HHS Region 6,3 wk ahead,3.6
 2014,6,2013/2014,58,HHS Region 6,4 wk ahead,3.4
@@ -9297,7 +9279,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,6,2013/2014,58,HHS Region 7,Season peak percentage,4.5
 2014,6,2013/2014,58,HHS Region 7,1 wk ahead,1.6
 2014,6,2013/2014,58,HHS Region 7,2 wk ahead,1.4
-2014,6,2013/2014,58,HHS Region 7,3 wk ahead,1.3
+2014,6,2013/2014,58,HHS Region 7,3 wk ahead,1.2
 2014,6,2013/2014,58,HHS Region 7,4 wk ahead,1.1
 2014,6,2013/2014,58,HHS Region 8,Season onset,49
 2014,6,2013/2014,58,HHS Region 8,Season peak week,52
@@ -9307,12 +9289,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,6,2013/2014,58,HHS Region 8,3 wk ahead,1.2
 2014,6,2013/2014,58,HHS Region 8,4 wk ahead,1.4
 2014,6,2013/2014,58,HHS Region 9,Season onset,51
-2014,6,2013/2014,58,HHS Region 9,Season peak week,1
 2014,6,2013/2014,58,HHS Region 9,Season peak week,4
-2014,6,2013/2014,58,HHS Region 9,Season peak percentage,4.6
+2014,6,2013/2014,58,HHS Region 9,Season peak percentage,4.7
 2014,6,2013/2014,58,HHS Region 9,1 wk ahead,3.3
 2014,6,2013/2014,58,HHS Region 9,2 wk ahead,3.2
-2014,6,2013/2014,58,HHS Region 9,3 wk ahead,2.9
+2014,6,2013/2014,58,HHS Region 9,3 wk ahead,3
 2014,6,2013/2014,58,HHS Region 9,4 wk ahead,2.6
 2014,6,2013/2014,58,HHS Region 10,Season onset,51
 2014,6,2013/2014,58,HHS Region 10,Season peak week,1
@@ -9346,7 +9327,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,7,2013/2014,59,HHS Region 3,Season onset,51
 2014,7,2013/2014,59,HHS Region 3,Season peak week,1
 2014,7,2013/2014,59,HHS Region 3,Season peak percentage,3.6
-2014,7,2013/2014,59,HHS Region 3,1 wk ahead,2.1
+2014,7,2013/2014,59,HHS Region 3,1 wk ahead,2
 2014,7,2013/2014,59,HHS Region 3,2 wk ahead,2
 2014,7,2013/2014,59,HHS Region 3,3 wk ahead,1.8
 2014,7,2013/2014,59,HHS Region 3,4 wk ahead,1.6
@@ -9355,7 +9336,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,7,2013/2014,59,HHS Region 4,Season peak percentage,4.6
 2014,7,2013/2014,59,HHS Region 4,1 wk ahead,1.5
 2014,7,2013/2014,59,HHS Region 4,2 wk ahead,1.4
-2014,7,2013/2014,59,HHS Region 4,3 wk ahead,1.3
+2014,7,2013/2014,59,HHS Region 4,3 wk ahead,1.4
 2014,7,2013/2014,59,HHS Region 4,4 wk ahead,1.1
 2014,7,2013/2014,59,HHS Region 5,Season onset,48
 2014,7,2013/2014,59,HHS Region 5,Season peak week,52
@@ -9375,7 +9356,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,7,2013/2014,59,HHS Region 7,Season peak week,52
 2014,7,2013/2014,59,HHS Region 7,Season peak percentage,4.5
 2014,7,2013/2014,59,HHS Region 7,1 wk ahead,1.4
-2014,7,2013/2014,59,HHS Region 7,2 wk ahead,1.3
+2014,7,2013/2014,59,HHS Region 7,2 wk ahead,1.2
 2014,7,2013/2014,59,HHS Region 7,3 wk ahead,1.1
 2014,7,2013/2014,59,HHS Region 7,4 wk ahead,1.4
 2014,7,2013/2014,59,HHS Region 8,Season onset,49
@@ -9386,13 +9367,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,7,2013/2014,59,HHS Region 8,3 wk ahead,1.4
 2014,7,2013/2014,59,HHS Region 8,4 wk ahead,1.1
 2014,7,2013/2014,59,HHS Region 9,Season onset,51
-2014,7,2013/2014,59,HHS Region 9,Season peak week,1
 2014,7,2013/2014,59,HHS Region 9,Season peak week,4
-2014,7,2013/2014,59,HHS Region 9,Season peak percentage,4.6
+2014,7,2013/2014,59,HHS Region 9,Season peak percentage,4.7
 2014,7,2013/2014,59,HHS Region 9,1 wk ahead,3.2
-2014,7,2013/2014,59,HHS Region 9,2 wk ahead,2.9
+2014,7,2013/2014,59,HHS Region 9,2 wk ahead,3
 2014,7,2013/2014,59,HHS Region 9,3 wk ahead,2.6
-2014,7,2013/2014,59,HHS Region 9,4 wk ahead,2.2
+2014,7,2013/2014,59,HHS Region 9,4 wk ahead,2.1
 2014,7,2013/2014,59,HHS Region 10,Season onset,51
 2014,7,2013/2014,59,HHS Region 10,Season peak week,1
 2014,7,2013/2014,59,HHS Region 10,Season peak percentage,4
@@ -9433,7 +9413,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,8,2013/2014,60,HHS Region 4,Season peak week,52
 2014,8,2013/2014,60,HHS Region 4,Season peak percentage,4.6
 2014,8,2013/2014,60,HHS Region 4,1 wk ahead,1.4
-2014,8,2013/2014,60,HHS Region 4,2 wk ahead,1.3
+2014,8,2013/2014,60,HHS Region 4,2 wk ahead,1.4
 2014,8,2013/2014,60,HHS Region 4,3 wk ahead,1.1
 2014,8,2013/2014,60,HHS Region 4,4 wk ahead,1
 2014,8,2013/2014,60,HHS Region 5,Season onset,48
@@ -9453,7 +9433,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,8,2013/2014,60,HHS Region 7,Season onset,51
 2014,8,2013/2014,60,HHS Region 7,Season peak week,52
 2014,8,2013/2014,60,HHS Region 7,Season peak percentage,4.5
-2014,8,2013/2014,60,HHS Region 7,1 wk ahead,1.3
+2014,8,2013/2014,60,HHS Region 7,1 wk ahead,1.2
 2014,8,2013/2014,60,HHS Region 7,2 wk ahead,1.1
 2014,8,2013/2014,60,HHS Region 7,3 wk ahead,1.4
 2014,8,2013/2014,60,HHS Region 7,4 wk ahead,1
@@ -9465,12 +9445,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,8,2013/2014,60,HHS Region 8,3 wk ahead,1.1
 2014,8,2013/2014,60,HHS Region 8,4 wk ahead,1
 2014,8,2013/2014,60,HHS Region 9,Season onset,51
-2014,8,2013/2014,60,HHS Region 9,Season peak week,1
 2014,8,2013/2014,60,HHS Region 9,Season peak week,4
-2014,8,2013/2014,60,HHS Region 9,Season peak percentage,4.6
-2014,8,2013/2014,60,HHS Region 9,1 wk ahead,2.9
+2014,8,2013/2014,60,HHS Region 9,Season peak percentage,4.7
+2014,8,2013/2014,60,HHS Region 9,1 wk ahead,3
 2014,8,2013/2014,60,HHS Region 9,2 wk ahead,2.6
-2014,8,2013/2014,60,HHS Region 9,3 wk ahead,2.2
+2014,8,2013/2014,60,HHS Region 9,3 wk ahead,2.1
 2014,8,2013/2014,60,HHS Region 9,4 wk ahead,2.2
 2014,8,2013/2014,60,HHS Region 10,Season onset,51
 2014,8,2013/2014,60,HHS Region 10,Season peak week,1
@@ -9511,7 +9490,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,9,2013/2014,61,HHS Region 4,Season onset,48
 2014,9,2013/2014,61,HHS Region 4,Season peak week,52
 2014,9,2013/2014,61,HHS Region 4,Season peak percentage,4.6
-2014,9,2013/2014,61,HHS Region 4,1 wk ahead,1.3
+2014,9,2013/2014,61,HHS Region 4,1 wk ahead,1.4
 2014,9,2013/2014,61,HHS Region 4,2 wk ahead,1.1
 2014,9,2013/2014,61,HHS Region 4,3 wk ahead,1
 2014,9,2013/2014,61,HHS Region 4,4 wk ahead,1
@@ -9544,11 +9523,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,9,2013/2014,61,HHS Region 8,3 wk ahead,1
 2014,9,2013/2014,61,HHS Region 8,4 wk ahead,0.9
 2014,9,2013/2014,61,HHS Region 9,Season onset,51
-2014,9,2013/2014,61,HHS Region 9,Season peak week,1
 2014,9,2013/2014,61,HHS Region 9,Season peak week,4
-2014,9,2013/2014,61,HHS Region 9,Season peak percentage,4.6
+2014,9,2013/2014,61,HHS Region 9,Season peak percentage,4.7
 2014,9,2013/2014,61,HHS Region 9,1 wk ahead,2.6
-2014,9,2013/2014,61,HHS Region 9,2 wk ahead,2.2
+2014,9,2013/2014,61,HHS Region 9,2 wk ahead,2.1
 2014,9,2013/2014,61,HHS Region 9,3 wk ahead,2.2
 2014,9,2013/2014,61,HHS Region 9,4 wk ahead,1.9
 2014,9,2013/2014,61,HHS Region 10,Season onset,51
@@ -9623,10 +9601,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,10,2013/2014,62,HHS Region 8,3 wk ahead,0.9
 2014,10,2013/2014,62,HHS Region 8,4 wk ahead,0.9
 2014,10,2013/2014,62,HHS Region 9,Season onset,51
-2014,10,2013/2014,62,HHS Region 9,Season peak week,1
 2014,10,2013/2014,62,HHS Region 9,Season peak week,4
-2014,10,2013/2014,62,HHS Region 9,Season peak percentage,4.6
-2014,10,2013/2014,62,HHS Region 9,1 wk ahead,2.2
+2014,10,2013/2014,62,HHS Region 9,Season peak percentage,4.7
+2014,10,2013/2014,62,HHS Region 9,1 wk ahead,2.1
 2014,10,2013/2014,62,HHS Region 9,2 wk ahead,2.2
 2014,10,2013/2014,62,HHS Region 9,3 wk ahead,1.9
 2014,10,2013/2014,62,HHS Region 9,4 wk ahead,1.9
@@ -9702,9 +9679,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,11,2013/2014,63,HHS Region 8,3 wk ahead,0.9
 2014,11,2013/2014,63,HHS Region 8,4 wk ahead,0.9
 2014,11,2013/2014,63,HHS Region 9,Season onset,51
-2014,11,2013/2014,63,HHS Region 9,Season peak week,1
 2014,11,2013/2014,63,HHS Region 9,Season peak week,4
-2014,11,2013/2014,63,HHS Region 9,Season peak percentage,4.6
+2014,11,2013/2014,63,HHS Region 9,Season peak percentage,4.7
 2014,11,2013/2014,63,HHS Region 9,1 wk ahead,2.2
 2014,11,2013/2014,63,HHS Region 9,2 wk ahead,1.9
 2014,11,2013/2014,63,HHS Region 9,3 wk ahead,1.9
@@ -9781,13 +9757,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,12,2013/2014,64,HHS Region 8,3 wk ahead,0.9
 2014,12,2013/2014,64,HHS Region 8,4 wk ahead,0.8
 2014,12,2013/2014,64,HHS Region 9,Season onset,51
-2014,12,2013/2014,64,HHS Region 9,Season peak week,1
 2014,12,2013/2014,64,HHS Region 9,Season peak week,4
-2014,12,2013/2014,64,HHS Region 9,Season peak percentage,4.6
+2014,12,2013/2014,64,HHS Region 9,Season peak percentage,4.7
 2014,12,2013/2014,64,HHS Region 9,1 wk ahead,1.9
 2014,12,2013/2014,64,HHS Region 9,2 wk ahead,1.9
 2014,12,2013/2014,64,HHS Region 9,3 wk ahead,1.7
-2014,12,2013/2014,64,HHS Region 9,4 wk ahead,1.8
+2014,12,2013/2014,64,HHS Region 9,4 wk ahead,1.7
 2014,12,2013/2014,64,HHS Region 10,Season onset,51
 2014,12,2013/2014,64,HHS Region 10,Season peak week,1
 2014,12,2013/2014,64,HHS Region 10,Season peak percentage,4
@@ -9816,7 +9791,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,13,2013/2014,65,HHS Region 2,1 wk ahead,3.3
 2014,13,2013/2014,65,HHS Region 2,2 wk ahead,3.2
 2014,13,2013/2014,65,HHS Region 2,3 wk ahead,2.6
-2014,13,2013/2014,65,HHS Region 2,4 wk ahead,2.3
+2014,13,2013/2014,65,HHS Region 2,4 wk ahead,2.2
 2014,13,2013/2014,65,HHS Region 3,Season onset,51
 2014,13,2013/2014,65,HHS Region 3,Season peak week,1
 2014,13,2013/2014,65,HHS Region 3,Season peak percentage,3.6
@@ -9860,13 +9835,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,13,2013/2014,65,HHS Region 8,3 wk ahead,0.8
 2014,13,2013/2014,65,HHS Region 8,4 wk ahead,1
 2014,13,2013/2014,65,HHS Region 9,Season onset,51
-2014,13,2013/2014,65,HHS Region 9,Season peak week,1
 2014,13,2013/2014,65,HHS Region 9,Season peak week,4
-2014,13,2013/2014,65,HHS Region 9,Season peak percentage,4.6
+2014,13,2013/2014,65,HHS Region 9,Season peak percentage,4.7
 2014,13,2013/2014,65,HHS Region 9,1 wk ahead,1.9
 2014,13,2013/2014,65,HHS Region 9,2 wk ahead,1.7
-2014,13,2013/2014,65,HHS Region 9,3 wk ahead,1.8
-2014,13,2013/2014,65,HHS Region 9,4 wk ahead,1.7
+2014,13,2013/2014,65,HHS Region 9,3 wk ahead,1.7
+2014,13,2013/2014,65,HHS Region 9,4 wk ahead,1.6
 2014,13,2013/2014,65,HHS Region 10,Season onset,51
 2014,13,2013/2014,65,HHS Region 10,Season peak week,1
 2014,13,2013/2014,65,HHS Region 10,Season peak percentage,4
@@ -9894,7 +9868,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,14,2013/2014,66,HHS Region 2,Season peak percentage,3.4
 2014,14,2013/2014,66,HHS Region 2,1 wk ahead,3.2
 2014,14,2013/2014,66,HHS Region 2,2 wk ahead,2.6
-2014,14,2013/2014,66,HHS Region 2,3 wk ahead,2.3
+2014,14,2013/2014,66,HHS Region 2,3 wk ahead,2.2
 2014,14,2013/2014,66,HHS Region 2,4 wk ahead,1.9
 2014,14,2013/2014,66,HHS Region 3,Season onset,51
 2014,14,2013/2014,66,HHS Region 3,Season peak week,1
@@ -9939,12 +9913,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,14,2013/2014,66,HHS Region 8,3 wk ahead,1
 2014,14,2013/2014,66,HHS Region 8,4 wk ahead,0.8
 2014,14,2013/2014,66,HHS Region 9,Season onset,51
-2014,14,2013/2014,66,HHS Region 9,Season peak week,1
 2014,14,2013/2014,66,HHS Region 9,Season peak week,4
-2014,14,2013/2014,66,HHS Region 9,Season peak percentage,4.6
+2014,14,2013/2014,66,HHS Region 9,Season peak percentage,4.7
 2014,14,2013/2014,66,HHS Region 9,1 wk ahead,1.7
-2014,14,2013/2014,66,HHS Region 9,2 wk ahead,1.8
-2014,14,2013/2014,66,HHS Region 9,3 wk ahead,1.7
+2014,14,2013/2014,66,HHS Region 9,2 wk ahead,1.7
+2014,14,2013/2014,66,HHS Region 9,3 wk ahead,1.6
 2014,14,2013/2014,66,HHS Region 9,4 wk ahead,1.6
 2014,14,2013/2014,66,HHS Region 10,Season onset,51
 2014,14,2013/2014,66,HHS Region 10,Season peak week,1
@@ -9972,7 +9945,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,15,2013/2014,67,HHS Region 2,Season peak week,13
 2014,15,2013/2014,67,HHS Region 2,Season peak percentage,3.4
 2014,15,2013/2014,67,HHS Region 2,1 wk ahead,2.6
-2014,15,2013/2014,67,HHS Region 2,2 wk ahead,2.3
+2014,15,2013/2014,67,HHS Region 2,2 wk ahead,2.2
 2014,15,2013/2014,67,HHS Region 2,3 wk ahead,1.9
 2014,15,2013/2014,67,HHS Region 2,4 wk ahead,2.3
 2014,15,2013/2014,67,HHS Region 3,Season onset,51
@@ -10018,13 +9991,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,15,2013/2014,67,HHS Region 8,3 wk ahead,0.8
 2014,15,2013/2014,67,HHS Region 8,4 wk ahead,0.6
 2014,15,2013/2014,67,HHS Region 9,Season onset,51
-2014,15,2013/2014,67,HHS Region 9,Season peak week,1
 2014,15,2013/2014,67,HHS Region 9,Season peak week,4
-2014,15,2013/2014,67,HHS Region 9,Season peak percentage,4.6
-2014,15,2013/2014,67,HHS Region 9,1 wk ahead,1.8
-2014,15,2013/2014,67,HHS Region 9,2 wk ahead,1.7
+2014,15,2013/2014,67,HHS Region 9,Season peak percentage,4.7
+2014,15,2013/2014,67,HHS Region 9,1 wk ahead,1.7
+2014,15,2013/2014,67,HHS Region 9,2 wk ahead,1.6
 2014,15,2013/2014,67,HHS Region 9,3 wk ahead,1.6
-2014,15,2013/2014,67,HHS Region 9,4 wk ahead,1.7
+2014,15,2013/2014,67,HHS Region 9,4 wk ahead,1.6
 2014,15,2013/2014,67,HHS Region 10,Season onset,51
 2014,15,2013/2014,67,HHS Region 10,Season peak week,1
 2014,15,2013/2014,67,HHS Region 10,Season peak percentage,4
@@ -10045,12 +10017,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,16,2013/2014,68,HHS Region 1,1 wk ahead,1.6
 2014,16,2013/2014,68,HHS Region 1,2 wk ahead,1.3
 2014,16,2013/2014,68,HHS Region 1,3 wk ahead,1.3
-2014,16,2013/2014,68,HHS Region 1,4 wk ahead,1
+2014,16,2013/2014,68,HHS Region 1,4 wk ahead,1.1
 2014,16,2013/2014,68,HHS Region 2,Season onset,51
 2014,16,2013/2014,68,HHS Region 2,Season peak week,6
 2014,16,2013/2014,68,HHS Region 2,Season peak week,13
 2014,16,2013/2014,68,HHS Region 2,Season peak percentage,3.4
-2014,16,2013/2014,68,HHS Region 2,1 wk ahead,2.3
+2014,16,2013/2014,68,HHS Region 2,1 wk ahead,2.2
 2014,16,2013/2014,68,HHS Region 2,2 wk ahead,1.9
 2014,16,2013/2014,68,HHS Region 2,3 wk ahead,2.3
 2014,16,2013/2014,68,HHS Region 2,4 wk ahead,2.1
@@ -10097,12 +10069,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,16,2013/2014,68,HHS Region 8,3 wk ahead,0.6
 2014,16,2013/2014,68,HHS Region 8,4 wk ahead,0.7
 2014,16,2013/2014,68,HHS Region 9,Season onset,51
-2014,16,2013/2014,68,HHS Region 9,Season peak week,1
 2014,16,2013/2014,68,HHS Region 9,Season peak week,4
-2014,16,2013/2014,68,HHS Region 9,Season peak percentage,4.6
-2014,16,2013/2014,68,HHS Region 9,1 wk ahead,1.7
+2014,16,2013/2014,68,HHS Region 9,Season peak percentage,4.7
+2014,16,2013/2014,68,HHS Region 9,1 wk ahead,1.6
 2014,16,2013/2014,68,HHS Region 9,2 wk ahead,1.6
-2014,16,2013/2014,68,HHS Region 9,3 wk ahead,1.7
+2014,16,2013/2014,68,HHS Region 9,3 wk ahead,1.6
 2014,16,2013/2014,68,HHS Region 9,4 wk ahead,1.7
 2014,16,2013/2014,68,HHS Region 10,Season onset,51
 2014,16,2013/2014,68,HHS Region 10,Season peak week,1
@@ -10110,7 +10081,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,16,2013/2014,68,HHS Region 10,1 wk ahead,0.8
 2014,16,2013/2014,68,HHS Region 10,2 wk ahead,0.5
 2014,16,2013/2014,68,HHS Region 10,3 wk ahead,0.8
-2014,16,2013/2014,68,HHS Region 10,4 wk ahead,0.6
+2014,16,2013/2014,68,HHS Region 10,4 wk ahead,0.7
 2014,17,2013/2014,69,US National,Season onset,48
 2014,17,2013/2014,69,US National,Season peak week,52
 2014,17,2013/2014,69,US National,Season peak percentage,4.6
@@ -10123,7 +10094,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,17,2013/2014,69,HHS Region 1,Season peak percentage,2.2
 2014,17,2013/2014,69,HHS Region 1,1 wk ahead,1.3
 2014,17,2013/2014,69,HHS Region 1,2 wk ahead,1.3
-2014,17,2013/2014,69,HHS Region 1,3 wk ahead,1
+2014,17,2013/2014,69,HHS Region 1,3 wk ahead,1.1
 2014,17,2013/2014,69,HHS Region 1,4 wk ahead,0.5
 2014,17,2013/2014,69,HHS Region 2,Season onset,51
 2014,17,2013/2014,69,HHS Region 2,Season peak week,6
@@ -10132,7 +10103,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,17,2013/2014,69,HHS Region 2,1 wk ahead,1.9
 2014,17,2013/2014,69,HHS Region 2,2 wk ahead,2.3
 2014,17,2013/2014,69,HHS Region 2,3 wk ahead,2.1
-2014,17,2013/2014,69,HHS Region 2,4 wk ahead,1.9
+2014,17,2013/2014,69,HHS Region 2,4 wk ahead,2
 2014,17,2013/2014,69,HHS Region 3,Season onset,51
 2014,17,2013/2014,69,HHS Region 3,Season peak week,1
 2014,17,2013/2014,69,HHS Region 3,Season peak percentage,3.6
@@ -10153,7 +10124,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,17,2013/2014,69,HHS Region 5,1 wk ahead,1.2
 2014,17,2013/2014,69,HHS Region 5,2 wk ahead,1.3
 2014,17,2013/2014,69,HHS Region 5,3 wk ahead,1.2
-2014,17,2013/2014,69,HHS Region 5,4 wk ahead,1.2
+2014,17,2013/2014,69,HHS Region 5,4 wk ahead,1.3
 2014,17,2013/2014,69,HHS Region 6,Season onset,45
 2014,17,2013/2014,69,HHS Region 6,Season peak week,52
 2014,17,2013/2014,69,HHS Region 6,Season peak percentage,9.9
@@ -10176,19 +10147,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,17,2013/2014,69,HHS Region 8,3 wk ahead,0.7
 2014,17,2013/2014,69,HHS Region 8,4 wk ahead,0.6
 2014,17,2013/2014,69,HHS Region 9,Season onset,51
-2014,17,2013/2014,69,HHS Region 9,Season peak week,1
 2014,17,2013/2014,69,HHS Region 9,Season peak week,4
-2014,17,2013/2014,69,HHS Region 9,Season peak percentage,4.6
+2014,17,2013/2014,69,HHS Region 9,Season peak percentage,4.7
 2014,17,2013/2014,69,HHS Region 9,1 wk ahead,1.6
-2014,17,2013/2014,69,HHS Region 9,2 wk ahead,1.7
+2014,17,2013/2014,69,HHS Region 9,2 wk ahead,1.6
 2014,17,2013/2014,69,HHS Region 9,3 wk ahead,1.7
-2014,17,2013/2014,69,HHS Region 9,4 wk ahead,1.9
+2014,17,2013/2014,69,HHS Region 9,4 wk ahead,1.8
 2014,17,2013/2014,69,HHS Region 10,Season onset,51
 2014,17,2013/2014,69,HHS Region 10,Season peak week,1
 2014,17,2013/2014,69,HHS Region 10,Season peak percentage,4
 2014,17,2013/2014,69,HHS Region 10,1 wk ahead,0.5
 2014,17,2013/2014,69,HHS Region 10,2 wk ahead,0.8
-2014,17,2013/2014,69,HHS Region 10,3 wk ahead,0.6
+2014,17,2013/2014,69,HHS Region 10,3 wk ahead,0.7
 2014,17,2013/2014,69,HHS Region 10,4 wk ahead,0.6
 2014,18,2013/2014,70,US National,Season onset,48
 2014,18,2013/2014,70,US National,Season peak week,52
@@ -10201,7 +10171,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,18,2013/2014,70,HHS Region 1,Season peak week,6
 2014,18,2013/2014,70,HHS Region 1,Season peak percentage,2.2
 2014,18,2013/2014,70,HHS Region 1,1 wk ahead,1.3
-2014,18,2013/2014,70,HHS Region 1,2 wk ahead,1
+2014,18,2013/2014,70,HHS Region 1,2 wk ahead,1.1
 2014,18,2013/2014,70,HHS Region 1,3 wk ahead,0.5
 2014,18,2013/2014,70,HHS Region 1,4 wk ahead,0.5
 2014,18,2013/2014,70,HHS Region 2,Season onset,51
@@ -10210,15 +10180,15 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,18,2013/2014,70,HHS Region 2,Season peak percentage,3.4
 2014,18,2013/2014,70,HHS Region 2,1 wk ahead,2.3
 2014,18,2013/2014,70,HHS Region 2,2 wk ahead,2.1
-2014,18,2013/2014,70,HHS Region 2,3 wk ahead,1.9
-2014,18,2013/2014,70,HHS Region 2,4 wk ahead,2.1
+2014,18,2013/2014,70,HHS Region 2,3 wk ahead,2
+2014,18,2013/2014,70,HHS Region 2,4 wk ahead,2.2
 2014,18,2013/2014,70,HHS Region 3,Season onset,51
 2014,18,2013/2014,70,HHS Region 3,Season peak week,1
 2014,18,2013/2014,70,HHS Region 3,Season peak percentage,3.6
 2014,18,2013/2014,70,HHS Region 3,1 wk ahead,1.2
 2014,18,2013/2014,70,HHS Region 3,2 wk ahead,1.3
 2014,18,2013/2014,70,HHS Region 3,3 wk ahead,1.3
-2014,18,2013/2014,70,HHS Region 3,4 wk ahead,1.2
+2014,18,2013/2014,70,HHS Region 3,4 wk ahead,1.1
 2014,18,2013/2014,70,HHS Region 4,Season onset,48
 2014,18,2013/2014,70,HHS Region 4,Season peak week,52
 2014,18,2013/2014,70,HHS Region 4,Season peak percentage,4.6
@@ -10231,7 +10201,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,18,2013/2014,70,HHS Region 5,Season peak percentage,3.6
 2014,18,2013/2014,70,HHS Region 5,1 wk ahead,1.3
 2014,18,2013/2014,70,HHS Region 5,2 wk ahead,1.2
-2014,18,2013/2014,70,HHS Region 5,3 wk ahead,1.2
+2014,18,2013/2014,70,HHS Region 5,3 wk ahead,1.3
 2014,18,2013/2014,70,HHS Region 5,4 wk ahead,0.8
 2014,18,2013/2014,70,HHS Region 6,Season onset,45
 2014,18,2013/2014,70,HHS Region 6,Season peak week,52
@@ -10255,18 +10225,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,18,2013/2014,70,HHS Region 8,3 wk ahead,0.6
 2014,18,2013/2014,70,HHS Region 8,4 wk ahead,0.6
 2014,18,2013/2014,70,HHS Region 9,Season onset,51
-2014,18,2013/2014,70,HHS Region 9,Season peak week,1
 2014,18,2013/2014,70,HHS Region 9,Season peak week,4
-2014,18,2013/2014,70,HHS Region 9,Season peak percentage,4.6
-2014,18,2013/2014,70,HHS Region 9,1 wk ahead,1.7
+2014,18,2013/2014,70,HHS Region 9,Season peak percentage,4.7
+2014,18,2013/2014,70,HHS Region 9,1 wk ahead,1.6
 2014,18,2013/2014,70,HHS Region 9,2 wk ahead,1.7
-2014,18,2013/2014,70,HHS Region 9,3 wk ahead,1.9
-2014,18,2013/2014,70,HHS Region 9,4 wk ahead,1.8
+2014,18,2013/2014,70,HHS Region 9,3 wk ahead,1.8
+2014,18,2013/2014,70,HHS Region 9,4 wk ahead,1.7
 2014,18,2013/2014,70,HHS Region 10,Season onset,51
 2014,18,2013/2014,70,HHS Region 10,Season peak week,1
 2014,18,2013/2014,70,HHS Region 10,Season peak percentage,4
 2014,18,2013/2014,70,HHS Region 10,1 wk ahead,0.8
-2014,18,2013/2014,70,HHS Region 10,2 wk ahead,0.6
+2014,18,2013/2014,70,HHS Region 10,2 wk ahead,0.7
 2014,18,2013/2014,70,HHS Region 10,3 wk ahead,0.6
 2014,18,2013/2014,70,HHS Region 10,4 wk ahead,0.4
 2014,19,2013/2014,71,US National,Season onset,48
@@ -10279,24 +10248,24 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,19,2013/2014,71,HHS Region 1,Season onset,51
 2014,19,2013/2014,71,HHS Region 1,Season peak week,6
 2014,19,2013/2014,71,HHS Region 1,Season peak percentage,2.2
-2014,19,2013/2014,71,HHS Region 1,1 wk ahead,1
+2014,19,2013/2014,71,HHS Region 1,1 wk ahead,1.1
 2014,19,2013/2014,71,HHS Region 1,2 wk ahead,0.5
 2014,19,2013/2014,71,HHS Region 1,3 wk ahead,0.5
-2014,19,2013/2014,71,HHS Region 1,4 wk ahead,0.5
+2014,19,2013/2014,71,HHS Region 1,4 wk ahead,0.6
 2014,19,2013/2014,71,HHS Region 2,Season onset,51
 2014,19,2013/2014,71,HHS Region 2,Season peak week,6
 2014,19,2013/2014,71,HHS Region 2,Season peak week,13
 2014,19,2013/2014,71,HHS Region 2,Season peak percentage,3.4
 2014,19,2013/2014,71,HHS Region 2,1 wk ahead,2.1
-2014,19,2013/2014,71,HHS Region 2,2 wk ahead,1.9
-2014,19,2013/2014,71,HHS Region 2,3 wk ahead,2.1
-2014,19,2013/2014,71,HHS Region 2,4 wk ahead,2.3
+2014,19,2013/2014,71,HHS Region 2,2 wk ahead,2
+2014,19,2013/2014,71,HHS Region 2,3 wk ahead,2.2
+2014,19,2013/2014,71,HHS Region 2,4 wk ahead,2.4
 2014,19,2013/2014,71,HHS Region 3,Season onset,51
 2014,19,2013/2014,71,HHS Region 3,Season peak week,1
 2014,19,2013/2014,71,HHS Region 3,Season peak percentage,3.6
 2014,19,2013/2014,71,HHS Region 3,1 wk ahead,1.3
 2014,19,2013/2014,71,HHS Region 3,2 wk ahead,1.3
-2014,19,2013/2014,71,HHS Region 3,3 wk ahead,1.2
+2014,19,2013/2014,71,HHS Region 3,3 wk ahead,1.1
 2014,19,2013/2014,71,HHS Region 3,4 wk ahead,1.1
 2014,19,2013/2014,71,HHS Region 4,Season onset,48
 2014,19,2013/2014,71,HHS Region 4,Season peak week,52
@@ -10309,9 +10278,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,19,2013/2014,71,HHS Region 5,Season peak week,52
 2014,19,2013/2014,71,HHS Region 5,Season peak percentage,3.6
 2014,19,2013/2014,71,HHS Region 5,1 wk ahead,1.2
-2014,19,2013/2014,71,HHS Region 5,2 wk ahead,1.2
+2014,19,2013/2014,71,HHS Region 5,2 wk ahead,1.3
 2014,19,2013/2014,71,HHS Region 5,3 wk ahead,0.8
-2014,19,2013/2014,71,HHS Region 5,4 wk ahead,0.9
+2014,19,2013/2014,71,HHS Region 5,4 wk ahead,1
 2014,19,2013/2014,71,HHS Region 6,Season onset,45
 2014,19,2013/2014,71,HHS Region 6,Season peak week,52
 2014,19,2013/2014,71,HHS Region 6,Season peak percentage,9.9
@@ -10325,26 +10294,25 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,19,2013/2014,71,HHS Region 7,1 wk ahead,0.5
 2014,19,2013/2014,71,HHS Region 7,2 wk ahead,0.5
 2014,19,2013/2014,71,HHS Region 7,3 wk ahead,0.5
-2014,19,2013/2014,71,HHS Region 7,4 wk ahead,0.3
+2014,19,2013/2014,71,HHS Region 7,4 wk ahead,0.2
 2014,19,2013/2014,71,HHS Region 8,Season onset,49
 2014,19,2013/2014,71,HHS Region 8,Season peak week,52
 2014,19,2013/2014,71,HHS Region 8,Season peak percentage,3.7
 2014,19,2013/2014,71,HHS Region 8,1 wk ahead,0.7
 2014,19,2013/2014,71,HHS Region 8,2 wk ahead,0.6
 2014,19,2013/2014,71,HHS Region 8,3 wk ahead,0.6
-2014,19,2013/2014,71,HHS Region 8,4 wk ahead,0.3
+2014,19,2013/2014,71,HHS Region 8,4 wk ahead,0.4
 2014,19,2013/2014,71,HHS Region 9,Season onset,51
-2014,19,2013/2014,71,HHS Region 9,Season peak week,1
 2014,19,2013/2014,71,HHS Region 9,Season peak week,4
-2014,19,2013/2014,71,HHS Region 9,Season peak percentage,4.6
+2014,19,2013/2014,71,HHS Region 9,Season peak percentage,4.7
 2014,19,2013/2014,71,HHS Region 9,1 wk ahead,1.7
-2014,19,2013/2014,71,HHS Region 9,2 wk ahead,1.9
-2014,19,2013/2014,71,HHS Region 9,3 wk ahead,1.8
+2014,19,2013/2014,71,HHS Region 9,2 wk ahead,1.8
+2014,19,2013/2014,71,HHS Region 9,3 wk ahead,1.7
 2014,19,2013/2014,71,HHS Region 9,4 wk ahead,1.7
 2014,19,2013/2014,71,HHS Region 10,Season onset,51
 2014,19,2013/2014,71,HHS Region 10,Season peak week,1
 2014,19,2013/2014,71,HHS Region 10,Season peak percentage,4
-2014,19,2013/2014,71,HHS Region 10,1 wk ahead,0.6
+2014,19,2013/2014,71,HHS Region 10,1 wk ahead,0.7
 2014,19,2013/2014,71,HHS Region 10,2 wk ahead,0.6
 2014,19,2013/2014,71,HHS Region 10,3 wk ahead,0.4
 2014,19,2013/2014,71,HHS Region 10,4 wk ahead,0.4
@@ -10354,29 +10322,29 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,20,2013/2014,72,US National,1 wk ahead,1.3
 2014,20,2013/2014,72,US National,2 wk ahead,1.2
 2014,20,2013/2014,72,US National,3 wk ahead,1.2
-2014,20,2013/2014,72,US National,4 wk ahead,1.1
+2014,20,2013/2014,72,US National,4 wk ahead,1.2
 2014,20,2013/2014,72,HHS Region 1,Season onset,51
 2014,20,2013/2014,72,HHS Region 1,Season peak week,6
 2014,20,2013/2014,72,HHS Region 1,Season peak percentage,2.2
 2014,20,2013/2014,72,HHS Region 1,1 wk ahead,0.5
 2014,20,2013/2014,72,HHS Region 1,2 wk ahead,0.5
-2014,20,2013/2014,72,HHS Region 1,3 wk ahead,0.5
-2014,20,2013/2014,72,HHS Region 1,4 wk ahead,0.4
+2014,20,2013/2014,72,HHS Region 1,3 wk ahead,0.6
+2014,20,2013/2014,72,HHS Region 1,4 wk ahead,0.5
 2014,20,2013/2014,72,HHS Region 2,Season onset,51
 2014,20,2013/2014,72,HHS Region 2,Season peak week,6
 2014,20,2013/2014,72,HHS Region 2,Season peak week,13
 2014,20,2013/2014,72,HHS Region 2,Season peak percentage,3.4
-2014,20,2013/2014,72,HHS Region 2,1 wk ahead,1.9
-2014,20,2013/2014,72,HHS Region 2,2 wk ahead,2.1
-2014,20,2013/2014,72,HHS Region 2,3 wk ahead,2.3
-2014,20,2013/2014,72,HHS Region 2,4 wk ahead,2.4
+2014,20,2013/2014,72,HHS Region 2,1 wk ahead,2
+2014,20,2013/2014,72,HHS Region 2,2 wk ahead,2.2
+2014,20,2013/2014,72,HHS Region 2,3 wk ahead,2.4
+2014,20,2013/2014,72,HHS Region 2,4 wk ahead,2.5
 2014,20,2013/2014,72,HHS Region 3,Season onset,51
 2014,20,2013/2014,72,HHS Region 3,Season peak week,1
 2014,20,2013/2014,72,HHS Region 3,Season peak percentage,3.6
 2014,20,2013/2014,72,HHS Region 3,1 wk ahead,1.3
-2014,20,2013/2014,72,HHS Region 3,2 wk ahead,1.2
+2014,20,2013/2014,72,HHS Region 3,2 wk ahead,1.1
 2014,20,2013/2014,72,HHS Region 3,3 wk ahead,1.1
-2014,20,2013/2014,72,HHS Region 3,4 wk ahead,1
+2014,20,2013/2014,72,HHS Region 3,4 wk ahead,0.9
 2014,20,2013/2014,72,HHS Region 4,Season onset,48
 2014,20,2013/2014,72,HHS Region 4,Season peak week,52
 2014,20,2013/2014,72,HHS Region 4,Season peak percentage,4.6
@@ -10387,10 +10355,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,20,2013/2014,72,HHS Region 5,Season onset,48
 2014,20,2013/2014,72,HHS Region 5,Season peak week,52
 2014,20,2013/2014,72,HHS Region 5,Season peak percentage,3.6
-2014,20,2013/2014,72,HHS Region 5,1 wk ahead,1.2
+2014,20,2013/2014,72,HHS Region 5,1 wk ahead,1.3
 2014,20,2013/2014,72,HHS Region 5,2 wk ahead,0.8
-2014,20,2013/2014,72,HHS Region 5,3 wk ahead,0.9
-2014,20,2013/2014,72,HHS Region 5,4 wk ahead,0.8
+2014,20,2013/2014,72,HHS Region 5,3 wk ahead,1
+2014,20,2013/2014,72,HHS Region 5,4 wk ahead,0.9
 2014,20,2013/2014,72,HHS Region 6,Season onset,45
 2014,20,2013/2014,72,HHS Region 6,Season peak week,52
 2014,20,2013/2014,72,HHS Region 6,Season peak percentage,9.9
@@ -10403,21 +10371,20 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,20,2013/2014,72,HHS Region 7,Season peak percentage,4.5
 2014,20,2013/2014,72,HHS Region 7,1 wk ahead,0.5
 2014,20,2013/2014,72,HHS Region 7,2 wk ahead,0.5
-2014,20,2013/2014,72,HHS Region 7,3 wk ahead,0.3
-2014,20,2013/2014,72,HHS Region 7,4 wk ahead,0.2
+2014,20,2013/2014,72,HHS Region 7,3 wk ahead,0.2
+2014,20,2013/2014,72,HHS Region 7,4 wk ahead,0.1
 2014,20,2013/2014,72,HHS Region 8,Season onset,49
 2014,20,2013/2014,72,HHS Region 8,Season peak week,52
 2014,20,2013/2014,72,HHS Region 8,Season peak percentage,3.7
 2014,20,2013/2014,72,HHS Region 8,1 wk ahead,0.6
 2014,20,2013/2014,72,HHS Region 8,2 wk ahead,0.6
-2014,20,2013/2014,72,HHS Region 8,3 wk ahead,0.3
+2014,20,2013/2014,72,HHS Region 8,3 wk ahead,0.4
 2014,20,2013/2014,72,HHS Region 8,4 wk ahead,0.6
 2014,20,2013/2014,72,HHS Region 9,Season onset,51
-2014,20,2013/2014,72,HHS Region 9,Season peak week,1
 2014,20,2013/2014,72,HHS Region 9,Season peak week,4
-2014,20,2013/2014,72,HHS Region 9,Season peak percentage,4.6
-2014,20,2013/2014,72,HHS Region 9,1 wk ahead,1.9
-2014,20,2013/2014,72,HHS Region 9,2 wk ahead,1.8
+2014,20,2013/2014,72,HHS Region 9,Season peak percentage,4.7
+2014,20,2013/2014,72,HHS Region 9,1 wk ahead,1.8
+2014,20,2013/2014,72,HHS Region 9,2 wk ahead,1.7
 2014,20,2013/2014,72,HHS Region 9,3 wk ahead,1.7
 2014,20,2013/2014,72,HHS Region 9,4 wk ahead,1.7
 2014,20,2013/2014,72,HHS Region 10,Season onset,51
@@ -10432,8 +10399,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,40,2014/2015,40,US National,Season peak percentage,6
 2014,40,2014/2015,40,US National,1 wk ahead,1.3
 2014,40,2014/2015,40,US National,2 wk ahead,1.4
-2014,40,2014/2015,40,US National,3 wk ahead,1.4
-2014,40,2014/2015,40,US National,4 wk ahead,1.4
+2014,40,2014/2015,40,US National,3 wk ahead,1.5
+2014,40,2014/2015,40,US National,4 wk ahead,1.5
 2014,40,2014/2015,40,HHS Region 1,Season onset,50
 2014,40,2014/2015,40,HHS Region 1,Season peak week,3
 2014,40,2014/2015,40,HHS Region 1,Season peak percentage,3.9
@@ -10449,11 +10416,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,40,2014/2015,40,HHS Region 2,1 wk ahead,1.7
 2014,40,2014/2015,40,HHS Region 2,2 wk ahead,2.3
 2014,40,2014/2015,40,HHS Region 2,3 wk ahead,2.3
-2014,40,2014/2015,40,HHS Region 2,4 wk ahead,1.9
+2014,40,2014/2015,40,HHS Region 2,4 wk ahead,2
 2014,40,2014/2015,40,HHS Region 3,Season onset,48
 2014,40,2014/2015,40,HHS Region 3,Season peak week,52
-2014,40,2014/2015,40,HHS Region 3,Season peak percentage,7.3
-2014,40,2014/2015,40,HHS Region 3,1 wk ahead,1.4
+2014,40,2014/2015,40,HHS Region 3,Season peak percentage,7.2
+2014,40,2014/2015,40,HHS Region 3,1 wk ahead,1.3
 2014,40,2014/2015,40,HHS Region 3,2 wk ahead,1.3
 2014,40,2014/2015,40,HHS Region 3,3 wk ahead,1.3
 2014,40,2014/2015,40,HHS Region 3,4 wk ahead,1.3
@@ -10470,14 +10437,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,40,2014/2015,40,HHS Region 5,1 wk ahead,0.8
 2014,40,2014/2015,40,HHS Region 5,2 wk ahead,0.9
 2014,40,2014/2015,40,HHS Region 5,3 wk ahead,1
-2014,40,2014/2015,40,HHS Region 5,4 wk ahead,1.1
+2014,40,2014/2015,40,HHS Region 5,4 wk ahead,1
 2014,40,2014/2015,40,HHS Region 6,Season onset,47
 2014,40,2014/2015,40,HHS Region 6,Season peak week,51
-2014,40,2014/2015,40,HHS Region 6,Season peak percentage,10.6
-2014,40,2014/2015,40,HHS Region 6,1 wk ahead,1.8
-2014,40,2014/2015,40,HHS Region 6,2 wk ahead,1.9
-2014,40,2014/2015,40,HHS Region 6,3 wk ahead,2
-2014,40,2014/2015,40,HHS Region 6,4 wk ahead,2.1
+2014,40,2014/2015,40,HHS Region 6,Season peak percentage,11.1
+2014,40,2014/2015,40,HHS Region 6,1 wk ahead,2
+2014,40,2014/2015,40,HHS Region 6,2 wk ahead,2.1
+2014,40,2014/2015,40,HHS Region 6,3 wk ahead,2.2
+2014,40,2014/2015,40,HHS Region 6,4 wk ahead,2.3
 2014,40,2014/2015,40,HHS Region 7,Season onset,48
 2014,40,2014/2015,40,HHS Region 7,Season peak week,52
 2014,40,2014/2015,40,HHS Region 7,Season peak percentage,6.4
@@ -10497,23 +10464,23 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,40,2014/2015,40,HHS Region 9,Season peak week,4
 2014,40,2014/2015,40,HHS Region 9,Season peak percentage,5
 2014,40,2014/2015,40,HHS Region 9,1 wk ahead,1.9
-2014,40,2014/2015,40,HHS Region 9,2 wk ahead,1.8
+2014,40,2014/2015,40,HHS Region 9,2 wk ahead,1.7
 2014,40,2014/2015,40,HHS Region 9,3 wk ahead,1.7
-2014,40,2014/2015,40,HHS Region 9,4 wk ahead,1.8
+2014,40,2014/2015,40,HHS Region 9,4 wk ahead,1.7
 2014,40,2014/2015,40,HHS Region 10,Season onset,48
 2014,40,2014/2015,40,HHS Region 10,Season peak week,2
 2014,40,2014/2015,40,HHS Region 10,Season peak percentage,3.6
 2014,40,2014/2015,40,HHS Region 10,1 wk ahead,1.1
 2014,40,2014/2015,40,HHS Region 10,2 wk ahead,0.8
 2014,40,2014/2015,40,HHS Region 10,3 wk ahead,0.7
-2014,40,2014/2015,40,HHS Region 10,4 wk ahead,0.8
+2014,40,2014/2015,40,HHS Region 10,4 wk ahead,0.9
 2014,41,2014/2015,41,US National,Season onset,47
 2014,41,2014/2015,41,US National,Season peak week,52
 2014,41,2014/2015,41,US National,Season peak percentage,6
 2014,41,2014/2015,41,US National,1 wk ahead,1.4
-2014,41,2014/2015,41,US National,2 wk ahead,1.4
-2014,41,2014/2015,41,US National,3 wk ahead,1.4
-2014,41,2014/2015,41,US National,4 wk ahead,1.6
+2014,41,2014/2015,41,US National,2 wk ahead,1.5
+2014,41,2014/2015,41,US National,3 wk ahead,1.5
+2014,41,2014/2015,41,US National,4 wk ahead,1.7
 2014,41,2014/2015,41,HHS Region 1,Season onset,50
 2014,41,2014/2015,41,HHS Region 1,Season peak week,3
 2014,41,2014/2015,41,HHS Region 1,Season peak percentage,3.9
@@ -10528,15 +10495,15 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,41,2014/2015,41,HHS Region 2,Season peak percentage,5.2
 2014,41,2014/2015,41,HHS Region 2,1 wk ahead,2.3
 2014,41,2014/2015,41,HHS Region 2,2 wk ahead,2.3
-2014,41,2014/2015,41,HHS Region 2,3 wk ahead,1.9
+2014,41,2014/2015,41,HHS Region 2,3 wk ahead,2
 2014,41,2014/2015,41,HHS Region 2,4 wk ahead,2.5
 2014,41,2014/2015,41,HHS Region 3,Season onset,48
 2014,41,2014/2015,41,HHS Region 3,Season peak week,52
-2014,41,2014/2015,41,HHS Region 3,Season peak percentage,7.3
+2014,41,2014/2015,41,HHS Region 3,Season peak percentage,7.2
 2014,41,2014/2015,41,HHS Region 3,1 wk ahead,1.3
 2014,41,2014/2015,41,HHS Region 3,2 wk ahead,1.3
 2014,41,2014/2015,41,HHS Region 3,3 wk ahead,1.3
-2014,41,2014/2015,41,HHS Region 3,4 wk ahead,1.4
+2014,41,2014/2015,41,HHS Region 3,4 wk ahead,1.5
 2014,41,2014/2015,41,HHS Region 4,Season onset,47
 2014,41,2014/2015,41,HHS Region 4,Season peak week,52
 2014,41,2014/2015,41,HHS Region 4,Season peak percentage,7.5
@@ -10549,15 +10516,15 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,41,2014/2015,41,HHS Region 5,Season peak percentage,6.6
 2014,41,2014/2015,41,HHS Region 5,1 wk ahead,0.9
 2014,41,2014/2015,41,HHS Region 5,2 wk ahead,1
-2014,41,2014/2015,41,HHS Region 5,3 wk ahead,1.1
+2014,41,2014/2015,41,HHS Region 5,3 wk ahead,1
 2014,41,2014/2015,41,HHS Region 5,4 wk ahead,1.2
 2014,41,2014/2015,41,HHS Region 6,Season onset,47
 2014,41,2014/2015,41,HHS Region 6,Season peak week,51
-2014,41,2014/2015,41,HHS Region 6,Season peak percentage,10.6
-2014,41,2014/2015,41,HHS Region 6,1 wk ahead,1.9
-2014,41,2014/2015,41,HHS Region 6,2 wk ahead,2
-2014,41,2014/2015,41,HHS Region 6,3 wk ahead,2.1
-2014,41,2014/2015,41,HHS Region 6,4 wk ahead,2.2
+2014,41,2014/2015,41,HHS Region 6,Season peak percentage,11.1
+2014,41,2014/2015,41,HHS Region 6,1 wk ahead,2.1
+2014,41,2014/2015,41,HHS Region 6,2 wk ahead,2.2
+2014,41,2014/2015,41,HHS Region 6,3 wk ahead,2.3
+2014,41,2014/2015,41,HHS Region 6,4 wk ahead,2.4
 2014,41,2014/2015,41,HHS Region 7,Season onset,48
 2014,41,2014/2015,41,HHS Region 7,Season peak week,52
 2014,41,2014/2015,41,HHS Region 7,Season peak percentage,6.4
@@ -10576,24 +10543,24 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,41,2014/2015,41,HHS Region 9,Season peak week,3
 2014,41,2014/2015,41,HHS Region 9,Season peak week,4
 2014,41,2014/2015,41,HHS Region 9,Season peak percentage,5
-2014,41,2014/2015,41,HHS Region 9,1 wk ahead,1.8
+2014,41,2014/2015,41,HHS Region 9,1 wk ahead,1.7
 2014,41,2014/2015,41,HHS Region 9,2 wk ahead,1.7
-2014,41,2014/2015,41,HHS Region 9,3 wk ahead,1.8
+2014,41,2014/2015,41,HHS Region 9,3 wk ahead,1.7
 2014,41,2014/2015,41,HHS Region 9,4 wk ahead,2.1
 2014,41,2014/2015,41,HHS Region 10,Season onset,48
 2014,41,2014/2015,41,HHS Region 10,Season peak week,2
 2014,41,2014/2015,41,HHS Region 10,Season peak percentage,3.6
 2014,41,2014/2015,41,HHS Region 10,1 wk ahead,0.8
 2014,41,2014/2015,41,HHS Region 10,2 wk ahead,0.7
-2014,41,2014/2015,41,HHS Region 10,3 wk ahead,0.8
+2014,41,2014/2015,41,HHS Region 10,3 wk ahead,0.9
 2014,41,2014/2015,41,HHS Region 10,4 wk ahead,0.9
 2014,42,2014/2015,42,US National,Season onset,47
 2014,42,2014/2015,42,US National,Season peak week,52
 2014,42,2014/2015,42,US National,Season peak percentage,6
-2014,42,2014/2015,42,US National,1 wk ahead,1.4
-2014,42,2014/2015,42,US National,2 wk ahead,1.4
-2014,42,2014/2015,42,US National,3 wk ahead,1.6
-2014,42,2014/2015,42,US National,4 wk ahead,1.7
+2014,42,2014/2015,42,US National,1 wk ahead,1.5
+2014,42,2014/2015,42,US National,2 wk ahead,1.5
+2014,42,2014/2015,42,US National,3 wk ahead,1.7
+2014,42,2014/2015,42,US National,4 wk ahead,1.6
 2014,42,2014/2015,42,HHS Region 1,Season onset,50
 2014,42,2014/2015,42,HHS Region 1,Season peak week,3
 2014,42,2014/2015,42,HHS Region 1,Season peak percentage,3.9
@@ -10607,16 +10574,16 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,42,2014/2015,42,HHS Region 2,Season peak week,5
 2014,42,2014/2015,42,HHS Region 2,Season peak percentage,5.2
 2014,42,2014/2015,42,HHS Region 2,1 wk ahead,2.3
-2014,42,2014/2015,42,HHS Region 2,2 wk ahead,1.9
+2014,42,2014/2015,42,HHS Region 2,2 wk ahead,2
 2014,42,2014/2015,42,HHS Region 2,3 wk ahead,2.5
 2014,42,2014/2015,42,HHS Region 2,4 wk ahead,2.3
 2014,42,2014/2015,42,HHS Region 3,Season onset,48
 2014,42,2014/2015,42,HHS Region 3,Season peak week,52
-2014,42,2014/2015,42,HHS Region 3,Season peak percentage,7.3
+2014,42,2014/2015,42,HHS Region 3,Season peak percentage,7.2
 2014,42,2014/2015,42,HHS Region 3,1 wk ahead,1.3
 2014,42,2014/2015,42,HHS Region 3,2 wk ahead,1.3
-2014,42,2014/2015,42,HHS Region 3,3 wk ahead,1.4
-2014,42,2014/2015,42,HHS Region 3,4 wk ahead,1.4
+2014,42,2014/2015,42,HHS Region 3,3 wk ahead,1.5
+2014,42,2014/2015,42,HHS Region 3,4 wk ahead,1.3
 2014,42,2014/2015,42,HHS Region 4,Season onset,47
 2014,42,2014/2015,42,HHS Region 4,Season peak week,52
 2014,42,2014/2015,42,HHS Region 4,Season peak percentage,7.5
@@ -10628,15 +10595,15 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,42,2014/2015,42,HHS Region 5,Season peak week,52
 2014,42,2014/2015,42,HHS Region 5,Season peak percentage,6.6
 2014,42,2014/2015,42,HHS Region 5,1 wk ahead,1
-2014,42,2014/2015,42,HHS Region 5,2 wk ahead,1.1
+2014,42,2014/2015,42,HHS Region 5,2 wk ahead,1
 2014,42,2014/2015,42,HHS Region 5,3 wk ahead,1.2
 2014,42,2014/2015,42,HHS Region 5,4 wk ahead,1.2
 2014,42,2014/2015,42,HHS Region 6,Season onset,47
 2014,42,2014/2015,42,HHS Region 6,Season peak week,51
-2014,42,2014/2015,42,HHS Region 6,Season peak percentage,10.6
-2014,42,2014/2015,42,HHS Region 6,1 wk ahead,2
-2014,42,2014/2015,42,HHS Region 6,2 wk ahead,2.1
-2014,42,2014/2015,42,HHS Region 6,3 wk ahead,2.2
+2014,42,2014/2015,42,HHS Region 6,Season peak percentage,11.1
+2014,42,2014/2015,42,HHS Region 6,1 wk ahead,2.2
+2014,42,2014/2015,42,HHS Region 6,2 wk ahead,2.3
+2014,42,2014/2015,42,HHS Region 6,3 wk ahead,2.4
 2014,42,2014/2015,42,HHS Region 6,4 wk ahead,2.3
 2014,42,2014/2015,42,HHS Region 7,Season onset,48
 2014,42,2014/2015,42,HHS Region 7,Season peak week,52
@@ -10657,22 +10624,22 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,42,2014/2015,42,HHS Region 9,Season peak week,4
 2014,42,2014/2015,42,HHS Region 9,Season peak percentage,5
 2014,42,2014/2015,42,HHS Region 9,1 wk ahead,1.7
-2014,42,2014/2015,42,HHS Region 9,2 wk ahead,1.8
+2014,42,2014/2015,42,HHS Region 9,2 wk ahead,1.7
 2014,42,2014/2015,42,HHS Region 9,3 wk ahead,2.1
-2014,42,2014/2015,42,HHS Region 9,4 wk ahead,2.1
+2014,42,2014/2015,42,HHS Region 9,4 wk ahead,2
 2014,42,2014/2015,42,HHS Region 10,Season onset,48
 2014,42,2014/2015,42,HHS Region 10,Season peak week,2
 2014,42,2014/2015,42,HHS Region 10,Season peak percentage,3.6
 2014,42,2014/2015,42,HHS Region 10,1 wk ahead,0.7
-2014,42,2014/2015,42,HHS Region 10,2 wk ahead,0.8
+2014,42,2014/2015,42,HHS Region 10,2 wk ahead,0.9
 2014,42,2014/2015,42,HHS Region 10,3 wk ahead,0.9
 2014,42,2014/2015,42,HHS Region 10,4 wk ahead,0.9
 2014,43,2014/2015,43,US National,Season onset,47
 2014,43,2014/2015,43,US National,Season peak week,52
 2014,43,2014/2015,43,US National,Season peak percentage,6
-2014,43,2014/2015,43,US National,1 wk ahead,1.4
-2014,43,2014/2015,43,US National,2 wk ahead,1.6
-2014,43,2014/2015,43,US National,3 wk ahead,1.7
+2014,43,2014/2015,43,US National,1 wk ahead,1.5
+2014,43,2014/2015,43,US National,2 wk ahead,1.7
+2014,43,2014/2015,43,US National,3 wk ahead,1.6
 2014,43,2014/2015,43,US National,4 wk ahead,2.1
 2014,43,2014/2015,43,HHS Region 1,Season onset,50
 2014,43,2014/2015,43,HHS Region 1,Season peak week,3
@@ -10686,16 +10653,16 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,43,2014/2015,43,HHS Region 2,Season peak week,4
 2014,43,2014/2015,43,HHS Region 2,Season peak week,5
 2014,43,2014/2015,43,HHS Region 2,Season peak percentage,5.2
-2014,43,2014/2015,43,HHS Region 2,1 wk ahead,1.9
+2014,43,2014/2015,43,HHS Region 2,1 wk ahead,2
 2014,43,2014/2015,43,HHS Region 2,2 wk ahead,2.5
 2014,43,2014/2015,43,HHS Region 2,3 wk ahead,2.3
 2014,43,2014/2015,43,HHS Region 2,4 wk ahead,2.8
 2014,43,2014/2015,43,HHS Region 3,Season onset,48
 2014,43,2014/2015,43,HHS Region 3,Season peak week,52
-2014,43,2014/2015,43,HHS Region 3,Season peak percentage,7.3
+2014,43,2014/2015,43,HHS Region 3,Season peak percentage,7.2
 2014,43,2014/2015,43,HHS Region 3,1 wk ahead,1.3
-2014,43,2014/2015,43,HHS Region 3,2 wk ahead,1.4
-2014,43,2014/2015,43,HHS Region 3,3 wk ahead,1.4
+2014,43,2014/2015,43,HHS Region 3,2 wk ahead,1.5
+2014,43,2014/2015,43,HHS Region 3,3 wk ahead,1.3
 2014,43,2014/2015,43,HHS Region 3,4 wk ahead,1.7
 2014,43,2014/2015,43,HHS Region 4,Season onset,47
 2014,43,2014/2015,43,HHS Region 4,Season peak week,52
@@ -10707,17 +10674,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,43,2014/2015,43,HHS Region 5,Season onset,48
 2014,43,2014/2015,43,HHS Region 5,Season peak week,52
 2014,43,2014/2015,43,HHS Region 5,Season peak percentage,6.6
-2014,43,2014/2015,43,HHS Region 5,1 wk ahead,1.1
+2014,43,2014/2015,43,HHS Region 5,1 wk ahead,1
 2014,43,2014/2015,43,HHS Region 5,2 wk ahead,1.2
 2014,43,2014/2015,43,HHS Region 5,3 wk ahead,1.2
 2014,43,2014/2015,43,HHS Region 5,4 wk ahead,1.5
 2014,43,2014/2015,43,HHS Region 6,Season onset,47
 2014,43,2014/2015,43,HHS Region 6,Season peak week,51
-2014,43,2014/2015,43,HHS Region 6,Season peak percentage,10.6
-2014,43,2014/2015,43,HHS Region 6,1 wk ahead,2.1
-2014,43,2014/2015,43,HHS Region 6,2 wk ahead,2.2
+2014,43,2014/2015,43,HHS Region 6,Season peak percentage,11.1
+2014,43,2014/2015,43,HHS Region 6,1 wk ahead,2.3
+2014,43,2014/2015,43,HHS Region 6,2 wk ahead,2.4
 2014,43,2014/2015,43,HHS Region 6,3 wk ahead,2.3
-2014,43,2014/2015,43,HHS Region 6,4 wk ahead,3.5
+2014,43,2014/2015,43,HHS Region 6,4 wk ahead,3.9
 2014,43,2014/2015,43,HHS Region 7,Season onset,48
 2014,43,2014/2015,43,HHS Region 7,Season peak week,52
 2014,43,2014/2015,43,HHS Region 7,Season peak percentage,6.4
@@ -10731,29 +10698,29 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,43,2014/2015,43,HHS Region 8,1 wk ahead,0.8
 2014,43,2014/2015,43,HHS Region 8,2 wk ahead,0.8
 2014,43,2014/2015,43,HHS Region 8,3 wk ahead,0.8
-2014,43,2014/2015,43,HHS Region 8,4 wk ahead,0.7
+2014,43,2014/2015,43,HHS Region 8,4 wk ahead,0.8
 2014,43,2014/2015,43,HHS Region 9,Season onset,51
 2014,43,2014/2015,43,HHS Region 9,Season peak week,3
 2014,43,2014/2015,43,HHS Region 9,Season peak week,4
 2014,43,2014/2015,43,HHS Region 9,Season peak percentage,5
-2014,43,2014/2015,43,HHS Region 9,1 wk ahead,1.8
+2014,43,2014/2015,43,HHS Region 9,1 wk ahead,1.7
 2014,43,2014/2015,43,HHS Region 9,2 wk ahead,2.1
-2014,43,2014/2015,43,HHS Region 9,3 wk ahead,2.1
+2014,43,2014/2015,43,HHS Region 9,3 wk ahead,2
 2014,43,2014/2015,43,HHS Region 9,4 wk ahead,2.2
 2014,43,2014/2015,43,HHS Region 10,Season onset,48
 2014,43,2014/2015,43,HHS Region 10,Season peak week,2
 2014,43,2014/2015,43,HHS Region 10,Season peak percentage,3.6
-2014,43,2014/2015,43,HHS Region 10,1 wk ahead,0.8
+2014,43,2014/2015,43,HHS Region 10,1 wk ahead,0.9
 2014,43,2014/2015,43,HHS Region 10,2 wk ahead,0.9
 2014,43,2014/2015,43,HHS Region 10,3 wk ahead,0.9
 2014,43,2014/2015,43,HHS Region 10,4 wk ahead,1
 2014,44,2014/2015,44,US National,Season onset,47
 2014,44,2014/2015,44,US National,Season peak week,52
 2014,44,2014/2015,44,US National,Season peak percentage,6
-2014,44,2014/2015,44,US National,1 wk ahead,1.6
-2014,44,2014/2015,44,US National,2 wk ahead,1.7
+2014,44,2014/2015,44,US National,1 wk ahead,1.7
+2014,44,2014/2015,44,US National,2 wk ahead,1.6
 2014,44,2014/2015,44,US National,3 wk ahead,2.1
-2014,44,2014/2015,44,US National,4 wk ahead,2.5
+2014,44,2014/2015,44,US National,4 wk ahead,2.6
 2014,44,2014/2015,44,HHS Region 1,Season onset,50
 2014,44,2014/2015,44,HHS Region 1,Season peak week,3
 2014,44,2014/2015,44,HHS Region 1,Season peak percentage,3.9
@@ -10772,9 +10739,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,44,2014/2015,44,HHS Region 2,4 wk ahead,2.9
 2014,44,2014/2015,44,HHS Region 3,Season onset,48
 2014,44,2014/2015,44,HHS Region 3,Season peak week,52
-2014,44,2014/2015,44,HHS Region 3,Season peak percentage,7.3
-2014,44,2014/2015,44,HHS Region 3,1 wk ahead,1.4
-2014,44,2014/2015,44,HHS Region 3,2 wk ahead,1.4
+2014,44,2014/2015,44,HHS Region 3,Season peak percentage,7.2
+2014,44,2014/2015,44,HHS Region 3,1 wk ahead,1.5
+2014,44,2014/2015,44,HHS Region 3,2 wk ahead,1.3
 2014,44,2014/2015,44,HHS Region 3,3 wk ahead,1.7
 2014,44,2014/2015,44,HHS Region 3,4 wk ahead,2.2
 2014,44,2014/2015,44,HHS Region 4,Season onset,47
@@ -10793,11 +10760,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,44,2014/2015,44,HHS Region 5,4 wk ahead,1.9
 2014,44,2014/2015,44,HHS Region 6,Season onset,47
 2014,44,2014/2015,44,HHS Region 6,Season peak week,51
-2014,44,2014/2015,44,HHS Region 6,Season peak percentage,10.6
-2014,44,2014/2015,44,HHS Region 6,1 wk ahead,2.2
+2014,44,2014/2015,44,HHS Region 6,Season peak percentage,11.1
+2014,44,2014/2015,44,HHS Region 6,1 wk ahead,2.4
 2014,44,2014/2015,44,HHS Region 6,2 wk ahead,2.3
-2014,44,2014/2015,44,HHS Region 6,3 wk ahead,3.5
-2014,44,2014/2015,44,HHS Region 6,4 wk ahead,4.2
+2014,44,2014/2015,44,HHS Region 6,3 wk ahead,3.9
+2014,44,2014/2015,44,HHS Region 6,4 wk ahead,4.7
 2014,44,2014/2015,44,HHS Region 7,Season onset,48
 2014,44,2014/2015,44,HHS Region 7,Season peak week,52
 2014,44,2014/2015,44,HHS Region 7,Season peak percentage,6.4
@@ -10810,14 +10777,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,44,2014/2015,44,HHS Region 8,Season peak percentage,4.4
 2014,44,2014/2015,44,HHS Region 8,1 wk ahead,0.8
 2014,44,2014/2015,44,HHS Region 8,2 wk ahead,0.8
-2014,44,2014/2015,44,HHS Region 8,3 wk ahead,0.7
+2014,44,2014/2015,44,HHS Region 8,3 wk ahead,0.8
 2014,44,2014/2015,44,HHS Region 8,4 wk ahead,1
 2014,44,2014/2015,44,HHS Region 9,Season onset,51
 2014,44,2014/2015,44,HHS Region 9,Season peak week,3
 2014,44,2014/2015,44,HHS Region 9,Season peak week,4
 2014,44,2014/2015,44,HHS Region 9,Season peak percentage,5
 2014,44,2014/2015,44,HHS Region 9,1 wk ahead,2.1
-2014,44,2014/2015,44,HHS Region 9,2 wk ahead,2.1
+2014,44,2014/2015,44,HHS Region 9,2 wk ahead,2
 2014,44,2014/2015,44,HHS Region 9,3 wk ahead,2.2
 2014,44,2014/2015,44,HHS Region 9,4 wk ahead,2.5
 2014,44,2014/2015,44,HHS Region 10,Season onset,48
@@ -10830,10 +10797,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,45,2014/2015,45,US National,Season onset,47
 2014,45,2014/2015,45,US National,Season peak week,52
 2014,45,2014/2015,45,US National,Season peak percentage,6
-2014,45,2014/2015,45,US National,1 wk ahead,1.7
+2014,45,2014/2015,45,US National,1 wk ahead,1.6
 2014,45,2014/2015,45,US National,2 wk ahead,2.1
-2014,45,2014/2015,45,US National,3 wk ahead,2.5
-2014,45,2014/2015,45,US National,4 wk ahead,2.5
+2014,45,2014/2015,45,US National,3 wk ahead,2.6
+2014,45,2014/2015,45,US National,4 wk ahead,2.6
 2014,45,2014/2015,45,HHS Region 1,Season onset,50
 2014,45,2014/2015,45,HHS Region 1,Season peak week,3
 2014,45,2014/2015,45,HHS Region 1,Season peak percentage,3.9
@@ -10852,8 +10819,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,45,2014/2015,45,HHS Region 2,4 wk ahead,2.4
 2014,45,2014/2015,45,HHS Region 3,Season onset,48
 2014,45,2014/2015,45,HHS Region 3,Season peak week,52
-2014,45,2014/2015,45,HHS Region 3,Season peak percentage,7.3
-2014,45,2014/2015,45,HHS Region 3,1 wk ahead,1.4
+2014,45,2014/2015,45,HHS Region 3,Season peak percentage,7.2
+2014,45,2014/2015,45,HHS Region 3,1 wk ahead,1.3
 2014,45,2014/2015,45,HHS Region 3,2 wk ahead,1.7
 2014,45,2014/2015,45,HHS Region 3,3 wk ahead,2.2
 2014,45,2014/2015,45,HHS Region 3,4 wk ahead,2.1
@@ -10873,11 +10840,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,45,2014/2015,45,HHS Region 5,4 wk ahead,2.4
 2014,45,2014/2015,45,HHS Region 6,Season onset,47
 2014,45,2014/2015,45,HHS Region 6,Season peak week,51
-2014,45,2014/2015,45,HHS Region 6,Season peak percentage,10.6
+2014,45,2014/2015,45,HHS Region 6,Season peak percentage,11.1
 2014,45,2014/2015,45,HHS Region 6,1 wk ahead,2.3
-2014,45,2014/2015,45,HHS Region 6,2 wk ahead,3.5
-2014,45,2014/2015,45,HHS Region 6,3 wk ahead,4.2
-2014,45,2014/2015,45,HHS Region 6,4 wk ahead,4.4
+2014,45,2014/2015,45,HHS Region 6,2 wk ahead,3.9
+2014,45,2014/2015,45,HHS Region 6,3 wk ahead,4.7
+2014,45,2014/2015,45,HHS Region 6,4 wk ahead,4.8
 2014,45,2014/2015,45,HHS Region 7,Season onset,48
 2014,45,2014/2015,45,HHS Region 7,Season peak week,52
 2014,45,2014/2015,45,HHS Region 7,Season peak percentage,6.4
@@ -10889,17 +10856,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,45,2014/2015,45,HHS Region 8,Season peak week,53
 2014,45,2014/2015,45,HHS Region 8,Season peak percentage,4.4
 2014,45,2014/2015,45,HHS Region 8,1 wk ahead,0.8
-2014,45,2014/2015,45,HHS Region 8,2 wk ahead,0.7
+2014,45,2014/2015,45,HHS Region 8,2 wk ahead,0.8
 2014,45,2014/2015,45,HHS Region 8,3 wk ahead,1
 2014,45,2014/2015,45,HHS Region 8,4 wk ahead,1.3
 2014,45,2014/2015,45,HHS Region 9,Season onset,51
 2014,45,2014/2015,45,HHS Region 9,Season peak week,3
 2014,45,2014/2015,45,HHS Region 9,Season peak week,4
 2014,45,2014/2015,45,HHS Region 9,Season peak percentage,5
-2014,45,2014/2015,45,HHS Region 9,1 wk ahead,2.1
+2014,45,2014/2015,45,HHS Region 9,1 wk ahead,2
 2014,45,2014/2015,45,HHS Region 9,2 wk ahead,2.2
 2014,45,2014/2015,45,HHS Region 9,3 wk ahead,2.5
-2014,45,2014/2015,45,HHS Region 9,4 wk ahead,2.3
+2014,45,2014/2015,45,HHS Region 9,4 wk ahead,2.2
 2014,45,2014/2015,45,HHS Region 10,Season onset,48
 2014,45,2014/2015,45,HHS Region 10,Season peak week,2
 2014,45,2014/2015,45,HHS Region 10,Season peak percentage,3.6
@@ -10911,9 +10878,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,46,2014/2015,46,US National,Season peak week,52
 2014,46,2014/2015,46,US National,Season peak percentage,6
 2014,46,2014/2015,46,US National,1 wk ahead,2.1
-2014,46,2014/2015,46,US National,2 wk ahead,2.5
-2014,46,2014/2015,46,US National,3 wk ahead,2.5
-2014,46,2014/2015,46,US National,4 wk ahead,3.6
+2014,46,2014/2015,46,US National,2 wk ahead,2.6
+2014,46,2014/2015,46,US National,3 wk ahead,2.6
+2014,46,2014/2015,46,US National,4 wk ahead,3.7
 2014,46,2014/2015,46,HHS Region 1,Season onset,50
 2014,46,2014/2015,46,HHS Region 1,Season peak week,3
 2014,46,2014/2015,46,HHS Region 1,Season peak percentage,3.9
@@ -10932,7 +10899,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,46,2014/2015,46,HHS Region 2,4 wk ahead,2.9
 2014,46,2014/2015,46,HHS Region 3,Season onset,48
 2014,46,2014/2015,46,HHS Region 3,Season peak week,52
-2014,46,2014/2015,46,HHS Region 3,Season peak percentage,7.3
+2014,46,2014/2015,46,HHS Region 3,Season peak percentage,7.2
 2014,46,2014/2015,46,HHS Region 3,1 wk ahead,1.7
 2014,46,2014/2015,46,HHS Region 3,2 wk ahead,2.2
 2014,46,2014/2015,46,HHS Region 3,3 wk ahead,2.1
@@ -10953,11 +10920,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,46,2014/2015,46,HHS Region 5,4 wk ahead,3.9
 2014,46,2014/2015,46,HHS Region 6,Season onset,47
 2014,46,2014/2015,46,HHS Region 6,Season peak week,51
-2014,46,2014/2015,46,HHS Region 6,Season peak percentage,10.6
-2014,46,2014/2015,46,HHS Region 6,1 wk ahead,3.5
-2014,46,2014/2015,46,HHS Region 6,2 wk ahead,4.2
-2014,46,2014/2015,46,HHS Region 6,3 wk ahead,4.4
-2014,46,2014/2015,46,HHS Region 6,4 wk ahead,7.6
+2014,46,2014/2015,46,HHS Region 6,Season peak percentage,11.1
+2014,46,2014/2015,46,HHS Region 6,1 wk ahead,3.9
+2014,46,2014/2015,46,HHS Region 6,2 wk ahead,4.7
+2014,46,2014/2015,46,HHS Region 6,3 wk ahead,4.8
+2014,46,2014/2015,46,HHS Region 6,4 wk ahead,8.1
 2014,46,2014/2015,46,HHS Region 7,Season onset,48
 2014,46,2014/2015,46,HHS Region 7,Season peak week,52
 2014,46,2014/2015,46,HHS Region 7,Season peak percentage,6.4
@@ -10968,17 +10935,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,46,2014/2015,46,HHS Region 8,Season onset,49
 2014,46,2014/2015,46,HHS Region 8,Season peak week,53
 2014,46,2014/2015,46,HHS Region 8,Season peak percentage,4.4
-2014,46,2014/2015,46,HHS Region 8,1 wk ahead,0.7
+2014,46,2014/2015,46,HHS Region 8,1 wk ahead,0.8
 2014,46,2014/2015,46,HHS Region 8,2 wk ahead,1
 2014,46,2014/2015,46,HHS Region 8,3 wk ahead,1.3
-2014,46,2014/2015,46,HHS Region 8,4 wk ahead,1.8
+2014,46,2014/2015,46,HHS Region 8,4 wk ahead,1.9
 2014,46,2014/2015,46,HHS Region 9,Season onset,51
 2014,46,2014/2015,46,HHS Region 9,Season peak week,3
 2014,46,2014/2015,46,HHS Region 9,Season peak week,4
 2014,46,2014/2015,46,HHS Region 9,Season peak percentage,5
 2014,46,2014/2015,46,HHS Region 9,1 wk ahead,2.2
 2014,46,2014/2015,46,HHS Region 9,2 wk ahead,2.5
-2014,46,2014/2015,46,HHS Region 9,3 wk ahead,2.3
+2014,46,2014/2015,46,HHS Region 9,3 wk ahead,2.2
 2014,46,2014/2015,46,HHS Region 9,4 wk ahead,2.4
 2014,46,2014/2015,46,HHS Region 10,Season onset,48
 2014,46,2014/2015,46,HHS Region 10,Season peak week,2
@@ -10990,10 +10957,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,47,2014/2015,47,US National,Season onset,47
 2014,47,2014/2015,47,US National,Season peak week,52
 2014,47,2014/2015,47,US National,Season peak percentage,6
-2014,47,2014/2015,47,US National,1 wk ahead,2.5
-2014,47,2014/2015,47,US National,2 wk ahead,2.5
-2014,47,2014/2015,47,US National,3 wk ahead,3.6
-2014,47,2014/2015,47,US National,4 wk ahead,4.9
+2014,47,2014/2015,47,US National,1 wk ahead,2.6
+2014,47,2014/2015,47,US National,2 wk ahead,2.6
+2014,47,2014/2015,47,US National,3 wk ahead,3.7
+2014,47,2014/2015,47,US National,4 wk ahead,5
 2014,47,2014/2015,47,HHS Region 1,Season onset,50
 2014,47,2014/2015,47,HHS Region 1,Season peak week,3
 2014,47,2014/2015,47,HHS Region 1,Season peak percentage,3.9
@@ -11012,11 +10979,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,47,2014/2015,47,HHS Region 2,4 wk ahead,3.6
 2014,47,2014/2015,47,HHS Region 3,Season onset,48
 2014,47,2014/2015,47,HHS Region 3,Season peak week,52
-2014,47,2014/2015,47,HHS Region 3,Season peak percentage,7.3
+2014,47,2014/2015,47,HHS Region 3,Season peak percentage,7.2
 2014,47,2014/2015,47,HHS Region 3,1 wk ahead,2.2
 2014,47,2014/2015,47,HHS Region 3,2 wk ahead,2.1
 2014,47,2014/2015,47,HHS Region 3,3 wk ahead,2.9
-2014,47,2014/2015,47,HHS Region 3,4 wk ahead,4.6
+2014,47,2014/2015,47,HHS Region 3,4 wk ahead,4.5
 2014,47,2014/2015,47,HHS Region 4,Season onset,47
 2014,47,2014/2015,47,HHS Region 4,Season peak week,52
 2014,47,2014/2015,47,HHS Region 4,Season peak percentage,7.5
@@ -11033,11 +11000,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,47,2014/2015,47,HHS Region 5,4 wk ahead,4.9
 2014,47,2014/2015,47,HHS Region 6,Season onset,47
 2014,47,2014/2015,47,HHS Region 6,Season peak week,51
-2014,47,2014/2015,47,HHS Region 6,Season peak percentage,10.6
-2014,47,2014/2015,47,HHS Region 6,1 wk ahead,4.2
-2014,47,2014/2015,47,HHS Region 6,2 wk ahead,4.4
-2014,47,2014/2015,47,HHS Region 6,3 wk ahead,7.6
-2014,47,2014/2015,47,HHS Region 6,4 wk ahead,10.6
+2014,47,2014/2015,47,HHS Region 6,Season peak percentage,11.1
+2014,47,2014/2015,47,HHS Region 6,1 wk ahead,4.7
+2014,47,2014/2015,47,HHS Region 6,2 wk ahead,4.8
+2014,47,2014/2015,47,HHS Region 6,3 wk ahead,8.1
+2014,47,2014/2015,47,HHS Region 6,4 wk ahead,11.1
 2014,47,2014/2015,47,HHS Region 7,Season onset,48
 2014,47,2014/2015,47,HHS Region 7,Season peak week,52
 2014,47,2014/2015,47,HHS Region 7,Season peak percentage,6.4
@@ -11050,14 +11017,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,47,2014/2015,47,HHS Region 8,Season peak percentage,4.4
 2014,47,2014/2015,47,HHS Region 8,1 wk ahead,1
 2014,47,2014/2015,47,HHS Region 8,2 wk ahead,1.3
-2014,47,2014/2015,47,HHS Region 8,3 wk ahead,1.8
-2014,47,2014/2015,47,HHS Region 8,4 wk ahead,2.4
+2014,47,2014/2015,47,HHS Region 8,3 wk ahead,1.9
+2014,47,2014/2015,47,HHS Region 8,4 wk ahead,2.5
 2014,47,2014/2015,47,HHS Region 9,Season onset,51
 2014,47,2014/2015,47,HHS Region 9,Season peak week,3
 2014,47,2014/2015,47,HHS Region 9,Season peak week,4
 2014,47,2014/2015,47,HHS Region 9,Season peak percentage,5
 2014,47,2014/2015,47,HHS Region 9,1 wk ahead,2.5
-2014,47,2014/2015,47,HHS Region 9,2 wk ahead,2.3
+2014,47,2014/2015,47,HHS Region 9,2 wk ahead,2.2
 2014,47,2014/2015,47,HHS Region 9,3 wk ahead,2.4
 2014,47,2014/2015,47,HHS Region 9,4 wk ahead,2.8
 2014,47,2014/2015,47,HHS Region 10,Season onset,48
@@ -11070,9 +11037,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,48,2014/2015,48,US National,Season onset,47
 2014,48,2014/2015,48,US National,Season peak week,52
 2014,48,2014/2015,48,US National,Season peak percentage,6
-2014,48,2014/2015,48,US National,1 wk ahead,2.5
-2014,48,2014/2015,48,US National,2 wk ahead,3.6
-2014,48,2014/2015,48,US National,3 wk ahead,4.9
+2014,48,2014/2015,48,US National,1 wk ahead,2.6
+2014,48,2014/2015,48,US National,2 wk ahead,3.7
+2014,48,2014/2015,48,US National,3 wk ahead,5
 2014,48,2014/2015,48,US National,4 wk ahead,6
 2014,48,2014/2015,48,HHS Region 1,Season onset,50
 2014,48,2014/2015,48,HHS Region 1,Season peak week,3
@@ -11092,11 +11059,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,48,2014/2015,48,HHS Region 2,4 wk ahead,5.2
 2014,48,2014/2015,48,HHS Region 3,Season onset,48
 2014,48,2014/2015,48,HHS Region 3,Season peak week,52
-2014,48,2014/2015,48,HHS Region 3,Season peak percentage,7.3
+2014,48,2014/2015,48,HHS Region 3,Season peak percentage,7.2
 2014,48,2014/2015,48,HHS Region 3,1 wk ahead,2.1
 2014,48,2014/2015,48,HHS Region 3,2 wk ahead,2.9
-2014,48,2014/2015,48,HHS Region 3,3 wk ahead,4.6
-2014,48,2014/2015,48,HHS Region 3,4 wk ahead,7.3
+2014,48,2014/2015,48,HHS Region 3,3 wk ahead,4.5
+2014,48,2014/2015,48,HHS Region 3,4 wk ahead,7.2
 2014,48,2014/2015,48,HHS Region 4,Season onset,47
 2014,48,2014/2015,48,HHS Region 4,Season peak week,52
 2014,48,2014/2015,48,HHS Region 4,Season peak percentage,7.5
@@ -11113,11 +11080,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,48,2014/2015,48,HHS Region 5,4 wk ahead,6.6
 2014,48,2014/2015,48,HHS Region 6,Season onset,47
 2014,48,2014/2015,48,HHS Region 6,Season peak week,51
-2014,48,2014/2015,48,HHS Region 6,Season peak percentage,10.6
-2014,48,2014/2015,48,HHS Region 6,1 wk ahead,4.4
-2014,48,2014/2015,48,HHS Region 6,2 wk ahead,7.6
-2014,48,2014/2015,48,HHS Region 6,3 wk ahead,10.6
-2014,48,2014/2015,48,HHS Region 6,4 wk ahead,7.5
+2014,48,2014/2015,48,HHS Region 6,Season peak percentage,11.1
+2014,48,2014/2015,48,HHS Region 6,1 wk ahead,4.8
+2014,48,2014/2015,48,HHS Region 6,2 wk ahead,8.1
+2014,48,2014/2015,48,HHS Region 6,3 wk ahead,11.1
+2014,48,2014/2015,48,HHS Region 6,4 wk ahead,7.8
 2014,48,2014/2015,48,HHS Region 7,Season onset,48
 2014,48,2014/2015,48,HHS Region 7,Season peak week,52
 2014,48,2014/2015,48,HHS Region 7,Season peak percentage,6.4
@@ -11129,14 +11096,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,48,2014/2015,48,HHS Region 8,Season peak week,53
 2014,48,2014/2015,48,HHS Region 8,Season peak percentage,4.4
 2014,48,2014/2015,48,HHS Region 8,1 wk ahead,1.3
-2014,48,2014/2015,48,HHS Region 8,2 wk ahead,1.8
-2014,48,2014/2015,48,HHS Region 8,3 wk ahead,2.4
-2014,48,2014/2015,48,HHS Region 8,4 wk ahead,3.8
+2014,48,2014/2015,48,HHS Region 8,2 wk ahead,1.9
+2014,48,2014/2015,48,HHS Region 8,3 wk ahead,2.5
+2014,48,2014/2015,48,HHS Region 8,4 wk ahead,3.9
 2014,48,2014/2015,48,HHS Region 9,Season onset,51
 2014,48,2014/2015,48,HHS Region 9,Season peak week,3
 2014,48,2014/2015,48,HHS Region 9,Season peak week,4
 2014,48,2014/2015,48,HHS Region 9,Season peak percentage,5
-2014,48,2014/2015,48,HHS Region 9,1 wk ahead,2.3
+2014,48,2014/2015,48,HHS Region 9,1 wk ahead,2.2
 2014,48,2014/2015,48,HHS Region 9,2 wk ahead,2.4
 2014,48,2014/2015,48,HHS Region 9,3 wk ahead,2.8
 2014,48,2014/2015,48,HHS Region 9,4 wk ahead,4.3
@@ -11150,8 +11117,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,49,2014/2015,49,US National,Season onset,47
 2014,49,2014/2015,49,US National,Season peak week,52
 2014,49,2014/2015,49,US National,Season peak percentage,6
-2014,49,2014/2015,49,US National,1 wk ahead,3.6
-2014,49,2014/2015,49,US National,2 wk ahead,4.9
+2014,49,2014/2015,49,US National,1 wk ahead,3.7
+2014,49,2014/2015,49,US National,2 wk ahead,5
 2014,49,2014/2015,49,US National,3 wk ahead,6
 2014,49,2014/2015,49,US National,4 wk ahead,5.5
 2014,49,2014/2015,49,HHS Region 1,Season onset,50
@@ -11172,11 +11139,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,49,2014/2015,49,HHS Region 2,4 wk ahead,4.5
 2014,49,2014/2015,49,HHS Region 3,Season onset,48
 2014,49,2014/2015,49,HHS Region 3,Season peak week,52
-2014,49,2014/2015,49,HHS Region 3,Season peak percentage,7.3
+2014,49,2014/2015,49,HHS Region 3,Season peak percentage,7.2
 2014,49,2014/2015,49,HHS Region 3,1 wk ahead,2.9
-2014,49,2014/2015,49,HHS Region 3,2 wk ahead,4.6
-2014,49,2014/2015,49,HHS Region 3,3 wk ahead,7.3
-2014,49,2014/2015,49,HHS Region 3,4 wk ahead,7
+2014,49,2014/2015,49,HHS Region 3,2 wk ahead,4.5
+2014,49,2014/2015,49,HHS Region 3,3 wk ahead,7.2
+2014,49,2014/2015,49,HHS Region 3,4 wk ahead,6.9
 2014,49,2014/2015,49,HHS Region 4,Season onset,47
 2014,49,2014/2015,49,HHS Region 4,Season peak week,52
 2014,49,2014/2015,49,HHS Region 4,Season peak percentage,7.5
@@ -11193,11 +11160,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,49,2014/2015,49,HHS Region 5,4 wk ahead,4.8
 2014,49,2014/2015,49,HHS Region 6,Season onset,47
 2014,49,2014/2015,49,HHS Region 6,Season peak week,51
-2014,49,2014/2015,49,HHS Region 6,Season peak percentage,10.6
-2014,49,2014/2015,49,HHS Region 6,1 wk ahead,7.6
-2014,49,2014/2015,49,HHS Region 6,2 wk ahead,10.6
-2014,49,2014/2015,49,HHS Region 6,3 wk ahead,7.5
-2014,49,2014/2015,49,HHS Region 6,4 wk ahead,9.6
+2014,49,2014/2015,49,HHS Region 6,Season peak percentage,11.1
+2014,49,2014/2015,49,HHS Region 6,1 wk ahead,8.1
+2014,49,2014/2015,49,HHS Region 6,2 wk ahead,11.1
+2014,49,2014/2015,49,HHS Region 6,3 wk ahead,7.8
+2014,49,2014/2015,49,HHS Region 6,4 wk ahead,10
 2014,49,2014/2015,49,HHS Region 7,Season onset,48
 2014,49,2014/2015,49,HHS Region 7,Season peak week,52
 2014,49,2014/2015,49,HHS Region 7,Season peak percentage,6.4
@@ -11208,9 +11175,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,49,2014/2015,49,HHS Region 8,Season onset,49
 2014,49,2014/2015,49,HHS Region 8,Season peak week,53
 2014,49,2014/2015,49,HHS Region 8,Season peak percentage,4.4
-2014,49,2014/2015,49,HHS Region 8,1 wk ahead,1.8
-2014,49,2014/2015,49,HHS Region 8,2 wk ahead,2.4
-2014,49,2014/2015,49,HHS Region 8,3 wk ahead,3.8
+2014,49,2014/2015,49,HHS Region 8,1 wk ahead,1.9
+2014,49,2014/2015,49,HHS Region 8,2 wk ahead,2.5
+2014,49,2014/2015,49,HHS Region 8,3 wk ahead,3.9
 2014,49,2014/2015,49,HHS Region 8,4 wk ahead,4.4
 2014,49,2014/2015,49,HHS Region 9,Season onset,51
 2014,49,2014/2015,49,HHS Region 9,Season peak week,3
@@ -11230,7 +11197,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,50,2014/2015,50,US National,Season onset,47
 2014,50,2014/2015,50,US National,Season peak week,52
 2014,50,2014/2015,50,US National,Season peak percentage,6
-2014,50,2014/2015,50,US National,1 wk ahead,4.9
+2014,50,2014/2015,50,US National,1 wk ahead,5
 2014,50,2014/2015,50,US National,2 wk ahead,6
 2014,50,2014/2015,50,US National,3 wk ahead,5.5
 2014,50,2014/2015,50,US National,4 wk ahead,4.2
@@ -11249,21 +11216,21 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,50,2014/2015,50,HHS Region 2,1 wk ahead,3.6
 2014,50,2014/2015,50,HHS Region 2,2 wk ahead,5.2
 2014,50,2014/2015,50,HHS Region 2,3 wk ahead,4.5
-2014,50,2014/2015,50,HHS Region 2,4 wk ahead,4.3
+2014,50,2014/2015,50,HHS Region 2,4 wk ahead,4
 2014,50,2014/2015,50,HHS Region 3,Season onset,48
 2014,50,2014/2015,50,HHS Region 3,Season peak week,52
-2014,50,2014/2015,50,HHS Region 3,Season peak percentage,7.3
-2014,50,2014/2015,50,HHS Region 3,1 wk ahead,4.6
-2014,50,2014/2015,50,HHS Region 3,2 wk ahead,7.3
-2014,50,2014/2015,50,HHS Region 3,3 wk ahead,7
-2014,50,2014/2015,50,HHS Region 3,4 wk ahead,4.9
+2014,50,2014/2015,50,HHS Region 3,Season peak percentage,7.2
+2014,50,2014/2015,50,HHS Region 3,1 wk ahead,4.5
+2014,50,2014/2015,50,HHS Region 3,2 wk ahead,7.2
+2014,50,2014/2015,50,HHS Region 3,3 wk ahead,6.9
+2014,50,2014/2015,50,HHS Region 3,4 wk ahead,4.8
 2014,50,2014/2015,50,HHS Region 4,Season onset,47
 2014,50,2014/2015,50,HHS Region 4,Season peak week,52
 2014,50,2014/2015,50,HHS Region 4,Season peak percentage,7.5
 2014,50,2014/2015,50,HHS Region 4,1 wk ahead,5.7
 2014,50,2014/2015,50,HHS Region 4,2 wk ahead,7.5
 2014,50,2014/2015,50,HHS Region 4,3 wk ahead,5.2
-2014,50,2014/2015,50,HHS Region 4,4 wk ahead,3.5
+2014,50,2014/2015,50,HHS Region 4,4 wk ahead,3.4
 2014,50,2014/2015,50,HHS Region 5,Season onset,48
 2014,50,2014/2015,50,HHS Region 5,Season peak week,52
 2014,50,2014/2015,50,HHS Region 5,Season peak percentage,6.6
@@ -11273,11 +11240,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,50,2014/2015,50,HHS Region 5,4 wk ahead,3.2
 2014,50,2014/2015,50,HHS Region 6,Season onset,47
 2014,50,2014/2015,50,HHS Region 6,Season peak week,51
-2014,50,2014/2015,50,HHS Region 6,Season peak percentage,10.6
-2014,50,2014/2015,50,HHS Region 6,1 wk ahead,10.6
-2014,50,2014/2015,50,HHS Region 6,2 wk ahead,7.5
-2014,50,2014/2015,50,HHS Region 6,3 wk ahead,9.6
-2014,50,2014/2015,50,HHS Region 6,4 wk ahead,7.7
+2014,50,2014/2015,50,HHS Region 6,Season peak percentage,11.1
+2014,50,2014/2015,50,HHS Region 6,1 wk ahead,11.1
+2014,50,2014/2015,50,HHS Region 6,2 wk ahead,7.8
+2014,50,2014/2015,50,HHS Region 6,3 wk ahead,10
+2014,50,2014/2015,50,HHS Region 6,4 wk ahead,8.3
 2014,50,2014/2015,50,HHS Region 7,Season onset,48
 2014,50,2014/2015,50,HHS Region 7,Season peak week,52
 2014,50,2014/2015,50,HHS Region 7,Season peak percentage,6.4
@@ -11288,10 +11255,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,50,2014/2015,50,HHS Region 8,Season onset,49
 2014,50,2014/2015,50,HHS Region 8,Season peak week,53
 2014,50,2014/2015,50,HHS Region 8,Season peak percentage,4.4
-2014,50,2014/2015,50,HHS Region 8,1 wk ahead,2.4
-2014,50,2014/2015,50,HHS Region 8,2 wk ahead,3.8
+2014,50,2014/2015,50,HHS Region 8,1 wk ahead,2.5
+2014,50,2014/2015,50,HHS Region 8,2 wk ahead,3.9
 2014,50,2014/2015,50,HHS Region 8,3 wk ahead,4.4
-2014,50,2014/2015,50,HHS Region 8,4 wk ahead,3.4
+2014,50,2014/2015,50,HHS Region 8,4 wk ahead,3.5
 2014,50,2014/2015,50,HHS Region 9,Season onset,51
 2014,50,2014/2015,50,HHS Region 9,Season peak week,3
 2014,50,2014/2015,50,HHS Region 9,Season peak week,4
@@ -11313,7 +11280,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,51,2014/2015,51,US National,1 wk ahead,6
 2014,51,2014/2015,51,US National,2 wk ahead,5.5
 2014,51,2014/2015,51,US National,3 wk ahead,4.2
-2014,51,2014/2015,51,US National,4 wk ahead,4.2
+2014,51,2014/2015,51,US National,4 wk ahead,4.3
 2014,51,2014/2015,51,HHS Region 1,Season onset,50
 2014,51,2014/2015,51,HHS Region 1,Season peak week,3
 2014,51,2014/2015,51,HHS Region 1,Season peak percentage,3.9
@@ -11328,21 +11295,21 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,51,2014/2015,51,HHS Region 2,Season peak percentage,5.2
 2014,51,2014/2015,51,HHS Region 2,1 wk ahead,5.2
 2014,51,2014/2015,51,HHS Region 2,2 wk ahead,4.5
-2014,51,2014/2015,51,HHS Region 2,3 wk ahead,4.3
+2014,51,2014/2015,51,HHS Region 2,3 wk ahead,4
 2014,51,2014/2015,51,HHS Region 2,4 wk ahead,4.6
 2014,51,2014/2015,51,HHS Region 3,Season onset,48
 2014,51,2014/2015,51,HHS Region 3,Season peak week,52
-2014,51,2014/2015,51,HHS Region 3,Season peak percentage,7.3
-2014,51,2014/2015,51,HHS Region 3,1 wk ahead,7.3
-2014,51,2014/2015,51,HHS Region 3,2 wk ahead,7
-2014,51,2014/2015,51,HHS Region 3,3 wk ahead,4.9
+2014,51,2014/2015,51,HHS Region 3,Season peak percentage,7.2
+2014,51,2014/2015,51,HHS Region 3,1 wk ahead,7.2
+2014,51,2014/2015,51,HHS Region 3,2 wk ahead,6.9
+2014,51,2014/2015,51,HHS Region 3,3 wk ahead,4.8
 2014,51,2014/2015,51,HHS Region 3,4 wk ahead,4.1
 2014,51,2014/2015,51,HHS Region 4,Season onset,47
 2014,51,2014/2015,51,HHS Region 4,Season peak week,52
 2014,51,2014/2015,51,HHS Region 4,Season peak percentage,7.5
 2014,51,2014/2015,51,HHS Region 4,1 wk ahead,7.5
 2014,51,2014/2015,51,HHS Region 4,2 wk ahead,5.2
-2014,51,2014/2015,51,HHS Region 4,3 wk ahead,3.5
+2014,51,2014/2015,51,HHS Region 4,3 wk ahead,3.4
 2014,51,2014/2015,51,HHS Region 4,4 wk ahead,3
 2014,51,2014/2015,51,HHS Region 5,Season onset,48
 2014,51,2014/2015,51,HHS Region 5,Season peak week,52
@@ -11353,11 +11320,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,51,2014/2015,51,HHS Region 5,4 wk ahead,2.6
 2014,51,2014/2015,51,HHS Region 6,Season onset,47
 2014,51,2014/2015,51,HHS Region 6,Season peak week,51
-2014,51,2014/2015,51,HHS Region 6,Season peak percentage,10.6
-2014,51,2014/2015,51,HHS Region 6,1 wk ahead,7.5
-2014,51,2014/2015,51,HHS Region 6,2 wk ahead,9.6
-2014,51,2014/2015,51,HHS Region 6,3 wk ahead,7.7
-2014,51,2014/2015,51,HHS Region 6,4 wk ahead,8.8
+2014,51,2014/2015,51,HHS Region 6,Season peak percentage,11.1
+2014,51,2014/2015,51,HHS Region 6,1 wk ahead,7.8
+2014,51,2014/2015,51,HHS Region 6,2 wk ahead,10
+2014,51,2014/2015,51,HHS Region 6,3 wk ahead,8.3
+2014,51,2014/2015,51,HHS Region 6,4 wk ahead,9.4
 2014,51,2014/2015,51,HHS Region 7,Season onset,48
 2014,51,2014/2015,51,HHS Region 7,Season peak week,52
 2014,51,2014/2015,51,HHS Region 7,Season peak percentage,6.4
@@ -11368,10 +11335,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,51,2014/2015,51,HHS Region 8,Season onset,49
 2014,51,2014/2015,51,HHS Region 8,Season peak week,53
 2014,51,2014/2015,51,HHS Region 8,Season peak percentage,4.4
-2014,51,2014/2015,51,HHS Region 8,1 wk ahead,3.8
+2014,51,2014/2015,51,HHS Region 8,1 wk ahead,3.9
 2014,51,2014/2015,51,HHS Region 8,2 wk ahead,4.4
-2014,51,2014/2015,51,HHS Region 8,3 wk ahead,3.4
-2014,51,2014/2015,51,HHS Region 8,4 wk ahead,3.3
+2014,51,2014/2015,51,HHS Region 8,3 wk ahead,3.5
+2014,51,2014/2015,51,HHS Region 8,4 wk ahead,3.4
 2014,51,2014/2015,51,HHS Region 9,Season onset,51
 2014,51,2014/2015,51,HHS Region 9,Season peak week,3
 2014,51,2014/2015,51,HHS Region 9,Season peak week,4
@@ -11379,7 +11346,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,51,2014/2015,51,HHS Region 9,1 wk ahead,4.3
 2014,51,2014/2015,51,HHS Region 9,2 wk ahead,4.7
 2014,51,2014/2015,51,HHS Region 9,3 wk ahead,4
-2014,51,2014/2015,51,HHS Region 9,4 wk ahead,4.5
+2014,51,2014/2015,51,HHS Region 9,4 wk ahead,4.4
 2014,51,2014/2015,51,HHS Region 10,Season onset,48
 2014,51,2014/2015,51,HHS Region 10,Season peak week,2
 2014,51,2014/2015,51,HHS Region 10,Season peak percentage,3.6
@@ -11392,7 +11359,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,52,2014/2015,52,US National,Season peak percentage,6
 2014,52,2014/2015,52,US National,1 wk ahead,5.5
 2014,52,2014/2015,52,US National,2 wk ahead,4.2
-2014,52,2014/2015,52,US National,3 wk ahead,4.2
+2014,52,2014/2015,52,US National,3 wk ahead,4.3
 2014,52,2014/2015,52,US National,4 wk ahead,4.3
 2014,52,2014/2015,52,HHS Region 1,Season onset,50
 2014,52,2014/2015,52,HHS Region 1,Season peak week,3
@@ -11407,23 +11374,23 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,52,2014/2015,52,HHS Region 2,Season peak week,5
 2014,52,2014/2015,52,HHS Region 2,Season peak percentage,5.2
 2014,52,2014/2015,52,HHS Region 2,1 wk ahead,4.5
-2014,52,2014/2015,52,HHS Region 2,2 wk ahead,4.3
+2014,52,2014/2015,52,HHS Region 2,2 wk ahead,4
 2014,52,2014/2015,52,HHS Region 2,3 wk ahead,4.6
-2014,52,2014/2015,52,HHS Region 2,4 wk ahead,5.1
+2014,52,2014/2015,52,HHS Region 2,4 wk ahead,5
 2014,52,2014/2015,52,HHS Region 3,Season onset,48
 2014,52,2014/2015,52,HHS Region 3,Season peak week,52
-2014,52,2014/2015,52,HHS Region 3,Season peak percentage,7.3
-2014,52,2014/2015,52,HHS Region 3,1 wk ahead,7
-2014,52,2014/2015,52,HHS Region 3,2 wk ahead,4.9
+2014,52,2014/2015,52,HHS Region 3,Season peak percentage,7.2
+2014,52,2014/2015,52,HHS Region 3,1 wk ahead,6.9
+2014,52,2014/2015,52,HHS Region 3,2 wk ahead,4.8
 2014,52,2014/2015,52,HHS Region 3,3 wk ahead,4.1
 2014,52,2014/2015,52,HHS Region 3,4 wk ahead,4.5
 2014,52,2014/2015,52,HHS Region 4,Season onset,47
 2014,52,2014/2015,52,HHS Region 4,Season peak week,52
 2014,52,2014/2015,52,HHS Region 4,Season peak percentage,7.5
 2014,52,2014/2015,52,HHS Region 4,1 wk ahead,5.2
-2014,52,2014/2015,52,HHS Region 4,2 wk ahead,3.5
+2014,52,2014/2015,52,HHS Region 4,2 wk ahead,3.4
 2014,52,2014/2015,52,HHS Region 4,3 wk ahead,3
-2014,52,2014/2015,52,HHS Region 4,4 wk ahead,3.3
+2014,52,2014/2015,52,HHS Region 4,4 wk ahead,3.2
 2014,52,2014/2015,52,HHS Region 5,Season onset,48
 2014,52,2014/2015,52,HHS Region 5,Season peak week,52
 2014,52,2014/2015,52,HHS Region 5,Season peak percentage,6.6
@@ -11433,11 +11400,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,52,2014/2015,52,HHS Region 5,4 wk ahead,2.3
 2014,52,2014/2015,52,HHS Region 6,Season onset,47
 2014,52,2014/2015,52,HHS Region 6,Season peak week,51
-2014,52,2014/2015,52,HHS Region 6,Season peak percentage,10.6
-2014,52,2014/2015,52,HHS Region 6,1 wk ahead,9.6
-2014,52,2014/2015,52,HHS Region 6,2 wk ahead,7.7
-2014,52,2014/2015,52,HHS Region 6,3 wk ahead,8.8
-2014,52,2014/2015,52,HHS Region 6,4 wk ahead,7.3
+2014,52,2014/2015,52,HHS Region 6,Season peak percentage,11.1
+2014,52,2014/2015,52,HHS Region 6,1 wk ahead,10
+2014,52,2014/2015,52,HHS Region 6,2 wk ahead,8.3
+2014,52,2014/2015,52,HHS Region 6,3 wk ahead,9.4
+2014,52,2014/2015,52,HHS Region 6,4 wk ahead,7.7
 2014,52,2014/2015,52,HHS Region 7,Season onset,48
 2014,52,2014/2015,52,HHS Region 7,Season peak week,52
 2014,52,2014/2015,52,HHS Region 7,Season peak percentage,6.4
@@ -11449,8 +11416,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,52,2014/2015,52,HHS Region 8,Season peak week,53
 2014,52,2014/2015,52,HHS Region 8,Season peak percentage,4.4
 2014,52,2014/2015,52,HHS Region 8,1 wk ahead,4.4
-2014,52,2014/2015,52,HHS Region 8,2 wk ahead,3.4
-2014,52,2014/2015,52,HHS Region 8,3 wk ahead,3.3
+2014,52,2014/2015,52,HHS Region 8,2 wk ahead,3.5
+2014,52,2014/2015,52,HHS Region 8,3 wk ahead,3.4
 2014,52,2014/2015,52,HHS Region 8,4 wk ahead,3.2
 2014,52,2014/2015,52,HHS Region 9,Season onset,51
 2014,52,2014/2015,52,HHS Region 9,Season peak week,3
@@ -11458,7 +11425,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,52,2014/2015,52,HHS Region 9,Season peak percentage,5
 2014,52,2014/2015,52,HHS Region 9,1 wk ahead,4.7
 2014,52,2014/2015,52,HHS Region 9,2 wk ahead,4
-2014,52,2014/2015,52,HHS Region 9,3 wk ahead,4.5
+2014,52,2014/2015,52,HHS Region 9,3 wk ahead,4.4
 2014,52,2014/2015,52,HHS Region 9,4 wk ahead,5
 2014,52,2014/2015,52,HHS Region 10,Season onset,48
 2014,52,2014/2015,52,HHS Region 10,Season peak week,2
@@ -11471,7 +11438,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,53,2014/2015,53,US National,Season peak week,52
 2014,53,2014/2015,53,US National,Season peak percentage,6
 2014,53,2014/2015,53,US National,1 wk ahead,4.2
-2014,53,2014/2015,53,US National,2 wk ahead,4.2
+2014,53,2014/2015,53,US National,2 wk ahead,4.3
 2014,53,2014/2015,53,US National,3 wk ahead,4.3
 2014,53,2014/2015,53,US National,4 wk ahead,4
 2014,53,2014/2015,53,HHS Region 1,Season onset,50
@@ -11486,24 +11453,24 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,53,2014/2015,53,HHS Region 2,Season peak week,4
 2014,53,2014/2015,53,HHS Region 2,Season peak week,5
 2014,53,2014/2015,53,HHS Region 2,Season peak percentage,5.2
-2014,53,2014/2015,53,HHS Region 2,1 wk ahead,4.3
+2014,53,2014/2015,53,HHS Region 2,1 wk ahead,4
 2014,53,2014/2015,53,HHS Region 2,2 wk ahead,4.6
-2014,53,2014/2015,53,HHS Region 2,3 wk ahead,5.1
+2014,53,2014/2015,53,HHS Region 2,3 wk ahead,5
 2014,53,2014/2015,53,HHS Region 2,4 wk ahead,5.2
 2014,53,2014/2015,53,HHS Region 3,Season onset,48
 2014,53,2014/2015,53,HHS Region 3,Season peak week,52
-2014,53,2014/2015,53,HHS Region 3,Season peak percentage,7.3
-2014,53,2014/2015,53,HHS Region 3,1 wk ahead,4.9
+2014,53,2014/2015,53,HHS Region 3,Season peak percentage,7.2
+2014,53,2014/2015,53,HHS Region 3,1 wk ahead,4.8
 2014,53,2014/2015,53,HHS Region 3,2 wk ahead,4.1
 2014,53,2014/2015,53,HHS Region 3,3 wk ahead,4.5
 2014,53,2014/2015,53,HHS Region 3,4 wk ahead,4.2
 2014,53,2014/2015,53,HHS Region 4,Season onset,47
 2014,53,2014/2015,53,HHS Region 4,Season peak week,52
 2014,53,2014/2015,53,HHS Region 4,Season peak percentage,7.5
-2014,53,2014/2015,53,HHS Region 4,1 wk ahead,3.5
+2014,53,2014/2015,53,HHS Region 4,1 wk ahead,3.4
 2014,53,2014/2015,53,HHS Region 4,2 wk ahead,3
-2014,53,2014/2015,53,HHS Region 4,3 wk ahead,3.3
-2014,53,2014/2015,53,HHS Region 4,4 wk ahead,3
+2014,53,2014/2015,53,HHS Region 4,3 wk ahead,3.2
+2014,53,2014/2015,53,HHS Region 4,4 wk ahead,2.8
 2014,53,2014/2015,53,HHS Region 5,Season onset,48
 2014,53,2014/2015,53,HHS Region 5,Season peak week,52
 2014,53,2014/2015,53,HHS Region 5,Season peak percentage,6.6
@@ -11513,11 +11480,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,53,2014/2015,53,HHS Region 5,4 wk ahead,1.9
 2014,53,2014/2015,53,HHS Region 6,Season onset,47
 2014,53,2014/2015,53,HHS Region 6,Season peak week,51
-2014,53,2014/2015,53,HHS Region 6,Season peak percentage,10.6
-2014,53,2014/2015,53,HHS Region 6,1 wk ahead,7.7
-2014,53,2014/2015,53,HHS Region 6,2 wk ahead,8.8
-2014,53,2014/2015,53,HHS Region 6,3 wk ahead,7.3
-2014,53,2014/2015,53,HHS Region 6,4 wk ahead,6.4
+2014,53,2014/2015,53,HHS Region 6,Season peak percentage,11.1
+2014,53,2014/2015,53,HHS Region 6,1 wk ahead,8.3
+2014,53,2014/2015,53,HHS Region 6,2 wk ahead,9.4
+2014,53,2014/2015,53,HHS Region 6,3 wk ahead,7.7
+2014,53,2014/2015,53,HHS Region 6,4 wk ahead,6.7
 2014,53,2014/2015,53,HHS Region 7,Season onset,48
 2014,53,2014/2015,53,HHS Region 7,Season peak week,52
 2014,53,2014/2015,53,HHS Region 7,Season peak percentage,6.4
@@ -11528,8 +11495,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,53,2014/2015,53,HHS Region 8,Season onset,49
 2014,53,2014/2015,53,HHS Region 8,Season peak week,53
 2014,53,2014/2015,53,HHS Region 8,Season peak percentage,4.4
-2014,53,2014/2015,53,HHS Region 8,1 wk ahead,3.4
-2014,53,2014/2015,53,HHS Region 8,2 wk ahead,3.3
+2014,53,2014/2015,53,HHS Region 8,1 wk ahead,3.5
+2014,53,2014/2015,53,HHS Region 8,2 wk ahead,3.4
 2014,53,2014/2015,53,HHS Region 8,3 wk ahead,3.2
 2014,53,2014/2015,53,HHS Region 8,4 wk ahead,3
 2014,53,2014/2015,53,HHS Region 9,Season onset,51
@@ -11537,7 +11504,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2014,53,2014/2015,53,HHS Region 9,Season peak week,4
 2014,53,2014/2015,53,HHS Region 9,Season peak percentage,5
 2014,53,2014/2015,53,HHS Region 9,1 wk ahead,4
-2014,53,2014/2015,53,HHS Region 9,2 wk ahead,4.5
+2014,53,2014/2015,53,HHS Region 9,2 wk ahead,4.4
 2014,53,2014/2015,53,HHS Region 9,3 wk ahead,5
 2014,53,2014/2015,53,HHS Region 9,4 wk ahead,5
 2014,53,2014/2015,53,HHS Region 10,Season onset,48
@@ -11550,7 +11517,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,1,2014/2015,54,US National,Season onset,47
 2015,1,2014/2015,54,US National,Season peak week,52
 2015,1,2014/2015,54,US National,Season peak percentage,6
-2015,1,2014/2015,54,US National,1 wk ahead,4.2
+2015,1,2014/2015,54,US National,1 wk ahead,4.3
 2015,1,2014/2015,54,US National,2 wk ahead,4.3
 2015,1,2014/2015,54,US National,3 wk ahead,4
 2015,1,2014/2015,54,US National,4 wk ahead,3.6
@@ -11567,12 +11534,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,1,2014/2015,54,HHS Region 2,Season peak week,5
 2015,1,2014/2015,54,HHS Region 2,Season peak percentage,5.2
 2015,1,2014/2015,54,HHS Region 2,1 wk ahead,4.6
-2015,1,2014/2015,54,HHS Region 2,2 wk ahead,5.1
+2015,1,2014/2015,54,HHS Region 2,2 wk ahead,5
 2015,1,2014/2015,54,HHS Region 2,3 wk ahead,5.2
 2015,1,2014/2015,54,HHS Region 2,4 wk ahead,5.2
 2015,1,2014/2015,54,HHS Region 3,Season onset,48
 2015,1,2014/2015,54,HHS Region 3,Season peak week,52
-2015,1,2014/2015,54,HHS Region 3,Season peak percentage,7.3
+2015,1,2014/2015,54,HHS Region 3,Season peak percentage,7.2
 2015,1,2014/2015,54,HHS Region 3,1 wk ahead,4.1
 2015,1,2014/2015,54,HHS Region 3,2 wk ahead,4.5
 2015,1,2014/2015,54,HHS Region 3,3 wk ahead,4.2
@@ -11581,9 +11548,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,1,2014/2015,54,HHS Region 4,Season peak week,52
 2015,1,2014/2015,54,HHS Region 4,Season peak percentage,7.5
 2015,1,2014/2015,54,HHS Region 4,1 wk ahead,3
-2015,1,2014/2015,54,HHS Region 4,2 wk ahead,3.3
-2015,1,2014/2015,54,HHS Region 4,3 wk ahead,3
-2015,1,2014/2015,54,HHS Region 4,4 wk ahead,2.8
+2015,1,2014/2015,54,HHS Region 4,2 wk ahead,3.2
+2015,1,2014/2015,54,HHS Region 4,3 wk ahead,2.8
+2015,1,2014/2015,54,HHS Region 4,4 wk ahead,2.6
 2015,1,2014/2015,54,HHS Region 5,Season onset,48
 2015,1,2014/2015,54,HHS Region 5,Season peak week,52
 2015,1,2014/2015,54,HHS Region 5,Season peak percentage,6.6
@@ -11593,11 +11560,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,1,2014/2015,54,HHS Region 5,4 wk ahead,1.9
 2015,1,2014/2015,54,HHS Region 6,Season onset,47
 2015,1,2014/2015,54,HHS Region 6,Season peak week,51
-2015,1,2014/2015,54,HHS Region 6,Season peak percentage,10.6
-2015,1,2014/2015,54,HHS Region 6,1 wk ahead,8.8
-2015,1,2014/2015,54,HHS Region 6,2 wk ahead,7.3
-2015,1,2014/2015,54,HHS Region 6,3 wk ahead,6.4
-2015,1,2014/2015,54,HHS Region 6,4 wk ahead,5.9
+2015,1,2014/2015,54,HHS Region 6,Season peak percentage,11.1
+2015,1,2014/2015,54,HHS Region 6,1 wk ahead,9.4
+2015,1,2014/2015,54,HHS Region 6,2 wk ahead,7.7
+2015,1,2014/2015,54,HHS Region 6,3 wk ahead,6.7
+2015,1,2014/2015,54,HHS Region 6,4 wk ahead,6.3
 2015,1,2014/2015,54,HHS Region 7,Season onset,48
 2015,1,2014/2015,54,HHS Region 7,Season peak week,52
 2015,1,2014/2015,54,HHS Region 7,Season peak percentage,6.4
@@ -11608,7 +11575,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,1,2014/2015,54,HHS Region 8,Season onset,49
 2015,1,2014/2015,54,HHS Region 8,Season peak week,53
 2015,1,2014/2015,54,HHS Region 8,Season peak percentage,4.4
-2015,1,2014/2015,54,HHS Region 8,1 wk ahead,3.3
+2015,1,2014/2015,54,HHS Region 8,1 wk ahead,3.4
 2015,1,2014/2015,54,HHS Region 8,2 wk ahead,3.2
 2015,1,2014/2015,54,HHS Region 8,3 wk ahead,3
 2015,1,2014/2015,54,HHS Region 8,4 wk ahead,2.8
@@ -11616,7 +11583,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,1,2014/2015,54,HHS Region 9,Season peak week,3
 2015,1,2014/2015,54,HHS Region 9,Season peak week,4
 2015,1,2014/2015,54,HHS Region 9,Season peak percentage,5
-2015,1,2014/2015,54,HHS Region 9,1 wk ahead,4.5
+2015,1,2014/2015,54,HHS Region 9,1 wk ahead,4.4
 2015,1,2014/2015,54,HHS Region 9,2 wk ahead,5
 2015,1,2014/2015,54,HHS Region 9,3 wk ahead,5
 2015,1,2014/2015,54,HHS Region 9,4 wk ahead,4.4
@@ -11646,24 +11613,24 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,2,2014/2015,55,HHS Region 2,Season peak week,4
 2015,2,2014/2015,55,HHS Region 2,Season peak week,5
 2015,2,2014/2015,55,HHS Region 2,Season peak percentage,5.2
-2015,2,2014/2015,55,HHS Region 2,1 wk ahead,5.1
+2015,2,2014/2015,55,HHS Region 2,1 wk ahead,5
 2015,2,2014/2015,55,HHS Region 2,2 wk ahead,5.2
 2015,2,2014/2015,55,HHS Region 2,3 wk ahead,5.2
 2015,2,2014/2015,55,HHS Region 2,4 wk ahead,4.9
 2015,2,2014/2015,55,HHS Region 3,Season onset,48
 2015,2,2014/2015,55,HHS Region 3,Season peak week,52
-2015,2,2014/2015,55,HHS Region 3,Season peak percentage,7.3
+2015,2,2014/2015,55,HHS Region 3,Season peak percentage,7.2
 2015,2,2014/2015,55,HHS Region 3,1 wk ahead,4.5
 2015,2,2014/2015,55,HHS Region 3,2 wk ahead,4.2
 2015,2,2014/2015,55,HHS Region 3,3 wk ahead,3.5
-2015,2,2014/2015,55,HHS Region 3,4 wk ahead,2.7
+2015,2,2014/2015,55,HHS Region 3,4 wk ahead,2.6
 2015,2,2014/2015,55,HHS Region 4,Season onset,47
 2015,2,2014/2015,55,HHS Region 4,Season peak week,52
 2015,2,2014/2015,55,HHS Region 4,Season peak percentage,7.5
-2015,2,2014/2015,55,HHS Region 4,1 wk ahead,3.3
-2015,2,2014/2015,55,HHS Region 4,2 wk ahead,3
-2015,2,2014/2015,55,HHS Region 4,3 wk ahead,2.8
-2015,2,2014/2015,55,HHS Region 4,4 wk ahead,2.6
+2015,2,2014/2015,55,HHS Region 4,1 wk ahead,3.2
+2015,2,2014/2015,55,HHS Region 4,2 wk ahead,2.8
+2015,2,2014/2015,55,HHS Region 4,3 wk ahead,2.6
+2015,2,2014/2015,55,HHS Region 4,4 wk ahead,2.4
 2015,2,2014/2015,55,HHS Region 5,Season onset,48
 2015,2,2014/2015,55,HHS Region 5,Season peak week,52
 2015,2,2014/2015,55,HHS Region 5,Season peak percentage,6.6
@@ -11673,11 +11640,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,2,2014/2015,55,HHS Region 5,4 wk ahead,1.9
 2015,2,2014/2015,55,HHS Region 6,Season onset,47
 2015,2,2014/2015,55,HHS Region 6,Season peak week,51
-2015,2,2014/2015,55,HHS Region 6,Season peak percentage,10.6
-2015,2,2014/2015,55,HHS Region 6,1 wk ahead,7.3
-2015,2,2014/2015,55,HHS Region 6,2 wk ahead,6.4
-2015,2,2014/2015,55,HHS Region 6,3 wk ahead,5.9
-2015,2,2014/2015,55,HHS Region 6,4 wk ahead,5.5
+2015,2,2014/2015,55,HHS Region 6,Season peak percentage,11.1
+2015,2,2014/2015,55,HHS Region 6,1 wk ahead,7.7
+2015,2,2014/2015,55,HHS Region 6,2 wk ahead,6.7
+2015,2,2014/2015,55,HHS Region 6,3 wk ahead,6.3
+2015,2,2014/2015,55,HHS Region 6,4 wk ahead,5.9
 2015,2,2014/2015,55,HHS Region 7,Season onset,48
 2015,2,2014/2015,55,HHS Region 7,Season peak week,52
 2015,2,2014/2015,55,HHS Region 7,Season peak percentage,6.4
@@ -11713,7 +11680,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,3,2014/2015,56,US National,1 wk ahead,4
 2015,3,2014/2015,56,US National,2 wk ahead,3.6
 2015,3,2014/2015,56,US National,3 wk ahead,3.3
-2015,3,2014/2015,56,US National,4 wk ahead,2.9
+2015,3,2014/2015,56,US National,4 wk ahead,3
 2015,3,2014/2015,56,HHS Region 1,Season onset,50
 2015,3,2014/2015,56,HHS Region 1,Season peak week,3
 2015,3,2014/2015,56,HHS Region 1,Season peak percentage,3.9
@@ -11732,17 +11699,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,3,2014/2015,56,HHS Region 2,4 wk ahead,3.7
 2015,3,2014/2015,56,HHS Region 3,Season onset,48
 2015,3,2014/2015,56,HHS Region 3,Season peak week,52
-2015,3,2014/2015,56,HHS Region 3,Season peak percentage,7.3
+2015,3,2014/2015,56,HHS Region 3,Season peak percentage,7.2
 2015,3,2014/2015,56,HHS Region 3,1 wk ahead,4.2
 2015,3,2014/2015,56,HHS Region 3,2 wk ahead,3.5
-2015,3,2014/2015,56,HHS Region 3,3 wk ahead,2.7
-2015,3,2014/2015,56,HHS Region 3,4 wk ahead,2.6
+2015,3,2014/2015,56,HHS Region 3,3 wk ahead,2.6
+2015,3,2014/2015,56,HHS Region 3,4 wk ahead,2.5
 2015,3,2014/2015,56,HHS Region 4,Season onset,47
 2015,3,2014/2015,56,HHS Region 4,Season peak week,52
 2015,3,2014/2015,56,HHS Region 4,Season peak percentage,7.5
-2015,3,2014/2015,56,HHS Region 4,1 wk ahead,3
-2015,3,2014/2015,56,HHS Region 4,2 wk ahead,2.8
-2015,3,2014/2015,56,HHS Region 4,3 wk ahead,2.6
+2015,3,2014/2015,56,HHS Region 4,1 wk ahead,2.8
+2015,3,2014/2015,56,HHS Region 4,2 wk ahead,2.6
+2015,3,2014/2015,56,HHS Region 4,3 wk ahead,2.4
 2015,3,2014/2015,56,HHS Region 4,4 wk ahead,2.6
 2015,3,2014/2015,56,HHS Region 5,Season onset,48
 2015,3,2014/2015,56,HHS Region 5,Season peak week,52
@@ -11753,11 +11720,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,3,2014/2015,56,HHS Region 5,4 wk ahead,1.8
 2015,3,2014/2015,56,HHS Region 6,Season onset,47
 2015,3,2014/2015,56,HHS Region 6,Season peak week,51
-2015,3,2014/2015,56,HHS Region 6,Season peak percentage,10.6
-2015,3,2014/2015,56,HHS Region 6,1 wk ahead,6.4
-2015,3,2014/2015,56,HHS Region 6,2 wk ahead,5.9
-2015,3,2014/2015,56,HHS Region 6,3 wk ahead,5.5
-2015,3,2014/2015,56,HHS Region 6,4 wk ahead,5
+2015,3,2014/2015,56,HHS Region 6,Season peak percentage,11.1
+2015,3,2014/2015,56,HHS Region 6,1 wk ahead,6.7
+2015,3,2014/2015,56,HHS Region 6,2 wk ahead,6.3
+2015,3,2014/2015,56,HHS Region 6,3 wk ahead,5.9
+2015,3,2014/2015,56,HHS Region 6,4 wk ahead,5.4
 2015,3,2014/2015,56,HHS Region 7,Season onset,48
 2015,3,2014/2015,56,HHS Region 7,Season peak week,52
 2015,3,2014/2015,56,HHS Region 7,Season peak percentage,6.4
@@ -11792,8 +11759,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,4,2014/2015,57,US National,Season peak percentage,6
 2015,4,2014/2015,57,US National,1 wk ahead,3.6
 2015,4,2014/2015,57,US National,2 wk ahead,3.3
-2015,4,2014/2015,57,US National,3 wk ahead,2.9
-2015,4,2014/2015,57,US National,4 wk ahead,2.5
+2015,4,2014/2015,57,US National,3 wk ahead,3
+2015,4,2014/2015,57,US National,4 wk ahead,2.6
 2015,4,2014/2015,57,HHS Region 1,Season onset,50
 2015,4,2014/2015,57,HHS Region 1,Season peak week,3
 2015,4,2014/2015,57,HHS Region 1,Season peak percentage,3.9
@@ -11812,16 +11779,16 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,4,2014/2015,57,HHS Region 2,4 wk ahead,3.4
 2015,4,2014/2015,57,HHS Region 3,Season onset,48
 2015,4,2014/2015,57,HHS Region 3,Season peak week,52
-2015,4,2014/2015,57,HHS Region 3,Season peak percentage,7.3
+2015,4,2014/2015,57,HHS Region 3,Season peak percentage,7.2
 2015,4,2014/2015,57,HHS Region 3,1 wk ahead,3.5
-2015,4,2014/2015,57,HHS Region 3,2 wk ahead,2.7
-2015,4,2014/2015,57,HHS Region 3,3 wk ahead,2.6
+2015,4,2014/2015,57,HHS Region 3,2 wk ahead,2.6
+2015,4,2014/2015,57,HHS Region 3,3 wk ahead,2.5
 2015,4,2014/2015,57,HHS Region 3,4 wk ahead,1.8
 2015,4,2014/2015,57,HHS Region 4,Season onset,47
 2015,4,2014/2015,57,HHS Region 4,Season peak week,52
 2015,4,2014/2015,57,HHS Region 4,Season peak percentage,7.5
-2015,4,2014/2015,57,HHS Region 4,1 wk ahead,2.8
-2015,4,2014/2015,57,HHS Region 4,2 wk ahead,2.6
+2015,4,2014/2015,57,HHS Region 4,1 wk ahead,2.6
+2015,4,2014/2015,57,HHS Region 4,2 wk ahead,2.4
 2015,4,2014/2015,57,HHS Region 4,3 wk ahead,2.6
 2015,4,2014/2015,57,HHS Region 4,4 wk ahead,2.4
 2015,4,2014/2015,57,HHS Region 5,Season onset,48
@@ -11833,11 +11800,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,4,2014/2015,57,HHS Region 5,4 wk ahead,1.6
 2015,4,2014/2015,57,HHS Region 6,Season onset,47
 2015,4,2014/2015,57,HHS Region 6,Season peak week,51
-2015,4,2014/2015,57,HHS Region 6,Season peak percentage,10.6
-2015,4,2014/2015,57,HHS Region 6,1 wk ahead,5.9
-2015,4,2014/2015,57,HHS Region 6,2 wk ahead,5.5
-2015,4,2014/2015,57,HHS Region 6,3 wk ahead,5
-2015,4,2014/2015,57,HHS Region 6,4 wk ahead,4.3
+2015,4,2014/2015,57,HHS Region 6,Season peak percentage,11.1
+2015,4,2014/2015,57,HHS Region 6,1 wk ahead,6.3
+2015,4,2014/2015,57,HHS Region 6,2 wk ahead,5.9
+2015,4,2014/2015,57,HHS Region 6,3 wk ahead,5.4
+2015,4,2014/2015,57,HHS Region 6,4 wk ahead,4.7
 2015,4,2014/2015,57,HHS Region 7,Season onset,48
 2015,4,2014/2015,57,HHS Region 7,Season peak week,52
 2015,4,2014/2015,57,HHS Region 7,Season peak percentage,6.4
@@ -11871,8 +11838,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,5,2014/2015,58,US National,Season peak week,52
 2015,5,2014/2015,58,US National,Season peak percentage,6
 2015,5,2014/2015,58,US National,1 wk ahead,3.3
-2015,5,2014/2015,58,US National,2 wk ahead,2.9
-2015,5,2014/2015,58,US National,3 wk ahead,2.5
+2015,5,2014/2015,58,US National,2 wk ahead,3
+2015,5,2014/2015,58,US National,3 wk ahead,2.6
 2015,5,2014/2015,58,US National,4 wk ahead,2.5
 2015,5,2014/2015,58,HHS Region 1,Season onset,50
 2015,5,2014/2015,58,HHS Region 1,Season peak week,3
@@ -11892,15 +11859,15 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,5,2014/2015,58,HHS Region 2,4 wk ahead,2.8
 2015,5,2014/2015,58,HHS Region 3,Season onset,48
 2015,5,2014/2015,58,HHS Region 3,Season peak week,52
-2015,5,2014/2015,58,HHS Region 3,Season peak percentage,7.3
-2015,5,2014/2015,58,HHS Region 3,1 wk ahead,2.7
-2015,5,2014/2015,58,HHS Region 3,2 wk ahead,2.6
+2015,5,2014/2015,58,HHS Region 3,Season peak percentage,7.2
+2015,5,2014/2015,58,HHS Region 3,1 wk ahead,2.6
+2015,5,2014/2015,58,HHS Region 3,2 wk ahead,2.5
 2015,5,2014/2015,58,HHS Region 3,3 wk ahead,1.8
 2015,5,2014/2015,58,HHS Region 3,4 wk ahead,2.1
 2015,5,2014/2015,58,HHS Region 4,Season onset,47
 2015,5,2014/2015,58,HHS Region 4,Season peak week,52
 2015,5,2014/2015,58,HHS Region 4,Season peak percentage,7.5
-2015,5,2014/2015,58,HHS Region 4,1 wk ahead,2.6
+2015,5,2014/2015,58,HHS Region 4,1 wk ahead,2.4
 2015,5,2014/2015,58,HHS Region 4,2 wk ahead,2.6
 2015,5,2014/2015,58,HHS Region 4,3 wk ahead,2.4
 2015,5,2014/2015,58,HHS Region 4,4 wk ahead,2.3
@@ -11913,11 +11880,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,5,2014/2015,58,HHS Region 5,4 wk ahead,1.8
 2015,5,2014/2015,58,HHS Region 6,Season onset,47
 2015,5,2014/2015,58,HHS Region 6,Season peak week,51
-2015,5,2014/2015,58,HHS Region 6,Season peak percentage,10.6
-2015,5,2014/2015,58,HHS Region 6,1 wk ahead,5.5
-2015,5,2014/2015,58,HHS Region 6,2 wk ahead,5
-2015,5,2014/2015,58,HHS Region 6,3 wk ahead,4.3
-2015,5,2014/2015,58,HHS Region 6,4 wk ahead,4.2
+2015,5,2014/2015,58,HHS Region 6,Season peak percentage,11.1
+2015,5,2014/2015,58,HHS Region 6,1 wk ahead,5.9
+2015,5,2014/2015,58,HHS Region 6,2 wk ahead,5.4
+2015,5,2014/2015,58,HHS Region 6,3 wk ahead,4.7
+2015,5,2014/2015,58,HHS Region 6,4 wk ahead,4.6
 2015,5,2014/2015,58,HHS Region 7,Season onset,48
 2015,5,2014/2015,58,HHS Region 7,Season peak week,52
 2015,5,2014/2015,58,HHS Region 7,Season peak percentage,6.4
@@ -11950,8 +11917,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,6,2014/2015,59,US National,Season onset,47
 2015,6,2014/2015,59,US National,Season peak week,52
 2015,6,2014/2015,59,US National,Season peak percentage,6
-2015,6,2014/2015,59,US National,1 wk ahead,2.9
-2015,6,2014/2015,59,US National,2 wk ahead,2.5
+2015,6,2014/2015,59,US National,1 wk ahead,3
+2015,6,2014/2015,59,US National,2 wk ahead,2.6
 2015,6,2014/2015,59,US National,3 wk ahead,2.5
 2015,6,2014/2015,59,US National,4 wk ahead,2.4
 2015,6,2014/2015,59,HHS Region 1,Season onset,50
@@ -11972,8 +11939,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,6,2014/2015,59,HHS Region 2,4 wk ahead,2.5
 2015,6,2014/2015,59,HHS Region 3,Season onset,48
 2015,6,2014/2015,59,HHS Region 3,Season peak week,52
-2015,6,2014/2015,59,HHS Region 3,Season peak percentage,7.3
-2015,6,2014/2015,59,HHS Region 3,1 wk ahead,2.6
+2015,6,2014/2015,59,HHS Region 3,Season peak percentage,7.2
+2015,6,2014/2015,59,HHS Region 3,1 wk ahead,2.5
 2015,6,2014/2015,59,HHS Region 3,2 wk ahead,1.8
 2015,6,2014/2015,59,HHS Region 3,3 wk ahead,2.1
 2015,6,2014/2015,59,HHS Region 3,4 wk ahead,1.7
@@ -11993,18 +11960,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,6,2014/2015,59,HHS Region 5,4 wk ahead,1.8
 2015,6,2014/2015,59,HHS Region 6,Season onset,47
 2015,6,2014/2015,59,HHS Region 6,Season peak week,51
-2015,6,2014/2015,59,HHS Region 6,Season peak percentage,10.6
-2015,6,2014/2015,59,HHS Region 6,1 wk ahead,5
-2015,6,2014/2015,59,HHS Region 6,2 wk ahead,4.3
-2015,6,2014/2015,59,HHS Region 6,3 wk ahead,4.2
-2015,6,2014/2015,59,HHS Region 6,4 wk ahead,4.2
+2015,6,2014/2015,59,HHS Region 6,Season peak percentage,11.1
+2015,6,2014/2015,59,HHS Region 6,1 wk ahead,5.4
+2015,6,2014/2015,59,HHS Region 6,2 wk ahead,4.7
+2015,6,2014/2015,59,HHS Region 6,3 wk ahead,4.6
+2015,6,2014/2015,59,HHS Region 6,4 wk ahead,4.7
 2015,6,2014/2015,59,HHS Region 7,Season onset,48
 2015,6,2014/2015,59,HHS Region 7,Season peak week,52
 2015,6,2014/2015,59,HHS Region 7,Season peak percentage,6.4
 2015,6,2014/2015,59,HHS Region 7,1 wk ahead,2.4
 2015,6,2014/2015,59,HHS Region 7,2 wk ahead,2.4
 2015,6,2014/2015,59,HHS Region 7,3 wk ahead,2.3
-2015,6,2014/2015,59,HHS Region 7,4 wk ahead,2.4
+2015,6,2014/2015,59,HHS Region 7,4 wk ahead,2.5
 2015,6,2014/2015,59,HHS Region 8,Season onset,49
 2015,6,2014/2015,59,HHS Region 8,Season peak week,53
 2015,6,2014/2015,59,HHS Region 8,Season peak percentage,4.4
@@ -12026,11 +11993,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,6,2014/2015,59,HHS Region 10,1 wk ahead,1.2
 2015,6,2014/2015,59,HHS Region 10,2 wk ahead,1.1
 2015,6,2014/2015,59,HHS Region 10,3 wk ahead,1.1
-2015,6,2014/2015,59,HHS Region 10,4 wk ahead,1.2
+2015,6,2014/2015,59,HHS Region 10,4 wk ahead,1.1
 2015,7,2014/2015,60,US National,Season onset,47
 2015,7,2014/2015,60,US National,Season peak week,52
 2015,7,2014/2015,60,US National,Season peak percentage,6
-2015,7,2014/2015,60,US National,1 wk ahead,2.5
+2015,7,2014/2015,60,US National,1 wk ahead,2.6
 2015,7,2014/2015,60,US National,2 wk ahead,2.5
 2015,7,2014/2015,60,US National,3 wk ahead,2.4
 2015,7,2014/2015,60,US National,4 wk ahead,2.2
@@ -12052,7 +12019,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,7,2014/2015,60,HHS Region 2,4 wk ahead,2.8
 2015,7,2014/2015,60,HHS Region 3,Season onset,48
 2015,7,2014/2015,60,HHS Region 3,Season peak week,52
-2015,7,2014/2015,60,HHS Region 3,Season peak percentage,7.3
+2015,7,2014/2015,60,HHS Region 3,Season peak percentage,7.2
 2015,7,2014/2015,60,HHS Region 3,1 wk ahead,1.8
 2015,7,2014/2015,60,HHS Region 3,2 wk ahead,2.1
 2015,7,2014/2015,60,HHS Region 3,3 wk ahead,1.7
@@ -12073,18 +12040,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,7,2014/2015,60,HHS Region 5,4 wk ahead,1.9
 2015,7,2014/2015,60,HHS Region 6,Season onset,47
 2015,7,2014/2015,60,HHS Region 6,Season peak week,51
-2015,7,2014/2015,60,HHS Region 6,Season peak percentage,10.6
-2015,7,2014/2015,60,HHS Region 6,1 wk ahead,4.3
-2015,7,2014/2015,60,HHS Region 6,2 wk ahead,4.2
-2015,7,2014/2015,60,HHS Region 6,3 wk ahead,4.2
-2015,7,2014/2015,60,HHS Region 6,4 wk ahead,3.7
+2015,7,2014/2015,60,HHS Region 6,Season peak percentage,11.1
+2015,7,2014/2015,60,HHS Region 6,1 wk ahead,4.7
+2015,7,2014/2015,60,HHS Region 6,2 wk ahead,4.6
+2015,7,2014/2015,60,HHS Region 6,3 wk ahead,4.7
+2015,7,2014/2015,60,HHS Region 6,4 wk ahead,4
 2015,7,2014/2015,60,HHS Region 7,Season onset,48
 2015,7,2014/2015,60,HHS Region 7,Season peak week,52
 2015,7,2014/2015,60,HHS Region 7,Season peak percentage,6.4
 2015,7,2014/2015,60,HHS Region 7,1 wk ahead,2.4
 2015,7,2014/2015,60,HHS Region 7,2 wk ahead,2.3
-2015,7,2014/2015,60,HHS Region 7,3 wk ahead,2.4
-2015,7,2014/2015,60,HHS Region 7,4 wk ahead,2.1
+2015,7,2014/2015,60,HHS Region 7,3 wk ahead,2.5
+2015,7,2014/2015,60,HHS Region 7,4 wk ahead,2.2
 2015,7,2014/2015,60,HHS Region 8,Season onset,49
 2015,7,2014/2015,60,HHS Region 8,Season peak week,53
 2015,7,2014/2015,60,HHS Region 8,Season peak percentage,4.4
@@ -12099,13 +12066,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,7,2014/2015,60,HHS Region 9,1 wk ahead,3.1
 2015,7,2014/2015,60,HHS Region 9,2 wk ahead,3
 2015,7,2014/2015,60,HHS Region 9,3 wk ahead,3
-2015,7,2014/2015,60,HHS Region 9,4 wk ahead,2.7
+2015,7,2014/2015,60,HHS Region 9,4 wk ahead,2.8
 2015,7,2014/2015,60,HHS Region 10,Season onset,48
 2015,7,2014/2015,60,HHS Region 10,Season peak week,2
 2015,7,2014/2015,60,HHS Region 10,Season peak percentage,3.6
 2015,7,2014/2015,60,HHS Region 10,1 wk ahead,1.1
 2015,7,2014/2015,60,HHS Region 10,2 wk ahead,1.1
-2015,7,2014/2015,60,HHS Region 10,3 wk ahead,1.2
+2015,7,2014/2015,60,HHS Region 10,3 wk ahead,1.1
 2015,7,2014/2015,60,HHS Region 10,4 wk ahead,1.2
 2015,8,2014/2015,61,US National,Season onset,47
 2015,8,2014/2015,61,US National,Season peak week,52
@@ -12113,7 +12080,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,8,2014/2015,61,US National,1 wk ahead,2.5
 2015,8,2014/2015,61,US National,2 wk ahead,2.4
 2015,8,2014/2015,61,US National,3 wk ahead,2.2
-2015,8,2014/2015,61,US National,4 wk ahead,2
+2015,8,2014/2015,61,US National,4 wk ahead,2.1
 2015,8,2014/2015,61,HHS Region 1,Season onset,50
 2015,8,2014/2015,61,HHS Region 1,Season peak week,3
 2015,8,2014/2015,61,HHS Region 1,Season peak percentage,3.9
@@ -12132,7 +12099,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,8,2014/2015,61,HHS Region 2,4 wk ahead,2.6
 2015,8,2014/2015,61,HHS Region 3,Season onset,48
 2015,8,2014/2015,61,HHS Region 3,Season peak week,52
-2015,8,2014/2015,61,HHS Region 3,Season peak percentage,7.3
+2015,8,2014/2015,61,HHS Region 3,Season peak percentage,7.2
 2015,8,2014/2015,61,HHS Region 3,1 wk ahead,2.1
 2015,8,2014/2015,61,HHS Region 3,2 wk ahead,1.7
 2015,8,2014/2015,61,HHS Region 3,3 wk ahead,1.6
@@ -12153,17 +12120,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,8,2014/2015,61,HHS Region 5,4 wk ahead,2
 2015,8,2014/2015,61,HHS Region 6,Season onset,47
 2015,8,2014/2015,61,HHS Region 6,Season peak week,51
-2015,8,2014/2015,61,HHS Region 6,Season peak percentage,10.6
-2015,8,2014/2015,61,HHS Region 6,1 wk ahead,4.2
-2015,8,2014/2015,61,HHS Region 6,2 wk ahead,4.2
-2015,8,2014/2015,61,HHS Region 6,3 wk ahead,3.7
-2015,8,2014/2015,61,HHS Region 6,4 wk ahead,3.2
+2015,8,2014/2015,61,HHS Region 6,Season peak percentage,11.1
+2015,8,2014/2015,61,HHS Region 6,1 wk ahead,4.6
+2015,8,2014/2015,61,HHS Region 6,2 wk ahead,4.7
+2015,8,2014/2015,61,HHS Region 6,3 wk ahead,4
+2015,8,2014/2015,61,HHS Region 6,4 wk ahead,3.6
 2015,8,2014/2015,61,HHS Region 7,Season onset,48
 2015,8,2014/2015,61,HHS Region 7,Season peak week,52
 2015,8,2014/2015,61,HHS Region 7,Season peak percentage,6.4
 2015,8,2014/2015,61,HHS Region 7,1 wk ahead,2.3
-2015,8,2014/2015,61,HHS Region 7,2 wk ahead,2.4
-2015,8,2014/2015,61,HHS Region 7,3 wk ahead,2.1
+2015,8,2014/2015,61,HHS Region 7,2 wk ahead,2.5
+2015,8,2014/2015,61,HHS Region 7,3 wk ahead,2.2
 2015,8,2014/2015,61,HHS Region 7,4 wk ahead,1.9
 2015,8,2014/2015,61,HHS Region 8,Season onset,49
 2015,8,2014/2015,61,HHS Region 8,Season peak week,53
@@ -12178,13 +12145,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,8,2014/2015,61,HHS Region 9,Season peak percentage,5
 2015,8,2014/2015,61,HHS Region 9,1 wk ahead,3
 2015,8,2014/2015,61,HHS Region 9,2 wk ahead,3
-2015,8,2014/2015,61,HHS Region 9,3 wk ahead,2.7
+2015,8,2014/2015,61,HHS Region 9,3 wk ahead,2.8
 2015,8,2014/2015,61,HHS Region 9,4 wk ahead,2.5
 2015,8,2014/2015,61,HHS Region 10,Season onset,48
 2015,8,2014/2015,61,HHS Region 10,Season peak week,2
 2015,8,2014/2015,61,HHS Region 10,Season peak percentage,3.6
 2015,8,2014/2015,61,HHS Region 10,1 wk ahead,1.1
-2015,8,2014/2015,61,HHS Region 10,2 wk ahead,1.2
+2015,8,2014/2015,61,HHS Region 10,2 wk ahead,1.1
 2015,8,2014/2015,61,HHS Region 10,3 wk ahead,1.2
 2015,8,2014/2015,61,HHS Region 10,4 wk ahead,0.9
 2015,9,2014/2015,62,US National,Season onset,47
@@ -12192,7 +12159,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,9,2014/2015,62,US National,Season peak percentage,6
 2015,9,2014/2015,62,US National,1 wk ahead,2.4
 2015,9,2014/2015,62,US National,2 wk ahead,2.2
-2015,9,2014/2015,62,US National,3 wk ahead,2
+2015,9,2014/2015,62,US National,3 wk ahead,2.1
 2015,9,2014/2015,62,US National,4 wk ahead,2
 2015,9,2014/2015,62,HHS Region 1,Season onset,50
 2015,9,2014/2015,62,HHS Region 1,Season peak week,3
@@ -12212,7 +12179,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,9,2014/2015,62,HHS Region 2,4 wk ahead,2.5
 2015,9,2014/2015,62,HHS Region 3,Season onset,48
 2015,9,2014/2015,62,HHS Region 3,Season peak week,52
-2015,9,2014/2015,62,HHS Region 3,Season peak percentage,7.3
+2015,9,2014/2015,62,HHS Region 3,Season peak percentage,7.2
 2015,9,2014/2015,62,HHS Region 3,1 wk ahead,1.7
 2015,9,2014/2015,62,HHS Region 3,2 wk ahead,1.6
 2015,9,2014/2015,62,HHS Region 3,3 wk ahead,1.8
@@ -12233,16 +12200,16 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,9,2014/2015,62,HHS Region 5,4 wk ahead,1.8
 2015,9,2014/2015,62,HHS Region 6,Season onset,47
 2015,9,2014/2015,62,HHS Region 6,Season peak week,51
-2015,9,2014/2015,62,HHS Region 6,Season peak percentage,10.6
-2015,9,2014/2015,62,HHS Region 6,1 wk ahead,4.2
-2015,9,2014/2015,62,HHS Region 6,2 wk ahead,3.7
-2015,9,2014/2015,62,HHS Region 6,3 wk ahead,3.2
-2015,9,2014/2015,62,HHS Region 6,4 wk ahead,3
+2015,9,2014/2015,62,HHS Region 6,Season peak percentage,11.1
+2015,9,2014/2015,62,HHS Region 6,1 wk ahead,4.7
+2015,9,2014/2015,62,HHS Region 6,2 wk ahead,4
+2015,9,2014/2015,62,HHS Region 6,3 wk ahead,3.6
+2015,9,2014/2015,62,HHS Region 6,4 wk ahead,3.3
 2015,9,2014/2015,62,HHS Region 7,Season onset,48
 2015,9,2014/2015,62,HHS Region 7,Season peak week,52
 2015,9,2014/2015,62,HHS Region 7,Season peak percentage,6.4
-2015,9,2014/2015,62,HHS Region 7,1 wk ahead,2.4
-2015,9,2014/2015,62,HHS Region 7,2 wk ahead,2.1
+2015,9,2014/2015,62,HHS Region 7,1 wk ahead,2.5
+2015,9,2014/2015,62,HHS Region 7,2 wk ahead,2.2
 2015,9,2014/2015,62,HHS Region 7,3 wk ahead,1.9
 2015,9,2014/2015,62,HHS Region 7,4 wk ahead,1.8
 2015,9,2014/2015,62,HHS Region 8,Season onset,49
@@ -12257,23 +12224,23 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,9,2014/2015,62,HHS Region 9,Season peak week,4
 2015,9,2014/2015,62,HHS Region 9,Season peak percentage,5
 2015,9,2014/2015,62,HHS Region 9,1 wk ahead,3
-2015,9,2014/2015,62,HHS Region 9,2 wk ahead,2.7
+2015,9,2014/2015,62,HHS Region 9,2 wk ahead,2.8
 2015,9,2014/2015,62,HHS Region 9,3 wk ahead,2.5
 2015,9,2014/2015,62,HHS Region 9,4 wk ahead,2.5
 2015,9,2014/2015,62,HHS Region 10,Season onset,48
 2015,9,2014/2015,62,HHS Region 10,Season peak week,2
 2015,9,2014/2015,62,HHS Region 10,Season peak percentage,3.6
-2015,9,2014/2015,62,HHS Region 10,1 wk ahead,1.2
+2015,9,2014/2015,62,HHS Region 10,1 wk ahead,1.1
 2015,9,2014/2015,62,HHS Region 10,2 wk ahead,1.2
 2015,9,2014/2015,62,HHS Region 10,3 wk ahead,0.9
-2015,9,2014/2015,62,HHS Region 10,4 wk ahead,1
+2015,9,2014/2015,62,HHS Region 10,4 wk ahead,0.9
 2015,10,2014/2015,63,US National,Season onset,47
 2015,10,2014/2015,63,US National,Season peak week,52
 2015,10,2014/2015,63,US National,Season peak percentage,6
 2015,10,2014/2015,63,US National,1 wk ahead,2.2
-2015,10,2014/2015,63,US National,2 wk ahead,2
+2015,10,2014/2015,63,US National,2 wk ahead,2.1
 2015,10,2014/2015,63,US National,3 wk ahead,2
-2015,10,2014/2015,63,US National,4 wk ahead,1.7
+2015,10,2014/2015,63,US National,4 wk ahead,1.8
 2015,10,2014/2015,63,HHS Region 1,Season onset,50
 2015,10,2014/2015,63,HHS Region 1,Season peak week,3
 2015,10,2014/2015,63,HHS Region 1,Season peak percentage,3.9
@@ -12292,7 +12259,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,10,2014/2015,63,HHS Region 2,4 wk ahead,2.3
 2015,10,2014/2015,63,HHS Region 3,Season onset,48
 2015,10,2014/2015,63,HHS Region 3,Season peak week,52
-2015,10,2014/2015,63,HHS Region 3,Season peak percentage,7.3
+2015,10,2014/2015,63,HHS Region 3,Season peak percentage,7.2
 2015,10,2014/2015,63,HHS Region 3,1 wk ahead,1.6
 2015,10,2014/2015,63,HHS Region 3,2 wk ahead,1.8
 2015,10,2014/2015,63,HHS Region 3,3 wk ahead,1.7
@@ -12313,18 +12280,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,10,2014/2015,63,HHS Region 5,4 wk ahead,1.7
 2015,10,2014/2015,63,HHS Region 6,Season onset,47
 2015,10,2014/2015,63,HHS Region 6,Season peak week,51
-2015,10,2014/2015,63,HHS Region 6,Season peak percentage,10.6
-2015,10,2014/2015,63,HHS Region 6,1 wk ahead,3.7
-2015,10,2014/2015,63,HHS Region 6,2 wk ahead,3.2
-2015,10,2014/2015,63,HHS Region 6,3 wk ahead,3
-2015,10,2014/2015,63,HHS Region 6,4 wk ahead,2.5
+2015,10,2014/2015,63,HHS Region 6,Season peak percentage,11.1
+2015,10,2014/2015,63,HHS Region 6,1 wk ahead,4
+2015,10,2014/2015,63,HHS Region 6,2 wk ahead,3.6
+2015,10,2014/2015,63,HHS Region 6,3 wk ahead,3.3
+2015,10,2014/2015,63,HHS Region 6,4 wk ahead,2.8
 2015,10,2014/2015,63,HHS Region 7,Season onset,48
 2015,10,2014/2015,63,HHS Region 7,Season peak week,52
 2015,10,2014/2015,63,HHS Region 7,Season peak percentage,6.4
-2015,10,2014/2015,63,HHS Region 7,1 wk ahead,2.1
+2015,10,2014/2015,63,HHS Region 7,1 wk ahead,2.2
 2015,10,2014/2015,63,HHS Region 7,2 wk ahead,1.9
 2015,10,2014/2015,63,HHS Region 7,3 wk ahead,1.8
-2015,10,2014/2015,63,HHS Region 7,4 wk ahead,1.4
+2015,10,2014/2015,63,HHS Region 7,4 wk ahead,1.5
 2015,10,2014/2015,63,HHS Region 8,Season onset,49
 2015,10,2014/2015,63,HHS Region 8,Season peak week,53
 2015,10,2014/2015,63,HHS Region 8,Season peak percentage,4.4
@@ -12336,7 +12303,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,10,2014/2015,63,HHS Region 9,Season peak week,3
 2015,10,2014/2015,63,HHS Region 9,Season peak week,4
 2015,10,2014/2015,63,HHS Region 9,Season peak percentage,5
-2015,10,2014/2015,63,HHS Region 9,1 wk ahead,2.7
+2015,10,2014/2015,63,HHS Region 9,1 wk ahead,2.8
 2015,10,2014/2015,63,HHS Region 9,2 wk ahead,2.5
 2015,10,2014/2015,63,HHS Region 9,3 wk ahead,2.5
 2015,10,2014/2015,63,HHS Region 9,4 wk ahead,2.3
@@ -12345,15 +12312,15 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,10,2014/2015,63,HHS Region 10,Season peak percentage,3.6
 2015,10,2014/2015,63,HHS Region 10,1 wk ahead,1.2
 2015,10,2014/2015,63,HHS Region 10,2 wk ahead,0.9
-2015,10,2014/2015,63,HHS Region 10,3 wk ahead,1
-2015,10,2014/2015,63,HHS Region 10,4 wk ahead,0.7
+2015,10,2014/2015,63,HHS Region 10,3 wk ahead,0.9
+2015,10,2014/2015,63,HHS Region 10,4 wk ahead,0.6
 2015,11,2014/2015,64,US National,Season onset,47
 2015,11,2014/2015,64,US National,Season peak week,52
 2015,11,2014/2015,64,US National,Season peak percentage,6
-2015,11,2014/2015,64,US National,1 wk ahead,2
+2015,11,2014/2015,64,US National,1 wk ahead,2.1
 2015,11,2014/2015,64,US National,2 wk ahead,2
-2015,11,2014/2015,64,US National,3 wk ahead,1.7
-2015,11,2014/2015,64,US National,4 wk ahead,1.5
+2015,11,2014/2015,64,US National,3 wk ahead,1.8
+2015,11,2014/2015,64,US National,4 wk ahead,1.6
 2015,11,2014/2015,64,HHS Region 1,Season onset,50
 2015,11,2014/2015,64,HHS Region 1,Season peak week,3
 2015,11,2014/2015,64,HHS Region 1,Season peak percentage,3.9
@@ -12369,10 +12336,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,11,2014/2015,64,HHS Region 2,1 wk ahead,2.6
 2015,11,2014/2015,64,HHS Region 2,2 wk ahead,2.5
 2015,11,2014/2015,64,HHS Region 2,3 wk ahead,2.3
-2015,11,2014/2015,64,HHS Region 2,4 wk ahead,1.9
+2015,11,2014/2015,64,HHS Region 2,4 wk ahead,2
 2015,11,2014/2015,64,HHS Region 3,Season onset,48
 2015,11,2014/2015,64,HHS Region 3,Season peak week,52
-2015,11,2014/2015,64,HHS Region 3,Season peak percentage,7.3
+2015,11,2014/2015,64,HHS Region 3,Season peak percentage,7.2
 2015,11,2014/2015,64,HHS Region 3,1 wk ahead,1.8
 2015,11,2014/2015,64,HHS Region 3,2 wk ahead,1.7
 2015,11,2014/2015,64,HHS Region 3,3 wk ahead,1.7
@@ -12393,18 +12360,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,11,2014/2015,64,HHS Region 5,4 wk ahead,1.4
 2015,11,2014/2015,64,HHS Region 6,Season onset,47
 2015,11,2014/2015,64,HHS Region 6,Season peak week,51
-2015,11,2014/2015,64,HHS Region 6,Season peak percentage,10.6
-2015,11,2014/2015,64,HHS Region 6,1 wk ahead,3.2
-2015,11,2014/2015,64,HHS Region 6,2 wk ahead,3
-2015,11,2014/2015,64,HHS Region 6,3 wk ahead,2.5
-2015,11,2014/2015,64,HHS Region 6,4 wk ahead,2.3
+2015,11,2014/2015,64,HHS Region 6,Season peak percentage,11.1
+2015,11,2014/2015,64,HHS Region 6,1 wk ahead,3.6
+2015,11,2014/2015,64,HHS Region 6,2 wk ahead,3.3
+2015,11,2014/2015,64,HHS Region 6,3 wk ahead,2.8
+2015,11,2014/2015,64,HHS Region 6,4 wk ahead,2.7
 2015,11,2014/2015,64,HHS Region 7,Season onset,48
 2015,11,2014/2015,64,HHS Region 7,Season peak week,52
 2015,11,2014/2015,64,HHS Region 7,Season peak percentage,6.4
 2015,11,2014/2015,64,HHS Region 7,1 wk ahead,1.9
 2015,11,2014/2015,64,HHS Region 7,2 wk ahead,1.8
-2015,11,2014/2015,64,HHS Region 7,3 wk ahead,1.4
-2015,11,2014/2015,64,HHS Region 7,4 wk ahead,1.1
+2015,11,2014/2015,64,HHS Region 7,3 wk ahead,1.5
+2015,11,2014/2015,64,HHS Region 7,4 wk ahead,1.2
 2015,11,2014/2015,64,HHS Region 8,Season onset,49
 2015,11,2014/2015,64,HHS Region 8,Season peak week,53
 2015,11,2014/2015,64,HHS Region 8,Season peak percentage,4.4
@@ -12424,15 +12391,15 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,11,2014/2015,64,HHS Region 10,Season peak week,2
 2015,11,2014/2015,64,HHS Region 10,Season peak percentage,3.6
 2015,11,2014/2015,64,HHS Region 10,1 wk ahead,0.9
-2015,11,2014/2015,64,HHS Region 10,2 wk ahead,1
-2015,11,2014/2015,64,HHS Region 10,3 wk ahead,0.7
+2015,11,2014/2015,64,HHS Region 10,2 wk ahead,0.9
+2015,11,2014/2015,64,HHS Region 10,3 wk ahead,0.6
 2015,11,2014/2015,64,HHS Region 10,4 wk ahead,0.8
 2015,12,2014/2015,65,US National,Season onset,47
 2015,12,2014/2015,65,US National,Season peak week,52
 2015,12,2014/2015,65,US National,Season peak percentage,6
 2015,12,2014/2015,65,US National,1 wk ahead,2
-2015,12,2014/2015,65,US National,2 wk ahead,1.7
-2015,12,2014/2015,65,US National,3 wk ahead,1.5
+2015,12,2014/2015,65,US National,2 wk ahead,1.8
+2015,12,2014/2015,65,US National,3 wk ahead,1.6
 2015,12,2014/2015,65,US National,4 wk ahead,1.4
 2015,12,2014/2015,65,HHS Region 1,Season onset,50
 2015,12,2014/2015,65,HHS Region 1,Season peak week,3
@@ -12448,15 +12415,15 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,12,2014/2015,65,HHS Region 2,Season peak percentage,5.2
 2015,12,2014/2015,65,HHS Region 2,1 wk ahead,2.5
 2015,12,2014/2015,65,HHS Region 2,2 wk ahead,2.3
-2015,12,2014/2015,65,HHS Region 2,3 wk ahead,1.9
+2015,12,2014/2015,65,HHS Region 2,3 wk ahead,2
 2015,12,2014/2015,65,HHS Region 2,4 wk ahead,1.9
 2015,12,2014/2015,65,HHS Region 3,Season onset,48
 2015,12,2014/2015,65,HHS Region 3,Season peak week,52
-2015,12,2014/2015,65,HHS Region 3,Season peak percentage,7.3
+2015,12,2014/2015,65,HHS Region 3,Season peak percentage,7.2
 2015,12,2014/2015,65,HHS Region 3,1 wk ahead,1.7
 2015,12,2014/2015,65,HHS Region 3,2 wk ahead,1.7
 2015,12,2014/2015,65,HHS Region 3,3 wk ahead,1.5
-2015,12,2014/2015,65,HHS Region 3,4 wk ahead,1.4
+2015,12,2014/2015,65,HHS Region 3,4 wk ahead,1.3
 2015,12,2014/2015,65,HHS Region 4,Season onset,47
 2015,12,2014/2015,65,HHS Region 4,Season peak week,52
 2015,12,2014/2015,65,HHS Region 4,Season peak percentage,7.5
@@ -12473,17 +12440,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,12,2014/2015,65,HHS Region 5,4 wk ahead,1.2
 2015,12,2014/2015,65,HHS Region 6,Season onset,47
 2015,12,2014/2015,65,HHS Region 6,Season peak week,51
-2015,12,2014/2015,65,HHS Region 6,Season peak percentage,10.6
-2015,12,2014/2015,65,HHS Region 6,1 wk ahead,3
-2015,12,2014/2015,65,HHS Region 6,2 wk ahead,2.5
-2015,12,2014/2015,65,HHS Region 6,3 wk ahead,2.3
-2015,12,2014/2015,65,HHS Region 6,4 wk ahead,1.6
+2015,12,2014/2015,65,HHS Region 6,Season peak percentage,11.1
+2015,12,2014/2015,65,HHS Region 6,1 wk ahead,3.3
+2015,12,2014/2015,65,HHS Region 6,2 wk ahead,2.8
+2015,12,2014/2015,65,HHS Region 6,3 wk ahead,2.7
+2015,12,2014/2015,65,HHS Region 6,4 wk ahead,1.8
 2015,12,2014/2015,65,HHS Region 7,Season onset,48
 2015,12,2014/2015,65,HHS Region 7,Season peak week,52
 2015,12,2014/2015,65,HHS Region 7,Season peak percentage,6.4
 2015,12,2014/2015,65,HHS Region 7,1 wk ahead,1.8
-2015,12,2014/2015,65,HHS Region 7,2 wk ahead,1.4
-2015,12,2014/2015,65,HHS Region 7,3 wk ahead,1.1
+2015,12,2014/2015,65,HHS Region 7,2 wk ahead,1.5
+2015,12,2014/2015,65,HHS Region 7,3 wk ahead,1.2
 2015,12,2014/2015,65,HHS Region 7,4 wk ahead,1.1
 2015,12,2014/2015,65,HHS Region 8,Season onset,49
 2015,12,2014/2015,65,HHS Region 8,Season peak week,53
@@ -12499,19 +12466,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,12,2014/2015,65,HHS Region 9,1 wk ahead,2.5
 2015,12,2014/2015,65,HHS Region 9,2 wk ahead,2.3
 2015,12,2014/2015,65,HHS Region 9,3 wk ahead,2
-2015,12,2014/2015,65,HHS Region 9,4 wk ahead,2
+2015,12,2014/2015,65,HHS Region 9,4 wk ahead,1.9
 2015,12,2014/2015,65,HHS Region 10,Season onset,48
 2015,12,2014/2015,65,HHS Region 10,Season peak week,2
 2015,12,2014/2015,65,HHS Region 10,Season peak percentage,3.6
-2015,12,2014/2015,65,HHS Region 10,1 wk ahead,1
-2015,12,2014/2015,65,HHS Region 10,2 wk ahead,0.7
+2015,12,2014/2015,65,HHS Region 10,1 wk ahead,0.9
+2015,12,2014/2015,65,HHS Region 10,2 wk ahead,0.6
 2015,12,2014/2015,65,HHS Region 10,3 wk ahead,0.8
 2015,12,2014/2015,65,HHS Region 10,4 wk ahead,0.9
 2015,13,2014/2015,66,US National,Season onset,47
 2015,13,2014/2015,66,US National,Season peak week,52
 2015,13,2014/2015,66,US National,Season peak percentage,6
-2015,13,2014/2015,66,US National,1 wk ahead,1.7
-2015,13,2014/2015,66,US National,2 wk ahead,1.5
+2015,13,2014/2015,66,US National,1 wk ahead,1.8
+2015,13,2014/2015,66,US National,2 wk ahead,1.6
 2015,13,2014/2015,66,US National,3 wk ahead,1.4
 2015,13,2014/2015,66,US National,4 wk ahead,1.5
 2015,13,2014/2015,66,HHS Region 1,Season onset,50
@@ -12527,15 +12494,15 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,13,2014/2015,66,HHS Region 2,Season peak week,5
 2015,13,2014/2015,66,HHS Region 2,Season peak percentage,5.2
 2015,13,2014/2015,66,HHS Region 2,1 wk ahead,2.3
-2015,13,2014/2015,66,HHS Region 2,2 wk ahead,1.9
+2015,13,2014/2015,66,HHS Region 2,2 wk ahead,2
 2015,13,2014/2015,66,HHS Region 2,3 wk ahead,1.9
 2015,13,2014/2015,66,HHS Region 2,4 wk ahead,1.8
 2015,13,2014/2015,66,HHS Region 3,Season onset,48
 2015,13,2014/2015,66,HHS Region 3,Season peak week,52
-2015,13,2014/2015,66,HHS Region 3,Season peak percentage,7.3
+2015,13,2014/2015,66,HHS Region 3,Season peak percentage,7.2
 2015,13,2014/2015,66,HHS Region 3,1 wk ahead,1.7
 2015,13,2014/2015,66,HHS Region 3,2 wk ahead,1.5
-2015,13,2014/2015,66,HHS Region 3,3 wk ahead,1.4
+2015,13,2014/2015,66,HHS Region 3,3 wk ahead,1.3
 2015,13,2014/2015,66,HHS Region 3,4 wk ahead,1.5
 2015,13,2014/2015,66,HHS Region 4,Season onset,47
 2015,13,2014/2015,66,HHS Region 4,Season peak week,52
@@ -12553,16 +12520,16 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,13,2014/2015,66,HHS Region 5,4 wk ahead,1.2
 2015,13,2014/2015,66,HHS Region 6,Season onset,47
 2015,13,2014/2015,66,HHS Region 6,Season peak week,51
-2015,13,2014/2015,66,HHS Region 6,Season peak percentage,10.6
-2015,13,2014/2015,66,HHS Region 6,1 wk ahead,2.5
-2015,13,2014/2015,66,HHS Region 6,2 wk ahead,2.3
-2015,13,2014/2015,66,HHS Region 6,3 wk ahead,1.6
-2015,13,2014/2015,66,HHS Region 6,4 wk ahead,2.2
+2015,13,2014/2015,66,HHS Region 6,Season peak percentage,11.1
+2015,13,2014/2015,66,HHS Region 6,1 wk ahead,2.8
+2015,13,2014/2015,66,HHS Region 6,2 wk ahead,2.7
+2015,13,2014/2015,66,HHS Region 6,3 wk ahead,1.8
+2015,13,2014/2015,66,HHS Region 6,4 wk ahead,2.5
 2015,13,2014/2015,66,HHS Region 7,Season onset,48
 2015,13,2014/2015,66,HHS Region 7,Season peak week,52
 2015,13,2014/2015,66,HHS Region 7,Season peak percentage,6.4
-2015,13,2014/2015,66,HHS Region 7,1 wk ahead,1.4
-2015,13,2014/2015,66,HHS Region 7,2 wk ahead,1.1
+2015,13,2014/2015,66,HHS Region 7,1 wk ahead,1.5
+2015,13,2014/2015,66,HHS Region 7,2 wk ahead,1.2
 2015,13,2014/2015,66,HHS Region 7,3 wk ahead,1.1
 2015,13,2014/2015,66,HHS Region 7,4 wk ahead,1.1
 2015,13,2014/2015,66,HHS Region 8,Season onset,49
@@ -12578,19 +12545,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,13,2014/2015,66,HHS Region 9,Season peak percentage,5
 2015,13,2014/2015,66,HHS Region 9,1 wk ahead,2.3
 2015,13,2014/2015,66,HHS Region 9,2 wk ahead,2
-2015,13,2014/2015,66,HHS Region 9,3 wk ahead,2
-2015,13,2014/2015,66,HHS Region 9,4 wk ahead,2
+2015,13,2014/2015,66,HHS Region 9,3 wk ahead,1.9
+2015,13,2014/2015,66,HHS Region 9,4 wk ahead,1.9
 2015,13,2014/2015,66,HHS Region 10,Season onset,48
 2015,13,2014/2015,66,HHS Region 10,Season peak week,2
 2015,13,2014/2015,66,HHS Region 10,Season peak percentage,3.6
-2015,13,2014/2015,66,HHS Region 10,1 wk ahead,0.7
+2015,13,2014/2015,66,HHS Region 10,1 wk ahead,0.6
 2015,13,2014/2015,66,HHS Region 10,2 wk ahead,0.8
 2015,13,2014/2015,66,HHS Region 10,3 wk ahead,0.9
 2015,13,2014/2015,66,HHS Region 10,4 wk ahead,0.8
 2015,14,2014/2015,67,US National,Season onset,47
 2015,14,2014/2015,67,US National,Season peak week,52
 2015,14,2014/2015,67,US National,Season peak percentage,6
-2015,14,2014/2015,67,US National,1 wk ahead,1.5
+2015,14,2014/2015,67,US National,1 wk ahead,1.6
 2015,14,2014/2015,67,US National,2 wk ahead,1.4
 2015,14,2014/2015,67,US National,3 wk ahead,1.5
 2015,14,2014/2015,67,US National,4 wk ahead,1.4
@@ -12606,15 +12573,15 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,14,2014/2015,67,HHS Region 2,Season peak week,4
 2015,14,2014/2015,67,HHS Region 2,Season peak week,5
 2015,14,2014/2015,67,HHS Region 2,Season peak percentage,5.2
-2015,14,2014/2015,67,HHS Region 2,1 wk ahead,1.9
+2015,14,2014/2015,67,HHS Region 2,1 wk ahead,2
 2015,14,2014/2015,67,HHS Region 2,2 wk ahead,1.9
 2015,14,2014/2015,67,HHS Region 2,3 wk ahead,1.8
 2015,14,2014/2015,67,HHS Region 2,4 wk ahead,1.9
 2015,14,2014/2015,67,HHS Region 3,Season onset,48
 2015,14,2014/2015,67,HHS Region 3,Season peak week,52
-2015,14,2014/2015,67,HHS Region 3,Season peak percentage,7.3
+2015,14,2014/2015,67,HHS Region 3,Season peak percentage,7.2
 2015,14,2014/2015,67,HHS Region 3,1 wk ahead,1.5
-2015,14,2014/2015,67,HHS Region 3,2 wk ahead,1.4
+2015,14,2014/2015,67,HHS Region 3,2 wk ahead,1.3
 2015,14,2014/2015,67,HHS Region 3,3 wk ahead,1.5
 2015,14,2014/2015,67,HHS Region 3,4 wk ahead,1.3
 2015,14,2014/2015,67,HHS Region 4,Season onset,47
@@ -12630,18 +12597,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,14,2014/2015,67,HHS Region 5,1 wk ahead,1.4
 2015,14,2014/2015,67,HHS Region 5,2 wk ahead,1.2
 2015,14,2014/2015,67,HHS Region 5,3 wk ahead,1.2
-2015,14,2014/2015,67,HHS Region 5,4 wk ahead,1
+2015,14,2014/2015,67,HHS Region 5,4 wk ahead,1.1
 2015,14,2014/2015,67,HHS Region 6,Season onset,47
 2015,14,2014/2015,67,HHS Region 6,Season peak week,51
-2015,14,2014/2015,67,HHS Region 6,Season peak percentage,10.6
-2015,14,2014/2015,67,HHS Region 6,1 wk ahead,2.3
-2015,14,2014/2015,67,HHS Region 6,2 wk ahead,1.6
-2015,14,2014/2015,67,HHS Region 6,3 wk ahead,2.2
-2015,14,2014/2015,67,HHS Region 6,4 wk ahead,2.1
+2015,14,2014/2015,67,HHS Region 6,Season peak percentage,11.1
+2015,14,2014/2015,67,HHS Region 6,1 wk ahead,2.7
+2015,14,2014/2015,67,HHS Region 6,2 wk ahead,1.8
+2015,14,2014/2015,67,HHS Region 6,3 wk ahead,2.5
+2015,14,2014/2015,67,HHS Region 6,4 wk ahead,2.4
 2015,14,2014/2015,67,HHS Region 7,Season onset,48
 2015,14,2014/2015,67,HHS Region 7,Season peak week,52
 2015,14,2014/2015,67,HHS Region 7,Season peak percentage,6.4
-2015,14,2014/2015,67,HHS Region 7,1 wk ahead,1.1
+2015,14,2014/2015,67,HHS Region 7,1 wk ahead,1.2
 2015,14,2014/2015,67,HHS Region 7,2 wk ahead,1.1
 2015,14,2014/2015,67,HHS Region 7,3 wk ahead,1.1
 2015,14,2014/2015,67,HHS Region 7,4 wk ahead,0.8
@@ -12657,9 +12624,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,14,2014/2015,67,HHS Region 9,Season peak week,4
 2015,14,2014/2015,67,HHS Region 9,Season peak percentage,5
 2015,14,2014/2015,67,HHS Region 9,1 wk ahead,2
-2015,14,2014/2015,67,HHS Region 9,2 wk ahead,2
-2015,14,2014/2015,67,HHS Region 9,3 wk ahead,2
-2015,14,2014/2015,67,HHS Region 9,4 wk ahead,2.1
+2015,14,2014/2015,67,HHS Region 9,2 wk ahead,1.9
+2015,14,2014/2015,67,HHS Region 9,3 wk ahead,1.9
+2015,14,2014/2015,67,HHS Region 9,4 wk ahead,2
 2015,14,2014/2015,67,HHS Region 10,Season onset,48
 2015,14,2014/2015,67,HHS Region 10,Season peak week,2
 2015,14,2014/2015,67,HHS Region 10,Season peak percentage,3.6
@@ -12673,7 +12640,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,15,2014/2015,68,US National,1 wk ahead,1.4
 2015,15,2014/2015,68,US National,2 wk ahead,1.5
 2015,15,2014/2015,68,US National,3 wk ahead,1.4
-2015,15,2014/2015,68,US National,4 wk ahead,1.3
+2015,15,2014/2015,68,US National,4 wk ahead,1.4
 2015,15,2014/2015,68,HHS Region 1,Season onset,50
 2015,15,2014/2015,68,HHS Region 1,Season peak week,3
 2015,15,2014/2015,68,HHS Region 1,Season peak percentage,3.9
@@ -12692,8 +12659,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,15,2014/2015,68,HHS Region 2,4 wk ahead,1.8
 2015,15,2014/2015,68,HHS Region 3,Season onset,48
 2015,15,2014/2015,68,HHS Region 3,Season peak week,52
-2015,15,2014/2015,68,HHS Region 3,Season peak percentage,7.3
-2015,15,2014/2015,68,HHS Region 3,1 wk ahead,1.4
+2015,15,2014/2015,68,HHS Region 3,Season peak percentage,7.2
+2015,15,2014/2015,68,HHS Region 3,1 wk ahead,1.3
 2015,15,2014/2015,68,HHS Region 3,2 wk ahead,1.5
 2015,15,2014/2015,68,HHS Region 3,3 wk ahead,1.3
 2015,15,2014/2015,68,HHS Region 3,4 wk ahead,1.2
@@ -12709,15 +12676,15 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,15,2014/2015,68,HHS Region 5,Season peak percentage,6.6
 2015,15,2014/2015,68,HHS Region 5,1 wk ahead,1.2
 2015,15,2014/2015,68,HHS Region 5,2 wk ahead,1.2
-2015,15,2014/2015,68,HHS Region 5,3 wk ahead,1
+2015,15,2014/2015,68,HHS Region 5,3 wk ahead,1.1
 2015,15,2014/2015,68,HHS Region 5,4 wk ahead,1
 2015,15,2014/2015,68,HHS Region 6,Season onset,47
 2015,15,2014/2015,68,HHS Region 6,Season peak week,51
-2015,15,2014/2015,68,HHS Region 6,Season peak percentage,10.6
-2015,15,2014/2015,68,HHS Region 6,1 wk ahead,1.6
-2015,15,2014/2015,68,HHS Region 6,2 wk ahead,2.2
-2015,15,2014/2015,68,HHS Region 6,3 wk ahead,2.1
-2015,15,2014/2015,68,HHS Region 6,4 wk ahead,1.9
+2015,15,2014/2015,68,HHS Region 6,Season peak percentage,11.1
+2015,15,2014/2015,68,HHS Region 6,1 wk ahead,1.8
+2015,15,2014/2015,68,HHS Region 6,2 wk ahead,2.5
+2015,15,2014/2015,68,HHS Region 6,3 wk ahead,2.4
+2015,15,2014/2015,68,HHS Region 6,4 wk ahead,2.3
 2015,15,2014/2015,68,HHS Region 7,Season onset,48
 2015,15,2014/2015,68,HHS Region 7,Season peak week,52
 2015,15,2014/2015,68,HHS Region 7,Season peak percentage,6.4
@@ -12736,10 +12703,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,15,2014/2015,68,HHS Region 9,Season peak week,3
 2015,15,2014/2015,68,HHS Region 9,Season peak week,4
 2015,15,2014/2015,68,HHS Region 9,Season peak percentage,5
-2015,15,2014/2015,68,HHS Region 9,1 wk ahead,2
-2015,15,2014/2015,68,HHS Region 9,2 wk ahead,2
-2015,15,2014/2015,68,HHS Region 9,3 wk ahead,2.1
-2015,15,2014/2015,68,HHS Region 9,4 wk ahead,2.1
+2015,15,2014/2015,68,HHS Region 9,1 wk ahead,1.9
+2015,15,2014/2015,68,HHS Region 9,2 wk ahead,1.9
+2015,15,2014/2015,68,HHS Region 9,3 wk ahead,2
+2015,15,2014/2015,68,HHS Region 9,4 wk ahead,2
 2015,15,2014/2015,68,HHS Region 10,Season onset,48
 2015,15,2014/2015,68,HHS Region 10,Season peak week,2
 2015,15,2014/2015,68,HHS Region 10,Season peak percentage,3.6
@@ -12752,7 +12719,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,16,2014/2015,69,US National,Season peak percentage,6
 2015,16,2014/2015,69,US National,1 wk ahead,1.5
 2015,16,2014/2015,69,US National,2 wk ahead,1.4
-2015,16,2014/2015,69,US National,3 wk ahead,1.3
+2015,16,2014/2015,69,US National,3 wk ahead,1.4
 2015,16,2014/2015,69,US National,4 wk ahead,1.3
 2015,16,2014/2015,69,HHS Region 1,Season onset,50
 2015,16,2014/2015,69,HHS Region 1,Season peak week,3
@@ -12772,7 +12739,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,16,2014/2015,69,HHS Region 2,4 wk ahead,1.6
 2015,16,2014/2015,69,HHS Region 3,Season onset,48
 2015,16,2014/2015,69,HHS Region 3,Season peak week,52
-2015,16,2014/2015,69,HHS Region 3,Season peak percentage,7.3
+2015,16,2014/2015,69,HHS Region 3,Season peak percentage,7.2
 2015,16,2014/2015,69,HHS Region 3,1 wk ahead,1.5
 2015,16,2014/2015,69,HHS Region 3,2 wk ahead,1.3
 2015,16,2014/2015,69,HHS Region 3,3 wk ahead,1.2
@@ -12788,16 +12755,16 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,16,2014/2015,69,HHS Region 5,Season peak week,52
 2015,16,2014/2015,69,HHS Region 5,Season peak percentage,6.6
 2015,16,2014/2015,69,HHS Region 5,1 wk ahead,1.2
-2015,16,2014/2015,69,HHS Region 5,2 wk ahead,1
+2015,16,2014/2015,69,HHS Region 5,2 wk ahead,1.1
 2015,16,2014/2015,69,HHS Region 5,3 wk ahead,1
-2015,16,2014/2015,69,HHS Region 5,4 wk ahead,0.8
+2015,16,2014/2015,69,HHS Region 5,4 wk ahead,0.9
 2015,16,2014/2015,69,HHS Region 6,Season onset,47
 2015,16,2014/2015,69,HHS Region 6,Season peak week,51
-2015,16,2014/2015,69,HHS Region 6,Season peak percentage,10.6
-2015,16,2014/2015,69,HHS Region 6,1 wk ahead,2.2
-2015,16,2014/2015,69,HHS Region 6,2 wk ahead,2.1
-2015,16,2014/2015,69,HHS Region 6,3 wk ahead,1.9
-2015,16,2014/2015,69,HHS Region 6,4 wk ahead,1.9
+2015,16,2014/2015,69,HHS Region 6,Season peak percentage,11.1
+2015,16,2014/2015,69,HHS Region 6,1 wk ahead,2.5
+2015,16,2014/2015,69,HHS Region 6,2 wk ahead,2.4
+2015,16,2014/2015,69,HHS Region 6,3 wk ahead,2.3
+2015,16,2014/2015,69,HHS Region 6,4 wk ahead,2.2
 2015,16,2014/2015,69,HHS Region 7,Season onset,48
 2015,16,2014/2015,69,HHS Region 7,Season peak week,52
 2015,16,2014/2015,69,HHS Region 7,Season peak percentage,6.4
@@ -12816,10 +12783,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,16,2014/2015,69,HHS Region 9,Season peak week,3
 2015,16,2014/2015,69,HHS Region 9,Season peak week,4
 2015,16,2014/2015,69,HHS Region 9,Season peak percentage,5
-2015,16,2014/2015,69,HHS Region 9,1 wk ahead,2
-2015,16,2014/2015,69,HHS Region 9,2 wk ahead,2.1
-2015,16,2014/2015,69,HHS Region 9,3 wk ahead,2.1
-2015,16,2014/2015,69,HHS Region 9,4 wk ahead,2
+2015,16,2014/2015,69,HHS Region 9,1 wk ahead,1.9
+2015,16,2014/2015,69,HHS Region 9,2 wk ahead,2
+2015,16,2014/2015,69,HHS Region 9,3 wk ahead,2
+2015,16,2014/2015,69,HHS Region 9,4 wk ahead,1.9
 2015,16,2014/2015,69,HHS Region 10,Season onset,48
 2015,16,2014/2015,69,HHS Region 10,Season peak week,2
 2015,16,2014/2015,69,HHS Region 10,Season peak percentage,3.6
@@ -12831,9 +12798,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,17,2014/2015,70,US National,Season peak week,52
 2015,17,2014/2015,70,US National,Season peak percentage,6
 2015,17,2014/2015,70,US National,1 wk ahead,1.4
-2015,17,2014/2015,70,US National,2 wk ahead,1.3
+2015,17,2014/2015,70,US National,2 wk ahead,1.4
 2015,17,2014/2015,70,US National,3 wk ahead,1.3
-2015,17,2014/2015,70,US National,4 wk ahead,1.2
+2015,17,2014/2015,70,US National,4 wk ahead,1.3
 2015,17,2014/2015,70,HHS Region 1,Season onset,50
 2015,17,2014/2015,70,HHS Region 1,Season peak week,3
 2015,17,2014/2015,70,HHS Region 1,Season peak percentage,3.9
@@ -12849,10 +12816,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,17,2014/2015,70,HHS Region 2,1 wk ahead,1.9
 2015,17,2014/2015,70,HHS Region 2,2 wk ahead,1.8
 2015,17,2014/2015,70,HHS Region 2,3 wk ahead,1.6
-2015,17,2014/2015,70,HHS Region 2,4 wk ahead,1.8
+2015,17,2014/2015,70,HHS Region 2,4 wk ahead,1.9
 2015,17,2014/2015,70,HHS Region 3,Season onset,48
 2015,17,2014/2015,70,HHS Region 3,Season peak week,52
-2015,17,2014/2015,70,HHS Region 3,Season peak percentage,7.3
+2015,17,2014/2015,70,HHS Region 3,Season peak percentage,7.2
 2015,17,2014/2015,70,HHS Region 3,1 wk ahead,1.3
 2015,17,2014/2015,70,HHS Region 3,2 wk ahead,1.2
 2015,17,2014/2015,70,HHS Region 3,3 wk ahead,1.2
@@ -12863,21 +12830,21 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,17,2014/2015,70,HHS Region 4,1 wk ahead,0.9
 2015,17,2014/2015,70,HHS Region 4,2 wk ahead,1
 2015,17,2014/2015,70,HHS Region 4,3 wk ahead,0.9
-2015,17,2014/2015,70,HHS Region 4,4 wk ahead,0.7
+2015,17,2014/2015,70,HHS Region 4,4 wk ahead,0.8
 2015,17,2014/2015,70,HHS Region 5,Season onset,48
 2015,17,2014/2015,70,HHS Region 5,Season peak week,52
 2015,17,2014/2015,70,HHS Region 5,Season peak percentage,6.6
-2015,17,2014/2015,70,HHS Region 5,1 wk ahead,1
+2015,17,2014/2015,70,HHS Region 5,1 wk ahead,1.1
 2015,17,2014/2015,70,HHS Region 5,2 wk ahead,1
-2015,17,2014/2015,70,HHS Region 5,3 wk ahead,0.8
+2015,17,2014/2015,70,HHS Region 5,3 wk ahead,0.9
 2015,17,2014/2015,70,HHS Region 5,4 wk ahead,0.7
 2015,17,2014/2015,70,HHS Region 6,Season onset,47
 2015,17,2014/2015,70,HHS Region 6,Season peak week,51
-2015,17,2014/2015,70,HHS Region 6,Season peak percentage,10.6
-2015,17,2014/2015,70,HHS Region 6,1 wk ahead,2.1
-2015,17,2014/2015,70,HHS Region 6,2 wk ahead,1.9
-2015,17,2014/2015,70,HHS Region 6,3 wk ahead,1.9
-2015,17,2014/2015,70,HHS Region 6,4 wk ahead,1.8
+2015,17,2014/2015,70,HHS Region 6,Season peak percentage,11.1
+2015,17,2014/2015,70,HHS Region 6,1 wk ahead,2.4
+2015,17,2014/2015,70,HHS Region 6,2 wk ahead,2.3
+2015,17,2014/2015,70,HHS Region 6,3 wk ahead,2.2
+2015,17,2014/2015,70,HHS Region 6,4 wk ahead,2.3
 2015,17,2014/2015,70,HHS Region 7,Season onset,48
 2015,17,2014/2015,70,HHS Region 7,Season peak week,52
 2015,17,2014/2015,70,HHS Region 7,Season peak percentage,6.4
@@ -12896,9 +12863,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,17,2014/2015,70,HHS Region 9,Season peak week,3
 2015,17,2014/2015,70,HHS Region 9,Season peak week,4
 2015,17,2014/2015,70,HHS Region 9,Season peak percentage,5
-2015,17,2014/2015,70,HHS Region 9,1 wk ahead,2.1
-2015,17,2014/2015,70,HHS Region 9,2 wk ahead,2.1
-2015,17,2014/2015,70,HHS Region 9,3 wk ahead,2
+2015,17,2014/2015,70,HHS Region 9,1 wk ahead,2
+2015,17,2014/2015,70,HHS Region 9,2 wk ahead,2
+2015,17,2014/2015,70,HHS Region 9,3 wk ahead,1.9
 2015,17,2014/2015,70,HHS Region 9,4 wk ahead,1.9
 2015,17,2014/2015,70,HHS Region 10,Season onset,48
 2015,17,2014/2015,70,HHS Region 10,Season peak week,2
@@ -12910,9 +12877,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,18,2014/2015,71,US National,Season onset,47
 2015,18,2014/2015,71,US National,Season peak week,52
 2015,18,2014/2015,71,US National,Season peak percentage,6
-2015,18,2014/2015,71,US National,1 wk ahead,1.3
+2015,18,2014/2015,71,US National,1 wk ahead,1.4
 2015,18,2014/2015,71,US National,2 wk ahead,1.3
-2015,18,2014/2015,71,US National,3 wk ahead,1.2
+2015,18,2014/2015,71,US National,3 wk ahead,1.3
 2015,18,2014/2015,71,US National,4 wk ahead,1.2
 2015,18,2014/2015,71,HHS Region 1,Season onset,50
 2015,18,2014/2015,71,HHS Region 1,Season peak week,3
@@ -12928,11 +12895,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,18,2014/2015,71,HHS Region 2,Season peak percentage,5.2
 2015,18,2014/2015,71,HHS Region 2,1 wk ahead,1.8
 2015,18,2014/2015,71,HHS Region 2,2 wk ahead,1.6
-2015,18,2014/2015,71,HHS Region 2,3 wk ahead,1.8
+2015,18,2014/2015,71,HHS Region 2,3 wk ahead,1.9
 2015,18,2014/2015,71,HHS Region 2,4 wk ahead,1.6
 2015,18,2014/2015,71,HHS Region 3,Season onset,48
 2015,18,2014/2015,71,HHS Region 3,Season peak week,52
-2015,18,2014/2015,71,HHS Region 3,Season peak percentage,7.3
+2015,18,2014/2015,71,HHS Region 3,Season peak percentage,7.2
 2015,18,2014/2015,71,HHS Region 3,1 wk ahead,1.2
 2015,18,2014/2015,71,HHS Region 3,2 wk ahead,1.2
 2015,18,2014/2015,71,HHS Region 3,3 wk ahead,1.6
@@ -12942,22 +12909,22 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,18,2014/2015,71,HHS Region 4,Season peak percentage,7.5
 2015,18,2014/2015,71,HHS Region 4,1 wk ahead,1
 2015,18,2014/2015,71,HHS Region 4,2 wk ahead,0.9
-2015,18,2014/2015,71,HHS Region 4,3 wk ahead,0.7
+2015,18,2014/2015,71,HHS Region 4,3 wk ahead,0.8
 2015,18,2014/2015,71,HHS Region 4,4 wk ahead,0.7
 2015,18,2014/2015,71,HHS Region 5,Season onset,48
 2015,18,2014/2015,71,HHS Region 5,Season peak week,52
 2015,18,2014/2015,71,HHS Region 5,Season peak percentage,6.6
 2015,18,2014/2015,71,HHS Region 5,1 wk ahead,1
-2015,18,2014/2015,71,HHS Region 5,2 wk ahead,0.8
+2015,18,2014/2015,71,HHS Region 5,2 wk ahead,0.9
 2015,18,2014/2015,71,HHS Region 5,3 wk ahead,0.7
 2015,18,2014/2015,71,HHS Region 5,4 wk ahead,0.7
 2015,18,2014/2015,71,HHS Region 6,Season onset,47
 2015,18,2014/2015,71,HHS Region 6,Season peak week,51
-2015,18,2014/2015,71,HHS Region 6,Season peak percentage,10.6
-2015,18,2014/2015,71,HHS Region 6,1 wk ahead,1.9
-2015,18,2014/2015,71,HHS Region 6,2 wk ahead,1.9
-2015,18,2014/2015,71,HHS Region 6,3 wk ahead,1.8
-2015,18,2014/2015,71,HHS Region 6,4 wk ahead,2
+2015,18,2014/2015,71,HHS Region 6,Season peak percentage,11.1
+2015,18,2014/2015,71,HHS Region 6,1 wk ahead,2.3
+2015,18,2014/2015,71,HHS Region 6,2 wk ahead,2.2
+2015,18,2014/2015,71,HHS Region 6,3 wk ahead,2.3
+2015,18,2014/2015,71,HHS Region 6,4 wk ahead,2.7
 2015,18,2014/2015,71,HHS Region 7,Season onset,48
 2015,18,2014/2015,71,HHS Region 7,Season peak week,52
 2015,18,2014/2015,71,HHS Region 7,Season peak percentage,6.4
@@ -12976,10 +12943,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,18,2014/2015,71,HHS Region 9,Season peak week,3
 2015,18,2014/2015,71,HHS Region 9,Season peak week,4
 2015,18,2014/2015,71,HHS Region 9,Season peak percentage,5
-2015,18,2014/2015,71,HHS Region 9,1 wk ahead,2.1
-2015,18,2014/2015,71,HHS Region 9,2 wk ahead,2
+2015,18,2014/2015,71,HHS Region 9,1 wk ahead,2
+2015,18,2014/2015,71,HHS Region 9,2 wk ahead,1.9
 2015,18,2014/2015,71,HHS Region 9,3 wk ahead,1.9
-2015,18,2014/2015,71,HHS Region 9,4 wk ahead,2
+2015,18,2014/2015,71,HHS Region 9,4 wk ahead,1.7
 2015,18,2014/2015,71,HHS Region 10,Season onset,48
 2015,18,2014/2015,71,HHS Region 10,Season peak week,2
 2015,18,2014/2015,71,HHS Region 10,Season peak percentage,3.6
@@ -12991,9 +12958,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,19,2014/2015,72,US National,Season peak week,52
 2015,19,2014/2015,72,US National,Season peak percentage,6
 2015,19,2014/2015,72,US National,1 wk ahead,1.3
-2015,19,2014/2015,72,US National,2 wk ahead,1.2
+2015,19,2014/2015,72,US National,2 wk ahead,1.3
 2015,19,2014/2015,72,US National,3 wk ahead,1.2
-2015,19,2014/2015,72,US National,4 wk ahead,1
+2015,19,2014/2015,72,US National,4 wk ahead,1.1
 2015,19,2014/2015,72,HHS Region 1,Season onset,50
 2015,19,2014/2015,72,HHS Region 1,Season peak week,3
 2015,19,2014/2015,72,HHS Region 1,Season peak percentage,3.9
@@ -13007,37 +12974,37 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,19,2014/2015,72,HHS Region 2,Season peak week,5
 2015,19,2014/2015,72,HHS Region 2,Season peak percentage,5.2
 2015,19,2014/2015,72,HHS Region 2,1 wk ahead,1.6
-2015,19,2014/2015,72,HHS Region 2,2 wk ahead,1.8
+2015,19,2014/2015,72,HHS Region 2,2 wk ahead,1.9
 2015,19,2014/2015,72,HHS Region 2,3 wk ahead,1.6
 2015,19,2014/2015,72,HHS Region 2,4 wk ahead,1.6
 2015,19,2014/2015,72,HHS Region 3,Season onset,48
 2015,19,2014/2015,72,HHS Region 3,Season peak week,52
-2015,19,2014/2015,72,HHS Region 3,Season peak percentage,7.3
+2015,19,2014/2015,72,HHS Region 3,Season peak percentage,7.2
 2015,19,2014/2015,72,HHS Region 3,1 wk ahead,1.2
 2015,19,2014/2015,72,HHS Region 3,2 wk ahead,1.6
 2015,19,2014/2015,72,HHS Region 3,3 wk ahead,1.2
-2015,19,2014/2015,72,HHS Region 3,4 wk ahead,1.3
+2015,19,2014/2015,72,HHS Region 3,4 wk ahead,1.4
 2015,19,2014/2015,72,HHS Region 4,Season onset,47
 2015,19,2014/2015,72,HHS Region 4,Season peak week,52
 2015,19,2014/2015,72,HHS Region 4,Season peak percentage,7.5
 2015,19,2014/2015,72,HHS Region 4,1 wk ahead,0.9
-2015,19,2014/2015,72,HHS Region 4,2 wk ahead,0.7
+2015,19,2014/2015,72,HHS Region 4,2 wk ahead,0.8
 2015,19,2014/2015,72,HHS Region 4,3 wk ahead,0.7
 2015,19,2014/2015,72,HHS Region 4,4 wk ahead,0.7
 2015,19,2014/2015,72,HHS Region 5,Season onset,48
 2015,19,2014/2015,72,HHS Region 5,Season peak week,52
 2015,19,2014/2015,72,HHS Region 5,Season peak percentage,6.6
-2015,19,2014/2015,72,HHS Region 5,1 wk ahead,0.8
+2015,19,2014/2015,72,HHS Region 5,1 wk ahead,0.9
 2015,19,2014/2015,72,HHS Region 5,2 wk ahead,0.7
 2015,19,2014/2015,72,HHS Region 5,3 wk ahead,0.7
-2015,19,2014/2015,72,HHS Region 5,4 wk ahead,0.6
+2015,19,2014/2015,72,HHS Region 5,4 wk ahead,0.7
 2015,19,2014/2015,72,HHS Region 6,Season onset,47
 2015,19,2014/2015,72,HHS Region 6,Season peak week,51
-2015,19,2014/2015,72,HHS Region 6,Season peak percentage,10.6
-2015,19,2014/2015,72,HHS Region 6,1 wk ahead,1.9
-2015,19,2014/2015,72,HHS Region 6,2 wk ahead,1.8
-2015,19,2014/2015,72,HHS Region 6,3 wk ahead,2
-2015,19,2014/2015,72,HHS Region 6,4 wk ahead,1.4
+2015,19,2014/2015,72,HHS Region 6,Season peak percentage,11.1
+2015,19,2014/2015,72,HHS Region 6,1 wk ahead,2.2
+2015,19,2014/2015,72,HHS Region 6,2 wk ahead,2.3
+2015,19,2014/2015,72,HHS Region 6,3 wk ahead,2.7
+2015,19,2014/2015,72,HHS Region 6,4 wk ahead,1.9
 2015,19,2014/2015,72,HHS Region 7,Season onset,48
 2015,19,2014/2015,72,HHS Region 7,Season peak week,52
 2015,19,2014/2015,72,HHS Region 7,Season peak percentage,6.4
@@ -13056,10 +13023,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,19,2014/2015,72,HHS Region 9,Season peak week,3
 2015,19,2014/2015,72,HHS Region 9,Season peak week,4
 2015,19,2014/2015,72,HHS Region 9,Season peak percentage,5
-2015,19,2014/2015,72,HHS Region 9,1 wk ahead,2
+2015,19,2014/2015,72,HHS Region 9,1 wk ahead,1.9
 2015,19,2014/2015,72,HHS Region 9,2 wk ahead,1.9
-2015,19,2014/2015,72,HHS Region 9,3 wk ahead,2
-2015,19,2014/2015,72,HHS Region 9,4 wk ahead,1.7
+2015,19,2014/2015,72,HHS Region 9,3 wk ahead,1.7
+2015,19,2014/2015,72,HHS Region 9,4 wk ahead,1.6
 2015,19,2014/2015,72,HHS Region 10,Season onset,48
 2015,19,2014/2015,72,HHS Region 10,Season peak week,2
 2015,19,2014/2015,72,HHS Region 10,Season peak percentage,3.6
@@ -13070,10 +13037,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,20,2014/2015,73,US National,Season onset,47
 2015,20,2014/2015,73,US National,Season peak week,52
 2015,20,2014/2015,73,US National,Season peak percentage,6
-2015,20,2014/2015,73,US National,1 wk ahead,1.2
+2015,20,2014/2015,73,US National,1 wk ahead,1.3
 2015,20,2014/2015,73,US National,2 wk ahead,1.2
-2015,20,2014/2015,73,US National,3 wk ahead,1
-2015,20,2014/2015,73,US National,4 wk ahead,0.9
+2015,20,2014/2015,73,US National,3 wk ahead,1.1
+2015,20,2014/2015,73,US National,4 wk ahead,1
 2015,20,2014/2015,73,HHS Region 1,Season onset,50
 2015,20,2014/2015,73,HHS Region 1,Season peak week,3
 2015,20,2014/2015,73,HHS Region 1,Season peak percentage,3.9
@@ -13086,21 +13053,21 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,20,2014/2015,73,HHS Region 2,Season peak week,4
 2015,20,2014/2015,73,HHS Region 2,Season peak week,5
 2015,20,2014/2015,73,HHS Region 2,Season peak percentage,5.2
-2015,20,2014/2015,73,HHS Region 2,1 wk ahead,1.8
+2015,20,2014/2015,73,HHS Region 2,1 wk ahead,1.9
 2015,20,2014/2015,73,HHS Region 2,2 wk ahead,1.6
 2015,20,2014/2015,73,HHS Region 2,3 wk ahead,1.6
 2015,20,2014/2015,73,HHS Region 2,4 wk ahead,1.2
 2015,20,2014/2015,73,HHS Region 3,Season onset,48
 2015,20,2014/2015,73,HHS Region 3,Season peak week,52
-2015,20,2014/2015,73,HHS Region 3,Season peak percentage,7.3
+2015,20,2014/2015,73,HHS Region 3,Season peak percentage,7.2
 2015,20,2014/2015,73,HHS Region 3,1 wk ahead,1.6
 2015,20,2014/2015,73,HHS Region 3,2 wk ahead,1.2
-2015,20,2014/2015,73,HHS Region 3,3 wk ahead,1.3
+2015,20,2014/2015,73,HHS Region 3,3 wk ahead,1.4
 2015,20,2014/2015,73,HHS Region 3,4 wk ahead,1.2
 2015,20,2014/2015,73,HHS Region 4,Season onset,47
 2015,20,2014/2015,73,HHS Region 4,Season peak week,52
 2015,20,2014/2015,73,HHS Region 4,Season peak percentage,7.5
-2015,20,2014/2015,73,HHS Region 4,1 wk ahead,0.7
+2015,20,2014/2015,73,HHS Region 4,1 wk ahead,0.8
 2015,20,2014/2015,73,HHS Region 4,2 wk ahead,0.7
 2015,20,2014/2015,73,HHS Region 4,3 wk ahead,0.7
 2015,20,2014/2015,73,HHS Region 4,4 wk ahead,0.7
@@ -13109,15 +13076,15 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,20,2014/2015,73,HHS Region 5,Season peak percentage,6.6
 2015,20,2014/2015,73,HHS Region 5,1 wk ahead,0.7
 2015,20,2014/2015,73,HHS Region 5,2 wk ahead,0.7
-2015,20,2014/2015,73,HHS Region 5,3 wk ahead,0.6
-2015,20,2014/2015,73,HHS Region 5,4 wk ahead,0.5
+2015,20,2014/2015,73,HHS Region 5,3 wk ahead,0.7
+2015,20,2014/2015,73,HHS Region 5,4 wk ahead,0.6
 2015,20,2014/2015,73,HHS Region 6,Season onset,47
 2015,20,2014/2015,73,HHS Region 6,Season peak week,51
-2015,20,2014/2015,73,HHS Region 6,Season peak percentage,10.6
-2015,20,2014/2015,73,HHS Region 6,1 wk ahead,1.8
-2015,20,2014/2015,73,HHS Region 6,2 wk ahead,2
-2015,20,2014/2015,73,HHS Region 6,3 wk ahead,1.4
-2015,20,2014/2015,73,HHS Region 6,4 wk ahead,1.4
+2015,20,2014/2015,73,HHS Region 6,Season peak percentage,11.1
+2015,20,2014/2015,73,HHS Region 6,1 wk ahead,2.3
+2015,20,2014/2015,73,HHS Region 6,2 wk ahead,2.7
+2015,20,2014/2015,73,HHS Region 6,3 wk ahead,1.9
+2015,20,2014/2015,73,HHS Region 6,4 wk ahead,1.9
 2015,20,2014/2015,73,HHS Region 7,Season onset,48
 2015,20,2014/2015,73,HHS Region 7,Season peak week,52
 2015,20,2014/2015,73,HHS Region 7,Season peak percentage,6.4
@@ -13137,9 +13104,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,20,2014/2015,73,HHS Region 9,Season peak week,4
 2015,20,2014/2015,73,HHS Region 9,Season peak percentage,5
 2015,20,2014/2015,73,HHS Region 9,1 wk ahead,1.9
-2015,20,2014/2015,73,HHS Region 9,2 wk ahead,2
-2015,20,2014/2015,73,HHS Region 9,3 wk ahead,1.7
-2015,20,2014/2015,73,HHS Region 9,4 wk ahead,1.6
+2015,20,2014/2015,73,HHS Region 9,2 wk ahead,1.7
+2015,20,2014/2015,73,HHS Region 9,3 wk ahead,1.6
+2015,20,2014/2015,73,HHS Region 9,4 wk ahead,1.4
 2015,20,2014/2015,73,HHS Region 10,Season onset,48
 2015,20,2014/2015,73,HHS Region 10,Season peak week,2
 2015,20,2014/2015,73,HHS Region 10,Season peak percentage,3.6
@@ -13153,7 +13120,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,40,2015/2016,40,US National,1 wk ahead,1.3
 2015,40,2015/2016,40,US National,2 wk ahead,1.4
 2015,40,2015/2016,40,US National,3 wk ahead,1.4
-2015,40,2015/2016,40,US National,4 wk ahead,1.4
+2015,40,2015/2016,40,US National,4 wk ahead,1.5
 2015,40,2015/2016,40,HHS Region 1,Season onset,51
 2015,40,2015/2016,40,HHS Region 1,Season peak week,10
 2015,40,2015/2016,40,HHS Region 1,Season peak percentage,2.5
@@ -13164,7 +13131,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,40,2015/2016,40,HHS Region 2,Season onset,4
 2015,40,2015/2016,40,HHS Region 2,Season peak week,11
 2015,40,2015/2016,40,HHS Region 2,Season peak percentage,4.1
-2015,40,2015/2016,40,HHS Region 2,1 wk ahead,1
+2015,40,2015/2016,40,HHS Region 2,1 wk ahead,0.9
 2015,40,2015/2016,40,HHS Region 2,2 wk ahead,1.2
 2015,40,2015/2016,40,HHS Region 2,3 wk ahead,1.1
 2015,40,2015/2016,40,HHS Region 2,4 wk ahead,1.2
@@ -13184,18 +13151,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,40,2015/2016,40,HHS Region 4,4 wk ahead,1.1
 2015,40,2015/2016,40,HHS Region 5,Season onset,7
 2015,40,2015/2016,40,HHS Region 5,Season peak week,10
-2015,40,2015/2016,40,HHS Region 5,Season peak percentage,3.4
+2015,40,2015/2016,40,HHS Region 5,Season peak percentage,3.3
 2015,40,2015/2016,40,HHS Region 5,1 wk ahead,1.2
 2015,40,2015/2016,40,HHS Region 5,2 wk ahead,1.1
-2015,40,2015/2016,40,HHS Region 5,3 wk ahead,1.1
+2015,40,2015/2016,40,HHS Region 5,3 wk ahead,1
 2015,40,2015/2016,40,HHS Region 5,4 wk ahead,1.2
 2015,40,2015/2016,40,HHS Region 6,Season onset,47
 2015,40,2015/2016,40,HHS Region 6,Season peak week,7
-2015,40,2015/2016,40,HHS Region 6,Season peak percentage,5.3
-2015,40,2015/2016,40,HHS Region 6,1 wk ahead,2.8
-2015,40,2015/2016,40,HHS Region 6,2 wk ahead,3
+2015,40,2015/2016,40,HHS Region 6,Season peak percentage,5.6
+2015,40,2015/2016,40,HHS Region 6,1 wk ahead,3
+2015,40,2015/2016,40,HHS Region 6,2 wk ahead,3.2
 2015,40,2015/2016,40,HHS Region 6,3 wk ahead,3.1
-2015,40,2015/2016,40,HHS Region 6,4 wk ahead,2.9
+2015,40,2015/2016,40,HHS Region 6,4 wk ahead,3
 2015,40,2015/2016,40,HHS Region 7,Season onset,7
 2015,40,2015/2016,40,HHS Region 7,Season peak week,10
 2015,40,2015/2016,40,HHS Region 7,Season peak percentage,2.5
@@ -13204,7 +13171,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,40,2015/2016,40,HHS Region 7,3 wk ahead,0.9
 2015,40,2015/2016,40,HHS Region 7,4 wk ahead,1.2
 2015,40,2015/2016,40,HHS Region 8,Season onset,5
-2015,40,2015/2016,40,HHS Region 8,Season peak week,7
 2015,40,2015/2016,40,HHS Region 8,Season peak week,8
 2015,40,2015/2016,40,HHS Region 8,Season peak week,11
 2015,40,2015/2016,40,HHS Region 8,Season peak percentage,2.2
@@ -13216,9 +13182,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,40,2015/2016,40,HHS Region 9,Season peak week,7
 2015,40,2015/2016,40,HHS Region 9,Season peak percentage,4.4
 2015,40,2015/2016,40,HHS Region 9,1 wk ahead,1.5
-2015,40,2015/2016,40,HHS Region 9,2 wk ahead,1.4
-2015,40,2015/2016,40,HHS Region 9,3 wk ahead,1.6
-2015,40,2015/2016,40,HHS Region 9,4 wk ahead,1.7
+2015,40,2015/2016,40,HHS Region 9,2 wk ahead,1.5
+2015,40,2015/2016,40,HHS Region 9,3 wk ahead,1.7
+2015,40,2015/2016,40,HHS Region 9,4 wk ahead,1.9
 2015,40,2015/2016,40,HHS Region 10,Season onset,2
 2015,40,2015/2016,40,HHS Region 10,Season peak week,7
 2015,40,2015/2016,40,HHS Region 10,Season peak percentage,2.4
@@ -13231,7 +13197,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,41,2015/2016,41,US National,Season peak percentage,3.6
 2015,41,2015/2016,41,US National,1 wk ahead,1.4
 2015,41,2015/2016,41,US National,2 wk ahead,1.4
-2015,41,2015/2016,41,US National,3 wk ahead,1.4
+2015,41,2015/2016,41,US National,3 wk ahead,1.5
 2015,41,2015/2016,41,US National,4 wk ahead,1.5
 2015,41,2015/2016,41,HHS Region 1,Season onset,51
 2015,41,2015/2016,41,HHS Region 1,Season peak week,10
@@ -13260,21 +13226,21 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,41,2015/2016,41,HHS Region 4,1 wk ahead,1
 2015,41,2015/2016,41,HHS Region 4,2 wk ahead,1.1
 2015,41,2015/2016,41,HHS Region 4,3 wk ahead,1.1
-2015,41,2015/2016,41,HHS Region 4,4 wk ahead,1.1
+2015,41,2015/2016,41,HHS Region 4,4 wk ahead,1.2
 2015,41,2015/2016,41,HHS Region 5,Season onset,7
 2015,41,2015/2016,41,HHS Region 5,Season peak week,10
-2015,41,2015/2016,41,HHS Region 5,Season peak percentage,3.4
+2015,41,2015/2016,41,HHS Region 5,Season peak percentage,3.3
 2015,41,2015/2016,41,HHS Region 5,1 wk ahead,1.1
-2015,41,2015/2016,41,HHS Region 5,2 wk ahead,1.1
+2015,41,2015/2016,41,HHS Region 5,2 wk ahead,1
 2015,41,2015/2016,41,HHS Region 5,3 wk ahead,1.2
 2015,41,2015/2016,41,HHS Region 5,4 wk ahead,1.3
 2015,41,2015/2016,41,HHS Region 6,Season onset,47
 2015,41,2015/2016,41,HHS Region 6,Season peak week,7
-2015,41,2015/2016,41,HHS Region 6,Season peak percentage,5.3
-2015,41,2015/2016,41,HHS Region 6,1 wk ahead,3
+2015,41,2015/2016,41,HHS Region 6,Season peak percentage,5.6
+2015,41,2015/2016,41,HHS Region 6,1 wk ahead,3.2
 2015,41,2015/2016,41,HHS Region 6,2 wk ahead,3.1
-2015,41,2015/2016,41,HHS Region 6,3 wk ahead,2.9
-2015,41,2015/2016,41,HHS Region 6,4 wk ahead,3.3
+2015,41,2015/2016,41,HHS Region 6,3 wk ahead,3
+2015,41,2015/2016,41,HHS Region 6,4 wk ahead,3.5
 2015,41,2015/2016,41,HHS Region 7,Season onset,7
 2015,41,2015/2016,41,HHS Region 7,Season peak week,10
 2015,41,2015/2016,41,HHS Region 7,Season peak percentage,2.5
@@ -13283,7 +13249,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,41,2015/2016,41,HHS Region 7,3 wk ahead,1.2
 2015,41,2015/2016,41,HHS Region 7,4 wk ahead,1.2
 2015,41,2015/2016,41,HHS Region 8,Season onset,5
-2015,41,2015/2016,41,HHS Region 8,Season peak week,7
 2015,41,2015/2016,41,HHS Region 8,Season peak week,8
 2015,41,2015/2016,41,HHS Region 8,Season peak week,11
 2015,41,2015/2016,41,HHS Region 8,Season peak percentage,2.2
@@ -13294,10 +13259,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,41,2015/2016,41,HHS Region 9,Season onset,3
 2015,41,2015/2016,41,HHS Region 9,Season peak week,7
 2015,41,2015/2016,41,HHS Region 9,Season peak percentage,4.4
-2015,41,2015/2016,41,HHS Region 9,1 wk ahead,1.4
-2015,41,2015/2016,41,HHS Region 9,2 wk ahead,1.6
-2015,41,2015/2016,41,HHS Region 9,3 wk ahead,1.7
-2015,41,2015/2016,41,HHS Region 9,4 wk ahead,1.7
+2015,41,2015/2016,41,HHS Region 9,1 wk ahead,1.5
+2015,41,2015/2016,41,HHS Region 9,2 wk ahead,1.7
+2015,41,2015/2016,41,HHS Region 9,3 wk ahead,1.9
+2015,41,2015/2016,41,HHS Region 9,4 wk ahead,1.8
 2015,41,2015/2016,41,HHS Region 10,Season onset,2
 2015,41,2015/2016,41,HHS Region 10,Season peak week,7
 2015,41,2015/2016,41,HHS Region 10,Season peak percentage,2.4
@@ -13309,7 +13274,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,42,2015/2016,42,US National,Season peak week,10
 2015,42,2015/2016,42,US National,Season peak percentage,3.6
 2015,42,2015/2016,42,US National,1 wk ahead,1.4
-2015,42,2015/2016,42,US National,2 wk ahead,1.4
+2015,42,2015/2016,42,US National,2 wk ahead,1.5
 2015,42,2015/2016,42,US National,3 wk ahead,1.5
 2015,42,2015/2016,42,US National,4 wk ahead,1.6
 2015,42,2015/2016,42,HHS Region 1,Season onset,51
@@ -13338,22 +13303,22 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,42,2015/2016,42,HHS Region 4,Season peak percentage,3.6
 2015,42,2015/2016,42,HHS Region 4,1 wk ahead,1.1
 2015,42,2015/2016,42,HHS Region 4,2 wk ahead,1.1
-2015,42,2015/2016,42,HHS Region 4,3 wk ahead,1.1
+2015,42,2015/2016,42,HHS Region 4,3 wk ahead,1.2
 2015,42,2015/2016,42,HHS Region 4,4 wk ahead,1.3
 2015,42,2015/2016,42,HHS Region 5,Season onset,7
 2015,42,2015/2016,42,HHS Region 5,Season peak week,10
-2015,42,2015/2016,42,HHS Region 5,Season peak percentage,3.4
-2015,42,2015/2016,42,HHS Region 5,1 wk ahead,1.1
+2015,42,2015/2016,42,HHS Region 5,Season peak percentage,3.3
+2015,42,2015/2016,42,HHS Region 5,1 wk ahead,1
 2015,42,2015/2016,42,HHS Region 5,2 wk ahead,1.2
 2015,42,2015/2016,42,HHS Region 5,3 wk ahead,1.3
 2015,42,2015/2016,42,HHS Region 5,4 wk ahead,1.2
 2015,42,2015/2016,42,HHS Region 6,Season onset,47
 2015,42,2015/2016,42,HHS Region 6,Season peak week,7
-2015,42,2015/2016,42,HHS Region 6,Season peak percentage,5.3
+2015,42,2015/2016,42,HHS Region 6,Season peak percentage,5.6
 2015,42,2015/2016,42,HHS Region 6,1 wk ahead,3.1
-2015,42,2015/2016,42,HHS Region 6,2 wk ahead,2.9
-2015,42,2015/2016,42,HHS Region 6,3 wk ahead,3.3
-2015,42,2015/2016,42,HHS Region 6,4 wk ahead,3.3
+2015,42,2015/2016,42,HHS Region 6,2 wk ahead,3
+2015,42,2015/2016,42,HHS Region 6,3 wk ahead,3.5
+2015,42,2015/2016,42,HHS Region 6,4 wk ahead,3.4
 2015,42,2015/2016,42,HHS Region 7,Season onset,7
 2015,42,2015/2016,42,HHS Region 7,Season peak week,10
 2015,42,2015/2016,42,HHS Region 7,Season peak percentage,2.5
@@ -13362,7 +13327,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,42,2015/2016,42,HHS Region 7,3 wk ahead,1.2
 2015,42,2015/2016,42,HHS Region 7,4 wk ahead,1.1
 2015,42,2015/2016,42,HHS Region 8,Season onset,5
-2015,42,2015/2016,42,HHS Region 8,Season peak week,7
 2015,42,2015/2016,42,HHS Region 8,Season peak week,8
 2015,42,2015/2016,42,HHS Region 8,Season peak week,11
 2015,42,2015/2016,42,HHS Region 8,Season peak percentage,2.2
@@ -13373,9 +13337,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,42,2015/2016,42,HHS Region 9,Season onset,3
 2015,42,2015/2016,42,HHS Region 9,Season peak week,7
 2015,42,2015/2016,42,HHS Region 9,Season peak percentage,4.4
-2015,42,2015/2016,42,HHS Region 9,1 wk ahead,1.6
-2015,42,2015/2016,42,HHS Region 9,2 wk ahead,1.7
-2015,42,2015/2016,42,HHS Region 9,3 wk ahead,1.7
+2015,42,2015/2016,42,HHS Region 9,1 wk ahead,1.7
+2015,42,2015/2016,42,HHS Region 9,2 wk ahead,1.9
+2015,42,2015/2016,42,HHS Region 9,3 wk ahead,1.8
 2015,42,2015/2016,42,HHS Region 9,4 wk ahead,2
 2015,42,2015/2016,42,HHS Region 10,Season onset,2
 2015,42,2015/2016,42,HHS Region 10,Season peak week,7
@@ -13387,7 +13351,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,43,2015/2016,43,US National,Season onset,3
 2015,43,2015/2016,43,US National,Season peak week,10
 2015,43,2015/2016,43,US National,Season peak percentage,3.6
-2015,43,2015/2016,43,US National,1 wk ahead,1.4
+2015,43,2015/2016,43,US National,1 wk ahead,1.5
 2015,43,2015/2016,43,US National,2 wk ahead,1.5
 2015,43,2015/2016,43,US National,3 wk ahead,1.6
 2015,43,2015/2016,43,US National,4 wk ahead,1.9
@@ -13416,23 +13380,23 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,43,2015/2016,43,HHS Region 4,Season peak week,10
 2015,43,2015/2016,43,HHS Region 4,Season peak percentage,3.6
 2015,43,2015/2016,43,HHS Region 4,1 wk ahead,1.1
-2015,43,2015/2016,43,HHS Region 4,2 wk ahead,1.1
+2015,43,2015/2016,43,HHS Region 4,2 wk ahead,1.2
 2015,43,2015/2016,43,HHS Region 4,3 wk ahead,1.3
-2015,43,2015/2016,43,HHS Region 4,4 wk ahead,1.6
+2015,43,2015/2016,43,HHS Region 4,4 wk ahead,1.7
 2015,43,2015/2016,43,HHS Region 5,Season onset,7
 2015,43,2015/2016,43,HHS Region 5,Season peak week,10
-2015,43,2015/2016,43,HHS Region 5,Season peak percentage,3.4
+2015,43,2015/2016,43,HHS Region 5,Season peak percentage,3.3
 2015,43,2015/2016,43,HHS Region 5,1 wk ahead,1.2
 2015,43,2015/2016,43,HHS Region 5,2 wk ahead,1.3
 2015,43,2015/2016,43,HHS Region 5,3 wk ahead,1.2
 2015,43,2015/2016,43,HHS Region 5,4 wk ahead,1.4
 2015,43,2015/2016,43,HHS Region 6,Season onset,47
 2015,43,2015/2016,43,HHS Region 6,Season peak week,7
-2015,43,2015/2016,43,HHS Region 6,Season peak percentage,5.3
-2015,43,2015/2016,43,HHS Region 6,1 wk ahead,2.9
-2015,43,2015/2016,43,HHS Region 6,2 wk ahead,3.3
-2015,43,2015/2016,43,HHS Region 6,3 wk ahead,3.3
-2015,43,2015/2016,43,HHS Region 6,4 wk ahead,4.1
+2015,43,2015/2016,43,HHS Region 6,Season peak percentage,5.6
+2015,43,2015/2016,43,HHS Region 6,1 wk ahead,3
+2015,43,2015/2016,43,HHS Region 6,2 wk ahead,3.5
+2015,43,2015/2016,43,HHS Region 6,3 wk ahead,3.4
+2015,43,2015/2016,43,HHS Region 6,4 wk ahead,4.2
 2015,43,2015/2016,43,HHS Region 7,Season onset,7
 2015,43,2015/2016,43,HHS Region 7,Season peak week,10
 2015,43,2015/2016,43,HHS Region 7,Season peak percentage,2.5
@@ -13441,7 +13405,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,43,2015/2016,43,HHS Region 7,3 wk ahead,1.1
 2015,43,2015/2016,43,HHS Region 7,4 wk ahead,1.3
 2015,43,2015/2016,43,HHS Region 8,Season onset,5
-2015,43,2015/2016,43,HHS Region 8,Season peak week,7
 2015,43,2015/2016,43,HHS Region 8,Season peak week,8
 2015,43,2015/2016,43,HHS Region 8,Season peak week,11
 2015,43,2015/2016,43,HHS Region 8,Season peak percentage,2.2
@@ -13452,10 +13415,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,43,2015/2016,43,HHS Region 9,Season onset,3
 2015,43,2015/2016,43,HHS Region 9,Season peak week,7
 2015,43,2015/2016,43,HHS Region 9,Season peak percentage,4.4
-2015,43,2015/2016,43,HHS Region 9,1 wk ahead,1.7
-2015,43,2015/2016,43,HHS Region 9,2 wk ahead,1.7
+2015,43,2015/2016,43,HHS Region 9,1 wk ahead,1.9
+2015,43,2015/2016,43,HHS Region 9,2 wk ahead,1.8
 2015,43,2015/2016,43,HHS Region 9,3 wk ahead,2
-2015,43,2015/2016,43,HHS Region 9,4 wk ahead,2.2
+2015,43,2015/2016,43,HHS Region 9,4 wk ahead,2.3
 2015,43,2015/2016,43,HHS Region 10,Season onset,2
 2015,43,2015/2016,43,HHS Region 10,Season peak week,7
 2015,43,2015/2016,43,HHS Region 10,Season peak percentage,2.4
@@ -13494,24 +13457,24 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,44,2015/2016,44,HHS Region 4,Season onset,3
 2015,44,2015/2016,44,HHS Region 4,Season peak week,10
 2015,44,2015/2016,44,HHS Region 4,Season peak percentage,3.6
-2015,44,2015/2016,44,HHS Region 4,1 wk ahead,1.1
+2015,44,2015/2016,44,HHS Region 4,1 wk ahead,1.2
 2015,44,2015/2016,44,HHS Region 4,2 wk ahead,1.3
-2015,44,2015/2016,44,HHS Region 4,3 wk ahead,1.6
-2015,44,2015/2016,44,HHS Region 4,4 wk ahead,1.3
+2015,44,2015/2016,44,HHS Region 4,3 wk ahead,1.7
+2015,44,2015/2016,44,HHS Region 4,4 wk ahead,1.4
 2015,44,2015/2016,44,HHS Region 5,Season onset,7
 2015,44,2015/2016,44,HHS Region 5,Season peak week,10
-2015,44,2015/2016,44,HHS Region 5,Season peak percentage,3.4
+2015,44,2015/2016,44,HHS Region 5,Season peak percentage,3.3
 2015,44,2015/2016,44,HHS Region 5,1 wk ahead,1.3
 2015,44,2015/2016,44,HHS Region 5,2 wk ahead,1.2
 2015,44,2015/2016,44,HHS Region 5,3 wk ahead,1.4
 2015,44,2015/2016,44,HHS Region 5,4 wk ahead,1.1
 2015,44,2015/2016,44,HHS Region 6,Season onset,47
 2015,44,2015/2016,44,HHS Region 6,Season peak week,7
-2015,44,2015/2016,44,HHS Region 6,Season peak percentage,5.3
-2015,44,2015/2016,44,HHS Region 6,1 wk ahead,3.3
-2015,44,2015/2016,44,HHS Region 6,2 wk ahead,3.3
-2015,44,2015/2016,44,HHS Region 6,3 wk ahead,4.1
-2015,44,2015/2016,44,HHS Region 6,4 wk ahead,3.6
+2015,44,2015/2016,44,HHS Region 6,Season peak percentage,5.6
+2015,44,2015/2016,44,HHS Region 6,1 wk ahead,3.5
+2015,44,2015/2016,44,HHS Region 6,2 wk ahead,3.4
+2015,44,2015/2016,44,HHS Region 6,3 wk ahead,4.2
+2015,44,2015/2016,44,HHS Region 6,4 wk ahead,3.9
 2015,44,2015/2016,44,HHS Region 7,Season onset,7
 2015,44,2015/2016,44,HHS Region 7,Season peak week,10
 2015,44,2015/2016,44,HHS Region 7,Season peak percentage,2.5
@@ -13520,7 +13483,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,44,2015/2016,44,HHS Region 7,3 wk ahead,1.3
 2015,44,2015/2016,44,HHS Region 7,4 wk ahead,1
 2015,44,2015/2016,44,HHS Region 8,Season onset,5
-2015,44,2015/2016,44,HHS Region 8,Season peak week,7
 2015,44,2015/2016,44,HHS Region 8,Season peak week,8
 2015,44,2015/2016,44,HHS Region 8,Season peak week,11
 2015,44,2015/2016,44,HHS Region 8,Season peak percentage,2.2
@@ -13531,9 +13493,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,44,2015/2016,44,HHS Region 9,Season onset,3
 2015,44,2015/2016,44,HHS Region 9,Season peak week,7
 2015,44,2015/2016,44,HHS Region 9,Season peak percentage,4.4
-2015,44,2015/2016,44,HHS Region 9,1 wk ahead,1.7
+2015,44,2015/2016,44,HHS Region 9,1 wk ahead,1.8
 2015,44,2015/2016,44,HHS Region 9,2 wk ahead,2
-2015,44,2015/2016,44,HHS Region 9,3 wk ahead,2.2
+2015,44,2015/2016,44,HHS Region 9,3 wk ahead,2.3
 2015,44,2015/2016,44,HHS Region 9,4 wk ahead,2
 2015,44,2015/2016,44,HHS Region 10,Season onset,2
 2015,44,2015/2016,44,HHS Region 10,Season peak week,7
@@ -13574,23 +13536,23 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,45,2015/2016,45,HHS Region 4,Season peak week,10
 2015,45,2015/2016,45,HHS Region 4,Season peak percentage,3.6
 2015,45,2015/2016,45,HHS Region 4,1 wk ahead,1.3
-2015,45,2015/2016,45,HHS Region 4,2 wk ahead,1.6
-2015,45,2015/2016,45,HHS Region 4,3 wk ahead,1.3
-2015,45,2015/2016,45,HHS Region 4,4 wk ahead,1.3
+2015,45,2015/2016,45,HHS Region 4,2 wk ahead,1.7
+2015,45,2015/2016,45,HHS Region 4,3 wk ahead,1.4
+2015,45,2015/2016,45,HHS Region 4,4 wk ahead,1.4
 2015,45,2015/2016,45,HHS Region 5,Season onset,7
 2015,45,2015/2016,45,HHS Region 5,Season peak week,10
-2015,45,2015/2016,45,HHS Region 5,Season peak percentage,3.4
+2015,45,2015/2016,45,HHS Region 5,Season peak percentage,3.3
 2015,45,2015/2016,45,HHS Region 5,1 wk ahead,1.2
 2015,45,2015/2016,45,HHS Region 5,2 wk ahead,1.4
 2015,45,2015/2016,45,HHS Region 5,3 wk ahead,1.1
 2015,45,2015/2016,45,HHS Region 5,4 wk ahead,1.4
 2015,45,2015/2016,45,HHS Region 6,Season onset,47
 2015,45,2015/2016,45,HHS Region 6,Season peak week,7
-2015,45,2015/2016,45,HHS Region 6,Season peak percentage,5.3
-2015,45,2015/2016,45,HHS Region 6,1 wk ahead,3.3
-2015,45,2015/2016,45,HHS Region 6,2 wk ahead,4.1
-2015,45,2015/2016,45,HHS Region 6,3 wk ahead,3.6
-2015,45,2015/2016,45,HHS Region 6,4 wk ahead,3.7
+2015,45,2015/2016,45,HHS Region 6,Season peak percentage,5.6
+2015,45,2015/2016,45,HHS Region 6,1 wk ahead,3.4
+2015,45,2015/2016,45,HHS Region 6,2 wk ahead,4.2
+2015,45,2015/2016,45,HHS Region 6,3 wk ahead,3.9
+2015,45,2015/2016,45,HHS Region 6,4 wk ahead,4
 2015,45,2015/2016,45,HHS Region 7,Season onset,7
 2015,45,2015/2016,45,HHS Region 7,Season peak week,10
 2015,45,2015/2016,45,HHS Region 7,Season peak percentage,2.5
@@ -13599,7 +13561,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,45,2015/2016,45,HHS Region 7,3 wk ahead,1
 2015,45,2015/2016,45,HHS Region 7,4 wk ahead,0.9
 2015,45,2015/2016,45,HHS Region 8,Season onset,5
-2015,45,2015/2016,45,HHS Region 8,Season peak week,7
 2015,45,2015/2016,45,HHS Region 8,Season peak week,8
 2015,45,2015/2016,45,HHS Region 8,Season peak week,11
 2015,45,2015/2016,45,HHS Region 8,Season peak percentage,2.2
@@ -13611,7 +13572,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,45,2015/2016,45,HHS Region 9,Season peak week,7
 2015,45,2015/2016,45,HHS Region 9,Season peak percentage,4.4
 2015,45,2015/2016,45,HHS Region 9,1 wk ahead,2
-2015,45,2015/2016,45,HHS Region 9,2 wk ahead,2.2
+2015,45,2015/2016,45,HHS Region 9,2 wk ahead,2.3
 2015,45,2015/2016,45,HHS Region 9,3 wk ahead,2
 2015,45,2015/2016,45,HHS Region 9,4 wk ahead,2
 2015,45,2015/2016,45,HHS Region 10,Season onset,2
@@ -13652,24 +13613,24 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,46,2015/2016,46,HHS Region 4,Season onset,3
 2015,46,2015/2016,46,HHS Region 4,Season peak week,10
 2015,46,2015/2016,46,HHS Region 4,Season peak percentage,3.6
-2015,46,2015/2016,46,HHS Region 4,1 wk ahead,1.6
-2015,46,2015/2016,46,HHS Region 4,2 wk ahead,1.3
-2015,46,2015/2016,46,HHS Region 4,3 wk ahead,1.3
+2015,46,2015/2016,46,HHS Region 4,1 wk ahead,1.7
+2015,46,2015/2016,46,HHS Region 4,2 wk ahead,1.4
+2015,46,2015/2016,46,HHS Region 4,3 wk ahead,1.4
 2015,46,2015/2016,46,HHS Region 4,4 wk ahead,1.5
 2015,46,2015/2016,46,HHS Region 5,Season onset,7
 2015,46,2015/2016,46,HHS Region 5,Season peak week,10
-2015,46,2015/2016,46,HHS Region 5,Season peak percentage,3.4
+2015,46,2015/2016,46,HHS Region 5,Season peak percentage,3.3
 2015,46,2015/2016,46,HHS Region 5,1 wk ahead,1.4
 2015,46,2015/2016,46,HHS Region 5,2 wk ahead,1.1
 2015,46,2015/2016,46,HHS Region 5,3 wk ahead,1.4
-2015,46,2015/2016,46,HHS Region 5,4 wk ahead,1.4
+2015,46,2015/2016,46,HHS Region 5,4 wk ahead,1.5
 2015,46,2015/2016,46,HHS Region 6,Season onset,47
 2015,46,2015/2016,46,HHS Region 6,Season peak week,7
-2015,46,2015/2016,46,HHS Region 6,Season peak percentage,5.3
-2015,46,2015/2016,46,HHS Region 6,1 wk ahead,4.1
-2015,46,2015/2016,46,HHS Region 6,2 wk ahead,3.6
-2015,46,2015/2016,46,HHS Region 6,3 wk ahead,3.7
-2015,46,2015/2016,46,HHS Region 6,4 wk ahead,3.8
+2015,46,2015/2016,46,HHS Region 6,Season peak percentage,5.6
+2015,46,2015/2016,46,HHS Region 6,1 wk ahead,4.2
+2015,46,2015/2016,46,HHS Region 6,2 wk ahead,3.9
+2015,46,2015/2016,46,HHS Region 6,3 wk ahead,4
+2015,46,2015/2016,46,HHS Region 6,4 wk ahead,4.1
 2015,46,2015/2016,46,HHS Region 7,Season onset,7
 2015,46,2015/2016,46,HHS Region 7,Season peak week,10
 2015,46,2015/2016,46,HHS Region 7,Season peak percentage,2.5
@@ -13678,7 +13639,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,46,2015/2016,46,HHS Region 7,3 wk ahead,0.9
 2015,46,2015/2016,46,HHS Region 7,4 wk ahead,1.2
 2015,46,2015/2016,46,HHS Region 8,Season onset,5
-2015,46,2015/2016,46,HHS Region 8,Season peak week,7
 2015,46,2015/2016,46,HHS Region 8,Season peak week,8
 2015,46,2015/2016,46,HHS Region 8,Season peak week,11
 2015,46,2015/2016,46,HHS Region 8,Season peak percentage,2.2
@@ -13689,7 +13649,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,46,2015/2016,46,HHS Region 9,Season onset,3
 2015,46,2015/2016,46,HHS Region 9,Season peak week,7
 2015,46,2015/2016,46,HHS Region 9,Season peak percentage,4.4
-2015,46,2015/2016,46,HHS Region 9,1 wk ahead,2.2
+2015,46,2015/2016,46,HHS Region 9,1 wk ahead,2.3
 2015,46,2015/2016,46,HHS Region 9,2 wk ahead,2
 2015,46,2015/2016,46,HHS Region 9,3 wk ahead,2
 2015,46,2015/2016,46,HHS Region 9,4 wk ahead,2.1
@@ -13706,7 +13666,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,47,2015/2016,47,US National,1 wk ahead,1.7
 2015,47,2015/2016,47,US National,2 wk ahead,1.8
 2015,47,2015/2016,47,US National,3 wk ahead,1.9
-2015,47,2015/2016,47,US National,4 wk ahead,2.3
+2015,47,2015/2016,47,US National,4 wk ahead,2.4
 2015,47,2015/2016,47,HHS Region 1,Season onset,51
 2015,47,2015/2016,47,HHS Region 1,Season peak week,10
 2015,47,2015/2016,47,HHS Region 1,Season peak percentage,2.5
@@ -13731,24 +13691,24 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,47,2015/2016,47,HHS Region 4,Season onset,3
 2015,47,2015/2016,47,HHS Region 4,Season peak week,10
 2015,47,2015/2016,47,HHS Region 4,Season peak percentage,3.6
-2015,47,2015/2016,47,HHS Region 4,1 wk ahead,1.3
-2015,47,2015/2016,47,HHS Region 4,2 wk ahead,1.3
+2015,47,2015/2016,47,HHS Region 4,1 wk ahead,1.4
+2015,47,2015/2016,47,HHS Region 4,2 wk ahead,1.4
 2015,47,2015/2016,47,HHS Region 4,3 wk ahead,1.5
 2015,47,2015/2016,47,HHS Region 4,4 wk ahead,1.9
 2015,47,2015/2016,47,HHS Region 5,Season onset,7
 2015,47,2015/2016,47,HHS Region 5,Season peak week,10
-2015,47,2015/2016,47,HHS Region 5,Season peak percentage,3.4
+2015,47,2015/2016,47,HHS Region 5,Season peak percentage,3.3
 2015,47,2015/2016,47,HHS Region 5,1 wk ahead,1.1
 2015,47,2015/2016,47,HHS Region 5,2 wk ahead,1.4
-2015,47,2015/2016,47,HHS Region 5,3 wk ahead,1.4
+2015,47,2015/2016,47,HHS Region 5,3 wk ahead,1.5
 2015,47,2015/2016,47,HHS Region 5,4 wk ahead,1.8
 2015,47,2015/2016,47,HHS Region 6,Season onset,47
 2015,47,2015/2016,47,HHS Region 6,Season peak week,7
-2015,47,2015/2016,47,HHS Region 6,Season peak percentage,5.3
-2015,47,2015/2016,47,HHS Region 6,1 wk ahead,3.6
-2015,47,2015/2016,47,HHS Region 6,2 wk ahead,3.7
-2015,47,2015/2016,47,HHS Region 6,3 wk ahead,3.8
-2015,47,2015/2016,47,HHS Region 6,4 wk ahead,4.3
+2015,47,2015/2016,47,HHS Region 6,Season peak percentage,5.6
+2015,47,2015/2016,47,HHS Region 6,1 wk ahead,3.9
+2015,47,2015/2016,47,HHS Region 6,2 wk ahead,4
+2015,47,2015/2016,47,HHS Region 6,3 wk ahead,4.1
+2015,47,2015/2016,47,HHS Region 6,4 wk ahead,4.5
 2015,47,2015/2016,47,HHS Region 7,Season onset,7
 2015,47,2015/2016,47,HHS Region 7,Season peak week,10
 2015,47,2015/2016,47,HHS Region 7,Season peak percentage,2.5
@@ -13757,7 +13717,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,47,2015/2016,47,HHS Region 7,3 wk ahead,1.2
 2015,47,2015/2016,47,HHS Region 7,4 wk ahead,1.4
 2015,47,2015/2016,47,HHS Region 8,Season onset,5
-2015,47,2015/2016,47,HHS Region 8,Season peak week,7
 2015,47,2015/2016,47,HHS Region 8,Season peak week,8
 2015,47,2015/2016,47,HHS Region 8,Season peak week,11
 2015,47,2015/2016,47,HHS Region 8,Season peak percentage,2.2
@@ -13784,8 +13743,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,48,2015/2016,48,US National,Season peak percentage,3.6
 2015,48,2015/2016,48,US National,1 wk ahead,1.8
 2015,48,2015/2016,48,US National,2 wk ahead,1.9
-2015,48,2015/2016,48,US National,3 wk ahead,2.3
-2015,48,2015/2016,48,US National,4 wk ahead,2.4
+2015,48,2015/2016,48,US National,3 wk ahead,2.4
+2015,48,2015/2016,48,US National,4 wk ahead,2.5
 2015,48,2015/2016,48,HHS Region 1,Season onset,51
 2015,48,2015/2016,48,HHS Region 1,Season peak week,10
 2015,48,2015/2016,48,HHS Region 1,Season peak percentage,2.5
@@ -13810,24 +13769,24 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,48,2015/2016,48,HHS Region 4,Season onset,3
 2015,48,2015/2016,48,HHS Region 4,Season peak week,10
 2015,48,2015/2016,48,HHS Region 4,Season peak percentage,3.6
-2015,48,2015/2016,48,HHS Region 4,1 wk ahead,1.3
+2015,48,2015/2016,48,HHS Region 4,1 wk ahead,1.4
 2015,48,2015/2016,48,HHS Region 4,2 wk ahead,1.5
 2015,48,2015/2016,48,HHS Region 4,3 wk ahead,1.9
-2015,48,2015/2016,48,HHS Region 4,4 wk ahead,1.7
+2015,48,2015/2016,48,HHS Region 4,4 wk ahead,1.8
 2015,48,2015/2016,48,HHS Region 5,Season onset,7
 2015,48,2015/2016,48,HHS Region 5,Season peak week,10
-2015,48,2015/2016,48,HHS Region 5,Season peak percentage,3.4
+2015,48,2015/2016,48,HHS Region 5,Season peak percentage,3.3
 2015,48,2015/2016,48,HHS Region 5,1 wk ahead,1.4
-2015,48,2015/2016,48,HHS Region 5,2 wk ahead,1.4
+2015,48,2015/2016,48,HHS Region 5,2 wk ahead,1.5
 2015,48,2015/2016,48,HHS Region 5,3 wk ahead,1.8
 2015,48,2015/2016,48,HHS Region 5,4 wk ahead,1.7
 2015,48,2015/2016,48,HHS Region 6,Season onset,47
 2015,48,2015/2016,48,HHS Region 6,Season peak week,7
-2015,48,2015/2016,48,HHS Region 6,Season peak percentage,5.3
-2015,48,2015/2016,48,HHS Region 6,1 wk ahead,3.7
-2015,48,2015/2016,48,HHS Region 6,2 wk ahead,3.8
-2015,48,2015/2016,48,HHS Region 6,3 wk ahead,4.3
-2015,48,2015/2016,48,HHS Region 6,4 wk ahead,4.6
+2015,48,2015/2016,48,HHS Region 6,Season peak percentage,5.6
+2015,48,2015/2016,48,HHS Region 6,1 wk ahead,4
+2015,48,2015/2016,48,HHS Region 6,2 wk ahead,4.1
+2015,48,2015/2016,48,HHS Region 6,3 wk ahead,4.5
+2015,48,2015/2016,48,HHS Region 6,4 wk ahead,5
 2015,48,2015/2016,48,HHS Region 7,Season onset,7
 2015,48,2015/2016,48,HHS Region 7,Season peak week,10
 2015,48,2015/2016,48,HHS Region 7,Season peak percentage,2.5
@@ -13836,7 +13795,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,48,2015/2016,48,HHS Region 7,3 wk ahead,1.4
 2015,48,2015/2016,48,HHS Region 7,4 wk ahead,1.6
 2015,48,2015/2016,48,HHS Region 8,Season onset,5
-2015,48,2015/2016,48,HHS Region 8,Season peak week,7
 2015,48,2015/2016,48,HHS Region 8,Season peak week,8
 2015,48,2015/2016,48,HHS Region 8,Season peak week,11
 2015,48,2015/2016,48,HHS Region 8,Season peak percentage,2.2
@@ -13862,9 +13820,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,49,2015/2016,49,US National,Season peak week,10
 2015,49,2015/2016,49,US National,Season peak percentage,3.6
 2015,49,2015/2016,49,US National,1 wk ahead,1.9
-2015,49,2015/2016,49,US National,2 wk ahead,2.3
-2015,49,2015/2016,49,US National,3 wk ahead,2.4
-2015,49,2015/2016,49,US National,4 wk ahead,1.9
+2015,49,2015/2016,49,US National,2 wk ahead,2.4
+2015,49,2015/2016,49,US National,3 wk ahead,2.5
+2015,49,2015/2016,49,US National,4 wk ahead,2
 2015,49,2015/2016,49,HHS Region 1,Season onset,51
 2015,49,2015/2016,49,HHS Region 1,Season peak week,10
 2015,49,2015/2016,49,HHS Region 1,Season peak percentage,2.5
@@ -13891,22 +13849,22 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,49,2015/2016,49,HHS Region 4,Season peak percentage,3.6
 2015,49,2015/2016,49,HHS Region 4,1 wk ahead,1.5
 2015,49,2015/2016,49,HHS Region 4,2 wk ahead,1.9
-2015,49,2015/2016,49,HHS Region 4,3 wk ahead,1.7
+2015,49,2015/2016,49,HHS Region 4,3 wk ahead,1.8
 2015,49,2015/2016,49,HHS Region 4,4 wk ahead,1.4
 2015,49,2015/2016,49,HHS Region 5,Season onset,7
 2015,49,2015/2016,49,HHS Region 5,Season peak week,10
-2015,49,2015/2016,49,HHS Region 5,Season peak percentage,3.4
-2015,49,2015/2016,49,HHS Region 5,1 wk ahead,1.4
+2015,49,2015/2016,49,HHS Region 5,Season peak percentage,3.3
+2015,49,2015/2016,49,HHS Region 5,1 wk ahead,1.5
 2015,49,2015/2016,49,HHS Region 5,2 wk ahead,1.8
 2015,49,2015/2016,49,HHS Region 5,3 wk ahead,1.7
 2015,49,2015/2016,49,HHS Region 5,4 wk ahead,1.4
 2015,49,2015/2016,49,HHS Region 6,Season onset,47
 2015,49,2015/2016,49,HHS Region 6,Season peak week,7
-2015,49,2015/2016,49,HHS Region 6,Season peak percentage,5.3
-2015,49,2015/2016,49,HHS Region 6,1 wk ahead,3.8
-2015,49,2015/2016,49,HHS Region 6,2 wk ahead,4.3
-2015,49,2015/2016,49,HHS Region 6,3 wk ahead,4.6
-2015,49,2015/2016,49,HHS Region 6,4 wk ahead,3.8
+2015,49,2015/2016,49,HHS Region 6,Season peak percentage,5.6
+2015,49,2015/2016,49,HHS Region 6,1 wk ahead,4.1
+2015,49,2015/2016,49,HHS Region 6,2 wk ahead,4.5
+2015,49,2015/2016,49,HHS Region 6,3 wk ahead,5
+2015,49,2015/2016,49,HHS Region 6,4 wk ahead,4.1
 2015,49,2015/2016,49,HHS Region 7,Season onset,7
 2015,49,2015/2016,49,HHS Region 7,Season peak week,10
 2015,49,2015/2016,49,HHS Region 7,Season peak percentage,2.5
@@ -13915,7 +13873,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,49,2015/2016,49,HHS Region 7,3 wk ahead,1.6
 2015,49,2015/2016,49,HHS Region 7,4 wk ahead,1.4
 2015,49,2015/2016,49,HHS Region 8,Season onset,5
-2015,49,2015/2016,49,HHS Region 8,Season peak week,7
 2015,49,2015/2016,49,HHS Region 8,Season peak week,8
 2015,49,2015/2016,49,HHS Region 8,Season peak week,11
 2015,49,2015/2016,49,HHS Region 8,Season peak percentage,2.2
@@ -13940,9 +13897,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,50,2015/2016,50,US National,Season onset,3
 2015,50,2015/2016,50,US National,Season peak week,10
 2015,50,2015/2016,50,US National,Season peak percentage,3.6
-2015,50,2015/2016,50,US National,1 wk ahead,2.3
-2015,50,2015/2016,50,US National,2 wk ahead,2.4
-2015,50,2015/2016,50,US National,3 wk ahead,1.9
+2015,50,2015/2016,50,US National,1 wk ahead,2.4
+2015,50,2015/2016,50,US National,2 wk ahead,2.5
+2015,50,2015/2016,50,US National,3 wk ahead,2
 2015,50,2015/2016,50,US National,4 wk ahead,2
 2015,50,2015/2016,50,HHS Region 1,Season onset,51
 2015,50,2015/2016,50,HHS Region 1,Season peak week,10
@@ -13969,23 +13926,23 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,50,2015/2016,50,HHS Region 4,Season peak week,10
 2015,50,2015/2016,50,HHS Region 4,Season peak percentage,3.6
 2015,50,2015/2016,50,HHS Region 4,1 wk ahead,1.9
-2015,50,2015/2016,50,HHS Region 4,2 wk ahead,1.7
+2015,50,2015/2016,50,HHS Region 4,2 wk ahead,1.8
 2015,50,2015/2016,50,HHS Region 4,3 wk ahead,1.4
 2015,50,2015/2016,50,HHS Region 4,4 wk ahead,1.5
 2015,50,2015/2016,50,HHS Region 5,Season onset,7
 2015,50,2015/2016,50,HHS Region 5,Season peak week,10
-2015,50,2015/2016,50,HHS Region 5,Season peak percentage,3.4
+2015,50,2015/2016,50,HHS Region 5,Season peak percentage,3.3
 2015,50,2015/2016,50,HHS Region 5,1 wk ahead,1.8
 2015,50,2015/2016,50,HHS Region 5,2 wk ahead,1.7
 2015,50,2015/2016,50,HHS Region 5,3 wk ahead,1.4
 2015,50,2015/2016,50,HHS Region 5,4 wk ahead,1.4
 2015,50,2015/2016,50,HHS Region 6,Season onset,47
 2015,50,2015/2016,50,HHS Region 6,Season peak week,7
-2015,50,2015/2016,50,HHS Region 6,Season peak percentage,5.3
-2015,50,2015/2016,50,HHS Region 6,1 wk ahead,4.3
-2015,50,2015/2016,50,HHS Region 6,2 wk ahead,4.6
-2015,50,2015/2016,50,HHS Region 6,3 wk ahead,3.8
-2015,50,2015/2016,50,HHS Region 6,4 wk ahead,3.5
+2015,50,2015/2016,50,HHS Region 6,Season peak percentage,5.6
+2015,50,2015/2016,50,HHS Region 6,1 wk ahead,4.5
+2015,50,2015/2016,50,HHS Region 6,2 wk ahead,5
+2015,50,2015/2016,50,HHS Region 6,3 wk ahead,4.1
+2015,50,2015/2016,50,HHS Region 6,4 wk ahead,3.8
 2015,50,2015/2016,50,HHS Region 7,Season onset,7
 2015,50,2015/2016,50,HHS Region 7,Season peak week,10
 2015,50,2015/2016,50,HHS Region 7,Season peak percentage,2.5
@@ -13994,7 +13951,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,50,2015/2016,50,HHS Region 7,3 wk ahead,1.4
 2015,50,2015/2016,50,HHS Region 7,4 wk ahead,1.1
 2015,50,2015/2016,50,HHS Region 8,Season onset,5
-2015,50,2015/2016,50,HHS Region 8,Season peak week,7
 2015,50,2015/2016,50,HHS Region 8,Season peak week,8
 2015,50,2015/2016,50,HHS Region 8,Season peak week,11
 2015,50,2015/2016,50,HHS Region 8,Season peak percentage,2.2
@@ -14019,10 +13975,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,51,2015/2016,51,US National,Season onset,3
 2015,51,2015/2016,51,US National,Season peak week,10
 2015,51,2015/2016,51,US National,Season peak percentage,3.6
-2015,51,2015/2016,51,US National,1 wk ahead,2.4
-2015,51,2015/2016,51,US National,2 wk ahead,1.9
+2015,51,2015/2016,51,US National,1 wk ahead,2.5
+2015,51,2015/2016,51,US National,2 wk ahead,2
 2015,51,2015/2016,51,US National,3 wk ahead,2
-2015,51,2015/2016,51,US National,4 wk ahead,2.1
+2015,51,2015/2016,51,US National,4 wk ahead,2.2
 2015,51,2015/2016,51,HHS Region 1,Season onset,51
 2015,51,2015/2016,51,HHS Region 1,Season peak week,10
 2015,51,2015/2016,51,HHS Region 1,Season peak percentage,2.5
@@ -14047,24 +14003,24 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,51,2015/2016,51,HHS Region 4,Season onset,3
 2015,51,2015/2016,51,HHS Region 4,Season peak week,10
 2015,51,2015/2016,51,HHS Region 4,Season peak percentage,3.6
-2015,51,2015/2016,51,HHS Region 4,1 wk ahead,1.7
+2015,51,2015/2016,51,HHS Region 4,1 wk ahead,1.8
 2015,51,2015/2016,51,HHS Region 4,2 wk ahead,1.4
 2015,51,2015/2016,51,HHS Region 4,3 wk ahead,1.5
-2015,51,2015/2016,51,HHS Region 4,4 wk ahead,1.7
+2015,51,2015/2016,51,HHS Region 4,4 wk ahead,1.8
 2015,51,2015/2016,51,HHS Region 5,Season onset,7
 2015,51,2015/2016,51,HHS Region 5,Season peak week,10
-2015,51,2015/2016,51,HHS Region 5,Season peak percentage,3.4
+2015,51,2015/2016,51,HHS Region 5,Season peak percentage,3.3
 2015,51,2015/2016,51,HHS Region 5,1 wk ahead,1.7
 2015,51,2015/2016,51,HHS Region 5,2 wk ahead,1.4
 2015,51,2015/2016,51,HHS Region 5,3 wk ahead,1.4
 2015,51,2015/2016,51,HHS Region 5,4 wk ahead,1.4
 2015,51,2015/2016,51,HHS Region 6,Season onset,47
 2015,51,2015/2016,51,HHS Region 6,Season peak week,7
-2015,51,2015/2016,51,HHS Region 6,Season peak percentage,5.3
-2015,51,2015/2016,51,HHS Region 6,1 wk ahead,4.6
-2015,51,2015/2016,51,HHS Region 6,2 wk ahead,3.8
-2015,51,2015/2016,51,HHS Region 6,3 wk ahead,3.5
-2015,51,2015/2016,51,HHS Region 6,4 wk ahead,3.8
+2015,51,2015/2016,51,HHS Region 6,Season peak percentage,5.6
+2015,51,2015/2016,51,HHS Region 6,1 wk ahead,5
+2015,51,2015/2016,51,HHS Region 6,2 wk ahead,4.1
+2015,51,2015/2016,51,HHS Region 6,3 wk ahead,3.8
+2015,51,2015/2016,51,HHS Region 6,4 wk ahead,4.1
 2015,51,2015/2016,51,HHS Region 7,Season onset,7
 2015,51,2015/2016,51,HHS Region 7,Season peak week,10
 2015,51,2015/2016,51,HHS Region 7,Season peak percentage,2.5
@@ -14073,7 +14029,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,51,2015/2016,51,HHS Region 7,3 wk ahead,1.1
 2015,51,2015/2016,51,HHS Region 7,4 wk ahead,1.2
 2015,51,2015/2016,51,HHS Region 8,Season onset,5
-2015,51,2015/2016,51,HHS Region 8,Season peak week,7
 2015,51,2015/2016,51,HHS Region 8,Season peak week,8
 2015,51,2015/2016,51,HHS Region 8,Season peak week,11
 2015,51,2015/2016,51,HHS Region 8,Season peak percentage,2.2
@@ -14098,9 +14053,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,52,2015/2016,52,US National,Season onset,3
 2015,52,2015/2016,52,US National,Season peak week,10
 2015,52,2015/2016,52,US National,Season peak percentage,3.6
-2015,52,2015/2016,52,US National,1 wk ahead,1.9
+2015,52,2015/2016,52,US National,1 wk ahead,2
 2015,52,2015/2016,52,US National,2 wk ahead,2
-2015,52,2015/2016,52,US National,3 wk ahead,2.1
+2015,52,2015/2016,52,US National,3 wk ahead,2.2
 2015,52,2015/2016,52,US National,4 wk ahead,2.3
 2015,52,2015/2016,52,HHS Region 1,Season onset,51
 2015,52,2015/2016,52,HHS Region 1,Season peak week,10
@@ -14128,22 +14083,22 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,52,2015/2016,52,HHS Region 4,Season peak percentage,3.6
 2015,52,2015/2016,52,HHS Region 4,1 wk ahead,1.4
 2015,52,2015/2016,52,HHS Region 4,2 wk ahead,1.5
-2015,52,2015/2016,52,HHS Region 4,3 wk ahead,1.7
+2015,52,2015/2016,52,HHS Region 4,3 wk ahead,1.8
 2015,52,2015/2016,52,HHS Region 4,4 wk ahead,1.9
 2015,52,2015/2016,52,HHS Region 5,Season onset,7
 2015,52,2015/2016,52,HHS Region 5,Season peak week,10
-2015,52,2015/2016,52,HHS Region 5,Season peak percentage,3.4
+2015,52,2015/2016,52,HHS Region 5,Season peak percentage,3.3
 2015,52,2015/2016,52,HHS Region 5,1 wk ahead,1.4
 2015,52,2015/2016,52,HHS Region 5,2 wk ahead,1.4
 2015,52,2015/2016,52,HHS Region 5,3 wk ahead,1.4
-2015,52,2015/2016,52,HHS Region 5,4 wk ahead,1.5
+2015,52,2015/2016,52,HHS Region 5,4 wk ahead,1.4
 2015,52,2015/2016,52,HHS Region 6,Season onset,47
 2015,52,2015/2016,52,HHS Region 6,Season peak week,7
-2015,52,2015/2016,52,HHS Region 6,Season peak percentage,5.3
-2015,52,2015/2016,52,HHS Region 6,1 wk ahead,3.8
-2015,52,2015/2016,52,HHS Region 6,2 wk ahead,3.5
-2015,52,2015/2016,52,HHS Region 6,3 wk ahead,3.8
-2015,52,2015/2016,52,HHS Region 6,4 wk ahead,4.2
+2015,52,2015/2016,52,HHS Region 6,Season peak percentage,5.6
+2015,52,2015/2016,52,HHS Region 6,1 wk ahead,4.1
+2015,52,2015/2016,52,HHS Region 6,2 wk ahead,3.8
+2015,52,2015/2016,52,HHS Region 6,3 wk ahead,4.1
+2015,52,2015/2016,52,HHS Region 6,4 wk ahead,4.5
 2015,52,2015/2016,52,HHS Region 7,Season onset,7
 2015,52,2015/2016,52,HHS Region 7,Season peak week,10
 2015,52,2015/2016,52,HHS Region 7,Season peak percentage,2.5
@@ -14152,7 +14107,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2015,52,2015/2016,52,HHS Region 7,3 wk ahead,1.2
 2015,52,2015/2016,52,HHS Region 7,4 wk ahead,1.2
 2015,52,2015/2016,52,HHS Region 8,Season onset,5
-2015,52,2015/2016,52,HHS Region 8,Season peak week,7
 2015,52,2015/2016,52,HHS Region 8,Season peak week,8
 2015,52,2015/2016,52,HHS Region 8,Season peak week,11
 2015,52,2015/2016,52,HHS Region 8,Season peak percentage,2.2
@@ -14178,7 +14132,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,1,2015/2016,53,US National,Season peak week,10
 2016,1,2015/2016,53,US National,Season peak percentage,3.6
 2016,1,2015/2016,53,US National,1 wk ahead,2
-2016,1,2015/2016,53,US National,2 wk ahead,2.1
+2016,1,2015/2016,53,US National,2 wk ahead,2.2
 2016,1,2015/2016,53,US National,3 wk ahead,2.3
 2016,1,2015/2016,53,US National,4 wk ahead,2.4
 2016,1,2015/2016,53,HHS Region 1,Season onset,51
@@ -14206,23 +14160,23 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,1,2015/2016,53,HHS Region 4,Season peak week,10
 2016,1,2015/2016,53,HHS Region 4,Season peak percentage,3.6
 2016,1,2015/2016,53,HHS Region 4,1 wk ahead,1.5
-2016,1,2015/2016,53,HHS Region 4,2 wk ahead,1.7
+2016,1,2015/2016,53,HHS Region 4,2 wk ahead,1.8
 2016,1,2015/2016,53,HHS Region 4,3 wk ahead,1.9
-2016,1,2015/2016,53,HHS Region 4,4 wk ahead,2
+2016,1,2015/2016,53,HHS Region 4,4 wk ahead,2.1
 2016,1,2015/2016,53,HHS Region 5,Season onset,7
 2016,1,2015/2016,53,HHS Region 5,Season peak week,10
-2016,1,2015/2016,53,HHS Region 5,Season peak percentage,3.4
+2016,1,2015/2016,53,HHS Region 5,Season peak percentage,3.3
 2016,1,2015/2016,53,HHS Region 5,1 wk ahead,1.4
 2016,1,2015/2016,53,HHS Region 5,2 wk ahead,1.4
-2016,1,2015/2016,53,HHS Region 5,3 wk ahead,1.5
+2016,1,2015/2016,53,HHS Region 5,3 wk ahead,1.4
 2016,1,2015/2016,53,HHS Region 5,4 wk ahead,1.6
 2016,1,2015/2016,53,HHS Region 6,Season onset,47
 2016,1,2015/2016,53,HHS Region 6,Season peak week,7
-2016,1,2015/2016,53,HHS Region 6,Season peak percentage,5.3
-2016,1,2015/2016,53,HHS Region 6,1 wk ahead,3.5
-2016,1,2015/2016,53,HHS Region 6,2 wk ahead,3.8
-2016,1,2015/2016,53,HHS Region 6,3 wk ahead,4.2
-2016,1,2015/2016,53,HHS Region 6,4 wk ahead,4.2
+2016,1,2015/2016,53,HHS Region 6,Season peak percentage,5.6
+2016,1,2015/2016,53,HHS Region 6,1 wk ahead,3.8
+2016,1,2015/2016,53,HHS Region 6,2 wk ahead,4.1
+2016,1,2015/2016,53,HHS Region 6,3 wk ahead,4.5
+2016,1,2015/2016,53,HHS Region 6,4 wk ahead,4.4
 2016,1,2015/2016,53,HHS Region 7,Season onset,7
 2016,1,2015/2016,53,HHS Region 7,Season peak week,10
 2016,1,2015/2016,53,HHS Region 7,Season peak percentage,2.5
@@ -14231,7 +14185,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,1,2015/2016,53,HHS Region 7,3 wk ahead,1.2
 2016,1,2015/2016,53,HHS Region 7,4 wk ahead,1.1
 2016,1,2015/2016,53,HHS Region 8,Season onset,5
-2016,1,2015/2016,53,HHS Region 8,Season peak week,7
 2016,1,2015/2016,53,HHS Region 8,Season peak week,8
 2016,1,2015/2016,53,HHS Region 8,Season peak week,11
 2016,1,2015/2016,53,HHS Region 8,Season peak percentage,2.2
@@ -14256,7 +14209,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,2,2015/2016,54,US National,Season onset,3
 2016,2,2015/2016,54,US National,Season peak week,10
 2016,2,2015/2016,54,US National,Season peak percentage,3.6
-2016,2,2015/2016,54,US National,1 wk ahead,2.1
+2016,2,2015/2016,54,US National,1 wk ahead,2.2
 2016,2,2015/2016,54,US National,2 wk ahead,2.3
 2016,2,2015/2016,54,US National,3 wk ahead,2.4
 2016,2,2015/2016,54,US National,4 wk ahead,2.8
@@ -14284,24 +14237,24 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,2,2015/2016,54,HHS Region 4,Season onset,3
 2016,2,2015/2016,54,HHS Region 4,Season peak week,10
 2016,2,2015/2016,54,HHS Region 4,Season peak percentage,3.6
-2016,2,2015/2016,54,HHS Region 4,1 wk ahead,1.7
+2016,2,2015/2016,54,HHS Region 4,1 wk ahead,1.8
 2016,2,2015/2016,54,HHS Region 4,2 wk ahead,1.9
-2016,2,2015/2016,54,HHS Region 4,3 wk ahead,2
-2016,2,2015/2016,54,HHS Region 4,4 wk ahead,2.2
+2016,2,2015/2016,54,HHS Region 4,3 wk ahead,2.1
+2016,2,2015/2016,54,HHS Region 4,4 wk ahead,2.3
 2016,2,2015/2016,54,HHS Region 5,Season onset,7
 2016,2,2015/2016,54,HHS Region 5,Season peak week,10
-2016,2,2015/2016,54,HHS Region 5,Season peak percentage,3.4
+2016,2,2015/2016,54,HHS Region 5,Season peak percentage,3.3
 2016,2,2015/2016,54,HHS Region 5,1 wk ahead,1.4
-2016,2,2015/2016,54,HHS Region 5,2 wk ahead,1.5
+2016,2,2015/2016,54,HHS Region 5,2 wk ahead,1.4
 2016,2,2015/2016,54,HHS Region 5,3 wk ahead,1.6
 2016,2,2015/2016,54,HHS Region 5,4 wk ahead,1.8
 2016,2,2015/2016,54,HHS Region 6,Season onset,47
 2016,2,2015/2016,54,HHS Region 6,Season peak week,7
-2016,2,2015/2016,54,HHS Region 6,Season peak percentage,5.3
-2016,2,2015/2016,54,HHS Region 6,1 wk ahead,3.8
-2016,2,2015/2016,54,HHS Region 6,2 wk ahead,4.2
-2016,2,2015/2016,54,HHS Region 6,3 wk ahead,4.2
-2016,2,2015/2016,54,HHS Region 6,4 wk ahead,4.8
+2016,2,2015/2016,54,HHS Region 6,Season peak percentage,5.6
+2016,2,2015/2016,54,HHS Region 6,1 wk ahead,4.1
+2016,2,2015/2016,54,HHS Region 6,2 wk ahead,4.5
+2016,2,2015/2016,54,HHS Region 6,3 wk ahead,4.4
+2016,2,2015/2016,54,HHS Region 6,4 wk ahead,5.1
 2016,2,2015/2016,54,HHS Region 7,Season onset,7
 2016,2,2015/2016,54,HHS Region 7,Season peak week,10
 2016,2,2015/2016,54,HHS Region 7,Season peak percentage,2.5
@@ -14310,7 +14263,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,2,2015/2016,54,HHS Region 7,3 wk ahead,1.1
 2016,2,2015/2016,54,HHS Region 7,4 wk ahead,1.5
 2016,2,2015/2016,54,HHS Region 8,Season onset,5
-2016,2,2015/2016,54,HHS Region 8,Season peak week,7
 2016,2,2015/2016,54,HHS Region 8,Season peak week,8
 2016,2,2015/2016,54,HHS Region 8,Season peak week,11
 2016,2,2015/2016,54,HHS Region 8,Season peak percentage,2.2
@@ -14364,23 +14316,23 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,3,2015/2016,55,HHS Region 4,Season peak week,10
 2016,3,2015/2016,55,HHS Region 4,Season peak percentage,3.6
 2016,3,2015/2016,55,HHS Region 4,1 wk ahead,1.9
-2016,3,2015/2016,55,HHS Region 4,2 wk ahead,2
-2016,3,2015/2016,55,HHS Region 4,3 wk ahead,2.2
+2016,3,2015/2016,55,HHS Region 4,2 wk ahead,2.1
+2016,3,2015/2016,55,HHS Region 4,3 wk ahead,2.3
 2016,3,2015/2016,55,HHS Region 4,4 wk ahead,2.9
 2016,3,2015/2016,55,HHS Region 5,Season onset,7
 2016,3,2015/2016,55,HHS Region 5,Season peak week,10
-2016,3,2015/2016,55,HHS Region 5,Season peak percentage,3.4
-2016,3,2015/2016,55,HHS Region 5,1 wk ahead,1.5
+2016,3,2015/2016,55,HHS Region 5,Season peak percentage,3.3
+2016,3,2015/2016,55,HHS Region 5,1 wk ahead,1.4
 2016,3,2015/2016,55,HHS Region 5,2 wk ahead,1.6
 2016,3,2015/2016,55,HHS Region 5,3 wk ahead,1.8
-2016,3,2015/2016,55,HHS Region 5,4 wk ahead,2.4
+2016,3,2015/2016,55,HHS Region 5,4 wk ahead,2.1
 2016,3,2015/2016,55,HHS Region 6,Season onset,47
 2016,3,2015/2016,55,HHS Region 6,Season peak week,7
-2016,3,2015/2016,55,HHS Region 6,Season peak percentage,5.3
-2016,3,2015/2016,55,HHS Region 6,1 wk ahead,4.2
-2016,3,2015/2016,55,HHS Region 6,2 wk ahead,4.2
-2016,3,2015/2016,55,HHS Region 6,3 wk ahead,4.8
-2016,3,2015/2016,55,HHS Region 6,4 wk ahead,5.3
+2016,3,2015/2016,55,HHS Region 6,Season peak percentage,5.6
+2016,3,2015/2016,55,HHS Region 6,1 wk ahead,4.5
+2016,3,2015/2016,55,HHS Region 6,2 wk ahead,4.4
+2016,3,2015/2016,55,HHS Region 6,3 wk ahead,5.1
+2016,3,2015/2016,55,HHS Region 6,4 wk ahead,5.6
 2016,3,2015/2016,55,HHS Region 7,Season onset,7
 2016,3,2015/2016,55,HHS Region 7,Season peak week,10
 2016,3,2015/2016,55,HHS Region 7,Season peak percentage,2.5
@@ -14389,14 +14341,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,3,2015/2016,55,HHS Region 7,3 wk ahead,1.5
 2016,3,2015/2016,55,HHS Region 7,4 wk ahead,1.8
 2016,3,2015/2016,55,HHS Region 8,Season onset,5
-2016,3,2015/2016,55,HHS Region 8,Season peak week,7
 2016,3,2015/2016,55,HHS Region 8,Season peak week,8
 2016,3,2015/2016,55,HHS Region 8,Season peak week,11
 2016,3,2015/2016,55,HHS Region 8,Season peak percentage,2.2
 2016,3,2015/2016,55,HHS Region 8,1 wk ahead,1.3
 2016,3,2015/2016,55,HHS Region 8,2 wk ahead,1.6
 2016,3,2015/2016,55,HHS Region 8,3 wk ahead,1.8
-2016,3,2015/2016,55,HHS Region 8,4 wk ahead,2.2
+2016,3,2015/2016,55,HHS Region 8,4 wk ahead,2.1
 2016,3,2015/2016,55,HHS Region 9,Season onset,3
 2016,3,2015/2016,55,HHS Region 9,Season peak week,7
 2016,3,2015/2016,55,HHS Region 9,Season peak percentage,4.4
@@ -14442,24 +14393,24 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,4,2015/2016,56,HHS Region 4,Season onset,3
 2016,4,2015/2016,56,HHS Region 4,Season peak week,10
 2016,4,2015/2016,56,HHS Region 4,Season peak percentage,3.6
-2016,4,2015/2016,56,HHS Region 4,1 wk ahead,2
-2016,4,2015/2016,56,HHS Region 4,2 wk ahead,2.2
+2016,4,2015/2016,56,HHS Region 4,1 wk ahead,2.1
+2016,4,2015/2016,56,HHS Region 4,2 wk ahead,2.3
 2016,4,2015/2016,56,HHS Region 4,3 wk ahead,2.9
-2016,4,2015/2016,56,HHS Region 4,4 wk ahead,3.3
+2016,4,2015/2016,56,HHS Region 4,4 wk ahead,3.4
 2016,4,2015/2016,56,HHS Region 5,Season onset,7
 2016,4,2015/2016,56,HHS Region 5,Season peak week,10
-2016,4,2015/2016,56,HHS Region 5,Season peak percentage,3.4
+2016,4,2015/2016,56,HHS Region 5,Season peak percentage,3.3
 2016,4,2015/2016,56,HHS Region 5,1 wk ahead,1.6
 2016,4,2015/2016,56,HHS Region 5,2 wk ahead,1.8
-2016,4,2015/2016,56,HHS Region 5,3 wk ahead,2.4
-2016,4,2015/2016,56,HHS Region 5,4 wk ahead,2.7
+2016,4,2015/2016,56,HHS Region 5,3 wk ahead,2.1
+2016,4,2015/2016,56,HHS Region 5,4 wk ahead,2.6
 2016,4,2015/2016,56,HHS Region 6,Season onset,47
 2016,4,2015/2016,56,HHS Region 6,Season peak week,7
-2016,4,2015/2016,56,HHS Region 6,Season peak percentage,5.3
-2016,4,2015/2016,56,HHS Region 6,1 wk ahead,4.2
-2016,4,2015/2016,56,HHS Region 6,2 wk ahead,4.8
-2016,4,2015/2016,56,HHS Region 6,3 wk ahead,5.3
-2016,4,2015/2016,56,HHS Region 6,4 wk ahead,4.2
+2016,4,2015/2016,56,HHS Region 6,Season peak percentage,5.6
+2016,4,2015/2016,56,HHS Region 6,1 wk ahead,4.4
+2016,4,2015/2016,56,HHS Region 6,2 wk ahead,5.1
+2016,4,2015/2016,56,HHS Region 6,3 wk ahead,5.6
+2016,4,2015/2016,56,HHS Region 6,4 wk ahead,4.5
 2016,4,2015/2016,56,HHS Region 7,Season onset,7
 2016,4,2015/2016,56,HHS Region 7,Season peak week,10
 2016,4,2015/2016,56,HHS Region 7,Season peak percentage,2.5
@@ -14468,13 +14419,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,4,2015/2016,56,HHS Region 7,3 wk ahead,1.8
 2016,4,2015/2016,56,HHS Region 7,4 wk ahead,1.8
 2016,4,2015/2016,56,HHS Region 8,Season onset,5
-2016,4,2015/2016,56,HHS Region 8,Season peak week,7
 2016,4,2015/2016,56,HHS Region 8,Season peak week,8
 2016,4,2015/2016,56,HHS Region 8,Season peak week,11
 2016,4,2015/2016,56,HHS Region 8,Season peak percentage,2.2
 2016,4,2015/2016,56,HHS Region 8,1 wk ahead,1.6
 2016,4,2015/2016,56,HHS Region 8,2 wk ahead,1.8
-2016,4,2015/2016,56,HHS Region 8,3 wk ahead,2.2
+2016,4,2015/2016,56,HHS Region 8,3 wk ahead,2.1
 2016,4,2015/2016,56,HHS Region 8,4 wk ahead,2.2
 2016,4,2015/2016,56,HHS Region 9,Season onset,3
 2016,4,2015/2016,56,HHS Region 9,Season peak week,7
@@ -14521,24 +14471,24 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,5,2015/2016,57,HHS Region 4,Season onset,3
 2016,5,2015/2016,57,HHS Region 4,Season peak week,10
 2016,5,2015/2016,57,HHS Region 4,Season peak percentage,3.6
-2016,5,2015/2016,57,HHS Region 4,1 wk ahead,2.2
+2016,5,2015/2016,57,HHS Region 4,1 wk ahead,2.3
 2016,5,2015/2016,57,HHS Region 4,2 wk ahead,2.9
-2016,5,2015/2016,57,HHS Region 4,3 wk ahead,3.3
+2016,5,2015/2016,57,HHS Region 4,3 wk ahead,3.4
 2016,5,2015/2016,57,HHS Region 4,4 wk ahead,3.3
 2016,5,2015/2016,57,HHS Region 5,Season onset,7
 2016,5,2015/2016,57,HHS Region 5,Season peak week,10
-2016,5,2015/2016,57,HHS Region 5,Season peak percentage,3.4
+2016,5,2015/2016,57,HHS Region 5,Season peak percentage,3.3
 2016,5,2015/2016,57,HHS Region 5,1 wk ahead,1.8
-2016,5,2015/2016,57,HHS Region 5,2 wk ahead,2.4
-2016,5,2015/2016,57,HHS Region 5,3 wk ahead,2.7
-2016,5,2015/2016,57,HHS Region 5,4 wk ahead,3
+2016,5,2015/2016,57,HHS Region 5,2 wk ahead,2.1
+2016,5,2015/2016,57,HHS Region 5,3 wk ahead,2.6
+2016,5,2015/2016,57,HHS Region 5,4 wk ahead,2.9
 2016,5,2015/2016,57,HHS Region 6,Season onset,47
 2016,5,2015/2016,57,HHS Region 6,Season peak week,7
-2016,5,2015/2016,57,HHS Region 6,Season peak percentage,5.3
-2016,5,2015/2016,57,HHS Region 6,1 wk ahead,4.8
-2016,5,2015/2016,57,HHS Region 6,2 wk ahead,5.3
-2016,5,2015/2016,57,HHS Region 6,3 wk ahead,4.2
-2016,5,2015/2016,57,HHS Region 6,4 wk ahead,4.5
+2016,5,2015/2016,57,HHS Region 6,Season peak percentage,5.6
+2016,5,2015/2016,57,HHS Region 6,1 wk ahead,5.1
+2016,5,2015/2016,57,HHS Region 6,2 wk ahead,5.6
+2016,5,2015/2016,57,HHS Region 6,3 wk ahead,4.5
+2016,5,2015/2016,57,HHS Region 6,4 wk ahead,4.7
 2016,5,2015/2016,57,HHS Region 7,Season onset,7
 2016,5,2015/2016,57,HHS Region 7,Season peak week,10
 2016,5,2015/2016,57,HHS Region 7,Season peak percentage,2.5
@@ -14547,12 +14497,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,5,2015/2016,57,HHS Region 7,3 wk ahead,1.8
 2016,5,2015/2016,57,HHS Region 7,4 wk ahead,2.4
 2016,5,2015/2016,57,HHS Region 8,Season onset,5
-2016,5,2015/2016,57,HHS Region 8,Season peak week,7
 2016,5,2015/2016,57,HHS Region 8,Season peak week,8
 2016,5,2015/2016,57,HHS Region 8,Season peak week,11
 2016,5,2015/2016,57,HHS Region 8,Season peak percentage,2.2
 2016,5,2015/2016,57,HHS Region 8,1 wk ahead,1.8
-2016,5,2015/2016,57,HHS Region 8,2 wk ahead,2.2
+2016,5,2015/2016,57,HHS Region 8,2 wk ahead,2.1
 2016,5,2015/2016,57,HHS Region 8,3 wk ahead,2.2
 2016,5,2015/2016,57,HHS Region 8,4 wk ahead,2
 2016,5,2015/2016,57,HHS Region 9,Season onset,3
@@ -14601,23 +14550,23 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,6,2015/2016,58,HHS Region 4,Season peak week,10
 2016,6,2015/2016,58,HHS Region 4,Season peak percentage,3.6
 2016,6,2015/2016,58,HHS Region 4,1 wk ahead,2.9
-2016,6,2015/2016,58,HHS Region 4,2 wk ahead,3.3
+2016,6,2015/2016,58,HHS Region 4,2 wk ahead,3.4
 2016,6,2015/2016,58,HHS Region 4,3 wk ahead,3.3
 2016,6,2015/2016,58,HHS Region 4,4 wk ahead,3.6
 2016,6,2015/2016,58,HHS Region 5,Season onset,7
 2016,6,2015/2016,58,HHS Region 5,Season peak week,10
-2016,6,2015/2016,58,HHS Region 5,Season peak percentage,3.4
-2016,6,2015/2016,58,HHS Region 5,1 wk ahead,2.4
-2016,6,2015/2016,58,HHS Region 5,2 wk ahead,2.7
-2016,6,2015/2016,58,HHS Region 5,3 wk ahead,3
-2016,6,2015/2016,58,HHS Region 5,4 wk ahead,3.4
+2016,6,2015/2016,58,HHS Region 5,Season peak percentage,3.3
+2016,6,2015/2016,58,HHS Region 5,1 wk ahead,2.1
+2016,6,2015/2016,58,HHS Region 5,2 wk ahead,2.6
+2016,6,2015/2016,58,HHS Region 5,3 wk ahead,2.9
+2016,6,2015/2016,58,HHS Region 5,4 wk ahead,3.3
 2016,6,2015/2016,58,HHS Region 6,Season onset,47
 2016,6,2015/2016,58,HHS Region 6,Season peak week,7
-2016,6,2015/2016,58,HHS Region 6,Season peak percentage,5.3
-2016,6,2015/2016,58,HHS Region 6,1 wk ahead,5.3
-2016,6,2015/2016,58,HHS Region 6,2 wk ahead,4.2
-2016,6,2015/2016,58,HHS Region 6,3 wk ahead,4.5
-2016,6,2015/2016,58,HHS Region 6,4 wk ahead,4.1
+2016,6,2015/2016,58,HHS Region 6,Season peak percentage,5.6
+2016,6,2015/2016,58,HHS Region 6,1 wk ahead,5.6
+2016,6,2015/2016,58,HHS Region 6,2 wk ahead,4.5
+2016,6,2015/2016,58,HHS Region 6,3 wk ahead,4.7
+2016,6,2015/2016,58,HHS Region 6,4 wk ahead,4.4
 2016,6,2015/2016,58,HHS Region 7,Season onset,7
 2016,6,2015/2016,58,HHS Region 7,Season peak week,10
 2016,6,2015/2016,58,HHS Region 7,Season peak percentage,2.5
@@ -14626,11 +14575,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,6,2015/2016,58,HHS Region 7,3 wk ahead,2.4
 2016,6,2015/2016,58,HHS Region 7,4 wk ahead,2.5
 2016,6,2015/2016,58,HHS Region 8,Season onset,5
-2016,6,2015/2016,58,HHS Region 8,Season peak week,7
 2016,6,2015/2016,58,HHS Region 8,Season peak week,8
 2016,6,2015/2016,58,HHS Region 8,Season peak week,11
 2016,6,2015/2016,58,HHS Region 8,Season peak percentage,2.2
-2016,6,2015/2016,58,HHS Region 8,1 wk ahead,2.2
+2016,6,2015/2016,58,HHS Region 8,1 wk ahead,2.1
 2016,6,2015/2016,58,HHS Region 8,2 wk ahead,2.2
 2016,6,2015/2016,58,HHS Region 8,3 wk ahead,2
 2016,6,2015/2016,58,HHS Region 8,4 wk ahead,2.1
@@ -14679,24 +14627,24 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,7,2015/2016,59,HHS Region 4,Season onset,3
 2016,7,2015/2016,59,HHS Region 4,Season peak week,10
 2016,7,2015/2016,59,HHS Region 4,Season peak percentage,3.6
-2016,7,2015/2016,59,HHS Region 4,1 wk ahead,3.3
+2016,7,2015/2016,59,HHS Region 4,1 wk ahead,3.4
 2016,7,2015/2016,59,HHS Region 4,2 wk ahead,3.3
 2016,7,2015/2016,59,HHS Region 4,3 wk ahead,3.6
 2016,7,2015/2016,59,HHS Region 4,4 wk ahead,2.9
 2016,7,2015/2016,59,HHS Region 5,Season onset,7
 2016,7,2015/2016,59,HHS Region 5,Season peak week,10
-2016,7,2015/2016,59,HHS Region 5,Season peak percentage,3.4
-2016,7,2015/2016,59,HHS Region 5,1 wk ahead,2.7
-2016,7,2015/2016,59,HHS Region 5,2 wk ahead,3
-2016,7,2015/2016,59,HHS Region 5,3 wk ahead,3.4
+2016,7,2015/2016,59,HHS Region 5,Season peak percentage,3.3
+2016,7,2015/2016,59,HHS Region 5,1 wk ahead,2.6
+2016,7,2015/2016,59,HHS Region 5,2 wk ahead,2.9
+2016,7,2015/2016,59,HHS Region 5,3 wk ahead,3.3
 2016,7,2015/2016,59,HHS Region 5,4 wk ahead,2.6
 2016,7,2015/2016,59,HHS Region 6,Season onset,47
 2016,7,2015/2016,59,HHS Region 6,Season peak week,7
-2016,7,2015/2016,59,HHS Region 6,Season peak percentage,5.3
-2016,7,2015/2016,59,HHS Region 6,1 wk ahead,4.2
-2016,7,2015/2016,59,HHS Region 6,2 wk ahead,4.5
-2016,7,2015/2016,59,HHS Region 6,3 wk ahead,4.1
-2016,7,2015/2016,59,HHS Region 6,4 wk ahead,3.7
+2016,7,2015/2016,59,HHS Region 6,Season peak percentage,5.6
+2016,7,2015/2016,59,HHS Region 6,1 wk ahead,4.5
+2016,7,2015/2016,59,HHS Region 6,2 wk ahead,4.7
+2016,7,2015/2016,59,HHS Region 6,3 wk ahead,4.4
+2016,7,2015/2016,59,HHS Region 6,4 wk ahead,3.9
 2016,7,2015/2016,59,HHS Region 7,Season onset,7
 2016,7,2015/2016,59,HHS Region 7,Season peak week,10
 2016,7,2015/2016,59,HHS Region 7,Season peak percentage,2.5
@@ -14705,7 +14653,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,7,2015/2016,59,HHS Region 7,3 wk ahead,2.5
 2016,7,2015/2016,59,HHS Region 7,4 wk ahead,2
 2016,7,2015/2016,59,HHS Region 8,Season onset,5
-2016,7,2015/2016,59,HHS Region 8,Season peak week,7
 2016,7,2015/2016,59,HHS Region 8,Season peak week,8
 2016,7,2015/2016,59,HHS Region 8,Season peak week,11
 2016,7,2015/2016,59,HHS Region 8,Season peak percentage,2.2
@@ -14764,18 +14711,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,8,2015/2016,60,HHS Region 4,4 wk ahead,2.8
 2016,8,2015/2016,60,HHS Region 5,Season onset,7
 2016,8,2015/2016,60,HHS Region 5,Season peak week,10
-2016,8,2015/2016,60,HHS Region 5,Season peak percentage,3.4
-2016,8,2015/2016,60,HHS Region 5,1 wk ahead,3
-2016,8,2015/2016,60,HHS Region 5,2 wk ahead,3.4
+2016,8,2015/2016,60,HHS Region 5,Season peak percentage,3.3
+2016,8,2015/2016,60,HHS Region 5,1 wk ahead,2.9
+2016,8,2015/2016,60,HHS Region 5,2 wk ahead,3.3
 2016,8,2015/2016,60,HHS Region 5,3 wk ahead,2.6
 2016,8,2015/2016,60,HHS Region 5,4 wk ahead,2.3
 2016,8,2015/2016,60,HHS Region 6,Season onset,47
 2016,8,2015/2016,60,HHS Region 6,Season peak week,7
-2016,8,2015/2016,60,HHS Region 6,Season peak percentage,5.3
-2016,8,2015/2016,60,HHS Region 6,1 wk ahead,4.5
-2016,8,2015/2016,60,HHS Region 6,2 wk ahead,4.1
-2016,8,2015/2016,60,HHS Region 6,3 wk ahead,3.7
-2016,8,2015/2016,60,HHS Region 6,4 wk ahead,3.4
+2016,8,2015/2016,60,HHS Region 6,Season peak percentage,5.6
+2016,8,2015/2016,60,HHS Region 6,1 wk ahead,4.7
+2016,8,2015/2016,60,HHS Region 6,2 wk ahead,4.4
+2016,8,2015/2016,60,HHS Region 6,3 wk ahead,3.9
+2016,8,2015/2016,60,HHS Region 6,4 wk ahead,3.6
 2016,8,2015/2016,60,HHS Region 7,Season onset,7
 2016,8,2015/2016,60,HHS Region 7,Season peak week,10
 2016,8,2015/2016,60,HHS Region 7,Season peak percentage,2.5
@@ -14784,7 +14731,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,8,2015/2016,60,HHS Region 7,3 wk ahead,2
 2016,8,2015/2016,60,HHS Region 7,4 wk ahead,2.1
 2016,8,2015/2016,60,HHS Region 8,Season onset,5
-2016,8,2015/2016,60,HHS Region 8,Season peak week,7
 2016,8,2015/2016,60,HHS Region 8,Season peak week,8
 2016,8,2015/2016,60,HHS Region 8,Season peak week,11
 2016,8,2015/2016,60,HHS Region 8,Season peak percentage,2.2
@@ -14812,7 +14758,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,9,2015/2016,61,US National,1 wk ahead,3.6
 2016,9,2015/2016,61,US National,2 wk ahead,3.1
 2016,9,2015/2016,61,US National,3 wk ahead,2.8
-2016,9,2015/2016,61,US National,4 wk ahead,2.4
+2016,9,2015/2016,61,US National,4 wk ahead,2.5
 2016,9,2015/2016,61,HHS Region 1,Season onset,51
 2016,9,2015/2016,61,HHS Region 1,Season peak week,10
 2016,9,2015/2016,61,HHS Region 1,Season peak percentage,2.5
@@ -14843,18 +14789,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,9,2015/2016,61,HHS Region 4,4 wk ahead,2.7
 2016,9,2015/2016,61,HHS Region 5,Season onset,7
 2016,9,2015/2016,61,HHS Region 5,Season peak week,10
-2016,9,2015/2016,61,HHS Region 5,Season peak percentage,3.4
-2016,9,2015/2016,61,HHS Region 5,1 wk ahead,3.4
+2016,9,2015/2016,61,HHS Region 5,Season peak percentage,3.3
+2016,9,2015/2016,61,HHS Region 5,1 wk ahead,3.3
 2016,9,2015/2016,61,HHS Region 5,2 wk ahead,2.6
 2016,9,2015/2016,61,HHS Region 5,3 wk ahead,2.3
 2016,9,2015/2016,61,HHS Region 5,4 wk ahead,2
 2016,9,2015/2016,61,HHS Region 6,Season onset,47
 2016,9,2015/2016,61,HHS Region 6,Season peak week,7
-2016,9,2015/2016,61,HHS Region 6,Season peak percentage,5.3
-2016,9,2015/2016,61,HHS Region 6,1 wk ahead,4.1
-2016,9,2015/2016,61,HHS Region 6,2 wk ahead,3.7
-2016,9,2015/2016,61,HHS Region 6,3 wk ahead,3.4
-2016,9,2015/2016,61,HHS Region 6,4 wk ahead,3.1
+2016,9,2015/2016,61,HHS Region 6,Season peak percentage,5.6
+2016,9,2015/2016,61,HHS Region 6,1 wk ahead,4.4
+2016,9,2015/2016,61,HHS Region 6,2 wk ahead,3.9
+2016,9,2015/2016,61,HHS Region 6,3 wk ahead,3.6
+2016,9,2015/2016,61,HHS Region 6,4 wk ahead,3.3
 2016,9,2015/2016,61,HHS Region 7,Season onset,7
 2016,9,2015/2016,61,HHS Region 7,Season peak week,10
 2016,9,2015/2016,61,HHS Region 7,Season peak percentage,2.5
@@ -14863,7 +14809,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,9,2015/2016,61,HHS Region 7,3 wk ahead,2.1
 2016,9,2015/2016,61,HHS Region 7,4 wk ahead,2.1
 2016,9,2015/2016,61,HHS Region 8,Season onset,5
-2016,9,2015/2016,61,HHS Region 8,Season peak week,7
 2016,9,2015/2016,61,HHS Region 8,Season peak week,8
 2016,9,2015/2016,61,HHS Region 8,Season peak week,11
 2016,9,2015/2016,61,HHS Region 8,Season peak percentage,2.2
@@ -14890,8 +14835,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,10,2015/2016,62,US National,Season peak percentage,3.6
 2016,10,2015/2016,62,US National,1 wk ahead,3.1
 2016,10,2015/2016,62,US National,2 wk ahead,2.8
-2016,10,2015/2016,62,US National,3 wk ahead,2.4
-2016,10,2015/2016,62,US National,4 wk ahead,2
+2016,10,2015/2016,62,US National,3 wk ahead,2.5
+2016,10,2015/2016,62,US National,4 wk ahead,2.1
 2016,10,2015/2016,62,HHS Region 1,Season onset,51
 2016,10,2015/2016,62,HHS Region 1,Season peak week,10
 2016,10,2015/2016,62,HHS Region 1,Season peak percentage,2.5
@@ -14922,18 +14867,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,10,2015/2016,62,HHS Region 4,4 wk ahead,2.1
 2016,10,2015/2016,62,HHS Region 5,Season onset,7
 2016,10,2015/2016,62,HHS Region 5,Season peak week,10
-2016,10,2015/2016,62,HHS Region 5,Season peak percentage,3.4
+2016,10,2015/2016,62,HHS Region 5,Season peak percentage,3.3
 2016,10,2015/2016,62,HHS Region 5,1 wk ahead,2.6
 2016,10,2015/2016,62,HHS Region 5,2 wk ahead,2.3
 2016,10,2015/2016,62,HHS Region 5,3 wk ahead,2
 2016,10,2015/2016,62,HHS Region 5,4 wk ahead,1.6
 2016,10,2015/2016,62,HHS Region 6,Season onset,47
 2016,10,2015/2016,62,HHS Region 6,Season peak week,7
-2016,10,2015/2016,62,HHS Region 6,Season peak percentage,5.3
-2016,10,2015/2016,62,HHS Region 6,1 wk ahead,3.7
-2016,10,2015/2016,62,HHS Region 6,2 wk ahead,3.4
-2016,10,2015/2016,62,HHS Region 6,3 wk ahead,3.1
-2016,10,2015/2016,62,HHS Region 6,4 wk ahead,2.7
+2016,10,2015/2016,62,HHS Region 6,Season peak percentage,5.6
+2016,10,2015/2016,62,HHS Region 6,1 wk ahead,3.9
+2016,10,2015/2016,62,HHS Region 6,2 wk ahead,3.6
+2016,10,2015/2016,62,HHS Region 6,3 wk ahead,3.3
+2016,10,2015/2016,62,HHS Region 6,4 wk ahead,2.9
 2016,10,2015/2016,62,HHS Region 7,Season onset,7
 2016,10,2015/2016,62,HHS Region 7,Season peak week,10
 2016,10,2015/2016,62,HHS Region 7,Season peak percentage,2.5
@@ -14942,21 +14887,20 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,10,2015/2016,62,HHS Region 7,3 wk ahead,2.1
 2016,10,2015/2016,62,HHS Region 7,4 wk ahead,1.5
 2016,10,2015/2016,62,HHS Region 8,Season onset,5
-2016,10,2015/2016,62,HHS Region 8,Season peak week,7
 2016,10,2015/2016,62,HHS Region 8,Season peak week,8
 2016,10,2015/2016,62,HHS Region 8,Season peak week,11
 2016,10,2015/2016,62,HHS Region 8,Season peak percentage,2.2
 2016,10,2015/2016,62,HHS Region 8,1 wk ahead,2.2
 2016,10,2015/2016,62,HHS Region 8,2 wk ahead,1.9
 2016,10,2015/2016,62,HHS Region 8,3 wk ahead,1.8
-2016,10,2015/2016,62,HHS Region 8,4 wk ahead,1.6
+2016,10,2015/2016,62,HHS Region 8,4 wk ahead,1.7
 2016,10,2015/2016,62,HHS Region 9,Season onset,3
 2016,10,2015/2016,62,HHS Region 9,Season peak week,7
 2016,10,2015/2016,62,HHS Region 9,Season peak percentage,4.4
 2016,10,2015/2016,62,HHS Region 9,1 wk ahead,3.3
 2016,10,2015/2016,62,HHS Region 9,2 wk ahead,3
 2016,10,2015/2016,62,HHS Region 9,3 wk ahead,2.8
-2016,10,2015/2016,62,HHS Region 9,4 wk ahead,2.2
+2016,10,2015/2016,62,HHS Region 9,4 wk ahead,2.3
 2016,10,2015/2016,62,HHS Region 10,Season onset,2
 2016,10,2015/2016,62,HHS Region 10,Season peak week,7
 2016,10,2015/2016,62,HHS Region 10,Season peak percentage,2.4
@@ -14968,8 +14912,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,11,2015/2016,63,US National,Season peak week,10
 2016,11,2015/2016,63,US National,Season peak percentage,3.6
 2016,11,2015/2016,63,US National,1 wk ahead,2.8
-2016,11,2015/2016,63,US National,2 wk ahead,2.4
-2016,11,2015/2016,63,US National,3 wk ahead,2
+2016,11,2015/2016,63,US National,2 wk ahead,2.5
+2016,11,2015/2016,63,US National,3 wk ahead,2.1
 2016,11,2015/2016,63,US National,4 wk ahead,2
 2016,11,2015/2016,63,HHS Region 1,Season onset,51
 2016,11,2015/2016,63,HHS Region 1,Season peak week,10
@@ -15001,18 +14945,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,11,2015/2016,63,HHS Region 4,4 wk ahead,2
 2016,11,2015/2016,63,HHS Region 5,Season onset,7
 2016,11,2015/2016,63,HHS Region 5,Season peak week,10
-2016,11,2015/2016,63,HHS Region 5,Season peak percentage,3.4
+2016,11,2015/2016,63,HHS Region 5,Season peak percentage,3.3
 2016,11,2015/2016,63,HHS Region 5,1 wk ahead,2.3
 2016,11,2015/2016,63,HHS Region 5,2 wk ahead,2
 2016,11,2015/2016,63,HHS Region 5,3 wk ahead,1.6
 2016,11,2015/2016,63,HHS Region 5,4 wk ahead,1.5
 2016,11,2015/2016,63,HHS Region 6,Season onset,47
 2016,11,2015/2016,63,HHS Region 6,Season peak week,7
-2016,11,2015/2016,63,HHS Region 6,Season peak percentage,5.3
-2016,11,2015/2016,63,HHS Region 6,1 wk ahead,3.4
-2016,11,2015/2016,63,HHS Region 6,2 wk ahead,3.1
-2016,11,2015/2016,63,HHS Region 6,3 wk ahead,2.7
-2016,11,2015/2016,63,HHS Region 6,4 wk ahead,3
+2016,11,2015/2016,63,HHS Region 6,Season peak percentage,5.6
+2016,11,2015/2016,63,HHS Region 6,1 wk ahead,3.6
+2016,11,2015/2016,63,HHS Region 6,2 wk ahead,3.3
+2016,11,2015/2016,63,HHS Region 6,3 wk ahead,2.9
+2016,11,2015/2016,63,HHS Region 6,4 wk ahead,3.1
 2016,11,2015/2016,63,HHS Region 7,Season onset,7
 2016,11,2015/2016,63,HHS Region 7,Season peak week,10
 2016,11,2015/2016,63,HHS Region 7,Season peak percentage,2.5
@@ -15021,20 +14965,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,11,2015/2016,63,HHS Region 7,3 wk ahead,1.5
 2016,11,2015/2016,63,HHS Region 7,4 wk ahead,1.4
 2016,11,2015/2016,63,HHS Region 8,Season onset,5
-2016,11,2015/2016,63,HHS Region 8,Season peak week,7
 2016,11,2015/2016,63,HHS Region 8,Season peak week,8
 2016,11,2015/2016,63,HHS Region 8,Season peak week,11
 2016,11,2015/2016,63,HHS Region 8,Season peak percentage,2.2
 2016,11,2015/2016,63,HHS Region 8,1 wk ahead,1.9
 2016,11,2015/2016,63,HHS Region 8,2 wk ahead,1.8
-2016,11,2015/2016,63,HHS Region 8,3 wk ahead,1.6
+2016,11,2015/2016,63,HHS Region 8,3 wk ahead,1.7
 2016,11,2015/2016,63,HHS Region 8,4 wk ahead,1.3
 2016,11,2015/2016,63,HHS Region 9,Season onset,3
 2016,11,2015/2016,63,HHS Region 9,Season peak week,7
 2016,11,2015/2016,63,HHS Region 9,Season peak percentage,4.4
 2016,11,2015/2016,63,HHS Region 9,1 wk ahead,3
 2016,11,2015/2016,63,HHS Region 9,2 wk ahead,2.8
-2016,11,2015/2016,63,HHS Region 9,3 wk ahead,2.2
+2016,11,2015/2016,63,HHS Region 9,3 wk ahead,2.3
 2016,11,2015/2016,63,HHS Region 9,4 wk ahead,2
 2016,11,2015/2016,63,HHS Region 10,Season onset,2
 2016,11,2015/2016,63,HHS Region 10,Season peak week,7
@@ -15046,8 +14989,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,12,2015/2016,64,US National,Season onset,3
 2016,12,2015/2016,64,US National,Season peak week,10
 2016,12,2015/2016,64,US National,Season peak percentage,3.6
-2016,12,2015/2016,64,US National,1 wk ahead,2.4
-2016,12,2015/2016,64,US National,2 wk ahead,2
+2016,12,2015/2016,64,US National,1 wk ahead,2.5
+2016,12,2015/2016,64,US National,2 wk ahead,2.1
 2016,12,2015/2016,64,US National,3 wk ahead,2
 2016,12,2015/2016,64,US National,4 wk ahead,1.9
 2016,12,2015/2016,64,HHS Region 1,Season onset,51
@@ -15080,18 +15023,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,12,2015/2016,64,HHS Region 4,4 wk ahead,2
 2016,12,2015/2016,64,HHS Region 5,Season onset,7
 2016,12,2015/2016,64,HHS Region 5,Season peak week,10
-2016,12,2015/2016,64,HHS Region 5,Season peak percentage,3.4
+2016,12,2015/2016,64,HHS Region 5,Season peak percentage,3.3
 2016,12,2015/2016,64,HHS Region 5,1 wk ahead,2
 2016,12,2015/2016,64,HHS Region 5,2 wk ahead,1.6
 2016,12,2015/2016,64,HHS Region 5,3 wk ahead,1.5
 2016,12,2015/2016,64,HHS Region 5,4 wk ahead,1.5
 2016,12,2015/2016,64,HHS Region 6,Season onset,47
 2016,12,2015/2016,64,HHS Region 6,Season peak week,7
-2016,12,2015/2016,64,HHS Region 6,Season peak percentage,5.3
-2016,12,2015/2016,64,HHS Region 6,1 wk ahead,3.1
-2016,12,2015/2016,64,HHS Region 6,2 wk ahead,2.7
-2016,12,2015/2016,64,HHS Region 6,3 wk ahead,3
-2016,12,2015/2016,64,HHS Region 6,4 wk ahead,3.1
+2016,12,2015/2016,64,HHS Region 6,Season peak percentage,5.6
+2016,12,2015/2016,64,HHS Region 6,1 wk ahead,3.3
+2016,12,2015/2016,64,HHS Region 6,2 wk ahead,2.9
+2016,12,2015/2016,64,HHS Region 6,3 wk ahead,3.1
+2016,12,2015/2016,64,HHS Region 6,4 wk ahead,3
 2016,12,2015/2016,64,HHS Region 7,Season onset,7
 2016,12,2015/2016,64,HHS Region 7,Season peak week,10
 2016,12,2015/2016,64,HHS Region 7,Season peak percentage,2.5
@@ -15100,19 +15043,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,12,2015/2016,64,HHS Region 7,3 wk ahead,1.4
 2016,12,2015/2016,64,HHS Region 7,4 wk ahead,1.2
 2016,12,2015/2016,64,HHS Region 8,Season onset,5
-2016,12,2015/2016,64,HHS Region 8,Season peak week,7
 2016,12,2015/2016,64,HHS Region 8,Season peak week,8
 2016,12,2015/2016,64,HHS Region 8,Season peak week,11
 2016,12,2015/2016,64,HHS Region 8,Season peak percentage,2.2
 2016,12,2015/2016,64,HHS Region 8,1 wk ahead,1.8
-2016,12,2015/2016,64,HHS Region 8,2 wk ahead,1.6
+2016,12,2015/2016,64,HHS Region 8,2 wk ahead,1.7
 2016,12,2015/2016,64,HHS Region 8,3 wk ahead,1.3
-2016,12,2015/2016,64,HHS Region 8,4 wk ahead,1.1
+2016,12,2015/2016,64,HHS Region 8,4 wk ahead,1.2
 2016,12,2015/2016,64,HHS Region 9,Season onset,3
 2016,12,2015/2016,64,HHS Region 9,Season peak week,7
 2016,12,2015/2016,64,HHS Region 9,Season peak percentage,4.4
 2016,12,2015/2016,64,HHS Region 9,1 wk ahead,2.8
-2016,12,2015/2016,64,HHS Region 9,2 wk ahead,2.2
+2016,12,2015/2016,64,HHS Region 9,2 wk ahead,2.3
 2016,12,2015/2016,64,HHS Region 9,3 wk ahead,2
 2016,12,2015/2016,64,HHS Region 9,4 wk ahead,1.8
 2016,12,2015/2016,64,HHS Region 10,Season onset,2
@@ -15125,7 +15067,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,13,2015/2016,65,US National,Season onset,3
 2016,13,2015/2016,65,US National,Season peak week,10
 2016,13,2015/2016,65,US National,Season peak percentage,3.6
-2016,13,2015/2016,65,US National,1 wk ahead,2
+2016,13,2015/2016,65,US National,1 wk ahead,2.1
 2016,13,2015/2016,65,US National,2 wk ahead,2
 2016,13,2015/2016,65,US National,3 wk ahead,1.9
 2016,13,2015/2016,65,US National,4 wk ahead,1.7
@@ -15159,18 +15101,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,13,2015/2016,65,HHS Region 4,4 wk ahead,1.8
 2016,13,2015/2016,65,HHS Region 5,Season onset,7
 2016,13,2015/2016,65,HHS Region 5,Season peak week,10
-2016,13,2015/2016,65,HHS Region 5,Season peak percentage,3.4
+2016,13,2015/2016,65,HHS Region 5,Season peak percentage,3.3
 2016,13,2015/2016,65,HHS Region 5,1 wk ahead,1.6
 2016,13,2015/2016,65,HHS Region 5,2 wk ahead,1.5
 2016,13,2015/2016,65,HHS Region 5,3 wk ahead,1.5
-2016,13,2015/2016,65,HHS Region 5,4 wk ahead,1.3
+2016,13,2015/2016,65,HHS Region 5,4 wk ahead,1.4
 2016,13,2015/2016,65,HHS Region 6,Season onset,47
 2016,13,2015/2016,65,HHS Region 6,Season peak week,7
-2016,13,2015/2016,65,HHS Region 6,Season peak percentage,5.3
-2016,13,2015/2016,65,HHS Region 6,1 wk ahead,2.7
-2016,13,2015/2016,65,HHS Region 6,2 wk ahead,3
-2016,13,2015/2016,65,HHS Region 6,3 wk ahead,3.1
-2016,13,2015/2016,65,HHS Region 6,4 wk ahead,2.6
+2016,13,2015/2016,65,HHS Region 6,Season peak percentage,5.6
+2016,13,2015/2016,65,HHS Region 6,1 wk ahead,2.9
+2016,13,2015/2016,65,HHS Region 6,2 wk ahead,3.1
+2016,13,2015/2016,65,HHS Region 6,3 wk ahead,3
+2016,13,2015/2016,65,HHS Region 6,4 wk ahead,2.8
 2016,13,2015/2016,65,HHS Region 7,Season onset,7
 2016,13,2015/2016,65,HHS Region 7,Season peak week,10
 2016,13,2015/2016,65,HHS Region 7,Season peak percentage,2.5
@@ -15179,28 +15121,27 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,13,2015/2016,65,HHS Region 7,3 wk ahead,1.2
 2016,13,2015/2016,65,HHS Region 7,4 wk ahead,1
 2016,13,2015/2016,65,HHS Region 8,Season onset,5
-2016,13,2015/2016,65,HHS Region 8,Season peak week,7
 2016,13,2015/2016,65,HHS Region 8,Season peak week,8
 2016,13,2015/2016,65,HHS Region 8,Season peak week,11
 2016,13,2015/2016,65,HHS Region 8,Season peak percentage,2.2
-2016,13,2015/2016,65,HHS Region 8,1 wk ahead,1.6
+2016,13,2015/2016,65,HHS Region 8,1 wk ahead,1.7
 2016,13,2015/2016,65,HHS Region 8,2 wk ahead,1.3
-2016,13,2015/2016,65,HHS Region 8,3 wk ahead,1.1
+2016,13,2015/2016,65,HHS Region 8,3 wk ahead,1.2
 2016,13,2015/2016,65,HHS Region 8,4 wk ahead,1
 2016,13,2015/2016,65,HHS Region 9,Season onset,3
 2016,13,2015/2016,65,HHS Region 9,Season peak week,7
 2016,13,2015/2016,65,HHS Region 9,Season peak percentage,4.4
-2016,13,2015/2016,65,HHS Region 9,1 wk ahead,2.2
+2016,13,2015/2016,65,HHS Region 9,1 wk ahead,2.3
 2016,13,2015/2016,65,HHS Region 9,2 wk ahead,2
 2016,13,2015/2016,65,HHS Region 9,3 wk ahead,1.8
-2016,13,2015/2016,65,HHS Region 9,4 wk ahead,1.7
+2016,13,2015/2016,65,HHS Region 9,4 wk ahead,1.8
 2016,13,2015/2016,65,HHS Region 10,Season onset,2
 2016,13,2015/2016,65,HHS Region 10,Season peak week,7
 2016,13,2015/2016,65,HHS Region 10,Season peak percentage,2.4
 2016,13,2015/2016,65,HHS Region 10,1 wk ahead,1.7
 2016,13,2015/2016,65,HHS Region 10,2 wk ahead,1
 2016,13,2015/2016,65,HHS Region 10,3 wk ahead,0.8
-2016,13,2015/2016,65,HHS Region 10,4 wk ahead,0.8
+2016,13,2015/2016,65,HHS Region 10,4 wk ahead,0.7
 2016,14,2015/2016,66,US National,Season onset,3
 2016,14,2015/2016,66,US National,Season peak week,10
 2016,14,2015/2016,66,US National,Season peak percentage,3.6
@@ -15238,18 +15179,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,14,2015/2016,66,HHS Region 4,4 wk ahead,1.7
 2016,14,2015/2016,66,HHS Region 5,Season onset,7
 2016,14,2015/2016,66,HHS Region 5,Season peak week,10
-2016,14,2015/2016,66,HHS Region 5,Season peak percentage,3.4
+2016,14,2015/2016,66,HHS Region 5,Season peak percentage,3.3
 2016,14,2015/2016,66,HHS Region 5,1 wk ahead,1.5
 2016,14,2015/2016,66,HHS Region 5,2 wk ahead,1.5
-2016,14,2015/2016,66,HHS Region 5,3 wk ahead,1.3
+2016,14,2015/2016,66,HHS Region 5,3 wk ahead,1.4
 2016,14,2015/2016,66,HHS Region 5,4 wk ahead,1
 2016,14,2015/2016,66,HHS Region 6,Season onset,47
 2016,14,2015/2016,66,HHS Region 6,Season peak week,7
-2016,14,2015/2016,66,HHS Region 6,Season peak percentage,5.3
-2016,14,2015/2016,66,HHS Region 6,1 wk ahead,3
-2016,14,2015/2016,66,HHS Region 6,2 wk ahead,3.1
-2016,14,2015/2016,66,HHS Region 6,3 wk ahead,2.6
-2016,14,2015/2016,66,HHS Region 6,4 wk ahead,2.5
+2016,14,2015/2016,66,HHS Region 6,Season peak percentage,5.6
+2016,14,2015/2016,66,HHS Region 6,1 wk ahead,3.1
+2016,14,2015/2016,66,HHS Region 6,2 wk ahead,3
+2016,14,2015/2016,66,HHS Region 6,3 wk ahead,2.8
+2016,14,2015/2016,66,HHS Region 6,4 wk ahead,2.7
 2016,14,2015/2016,66,HHS Region 7,Season onset,7
 2016,14,2015/2016,66,HHS Region 7,Season peak week,10
 2016,14,2015/2016,66,HHS Region 7,Season peak percentage,2.5
@@ -15258,12 +15199,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,14,2015/2016,66,HHS Region 7,3 wk ahead,1
 2016,14,2015/2016,66,HHS Region 7,4 wk ahead,0.9
 2016,14,2015/2016,66,HHS Region 8,Season onset,5
-2016,14,2015/2016,66,HHS Region 8,Season peak week,7
 2016,14,2015/2016,66,HHS Region 8,Season peak week,8
 2016,14,2015/2016,66,HHS Region 8,Season peak week,11
 2016,14,2015/2016,66,HHS Region 8,Season peak percentage,2.2
 2016,14,2015/2016,66,HHS Region 8,1 wk ahead,1.3
-2016,14,2015/2016,66,HHS Region 8,2 wk ahead,1.1
+2016,14,2015/2016,66,HHS Region 8,2 wk ahead,1.2
 2016,14,2015/2016,66,HHS Region 8,3 wk ahead,1
 2016,14,2015/2016,66,HHS Region 8,4 wk ahead,1
 2016,14,2015/2016,66,HHS Region 9,Season onset,3
@@ -15271,14 +15211,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,14,2015/2016,66,HHS Region 9,Season peak percentage,4.4
 2016,14,2015/2016,66,HHS Region 9,1 wk ahead,2
 2016,14,2015/2016,66,HHS Region 9,2 wk ahead,1.8
-2016,14,2015/2016,66,HHS Region 9,3 wk ahead,1.7
+2016,14,2015/2016,66,HHS Region 9,3 wk ahead,1.8
 2016,14,2015/2016,66,HHS Region 9,4 wk ahead,1.8
 2016,14,2015/2016,66,HHS Region 10,Season onset,2
 2016,14,2015/2016,66,HHS Region 10,Season peak week,7
 2016,14,2015/2016,66,HHS Region 10,Season peak percentage,2.4
 2016,14,2015/2016,66,HHS Region 10,1 wk ahead,1
 2016,14,2015/2016,66,HHS Region 10,2 wk ahead,0.8
-2016,14,2015/2016,66,HHS Region 10,3 wk ahead,0.8
+2016,14,2015/2016,66,HHS Region 10,3 wk ahead,0.7
 2016,14,2015/2016,66,HHS Region 10,4 wk ahead,0.9
 2016,15,2015/2016,67,US National,Season onset,3
 2016,15,2015/2016,67,US National,Season peak week,10
@@ -15300,7 +15240,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,15,2015/2016,67,HHS Region 2,1 wk ahead,2
 2016,15,2015/2016,67,HHS Region 2,2 wk ahead,1.7
 2016,15,2015/2016,67,HHS Region 2,3 wk ahead,1.5
-2016,15,2015/2016,67,HHS Region 2,4 wk ahead,1.4
+2016,15,2015/2016,67,HHS Region 2,4 wk ahead,1.3
 2016,15,2015/2016,67,HHS Region 3,Season onset,47
 2016,15,2015/2016,67,HHS Region 3,Season peak week,10
 2016,15,2015/2016,67,HHS Region 3,Season peak percentage,4
@@ -15314,21 +15254,21 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,15,2015/2016,67,HHS Region 4,1 wk ahead,2
 2016,15,2015/2016,67,HHS Region 4,2 wk ahead,1.8
 2016,15,2015/2016,67,HHS Region 4,3 wk ahead,1.7
-2016,15,2015/2016,67,HHS Region 4,4 wk ahead,1.5
+2016,15,2015/2016,67,HHS Region 4,4 wk ahead,1.4
 2016,15,2015/2016,67,HHS Region 5,Season onset,7
 2016,15,2015/2016,67,HHS Region 5,Season peak week,10
-2016,15,2015/2016,67,HHS Region 5,Season peak percentage,3.4
+2016,15,2015/2016,67,HHS Region 5,Season peak percentage,3.3
 2016,15,2015/2016,67,HHS Region 5,1 wk ahead,1.5
-2016,15,2015/2016,67,HHS Region 5,2 wk ahead,1.3
+2016,15,2015/2016,67,HHS Region 5,2 wk ahead,1.4
 2016,15,2015/2016,67,HHS Region 5,3 wk ahead,1
-2016,15,2015/2016,67,HHS Region 5,4 wk ahead,1.1
+2016,15,2015/2016,67,HHS Region 5,4 wk ahead,1.2
 2016,15,2015/2016,67,HHS Region 6,Season onset,47
 2016,15,2015/2016,67,HHS Region 6,Season peak week,7
-2016,15,2015/2016,67,HHS Region 6,Season peak percentage,5.3
-2016,15,2015/2016,67,HHS Region 6,1 wk ahead,3.1
-2016,15,2015/2016,67,HHS Region 6,2 wk ahead,2.6
-2016,15,2015/2016,67,HHS Region 6,3 wk ahead,2.5
-2016,15,2015/2016,67,HHS Region 6,4 wk ahead,2.1
+2016,15,2015/2016,67,HHS Region 6,Season peak percentage,5.6
+2016,15,2015/2016,67,HHS Region 6,1 wk ahead,3
+2016,15,2015/2016,67,HHS Region 6,2 wk ahead,2.8
+2016,15,2015/2016,67,HHS Region 6,3 wk ahead,2.7
+2016,15,2015/2016,67,HHS Region 6,4 wk ahead,2.3
 2016,15,2015/2016,67,HHS Region 7,Season onset,7
 2016,15,2015/2016,67,HHS Region 7,Season peak week,10
 2016,15,2015/2016,67,HHS Region 7,Season peak percentage,2.5
@@ -15337,11 +15277,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,15,2015/2016,67,HHS Region 7,3 wk ahead,0.9
 2016,15,2015/2016,67,HHS Region 7,4 wk ahead,0.7
 2016,15,2015/2016,67,HHS Region 8,Season onset,5
-2016,15,2015/2016,67,HHS Region 8,Season peak week,7
 2016,15,2015/2016,67,HHS Region 8,Season peak week,8
 2016,15,2015/2016,67,HHS Region 8,Season peak week,11
 2016,15,2015/2016,67,HHS Region 8,Season peak percentage,2.2
-2016,15,2015/2016,67,HHS Region 8,1 wk ahead,1.1
+2016,15,2015/2016,67,HHS Region 8,1 wk ahead,1.2
 2016,15,2015/2016,67,HHS Region 8,2 wk ahead,1
 2016,15,2015/2016,67,HHS Region 8,3 wk ahead,1
 2016,15,2015/2016,67,HHS Region 8,4 wk ahead,0.8
@@ -15349,14 +15288,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,15,2015/2016,67,HHS Region 9,Season peak week,7
 2016,15,2015/2016,67,HHS Region 9,Season peak percentage,4.4
 2016,15,2015/2016,67,HHS Region 9,1 wk ahead,1.8
-2016,15,2015/2016,67,HHS Region 9,2 wk ahead,1.7
+2016,15,2015/2016,67,HHS Region 9,2 wk ahead,1.8
 2016,15,2015/2016,67,HHS Region 9,3 wk ahead,1.8
 2016,15,2015/2016,67,HHS Region 9,4 wk ahead,1.5
 2016,15,2015/2016,67,HHS Region 10,Season onset,2
 2016,15,2015/2016,67,HHS Region 10,Season peak week,7
 2016,15,2015/2016,67,HHS Region 10,Season peak percentage,2.4
 2016,15,2015/2016,67,HHS Region 10,1 wk ahead,0.8
-2016,15,2015/2016,67,HHS Region 10,2 wk ahead,0.8
+2016,15,2015/2016,67,HHS Region 10,2 wk ahead,0.7
 2016,15,2015/2016,67,HHS Region 10,3 wk ahead,0.9
 2016,15,2015/2016,67,HHS Region 10,4 wk ahead,0.5
 2016,16,2015/2016,68,US National,Season onset,3
@@ -15378,7 +15317,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,16,2015/2016,68,HHS Region 2,Season peak percentage,4.1
 2016,16,2015/2016,68,HHS Region 2,1 wk ahead,1.7
 2016,16,2015/2016,68,HHS Region 2,2 wk ahead,1.5
-2016,16,2015/2016,68,HHS Region 2,3 wk ahead,1.4
+2016,16,2015/2016,68,HHS Region 2,3 wk ahead,1.3
 2016,16,2015/2016,68,HHS Region 2,4 wk ahead,1.3
 2016,16,2015/2016,68,HHS Region 3,Season onset,47
 2016,16,2015/2016,68,HHS Region 3,Season peak week,10
@@ -15392,22 +15331,22 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,16,2015/2016,68,HHS Region 4,Season peak percentage,3.6
 2016,16,2015/2016,68,HHS Region 4,1 wk ahead,1.8
 2016,16,2015/2016,68,HHS Region 4,2 wk ahead,1.7
-2016,16,2015/2016,68,HHS Region 4,3 wk ahead,1.5
+2016,16,2015/2016,68,HHS Region 4,3 wk ahead,1.4
 2016,16,2015/2016,68,HHS Region 4,4 wk ahead,1.2
 2016,16,2015/2016,68,HHS Region 5,Season onset,7
 2016,16,2015/2016,68,HHS Region 5,Season peak week,10
-2016,16,2015/2016,68,HHS Region 5,Season peak percentage,3.4
-2016,16,2015/2016,68,HHS Region 5,1 wk ahead,1.3
+2016,16,2015/2016,68,HHS Region 5,Season peak percentage,3.3
+2016,16,2015/2016,68,HHS Region 5,1 wk ahead,1.4
 2016,16,2015/2016,68,HHS Region 5,2 wk ahead,1
-2016,16,2015/2016,68,HHS Region 5,3 wk ahead,1.1
+2016,16,2015/2016,68,HHS Region 5,3 wk ahead,1.2
 2016,16,2015/2016,68,HHS Region 5,4 wk ahead,1
 2016,16,2015/2016,68,HHS Region 6,Season onset,47
 2016,16,2015/2016,68,HHS Region 6,Season peak week,7
-2016,16,2015/2016,68,HHS Region 6,Season peak percentage,5.3
-2016,16,2015/2016,68,HHS Region 6,1 wk ahead,2.6
-2016,16,2015/2016,68,HHS Region 6,2 wk ahead,2.5
-2016,16,2015/2016,68,HHS Region 6,3 wk ahead,2.1
-2016,16,2015/2016,68,HHS Region 6,4 wk ahead,2.1
+2016,16,2015/2016,68,HHS Region 6,Season peak percentage,5.6
+2016,16,2015/2016,68,HHS Region 6,1 wk ahead,2.8
+2016,16,2015/2016,68,HHS Region 6,2 wk ahead,2.7
+2016,16,2015/2016,68,HHS Region 6,3 wk ahead,2.3
+2016,16,2015/2016,68,HHS Region 6,4 wk ahead,2.3
 2016,16,2015/2016,68,HHS Region 7,Season onset,7
 2016,16,2015/2016,68,HHS Region 7,Season peak week,10
 2016,16,2015/2016,68,HHS Region 7,Season peak percentage,2.5
@@ -15416,7 +15355,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,16,2015/2016,68,HHS Region 7,3 wk ahead,0.7
 2016,16,2015/2016,68,HHS Region 7,4 wk ahead,0.6
 2016,16,2015/2016,68,HHS Region 8,Season onset,5
-2016,16,2015/2016,68,HHS Region 8,Season peak week,7
 2016,16,2015/2016,68,HHS Region 8,Season peak week,8
 2016,16,2015/2016,68,HHS Region 8,Season peak week,11
 2016,16,2015/2016,68,HHS Region 8,Season peak percentage,2.2
@@ -15427,14 +15365,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,16,2015/2016,68,HHS Region 9,Season onset,3
 2016,16,2015/2016,68,HHS Region 9,Season peak week,7
 2016,16,2015/2016,68,HHS Region 9,Season peak percentage,4.4
-2016,16,2015/2016,68,HHS Region 9,1 wk ahead,1.7
+2016,16,2015/2016,68,HHS Region 9,1 wk ahead,1.8
 2016,16,2015/2016,68,HHS Region 9,2 wk ahead,1.8
 2016,16,2015/2016,68,HHS Region 9,3 wk ahead,1.5
 2016,16,2015/2016,68,HHS Region 9,4 wk ahead,1.5
 2016,16,2015/2016,68,HHS Region 10,Season onset,2
 2016,16,2015/2016,68,HHS Region 10,Season peak week,7
 2016,16,2015/2016,68,HHS Region 10,Season peak percentage,2.4
-2016,16,2015/2016,68,HHS Region 10,1 wk ahead,0.8
+2016,16,2015/2016,68,HHS Region 10,1 wk ahead,0.7
 2016,16,2015/2016,68,HHS Region 10,2 wk ahead,0.9
 2016,16,2015/2016,68,HHS Region 10,3 wk ahead,0.5
 2016,16,2015/2016,68,HHS Region 10,4 wk ahead,0.5
@@ -15456,7 +15394,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,17,2015/2016,69,HHS Region 2,Season peak week,11
 2016,17,2015/2016,69,HHS Region 2,Season peak percentage,4.1
 2016,17,2015/2016,69,HHS Region 2,1 wk ahead,1.5
-2016,17,2015/2016,69,HHS Region 2,2 wk ahead,1.4
+2016,17,2015/2016,69,HHS Region 2,2 wk ahead,1.3
 2016,17,2015/2016,69,HHS Region 2,3 wk ahead,1.3
 2016,17,2015/2016,69,HHS Region 2,4 wk ahead,1.2
 2016,17,2015/2016,69,HHS Region 3,Season onset,47
@@ -15465,28 +15403,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,17,2015/2016,69,HHS Region 3,1 wk ahead,1.9
 2016,17,2015/2016,69,HHS Region 3,2 wk ahead,1.7
 2016,17,2015/2016,69,HHS Region 3,3 wk ahead,1.7
-2016,17,2015/2016,69,HHS Region 3,4 wk ahead,1.5
+2016,17,2015/2016,69,HHS Region 3,4 wk ahead,1.6
 2016,17,2015/2016,69,HHS Region 4,Season onset,3
 2016,17,2015/2016,69,HHS Region 4,Season peak week,10
 2016,17,2015/2016,69,HHS Region 4,Season peak percentage,3.6
 2016,17,2015/2016,69,HHS Region 4,1 wk ahead,1.7
-2016,17,2015/2016,69,HHS Region 4,2 wk ahead,1.5
+2016,17,2015/2016,69,HHS Region 4,2 wk ahead,1.4
 2016,17,2015/2016,69,HHS Region 4,3 wk ahead,1.2
 2016,17,2015/2016,69,HHS Region 4,4 wk ahead,1.1
 2016,17,2015/2016,69,HHS Region 5,Season onset,7
 2016,17,2015/2016,69,HHS Region 5,Season peak week,10
-2016,17,2015/2016,69,HHS Region 5,Season peak percentage,3.4
+2016,17,2015/2016,69,HHS Region 5,Season peak percentage,3.3
 2016,17,2015/2016,69,HHS Region 5,1 wk ahead,1
-2016,17,2015/2016,69,HHS Region 5,2 wk ahead,1.1
+2016,17,2015/2016,69,HHS Region 5,2 wk ahead,1.2
 2016,17,2015/2016,69,HHS Region 5,3 wk ahead,1
 2016,17,2015/2016,69,HHS Region 5,4 wk ahead,0.8
 2016,17,2015/2016,69,HHS Region 6,Season onset,47
 2016,17,2015/2016,69,HHS Region 6,Season peak week,7
-2016,17,2015/2016,69,HHS Region 6,Season peak percentage,5.3
-2016,17,2015/2016,69,HHS Region 6,1 wk ahead,2.5
-2016,17,2015/2016,69,HHS Region 6,2 wk ahead,2.1
-2016,17,2015/2016,69,HHS Region 6,3 wk ahead,2.1
-2016,17,2015/2016,69,HHS Region 6,4 wk ahead,2.2
+2016,17,2015/2016,69,HHS Region 6,Season peak percentage,5.6
+2016,17,2015/2016,69,HHS Region 6,1 wk ahead,2.7
+2016,17,2015/2016,69,HHS Region 6,2 wk ahead,2.3
+2016,17,2015/2016,69,HHS Region 6,3 wk ahead,2.3
+2016,17,2015/2016,69,HHS Region 6,4 wk ahead,2.4
 2016,17,2015/2016,69,HHS Region 7,Season onset,7
 2016,17,2015/2016,69,HHS Region 7,Season peak week,10
 2016,17,2015/2016,69,HHS Region 7,Season peak percentage,2.5
@@ -15495,7 +15433,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,17,2015/2016,69,HHS Region 7,3 wk ahead,0.6
 2016,17,2015/2016,69,HHS Region 7,4 wk ahead,0.3
 2016,17,2015/2016,69,HHS Region 8,Season onset,5
-2016,17,2015/2016,69,HHS Region 8,Season peak week,7
 2016,17,2015/2016,69,HHS Region 8,Season peak week,8
 2016,17,2015/2016,69,HHS Region 8,Season peak week,11
 2016,17,2015/2016,69,HHS Region 8,Season peak percentage,2.2
@@ -15523,7 +15460,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,18,2015/2016,70,US National,1 wk ahead,1.4
 2016,18,2015/2016,70,US National,2 wk ahead,1.3
 2016,18,2015/2016,70,US National,3 wk ahead,1.2
-2016,18,2015/2016,70,US National,4 wk ahead,1.1
+2016,18,2015/2016,70,US National,4 wk ahead,1.2
 2016,18,2015/2016,70,HHS Region 1,Season onset,51
 2016,18,2015/2016,70,HHS Region 1,Season peak week,10
 2016,18,2015/2016,70,HHS Region 1,Season peak percentage,2.5
@@ -15534,7 +15471,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,18,2015/2016,70,HHS Region 2,Season onset,4
 2016,18,2015/2016,70,HHS Region 2,Season peak week,11
 2016,18,2015/2016,70,HHS Region 2,Season peak percentage,4.1
-2016,18,2015/2016,70,HHS Region 2,1 wk ahead,1.4
+2016,18,2015/2016,70,HHS Region 2,1 wk ahead,1.3
 2016,18,2015/2016,70,HHS Region 2,2 wk ahead,1.3
 2016,18,2015/2016,70,HHS Region 2,3 wk ahead,1.2
 2016,18,2015/2016,70,HHS Region 2,4 wk ahead,0.8
@@ -15543,29 +15480,29 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,18,2015/2016,70,HHS Region 3,Season peak percentage,4
 2016,18,2015/2016,70,HHS Region 3,1 wk ahead,1.7
 2016,18,2015/2016,70,HHS Region 3,2 wk ahead,1.7
-2016,18,2015/2016,70,HHS Region 3,3 wk ahead,1.5
-2016,18,2015/2016,70,HHS Region 3,4 wk ahead,1.8
+2016,18,2015/2016,70,HHS Region 3,3 wk ahead,1.6
+2016,18,2015/2016,70,HHS Region 3,4 wk ahead,1.9
 2016,18,2015/2016,70,HHS Region 4,Season onset,3
 2016,18,2015/2016,70,HHS Region 4,Season peak week,10
 2016,18,2015/2016,70,HHS Region 4,Season peak percentage,3.6
-2016,18,2015/2016,70,HHS Region 4,1 wk ahead,1.5
+2016,18,2015/2016,70,HHS Region 4,1 wk ahead,1.4
 2016,18,2015/2016,70,HHS Region 4,2 wk ahead,1.2
 2016,18,2015/2016,70,HHS Region 4,3 wk ahead,1.1
 2016,18,2015/2016,70,HHS Region 4,4 wk ahead,1.1
 2016,18,2015/2016,70,HHS Region 5,Season onset,7
 2016,18,2015/2016,70,HHS Region 5,Season peak week,10
-2016,18,2015/2016,70,HHS Region 5,Season peak percentage,3.4
-2016,18,2015/2016,70,HHS Region 5,1 wk ahead,1.1
+2016,18,2015/2016,70,HHS Region 5,Season peak percentage,3.3
+2016,18,2015/2016,70,HHS Region 5,1 wk ahead,1.2
 2016,18,2015/2016,70,HHS Region 5,2 wk ahead,1
 2016,18,2015/2016,70,HHS Region 5,3 wk ahead,0.8
 2016,18,2015/2016,70,HHS Region 5,4 wk ahead,0.9
 2016,18,2015/2016,70,HHS Region 6,Season onset,47
 2016,18,2015/2016,70,HHS Region 6,Season peak week,7
-2016,18,2015/2016,70,HHS Region 6,Season peak percentage,5.3
-2016,18,2015/2016,70,HHS Region 6,1 wk ahead,2.1
-2016,18,2015/2016,70,HHS Region 6,2 wk ahead,2.1
-2016,18,2015/2016,70,HHS Region 6,3 wk ahead,2.2
-2016,18,2015/2016,70,HHS Region 6,4 wk ahead,2
+2016,18,2015/2016,70,HHS Region 6,Season peak percentage,5.6
+2016,18,2015/2016,70,HHS Region 6,1 wk ahead,2.3
+2016,18,2015/2016,70,HHS Region 6,2 wk ahead,2.3
+2016,18,2015/2016,70,HHS Region 6,3 wk ahead,2.4
+2016,18,2015/2016,70,HHS Region 6,4 wk ahead,2.1
 2016,18,2015/2016,70,HHS Region 7,Season onset,7
 2016,18,2015/2016,70,HHS Region 7,Season peak week,10
 2016,18,2015/2016,70,HHS Region 7,Season peak percentage,2.5
@@ -15574,7 +15511,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,18,2015/2016,70,HHS Region 7,3 wk ahead,0.3
 2016,18,2015/2016,70,HHS Region 7,4 wk ahead,0.4
 2016,18,2015/2016,70,HHS Region 8,Season onset,5
-2016,18,2015/2016,70,HHS Region 8,Season peak week,7
 2016,18,2015/2016,70,HHS Region 8,Season peak week,8
 2016,18,2015/2016,70,HHS Region 8,Season peak week,11
 2016,18,2015/2016,70,HHS Region 8,Season peak percentage,2.2
@@ -15588,7 +15524,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,18,2015/2016,70,HHS Region 9,1 wk ahead,1.5
 2016,18,2015/2016,70,HHS Region 9,2 wk ahead,1.5
 2016,18,2015/2016,70,HHS Region 9,3 wk ahead,1.4
-2016,18,2015/2016,70,HHS Region 9,4 wk ahead,1.3
+2016,18,2015/2016,70,HHS Region 9,4 wk ahead,1.4
 2016,18,2015/2016,70,HHS Region 10,Season onset,2
 2016,18,2015/2016,70,HHS Region 10,Season peak week,7
 2016,18,2015/2016,70,HHS Region 10,Season peak percentage,2.4
@@ -15601,8 +15537,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,19,2015/2016,71,US National,Season peak percentage,3.6
 2016,19,2015/2016,71,US National,1 wk ahead,1.3
 2016,19,2015/2016,71,US National,2 wk ahead,1.2
-2016,19,2015/2016,71,US National,3 wk ahead,1.1
-2016,19,2015/2016,71,US National,4 wk ahead,1
+2016,19,2015/2016,71,US National,3 wk ahead,1.2
+2016,19,2015/2016,71,US National,4 wk ahead,1.1
 2016,19,2015/2016,71,HHS Region 1,Season onset,51
 2016,19,2015/2016,71,HHS Region 1,Season peak week,10
 2016,19,2015/2016,71,HHS Region 1,Season peak percentage,2.5
@@ -15621,9 +15557,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,19,2015/2016,71,HHS Region 3,Season peak week,10
 2016,19,2015/2016,71,HHS Region 3,Season peak percentage,4
 2016,19,2015/2016,71,HHS Region 3,1 wk ahead,1.7
-2016,19,2015/2016,71,HHS Region 3,2 wk ahead,1.5
-2016,19,2015/2016,71,HHS Region 3,3 wk ahead,1.8
-2016,19,2015/2016,71,HHS Region 3,4 wk ahead,1.5
+2016,19,2015/2016,71,HHS Region 3,2 wk ahead,1.6
+2016,19,2015/2016,71,HHS Region 3,3 wk ahead,1.9
+2016,19,2015/2016,71,HHS Region 3,4 wk ahead,1.6
 2016,19,2015/2016,71,HHS Region 4,Season onset,3
 2016,19,2015/2016,71,HHS Region 4,Season peak week,10
 2016,19,2015/2016,71,HHS Region 4,Season peak percentage,3.6
@@ -15633,18 +15569,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,19,2015/2016,71,HHS Region 4,4 wk ahead,1
 2016,19,2015/2016,71,HHS Region 5,Season onset,7
 2016,19,2015/2016,71,HHS Region 5,Season peak week,10
-2016,19,2015/2016,71,HHS Region 5,Season peak percentage,3.4
+2016,19,2015/2016,71,HHS Region 5,Season peak percentage,3.3
 2016,19,2015/2016,71,HHS Region 5,1 wk ahead,1
 2016,19,2015/2016,71,HHS Region 5,2 wk ahead,0.8
 2016,19,2015/2016,71,HHS Region 5,3 wk ahead,0.9
 2016,19,2015/2016,71,HHS Region 5,4 wk ahead,0.8
 2016,19,2015/2016,71,HHS Region 6,Season onset,47
 2016,19,2015/2016,71,HHS Region 6,Season peak week,7
-2016,19,2015/2016,71,HHS Region 6,Season peak percentage,5.3
-2016,19,2015/2016,71,HHS Region 6,1 wk ahead,2.1
-2016,19,2015/2016,71,HHS Region 6,2 wk ahead,2.2
-2016,19,2015/2016,71,HHS Region 6,3 wk ahead,2
-2016,19,2015/2016,71,HHS Region 6,4 wk ahead,1.6
+2016,19,2015/2016,71,HHS Region 6,Season peak percentage,5.6
+2016,19,2015/2016,71,HHS Region 6,1 wk ahead,2.3
+2016,19,2015/2016,71,HHS Region 6,2 wk ahead,2.4
+2016,19,2015/2016,71,HHS Region 6,3 wk ahead,2.1
+2016,19,2015/2016,71,HHS Region 6,4 wk ahead,1.8
 2016,19,2015/2016,71,HHS Region 7,Season onset,7
 2016,19,2015/2016,71,HHS Region 7,Season peak week,10
 2016,19,2015/2016,71,HHS Region 7,Season peak percentage,2.5
@@ -15653,7 +15589,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,19,2015/2016,71,HHS Region 7,3 wk ahead,0.4
 2016,19,2015/2016,71,HHS Region 7,4 wk ahead,0.5
 2016,19,2015/2016,71,HHS Region 8,Season onset,5
-2016,19,2015/2016,71,HHS Region 8,Season peak week,7
 2016,19,2015/2016,71,HHS Region 8,Season peak week,8
 2016,19,2015/2016,71,HHS Region 8,Season peak week,11
 2016,19,2015/2016,71,HHS Region 8,Season peak percentage,2.2
@@ -15666,8 +15601,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,19,2015/2016,71,HHS Region 9,Season peak percentage,4.4
 2016,19,2015/2016,71,HHS Region 9,1 wk ahead,1.5
 2016,19,2015/2016,71,HHS Region 9,2 wk ahead,1.4
-2016,19,2015/2016,71,HHS Region 9,3 wk ahead,1.3
-2016,19,2015/2016,71,HHS Region 9,4 wk ahead,1.3
+2016,19,2015/2016,71,HHS Region 9,3 wk ahead,1.4
+2016,19,2015/2016,71,HHS Region 9,4 wk ahead,1.4
 2016,19,2015/2016,71,HHS Region 10,Season onset,2
 2016,19,2015/2016,71,HHS Region 10,Season peak week,7
 2016,19,2015/2016,71,HHS Region 10,Season peak percentage,2.4
@@ -15679,8 +15614,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,20,2015/2016,72,US National,Season peak week,10
 2016,20,2015/2016,72,US National,Season peak percentage,3.6
 2016,20,2015/2016,72,US National,1 wk ahead,1.2
-2016,20,2015/2016,72,US National,2 wk ahead,1.1
-2016,20,2015/2016,72,US National,3 wk ahead,1
+2016,20,2015/2016,72,US National,2 wk ahead,1.2
+2016,20,2015/2016,72,US National,3 wk ahead,1.1
 2016,20,2015/2016,72,US National,4 wk ahead,1
 2016,20,2015/2016,72,HHS Region 1,Season onset,51
 2016,20,2015/2016,72,HHS Region 1,Season peak week,10
@@ -15699,31 +15634,31 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,20,2015/2016,72,HHS Region 3,Season onset,47
 2016,20,2015/2016,72,HHS Region 3,Season peak week,10
 2016,20,2015/2016,72,HHS Region 3,Season peak percentage,4
-2016,20,2015/2016,72,HHS Region 3,1 wk ahead,1.5
-2016,20,2015/2016,72,HHS Region 3,2 wk ahead,1.8
-2016,20,2015/2016,72,HHS Region 3,3 wk ahead,1.5
-2016,20,2015/2016,72,HHS Region 3,4 wk ahead,1.2
+2016,20,2015/2016,72,HHS Region 3,1 wk ahead,1.6
+2016,20,2015/2016,72,HHS Region 3,2 wk ahead,1.9
+2016,20,2015/2016,72,HHS Region 3,3 wk ahead,1.6
+2016,20,2015/2016,72,HHS Region 3,4 wk ahead,1.3
 2016,20,2015/2016,72,HHS Region 4,Season onset,3
 2016,20,2015/2016,72,HHS Region 4,Season peak week,10
 2016,20,2015/2016,72,HHS Region 4,Season peak percentage,3.6
 2016,20,2015/2016,72,HHS Region 4,1 wk ahead,1.1
 2016,20,2015/2016,72,HHS Region 4,2 wk ahead,1.1
 2016,20,2015/2016,72,HHS Region 4,3 wk ahead,1
-2016,20,2015/2016,72,HHS Region 4,4 wk ahead,1
+2016,20,2015/2016,72,HHS Region 4,4 wk ahead,1.1
 2016,20,2015/2016,72,HHS Region 5,Season onset,7
 2016,20,2015/2016,72,HHS Region 5,Season peak week,10
-2016,20,2015/2016,72,HHS Region 5,Season peak percentage,3.4
+2016,20,2015/2016,72,HHS Region 5,Season peak percentage,3.3
 2016,20,2015/2016,72,HHS Region 5,1 wk ahead,0.8
 2016,20,2015/2016,72,HHS Region 5,2 wk ahead,0.9
 2016,20,2015/2016,72,HHS Region 5,3 wk ahead,0.8
 2016,20,2015/2016,72,HHS Region 5,4 wk ahead,0.7
 2016,20,2015/2016,72,HHS Region 6,Season onset,47
 2016,20,2015/2016,72,HHS Region 6,Season peak week,7
-2016,20,2015/2016,72,HHS Region 6,Season peak percentage,5.3
-2016,20,2015/2016,72,HHS Region 6,1 wk ahead,2.2
-2016,20,2015/2016,72,HHS Region 6,2 wk ahead,2
-2016,20,2015/2016,72,HHS Region 6,3 wk ahead,1.6
-2016,20,2015/2016,72,HHS Region 6,4 wk ahead,1.6
+2016,20,2015/2016,72,HHS Region 6,Season peak percentage,5.6
+2016,20,2015/2016,72,HHS Region 6,1 wk ahead,2.4
+2016,20,2015/2016,72,HHS Region 6,2 wk ahead,2.1
+2016,20,2015/2016,72,HHS Region 6,3 wk ahead,1.8
+2016,20,2015/2016,72,HHS Region 6,4 wk ahead,1.8
 2016,20,2015/2016,72,HHS Region 7,Season onset,7
 2016,20,2015/2016,72,HHS Region 7,Season peak week,10
 2016,20,2015/2016,72,HHS Region 7,Season peak percentage,2.5
@@ -15732,7 +15667,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,20,2015/2016,72,HHS Region 7,3 wk ahead,0.5
 2016,20,2015/2016,72,HHS Region 7,4 wk ahead,0.3
 2016,20,2015/2016,72,HHS Region 8,Season onset,5
-2016,20,2015/2016,72,HHS Region 8,Season peak week,7
 2016,20,2015/2016,72,HHS Region 8,Season peak week,8
 2016,20,2015/2016,72,HHS Region 8,Season peak week,11
 2016,20,2015/2016,72,HHS Region 8,Season peak percentage,2.2
@@ -15744,16 +15678,16 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,20,2015/2016,72,HHS Region 9,Season peak week,7
 2016,20,2015/2016,72,HHS Region 9,Season peak percentage,4.4
 2016,20,2015/2016,72,HHS Region 9,1 wk ahead,1.4
-2016,20,2015/2016,72,HHS Region 9,2 wk ahead,1.3
-2016,20,2015/2016,72,HHS Region 9,3 wk ahead,1.3
-2016,20,2015/2016,72,HHS Region 9,4 wk ahead,1.2
+2016,20,2015/2016,72,HHS Region 9,2 wk ahead,1.4
+2016,20,2015/2016,72,HHS Region 9,3 wk ahead,1.4
+2016,20,2015/2016,72,HHS Region 9,4 wk ahead,1.3
 2016,20,2015/2016,72,HHS Region 10,Season onset,2
 2016,20,2015/2016,72,HHS Region 10,Season peak week,7
 2016,20,2015/2016,72,HHS Region 10,Season peak percentage,2.4
 2016,20,2015/2016,72,HHS Region 10,1 wk ahead,0.2
 2016,20,2015/2016,72,HHS Region 10,2 wk ahead,0.2
 2016,20,2015/2016,72,HHS Region 10,3 wk ahead,0.3
-2016,20,2015/2016,72,HHS Region 10,4 wk ahead,0.3
+2016,20,2015/2016,72,HHS Region 10,4 wk ahead,0.4
 2016,40,2016/2017,40,US National,Season onset,50
 2016,40,2016/2017,40,US National,Season peak week,6
 2016,40,2016/2017,40,US National,Season peak percentage,5.1
@@ -15798,13 +15732,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,40,2016/2017,40,HHS Region 5,2 wk ahead,1
 2016,40,2016/2017,40,HHS Region 5,3 wk ahead,1.1
 2016,40,2016/2017,40,HHS Region 5,4 wk ahead,1.3
-2016,40,2016/2017,40,HHS Region 6,Season onset,2
+2016,40,2016/2017,40,HHS Region 6,Season onset,52
 2016,40,2016/2017,40,HHS Region 6,Season peak week,6
 2016,40,2016/2017,40,HHS Region 6,Season peak percentage,9.9
 2016,40,2016/2017,40,HHS Region 6,1 wk ahead,1.8
 2016,40,2016/2017,40,HHS Region 6,2 wk ahead,1.7
-2016,40,2016/2017,40,HHS Region 6,3 wk ahead,2
-2016,40,2016/2017,40,HHS Region 6,4 wk ahead,2
+2016,40,2016/2017,40,HHS Region 6,3 wk ahead,1.9
+2016,40,2016/2017,40,HHS Region 6,4 wk ahead,1.9
 2016,40,2016/2017,40,HHS Region 7,Season onset,51
 2016,40,2016/2017,40,HHS Region 7,Season peak week,6
 2016,40,2016/2017,40,HHS Region 7,Season peak percentage,6.4
@@ -15877,12 +15811,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,41,2016/2017,41,HHS Region 5,2 wk ahead,1.1
 2016,41,2016/2017,41,HHS Region 5,3 wk ahead,1.3
 2016,41,2016/2017,41,HHS Region 5,4 wk ahead,1.2
-2016,41,2016/2017,41,HHS Region 6,Season onset,2
+2016,41,2016/2017,41,HHS Region 6,Season onset,52
 2016,41,2016/2017,41,HHS Region 6,Season peak week,6
 2016,41,2016/2017,41,HHS Region 6,Season peak percentage,9.9
 2016,41,2016/2017,41,HHS Region 6,1 wk ahead,1.7
-2016,41,2016/2017,41,HHS Region 6,2 wk ahead,2
-2016,41,2016/2017,41,HHS Region 6,3 wk ahead,2
+2016,41,2016/2017,41,HHS Region 6,2 wk ahead,1.9
+2016,41,2016/2017,41,HHS Region 6,3 wk ahead,1.9
 2016,41,2016/2017,41,HHS Region 6,4 wk ahead,2.1
 2016,41,2016/2017,41,HHS Region 7,Season onset,51
 2016,41,2016/2017,41,HHS Region 7,Season peak week,6
@@ -15956,11 +15890,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,42,2016/2017,42,HHS Region 5,2 wk ahead,1.3
 2016,42,2016/2017,42,HHS Region 5,3 wk ahead,1.2
 2016,42,2016/2017,42,HHS Region 5,4 wk ahead,1.2
-2016,42,2016/2017,42,HHS Region 6,Season onset,2
+2016,42,2016/2017,42,HHS Region 6,Season onset,52
 2016,42,2016/2017,42,HHS Region 6,Season peak week,6
 2016,42,2016/2017,42,HHS Region 6,Season peak percentage,9.9
-2016,42,2016/2017,42,HHS Region 6,1 wk ahead,2
-2016,42,2016/2017,42,HHS Region 6,2 wk ahead,2
+2016,42,2016/2017,42,HHS Region 6,1 wk ahead,1.9
+2016,42,2016/2017,42,HHS Region 6,2 wk ahead,1.9
 2016,42,2016/2017,42,HHS Region 6,3 wk ahead,2.1
 2016,42,2016/2017,42,HHS Region 6,4 wk ahead,2.3
 2016,42,2016/2017,42,HHS Region 7,Season onset,51
@@ -16035,10 +15969,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,43,2016/2017,43,HHS Region 5,2 wk ahead,1.2
 2016,43,2016/2017,43,HHS Region 5,3 wk ahead,1.2
 2016,43,2016/2017,43,HHS Region 5,4 wk ahead,1.3
-2016,43,2016/2017,43,HHS Region 6,Season onset,2
+2016,43,2016/2017,43,HHS Region 6,Season onset,52
 2016,43,2016/2017,43,HHS Region 6,Season peak week,6
 2016,43,2016/2017,43,HHS Region 6,Season peak percentage,9.9
-2016,43,2016/2017,43,HHS Region 6,1 wk ahead,2
+2016,43,2016/2017,43,HHS Region 6,1 wk ahead,1.9
 2016,43,2016/2017,43,HHS Region 6,2 wk ahead,2.1
 2016,43,2016/2017,43,HHS Region 6,3 wk ahead,2.3
 2016,43,2016/2017,43,HHS Region 6,4 wk ahead,2.5
@@ -16114,13 +16048,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,44,2016/2017,44,HHS Region 5,2 wk ahead,1.2
 2016,44,2016/2017,44,HHS Region 5,3 wk ahead,1.3
 2016,44,2016/2017,44,HHS Region 5,4 wk ahead,1.2
-2016,44,2016/2017,44,HHS Region 6,Season onset,2
+2016,44,2016/2017,44,HHS Region 6,Season onset,52
 2016,44,2016/2017,44,HHS Region 6,Season peak week,6
 2016,44,2016/2017,44,HHS Region 6,Season peak percentage,9.9
 2016,44,2016/2017,44,HHS Region 6,1 wk ahead,2.1
 2016,44,2016/2017,44,HHS Region 6,2 wk ahead,2.3
 2016,44,2016/2017,44,HHS Region 6,3 wk ahead,2.5
-2016,44,2016/2017,44,HHS Region 6,4 wk ahead,2.4
+2016,44,2016/2017,44,HHS Region 6,4 wk ahead,2.5
 2016,44,2016/2017,44,HHS Region 7,Season onset,51
 2016,44,2016/2017,44,HHS Region 7,Season peak week,6
 2016,44,2016/2017,44,HHS Region 7,Season peak percentage,6.4
@@ -16193,13 +16127,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,45,2016/2017,45,HHS Region 5,2 wk ahead,1.3
 2016,45,2016/2017,45,HHS Region 5,3 wk ahead,1.2
 2016,45,2016/2017,45,HHS Region 5,4 wk ahead,1.5
-2016,45,2016/2017,45,HHS Region 6,Season onset,2
+2016,45,2016/2017,45,HHS Region 6,Season onset,52
 2016,45,2016/2017,45,HHS Region 6,Season peak week,6
 2016,45,2016/2017,45,HHS Region 6,Season peak percentage,9.9
 2016,45,2016/2017,45,HHS Region 6,1 wk ahead,2.3
 2016,45,2016/2017,45,HHS Region 6,2 wk ahead,2.5
-2016,45,2016/2017,45,HHS Region 6,3 wk ahead,2.4
-2016,45,2016/2017,45,HHS Region 6,4 wk ahead,2.8
+2016,45,2016/2017,45,HHS Region 6,3 wk ahead,2.5
+2016,45,2016/2017,45,HHS Region 6,4 wk ahead,2.9
 2016,45,2016/2017,45,HHS Region 7,Season onset,51
 2016,45,2016/2017,45,HHS Region 7,Season peak week,6
 2016,45,2016/2017,45,HHS Region 7,Season peak percentage,6.4
@@ -16272,13 +16206,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,46,2016/2017,46,HHS Region 5,2 wk ahead,1.2
 2016,46,2016/2017,46,HHS Region 5,3 wk ahead,1.5
 2016,46,2016/2017,46,HHS Region 5,4 wk ahead,1.6
-2016,46,2016/2017,46,HHS Region 6,Season onset,2
+2016,46,2016/2017,46,HHS Region 6,Season onset,52
 2016,46,2016/2017,46,HHS Region 6,Season peak week,6
 2016,46,2016/2017,46,HHS Region 6,Season peak percentage,9.9
 2016,46,2016/2017,46,HHS Region 6,1 wk ahead,2.5
-2016,46,2016/2017,46,HHS Region 6,2 wk ahead,2.4
-2016,46,2016/2017,46,HHS Region 6,3 wk ahead,2.8
-2016,46,2016/2017,46,HHS Region 6,4 wk ahead,3.3
+2016,46,2016/2017,46,HHS Region 6,2 wk ahead,2.5
+2016,46,2016/2017,46,HHS Region 6,3 wk ahead,2.9
+2016,46,2016/2017,46,HHS Region 6,4 wk ahead,3.4
 2016,46,2016/2017,46,HHS Region 7,Season onset,51
 2016,46,2016/2017,46,HHS Region 7,Season peak week,6
 2016,46,2016/2017,46,HHS Region 7,Season peak percentage,6.4
@@ -16351,13 +16285,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,47,2016/2017,47,HHS Region 5,2 wk ahead,1.5
 2016,47,2016/2017,47,HHS Region 5,3 wk ahead,1.6
 2016,47,2016/2017,47,HHS Region 5,4 wk ahead,1.8
-2016,47,2016/2017,47,HHS Region 6,Season onset,2
+2016,47,2016/2017,47,HHS Region 6,Season onset,52
 2016,47,2016/2017,47,HHS Region 6,Season peak week,6
 2016,47,2016/2017,47,HHS Region 6,Season peak percentage,9.9
-2016,47,2016/2017,47,HHS Region 6,1 wk ahead,2.4
-2016,47,2016/2017,47,HHS Region 6,2 wk ahead,2.8
-2016,47,2016/2017,47,HHS Region 6,3 wk ahead,3.3
-2016,47,2016/2017,47,HHS Region 6,4 wk ahead,3.8
+2016,47,2016/2017,47,HHS Region 6,1 wk ahead,2.5
+2016,47,2016/2017,47,HHS Region 6,2 wk ahead,2.9
+2016,47,2016/2017,47,HHS Region 6,3 wk ahead,3.4
+2016,47,2016/2017,47,HHS Region 6,4 wk ahead,3.9
 2016,47,2016/2017,47,HHS Region 7,Season onset,51
 2016,47,2016/2017,47,HHS Region 7,Season peak week,6
 2016,47,2016/2017,47,HHS Region 7,Season peak percentage,6.4
@@ -16430,12 +16364,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,48,2016/2017,48,HHS Region 5,2 wk ahead,1.6
 2016,48,2016/2017,48,HHS Region 5,3 wk ahead,1.8
 2016,48,2016/2017,48,HHS Region 5,4 wk ahead,2.4
-2016,48,2016/2017,48,HHS Region 6,Season onset,2
+2016,48,2016/2017,48,HHS Region 6,Season onset,52
 2016,48,2016/2017,48,HHS Region 6,Season peak week,6
 2016,48,2016/2017,48,HHS Region 6,Season peak percentage,9.9
-2016,48,2016/2017,48,HHS Region 6,1 wk ahead,2.8
-2016,48,2016/2017,48,HHS Region 6,2 wk ahead,3.3
-2016,48,2016/2017,48,HHS Region 6,3 wk ahead,3.8
+2016,48,2016/2017,48,HHS Region 6,1 wk ahead,2.9
+2016,48,2016/2017,48,HHS Region 6,2 wk ahead,3.4
+2016,48,2016/2017,48,HHS Region 6,3 wk ahead,3.9
 2016,48,2016/2017,48,HHS Region 6,4 wk ahead,4.2
 2016,48,2016/2017,48,HHS Region 7,Season onset,51
 2016,48,2016/2017,48,HHS Region 7,Season peak week,6
@@ -16509,13 +16443,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,49,2016/2017,49,HHS Region 5,2 wk ahead,1.8
 2016,49,2016/2017,49,HHS Region 5,3 wk ahead,2.4
 2016,49,2016/2017,49,HHS Region 5,4 wk ahead,2.1
-2016,49,2016/2017,49,HHS Region 6,Season onset,2
+2016,49,2016/2017,49,HHS Region 6,Season onset,52
 2016,49,2016/2017,49,HHS Region 6,Season peak week,6
 2016,49,2016/2017,49,HHS Region 6,Season peak percentage,9.9
-2016,49,2016/2017,49,HHS Region 6,1 wk ahead,3.3
-2016,49,2016/2017,49,HHS Region 6,2 wk ahead,3.8
+2016,49,2016/2017,49,HHS Region 6,1 wk ahead,3.4
+2016,49,2016/2017,49,HHS Region 6,2 wk ahead,3.9
 2016,49,2016/2017,49,HHS Region 6,3 wk ahead,4.2
-2016,49,2016/2017,49,HHS Region 6,4 wk ahead,4
+2016,49,2016/2017,49,HHS Region 6,4 wk ahead,4.1
 2016,49,2016/2017,49,HHS Region 7,Season onset,51
 2016,49,2016/2017,49,HHS Region 7,Season peak week,6
 2016,49,2016/2017,49,HHS Region 7,Season peak percentage,6.4
@@ -16588,13 +16522,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,50,2016/2017,50,HHS Region 5,2 wk ahead,2.4
 2016,50,2016/2017,50,HHS Region 5,3 wk ahead,2.1
 2016,50,2016/2017,50,HHS Region 5,4 wk ahead,2.1
-2016,50,2016/2017,50,HHS Region 6,Season onset,2
+2016,50,2016/2017,50,HHS Region 6,Season onset,52
 2016,50,2016/2017,50,HHS Region 6,Season peak week,6
 2016,50,2016/2017,50,HHS Region 6,Season peak percentage,9.9
-2016,50,2016/2017,50,HHS Region 6,1 wk ahead,3.8
+2016,50,2016/2017,50,HHS Region 6,1 wk ahead,3.9
 2016,50,2016/2017,50,HHS Region 6,2 wk ahead,4.2
-2016,50,2016/2017,50,HHS Region 6,3 wk ahead,4
-2016,50,2016/2017,50,HHS Region 6,4 wk ahead,4.8
+2016,50,2016/2017,50,HHS Region 6,3 wk ahead,4.1
+2016,50,2016/2017,50,HHS Region 6,4 wk ahead,4.9
 2016,50,2016/2017,50,HHS Region 7,Season onset,51
 2016,50,2016/2017,50,HHS Region 7,Season peak week,6
 2016,50,2016/2017,50,HHS Region 7,Season peak percentage,6.4
@@ -16667,12 +16601,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,51,2016/2017,51,HHS Region 5,2 wk ahead,2.1
 2016,51,2016/2017,51,HHS Region 5,3 wk ahead,2.1
 2016,51,2016/2017,51,HHS Region 5,4 wk ahead,2.4
-2016,51,2016/2017,51,HHS Region 6,Season onset,2
+2016,51,2016/2017,51,HHS Region 6,Season onset,52
 2016,51,2016/2017,51,HHS Region 6,Season peak week,6
 2016,51,2016/2017,51,HHS Region 6,Season peak percentage,9.9
 2016,51,2016/2017,51,HHS Region 6,1 wk ahead,4.2
-2016,51,2016/2017,51,HHS Region 6,2 wk ahead,4
-2016,51,2016/2017,51,HHS Region 6,3 wk ahead,4.8
+2016,51,2016/2017,51,HHS Region 6,2 wk ahead,4.1
+2016,51,2016/2017,51,HHS Region 6,3 wk ahead,4.9
 2016,51,2016/2017,51,HHS Region 6,4 wk ahead,5.3
 2016,51,2016/2017,51,HHS Region 7,Season onset,51
 2016,51,2016/2017,51,HHS Region 7,Season peak week,6
@@ -16737,7 +16671,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,52,2016/2017,52,HHS Region 4,1 wk ahead,2.9
 2016,52,2016/2017,52,HHS Region 4,2 wk ahead,2.9
 2016,52,2016/2017,52,HHS Region 4,3 wk ahead,3.7
-2016,52,2016/2017,52,HHS Region 4,4 wk ahead,3.7
+2016,52,2016/2017,52,HHS Region 4,4 wk ahead,3.6
 2016,52,2016/2017,52,HHS Region 5,Season onset,52
 2016,52,2016/2017,52,HHS Region 5,Season peak week,7
 2016,52,2016/2017,52,HHS Region 5,Season peak week,8
@@ -16746,11 +16680,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2016,52,2016/2017,52,HHS Region 5,2 wk ahead,2.1
 2016,52,2016/2017,52,HHS Region 5,3 wk ahead,2.4
 2016,52,2016/2017,52,HHS Region 5,4 wk ahead,2.8
-2016,52,2016/2017,52,HHS Region 6,Season onset,2
+2016,52,2016/2017,52,HHS Region 6,Season onset,52
 2016,52,2016/2017,52,HHS Region 6,Season peak week,6
 2016,52,2016/2017,52,HHS Region 6,Season peak percentage,9.9
-2016,52,2016/2017,52,HHS Region 6,1 wk ahead,4
-2016,52,2016/2017,52,HHS Region 6,2 wk ahead,4.8
+2016,52,2016/2017,52,HHS Region 6,1 wk ahead,4.1
+2016,52,2016/2017,52,HHS Region 6,2 wk ahead,4.9
 2016,52,2016/2017,52,HHS Region 6,3 wk ahead,5.3
 2016,52,2016/2017,52,HHS Region 6,4 wk ahead,6.1
 2016,52,2016/2017,52,HHS Region 7,Season onset,51
@@ -16815,7 +16749,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,1,2016/2017,53,HHS Region 4,Season peak percentage,5.5
 2017,1,2016/2017,53,HHS Region 4,1 wk ahead,2.9
 2017,1,2016/2017,53,HHS Region 4,2 wk ahead,3.7
-2017,1,2016/2017,53,HHS Region 4,3 wk ahead,3.7
+2017,1,2016/2017,53,HHS Region 4,3 wk ahead,3.6
 2017,1,2016/2017,53,HHS Region 4,4 wk ahead,4.5
 2017,1,2016/2017,53,HHS Region 5,Season onset,52
 2017,1,2016/2017,53,HHS Region 5,Season peak week,7
@@ -16825,13 +16759,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,1,2016/2017,53,HHS Region 5,2 wk ahead,2.4
 2017,1,2016/2017,53,HHS Region 5,3 wk ahead,2.8
 2017,1,2016/2017,53,HHS Region 5,4 wk ahead,3.2
-2017,1,2016/2017,53,HHS Region 6,Season onset,2
+2017,1,2016/2017,53,HHS Region 6,Season onset,52
 2017,1,2016/2017,53,HHS Region 6,Season peak week,6
 2017,1,2016/2017,53,HHS Region 6,Season peak percentage,9.9
-2017,1,2016/2017,53,HHS Region 6,1 wk ahead,4.8
+2017,1,2016/2017,53,HHS Region 6,1 wk ahead,4.9
 2017,1,2016/2017,53,HHS Region 6,2 wk ahead,5.3
 2017,1,2016/2017,53,HHS Region 6,3 wk ahead,6.1
-2017,1,2016/2017,53,HHS Region 6,4 wk ahead,8.1
+2017,1,2016/2017,53,HHS Region 6,4 wk ahead,8.2
 2017,1,2016/2017,53,HHS Region 7,Season onset,51
 2017,1,2016/2017,53,HHS Region 7,Season peak week,6
 2017,1,2016/2017,53,HHS Region 7,Season peak percentage,6.4
@@ -16852,7 +16786,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,1,2016/2017,53,HHS Region 9,1 wk ahead,2.8
 2017,1,2016/2017,53,HHS Region 9,2 wk ahead,2.7
 2017,1,2016/2017,53,HHS Region 9,3 wk ahead,3
-2017,1,2016/2017,53,HHS Region 9,4 wk ahead,3
+2017,1,2016/2017,53,HHS Region 9,4 wk ahead,3.1
 2017,1,2016/2017,53,HHS Region 10,Season onset,50
 2017,1,2016/2017,53,HHS Region 10,Season peak week,52
 2017,1,2016/2017,53,HHS Region 10,Season peak percentage,3.7
@@ -16893,7 +16827,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,2,2016/2017,54,HHS Region 4,Season peak week,8
 2017,2,2016/2017,54,HHS Region 4,Season peak percentage,5.5
 2017,2,2016/2017,54,HHS Region 4,1 wk ahead,3.7
-2017,2,2016/2017,54,HHS Region 4,2 wk ahead,3.7
+2017,2,2016/2017,54,HHS Region 4,2 wk ahead,3.6
 2017,2,2016/2017,54,HHS Region 4,3 wk ahead,4.5
 2017,2,2016/2017,54,HHS Region 4,4 wk ahead,5.1
 2017,2,2016/2017,54,HHS Region 5,Season onset,52
@@ -16904,12 +16838,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,2,2016/2017,54,HHS Region 5,2 wk ahead,2.8
 2017,2,2016/2017,54,HHS Region 5,3 wk ahead,3.2
 2017,2,2016/2017,54,HHS Region 5,4 wk ahead,3.9
-2017,2,2016/2017,54,HHS Region 6,Season onset,2
+2017,2,2016/2017,54,HHS Region 6,Season onset,52
 2017,2,2016/2017,54,HHS Region 6,Season peak week,6
 2017,2,2016/2017,54,HHS Region 6,Season peak percentage,9.9
 2017,2,2016/2017,54,HHS Region 6,1 wk ahead,5.3
 2017,2,2016/2017,54,HHS Region 6,2 wk ahead,6.1
-2017,2,2016/2017,54,HHS Region 6,3 wk ahead,8.1
+2017,2,2016/2017,54,HHS Region 6,3 wk ahead,8.2
 2017,2,2016/2017,54,HHS Region 6,4 wk ahead,9.9
 2017,2,2016/2017,54,HHS Region 7,Season onset,51
 2017,2,2016/2017,54,HHS Region 7,Season peak week,6
@@ -16930,8 +16864,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,2,2016/2017,54,HHS Region 9,Season peak percentage,3.3
 2017,2,2016/2017,54,HHS Region 9,1 wk ahead,2.7
 2017,2,2016/2017,54,HHS Region 9,2 wk ahead,3
-2017,2,2016/2017,54,HHS Region 9,3 wk ahead,3
-2017,2,2016/2017,54,HHS Region 9,4 wk ahead,2.6
+2017,2,2016/2017,54,HHS Region 9,3 wk ahead,3.1
+2017,2,2016/2017,54,HHS Region 9,4 wk ahead,2.7
 2017,2,2016/2017,54,HHS Region 10,Season onset,50
 2017,2,2016/2017,54,HHS Region 10,Season peak week,52
 2017,2,2016/2017,54,HHS Region 10,Season peak percentage,3.7
@@ -16971,7 +16905,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,3,2016/2017,55,HHS Region 4,Season peak week,7
 2017,3,2016/2017,55,HHS Region 4,Season peak week,8
 2017,3,2016/2017,55,HHS Region 4,Season peak percentage,5.5
-2017,3,2016/2017,55,HHS Region 4,1 wk ahead,3.7
+2017,3,2016/2017,55,HHS Region 4,1 wk ahead,3.6
 2017,3,2016/2017,55,HHS Region 4,2 wk ahead,4.5
 2017,3,2016/2017,55,HHS Region 4,3 wk ahead,5.1
 2017,3,2016/2017,55,HHS Region 4,4 wk ahead,5.5
@@ -16983,13 +16917,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,3,2016/2017,55,HHS Region 5,2 wk ahead,3.2
 2017,3,2016/2017,55,HHS Region 5,3 wk ahead,3.9
 2017,3,2016/2017,55,HHS Region 5,4 wk ahead,4.3
-2017,3,2016/2017,55,HHS Region 6,Season onset,2
+2017,3,2016/2017,55,HHS Region 6,Season onset,52
 2017,3,2016/2017,55,HHS Region 6,Season peak week,6
 2017,3,2016/2017,55,HHS Region 6,Season peak percentage,9.9
 2017,3,2016/2017,55,HHS Region 6,1 wk ahead,6.1
-2017,3,2016/2017,55,HHS Region 6,2 wk ahead,8.1
+2017,3,2016/2017,55,HHS Region 6,2 wk ahead,8.2
 2017,3,2016/2017,55,HHS Region 6,3 wk ahead,9.9
-2017,3,2016/2017,55,HHS Region 6,4 wk ahead,8.8
+2017,3,2016/2017,55,HHS Region 6,4 wk ahead,8.9
 2017,3,2016/2017,55,HHS Region 7,Season onset,51
 2017,3,2016/2017,55,HHS Region 7,Season peak week,6
 2017,3,2016/2017,55,HHS Region 7,Season peak percentage,6.4
@@ -17008,8 +16942,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,3,2016/2017,55,HHS Region 9,Season peak week,52
 2017,3,2016/2017,55,HHS Region 9,Season peak percentage,3.3
 2017,3,2016/2017,55,HHS Region 9,1 wk ahead,3
-2017,3,2016/2017,55,HHS Region 9,2 wk ahead,3
-2017,3,2016/2017,55,HHS Region 9,3 wk ahead,2.6
+2017,3,2016/2017,55,HHS Region 9,2 wk ahead,3.1
+2017,3,2016/2017,55,HHS Region 9,3 wk ahead,2.7
 2017,3,2016/2017,55,HHS Region 9,4 wk ahead,2.5
 2017,3,2016/2017,55,HHS Region 10,Season onset,50
 2017,3,2016/2017,55,HHS Region 10,Season peak week,52
@@ -17062,13 +16996,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,4,2016/2017,56,HHS Region 5,2 wk ahead,3.9
 2017,4,2016/2017,56,HHS Region 5,3 wk ahead,4.3
 2017,4,2016/2017,56,HHS Region 5,4 wk ahead,4.3
-2017,4,2016/2017,56,HHS Region 6,Season onset,2
+2017,4,2016/2017,56,HHS Region 6,Season onset,52
 2017,4,2016/2017,56,HHS Region 6,Season peak week,6
 2017,4,2016/2017,56,HHS Region 6,Season peak percentage,9.9
-2017,4,2016/2017,56,HHS Region 6,1 wk ahead,8.1
+2017,4,2016/2017,56,HHS Region 6,1 wk ahead,8.2
 2017,4,2016/2017,56,HHS Region 6,2 wk ahead,9.9
-2017,4,2016/2017,56,HHS Region 6,3 wk ahead,8.8
-2017,4,2016/2017,56,HHS Region 6,4 wk ahead,8.3
+2017,4,2016/2017,56,HHS Region 6,3 wk ahead,8.9
+2017,4,2016/2017,56,HHS Region 6,4 wk ahead,8.2
 2017,4,2016/2017,56,HHS Region 7,Season onset,51
 2017,4,2016/2017,56,HHS Region 7,Season peak week,6
 2017,4,2016/2017,56,HHS Region 7,Season peak percentage,6.4
@@ -17086,10 +17020,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,4,2016/2017,56,HHS Region 9,Season onset,51
 2017,4,2016/2017,56,HHS Region 9,Season peak week,52
 2017,4,2016/2017,56,HHS Region 9,Season peak percentage,3.3
-2017,4,2016/2017,56,HHS Region 9,1 wk ahead,3
-2017,4,2016/2017,56,HHS Region 9,2 wk ahead,2.6
+2017,4,2016/2017,56,HHS Region 9,1 wk ahead,3.1
+2017,4,2016/2017,56,HHS Region 9,2 wk ahead,2.7
 2017,4,2016/2017,56,HHS Region 9,3 wk ahead,2.5
-2017,4,2016/2017,56,HHS Region 9,4 wk ahead,2.4
+2017,4,2016/2017,56,HHS Region 9,4 wk ahead,2.5
 2017,4,2016/2017,56,HHS Region 10,Season onset,50
 2017,4,2016/2017,56,HHS Region 10,Season peak week,52
 2017,4,2016/2017,56,HHS Region 10,Season peak percentage,3.7
@@ -17132,7 +17066,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,5,2016/2017,57,HHS Region 4,1 wk ahead,5.1
 2017,5,2016/2017,57,HHS Region 4,2 wk ahead,5.5
 2017,5,2016/2017,57,HHS Region 4,3 wk ahead,5.5
-2017,5,2016/2017,57,HHS Region 4,4 wk ahead,4.5
+2017,5,2016/2017,57,HHS Region 4,4 wk ahead,4.6
 2017,5,2016/2017,57,HHS Region 5,Season onset,52
 2017,5,2016/2017,57,HHS Region 5,Season peak week,7
 2017,5,2016/2017,57,HHS Region 5,Season peak week,8
@@ -17141,12 +17075,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,5,2016/2017,57,HHS Region 5,2 wk ahead,4.3
 2017,5,2016/2017,57,HHS Region 5,3 wk ahead,4.3
 2017,5,2016/2017,57,HHS Region 5,4 wk ahead,3
-2017,5,2016/2017,57,HHS Region 6,Season onset,2
+2017,5,2016/2017,57,HHS Region 6,Season onset,52
 2017,5,2016/2017,57,HHS Region 6,Season peak week,6
 2017,5,2016/2017,57,HHS Region 6,Season peak percentage,9.9
 2017,5,2016/2017,57,HHS Region 6,1 wk ahead,9.9
-2017,5,2016/2017,57,HHS Region 6,2 wk ahead,8.8
-2017,5,2016/2017,57,HHS Region 6,3 wk ahead,8.3
+2017,5,2016/2017,57,HHS Region 6,2 wk ahead,8.9
+2017,5,2016/2017,57,HHS Region 6,3 wk ahead,8.2
 2017,5,2016/2017,57,HHS Region 6,4 wk ahead,6.9
 2017,5,2016/2017,57,HHS Region 7,Season onset,51
 2017,5,2016/2017,57,HHS Region 7,Season peak week,6
@@ -17165,10 +17099,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,5,2016/2017,57,HHS Region 9,Season onset,51
 2017,5,2016/2017,57,HHS Region 9,Season peak week,52
 2017,5,2016/2017,57,HHS Region 9,Season peak percentage,3.3
-2017,5,2016/2017,57,HHS Region 9,1 wk ahead,2.6
+2017,5,2016/2017,57,HHS Region 9,1 wk ahead,2.7
 2017,5,2016/2017,57,HHS Region 9,2 wk ahead,2.5
-2017,5,2016/2017,57,HHS Region 9,3 wk ahead,2.4
-2017,5,2016/2017,57,HHS Region 9,4 wk ahead,2.2
+2017,5,2016/2017,57,HHS Region 9,3 wk ahead,2.5
+2017,5,2016/2017,57,HHS Region 9,4 wk ahead,2.3
 2017,5,2016/2017,57,HHS Region 10,Season onset,50
 2017,5,2016/2017,57,HHS Region 10,Season peak week,52
 2017,5,2016/2017,57,HHS Region 10,Season peak percentage,3.7
@@ -17210,7 +17144,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,6,2016/2017,58,HHS Region 4,Season peak percentage,5.5
 2017,6,2016/2017,58,HHS Region 4,1 wk ahead,5.5
 2017,6,2016/2017,58,HHS Region 4,2 wk ahead,5.5
-2017,6,2016/2017,58,HHS Region 4,3 wk ahead,4.5
+2017,6,2016/2017,58,HHS Region 4,3 wk ahead,4.6
 2017,6,2016/2017,58,HHS Region 4,4 wk ahead,4.5
 2017,6,2016/2017,58,HHS Region 5,Season onset,52
 2017,6,2016/2017,58,HHS Region 5,Season peak week,7
@@ -17220,11 +17154,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,6,2016/2017,58,HHS Region 5,2 wk ahead,4.3
 2017,6,2016/2017,58,HHS Region 5,3 wk ahead,3
 2017,6,2016/2017,58,HHS Region 5,4 wk ahead,3.3
-2017,6,2016/2017,58,HHS Region 6,Season onset,2
+2017,6,2016/2017,58,HHS Region 6,Season onset,52
 2017,6,2016/2017,58,HHS Region 6,Season peak week,6
 2017,6,2016/2017,58,HHS Region 6,Season peak percentage,9.9
-2017,6,2016/2017,58,HHS Region 6,1 wk ahead,8.8
-2017,6,2016/2017,58,HHS Region 6,2 wk ahead,8.3
+2017,6,2016/2017,58,HHS Region 6,1 wk ahead,8.9
+2017,6,2016/2017,58,HHS Region 6,2 wk ahead,8.2
 2017,6,2016/2017,58,HHS Region 6,3 wk ahead,6.9
 2017,6,2016/2017,58,HHS Region 6,4 wk ahead,6.5
 2017,6,2016/2017,58,HHS Region 7,Season onset,51
@@ -17245,9 +17179,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,6,2016/2017,58,HHS Region 9,Season peak week,52
 2017,6,2016/2017,58,HHS Region 9,Season peak percentage,3.3
 2017,6,2016/2017,58,HHS Region 9,1 wk ahead,2.5
-2017,6,2016/2017,58,HHS Region 9,2 wk ahead,2.4
-2017,6,2016/2017,58,HHS Region 9,3 wk ahead,2.2
-2017,6,2016/2017,58,HHS Region 9,4 wk ahead,2.2
+2017,6,2016/2017,58,HHS Region 9,2 wk ahead,2.5
+2017,6,2016/2017,58,HHS Region 9,3 wk ahead,2.3
+2017,6,2016/2017,58,HHS Region 9,4 wk ahead,2.3
 2017,6,2016/2017,58,HHS Region 10,Season onset,50
 2017,6,2016/2017,58,HHS Region 10,Season peak week,52
 2017,6,2016/2017,58,HHS Region 10,Season peak percentage,3.7
@@ -17288,7 +17222,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,7,2016/2017,59,HHS Region 4,Season peak week,8
 2017,7,2016/2017,59,HHS Region 4,Season peak percentage,5.5
 2017,7,2016/2017,59,HHS Region 4,1 wk ahead,5.5
-2017,7,2016/2017,59,HHS Region 4,2 wk ahead,4.5
+2017,7,2016/2017,59,HHS Region 4,2 wk ahead,4.6
 2017,7,2016/2017,59,HHS Region 4,3 wk ahead,4.5
 2017,7,2016/2017,59,HHS Region 4,4 wk ahead,3.9
 2017,7,2016/2017,59,HHS Region 5,Season onset,52
@@ -17299,10 +17233,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,7,2016/2017,59,HHS Region 5,2 wk ahead,3
 2017,7,2016/2017,59,HHS Region 5,3 wk ahead,3.3
 2017,7,2016/2017,59,HHS Region 5,4 wk ahead,3
-2017,7,2016/2017,59,HHS Region 6,Season onset,2
+2017,7,2016/2017,59,HHS Region 6,Season onset,52
 2017,7,2016/2017,59,HHS Region 6,Season peak week,6
 2017,7,2016/2017,59,HHS Region 6,Season peak percentage,9.9
-2017,7,2016/2017,59,HHS Region 6,1 wk ahead,8.3
+2017,7,2016/2017,59,HHS Region 6,1 wk ahead,8.2
 2017,7,2016/2017,59,HHS Region 6,2 wk ahead,6.9
 2017,7,2016/2017,59,HHS Region 6,3 wk ahead,6.5
 2017,7,2016/2017,59,HHS Region 6,4 wk ahead,5.4
@@ -17323,9 +17257,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,7,2016/2017,59,HHS Region 9,Season onset,51
 2017,7,2016/2017,59,HHS Region 9,Season peak week,52
 2017,7,2016/2017,59,HHS Region 9,Season peak percentage,3.3
-2017,7,2016/2017,59,HHS Region 9,1 wk ahead,2.4
-2017,7,2016/2017,59,HHS Region 9,2 wk ahead,2.2
-2017,7,2016/2017,59,HHS Region 9,3 wk ahead,2.2
+2017,7,2016/2017,59,HHS Region 9,1 wk ahead,2.5
+2017,7,2016/2017,59,HHS Region 9,2 wk ahead,2.3
+2017,7,2016/2017,59,HHS Region 9,3 wk ahead,2.3
 2017,7,2016/2017,59,HHS Region 9,4 wk ahead,2.3
 2017,7,2016/2017,59,HHS Region 10,Season onset,50
 2017,7,2016/2017,59,HHS Region 10,Season peak week,52
@@ -17366,7 +17300,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,8,2016/2017,60,HHS Region 4,Season peak week,7
 2017,8,2016/2017,60,HHS Region 4,Season peak week,8
 2017,8,2016/2017,60,HHS Region 4,Season peak percentage,5.5
-2017,8,2016/2017,60,HHS Region 4,1 wk ahead,4.5
+2017,8,2016/2017,60,HHS Region 4,1 wk ahead,4.6
 2017,8,2016/2017,60,HHS Region 4,2 wk ahead,4.5
 2017,8,2016/2017,60,HHS Region 4,3 wk ahead,3.9
 2017,8,2016/2017,60,HHS Region 4,4 wk ahead,4.7
@@ -17378,7 +17312,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,8,2016/2017,60,HHS Region 5,2 wk ahead,3.3
 2017,8,2016/2017,60,HHS Region 5,3 wk ahead,3
 2017,8,2016/2017,60,HHS Region 5,4 wk ahead,2.8
-2017,8,2016/2017,60,HHS Region 6,Season onset,2
+2017,8,2016/2017,60,HHS Region 6,Season onset,52
 2017,8,2016/2017,60,HHS Region 6,Season peak week,6
 2017,8,2016/2017,60,HHS Region 6,Season peak percentage,9.9
 2017,8,2016/2017,60,HHS Region 6,1 wk ahead,6.9
@@ -17402,10 +17336,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,8,2016/2017,60,HHS Region 9,Season onset,51
 2017,8,2016/2017,60,HHS Region 9,Season peak week,52
 2017,8,2016/2017,60,HHS Region 9,Season peak percentage,3.3
-2017,8,2016/2017,60,HHS Region 9,1 wk ahead,2.2
-2017,8,2016/2017,60,HHS Region 9,2 wk ahead,2.2
+2017,8,2016/2017,60,HHS Region 9,1 wk ahead,2.3
+2017,8,2016/2017,60,HHS Region 9,2 wk ahead,2.3
 2017,8,2016/2017,60,HHS Region 9,3 wk ahead,2.3
-2017,8,2016/2017,60,HHS Region 9,4 wk ahead,2
+2017,8,2016/2017,60,HHS Region 9,4 wk ahead,2.1
 2017,8,2016/2017,60,HHS Region 10,Season onset,50
 2017,8,2016/2017,60,HHS Region 10,Season peak week,52
 2017,8,2016/2017,60,HHS Region 10,Season peak percentage,3.7
@@ -17457,7 +17391,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,9,2016/2017,61,HHS Region 5,2 wk ahead,3
 2017,9,2016/2017,61,HHS Region 5,3 wk ahead,2.8
 2017,9,2016/2017,61,HHS Region 5,4 wk ahead,2.4
-2017,9,2016/2017,61,HHS Region 6,Season onset,2
+2017,9,2016/2017,61,HHS Region 6,Season onset,52
 2017,9,2016/2017,61,HHS Region 6,Season peak week,6
 2017,9,2016/2017,61,HHS Region 6,Season peak percentage,9.9
 2017,9,2016/2017,61,HHS Region 6,1 wk ahead,6.5
@@ -17481,10 +17415,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,9,2016/2017,61,HHS Region 9,Season onset,51
 2017,9,2016/2017,61,HHS Region 9,Season peak week,52
 2017,9,2016/2017,61,HHS Region 9,Season peak percentage,3.3
-2017,9,2016/2017,61,HHS Region 9,1 wk ahead,2.2
+2017,9,2016/2017,61,HHS Region 9,1 wk ahead,2.3
 2017,9,2016/2017,61,HHS Region 9,2 wk ahead,2.3
-2017,9,2016/2017,61,HHS Region 9,3 wk ahead,2
-2017,9,2016/2017,61,HHS Region 9,4 wk ahead,2
+2017,9,2016/2017,61,HHS Region 9,3 wk ahead,2.1
+2017,9,2016/2017,61,HHS Region 9,4 wk ahead,2.1
 2017,9,2016/2017,61,HHS Region 10,Season onset,50
 2017,9,2016/2017,61,HHS Region 10,Season peak week,52
 2017,9,2016/2017,61,HHS Region 10,Season peak percentage,3.7
@@ -17527,7 +17461,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,10,2016/2017,62,HHS Region 4,1 wk ahead,3.9
 2017,10,2016/2017,62,HHS Region 4,2 wk ahead,4.7
 2017,10,2016/2017,62,HHS Region 4,3 wk ahead,3.7
-2017,10,2016/2017,62,HHS Region 4,4 wk ahead,2.7
+2017,10,2016/2017,62,HHS Region 4,4 wk ahead,2.8
 2017,10,2016/2017,62,HHS Region 5,Season onset,52
 2017,10,2016/2017,62,HHS Region 5,Season peak week,7
 2017,10,2016/2017,62,HHS Region 5,Season peak week,8
@@ -17536,13 +17470,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,10,2016/2017,62,HHS Region 5,2 wk ahead,2.8
 2017,10,2016/2017,62,HHS Region 5,3 wk ahead,2.4
 2017,10,2016/2017,62,HHS Region 5,4 wk ahead,2.1
-2017,10,2016/2017,62,HHS Region 6,Season onset,2
+2017,10,2016/2017,62,HHS Region 6,Season onset,52
 2017,10,2016/2017,62,HHS Region 6,Season peak week,6
 2017,10,2016/2017,62,HHS Region 6,Season peak percentage,9.9
 2017,10,2016/2017,62,HHS Region 6,1 wk ahead,5.4
 2017,10,2016/2017,62,HHS Region 6,2 wk ahead,4.4
 2017,10,2016/2017,62,HHS Region 6,3 wk ahead,3.7
-2017,10,2016/2017,62,HHS Region 6,4 wk ahead,3.3
+2017,10,2016/2017,62,HHS Region 6,4 wk ahead,3.4
 2017,10,2016/2017,62,HHS Region 7,Season onset,51
 2017,10,2016/2017,62,HHS Region 7,Season peak week,6
 2017,10,2016/2017,62,HHS Region 7,Season peak percentage,6.4
@@ -17561,9 +17495,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,10,2016/2017,62,HHS Region 9,Season peak week,52
 2017,10,2016/2017,62,HHS Region 9,Season peak percentage,3.3
 2017,10,2016/2017,62,HHS Region 9,1 wk ahead,2.3
-2017,10,2016/2017,62,HHS Region 9,2 wk ahead,2
-2017,10,2016/2017,62,HHS Region 9,3 wk ahead,2
-2017,10,2016/2017,62,HHS Region 9,4 wk ahead,1.8
+2017,10,2016/2017,62,HHS Region 9,2 wk ahead,2.1
+2017,10,2016/2017,62,HHS Region 9,3 wk ahead,2.1
+2017,10,2016/2017,62,HHS Region 9,4 wk ahead,1.9
 2017,10,2016/2017,62,HHS Region 10,Season onset,50
 2017,10,2016/2017,62,HHS Region 10,Season peak week,52
 2017,10,2016/2017,62,HHS Region 10,Season peak percentage,3.7
@@ -17605,7 +17539,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,11,2016/2017,63,HHS Region 4,Season peak percentage,5.5
 2017,11,2016/2017,63,HHS Region 4,1 wk ahead,4.7
 2017,11,2016/2017,63,HHS Region 4,2 wk ahead,3.7
-2017,11,2016/2017,63,HHS Region 4,3 wk ahead,2.7
+2017,11,2016/2017,63,HHS Region 4,3 wk ahead,2.8
 2017,11,2016/2017,63,HHS Region 4,4 wk ahead,2.2
 2017,11,2016/2017,63,HHS Region 5,Season onset,52
 2017,11,2016/2017,63,HHS Region 5,Season peak week,7
@@ -17615,12 +17549,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,11,2016/2017,63,HHS Region 5,2 wk ahead,2.4
 2017,11,2016/2017,63,HHS Region 5,3 wk ahead,2.1
 2017,11,2016/2017,63,HHS Region 5,4 wk ahead,1.6
-2017,11,2016/2017,63,HHS Region 6,Season onset,2
+2017,11,2016/2017,63,HHS Region 6,Season onset,52
 2017,11,2016/2017,63,HHS Region 6,Season peak week,6
 2017,11,2016/2017,63,HHS Region 6,Season peak percentage,9.9
 2017,11,2016/2017,63,HHS Region 6,1 wk ahead,4.4
 2017,11,2016/2017,63,HHS Region 6,2 wk ahead,3.7
-2017,11,2016/2017,63,HHS Region 6,3 wk ahead,3.3
+2017,11,2016/2017,63,HHS Region 6,3 wk ahead,3.4
 2017,11,2016/2017,63,HHS Region 6,4 wk ahead,3
 2017,11,2016/2017,63,HHS Region 7,Season onset,51
 2017,11,2016/2017,63,HHS Region 7,Season peak week,6
@@ -17635,14 +17569,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,11,2016/2017,63,HHS Region 8,1 wk ahead,1.3
 2017,11,2016/2017,63,HHS Region 8,2 wk ahead,1.1
 2017,11,2016/2017,63,HHS Region 8,3 wk ahead,1.1
-2017,11,2016/2017,63,HHS Region 8,4 wk ahead,0.8
+2017,11,2016/2017,63,HHS Region 8,4 wk ahead,0.9
 2017,11,2016/2017,63,HHS Region 9,Season onset,51
 2017,11,2016/2017,63,HHS Region 9,Season peak week,52
 2017,11,2016/2017,63,HHS Region 9,Season peak percentage,3.3
-2017,11,2016/2017,63,HHS Region 9,1 wk ahead,2
-2017,11,2016/2017,63,HHS Region 9,2 wk ahead,2
-2017,11,2016/2017,63,HHS Region 9,3 wk ahead,1.8
-2017,11,2016/2017,63,HHS Region 9,4 wk ahead,1.6
+2017,11,2016/2017,63,HHS Region 9,1 wk ahead,2.1
+2017,11,2016/2017,63,HHS Region 9,2 wk ahead,2.1
+2017,11,2016/2017,63,HHS Region 9,3 wk ahead,1.9
+2017,11,2016/2017,63,HHS Region 9,4 wk ahead,1.7
 2017,11,2016/2017,63,HHS Region 10,Season onset,50
 2017,11,2016/2017,63,HHS Region 10,Season peak week,52
 2017,11,2016/2017,63,HHS Region 10,Season peak percentage,3.7
@@ -17656,7 +17590,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,12,2016/2017,64,US National,1 wk ahead,2.8
 2017,12,2016/2017,64,US National,2 wk ahead,2.4
 2017,12,2016/2017,64,US National,3 wk ahead,2
-2017,12,2016/2017,64,US National,4 wk ahead,1.7
+2017,12,2016/2017,64,US National,4 wk ahead,1.8
 2017,12,2016/2017,64,HHS Region 1,Season onset,52
 2017,12,2016/2017,64,HHS Region 1,Season peak week,6
 2017,12,2016/2017,64,HHS Region 1,Season peak percentage,3.2
@@ -17683,7 +17617,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,12,2016/2017,64,HHS Region 4,Season peak week,8
 2017,12,2016/2017,64,HHS Region 4,Season peak percentage,5.5
 2017,12,2016/2017,64,HHS Region 4,1 wk ahead,3.7
-2017,12,2016/2017,64,HHS Region 4,2 wk ahead,2.7
+2017,12,2016/2017,64,HHS Region 4,2 wk ahead,2.8
 2017,12,2016/2017,64,HHS Region 4,3 wk ahead,2.2
 2017,12,2016/2017,64,HHS Region 4,4 wk ahead,1.8
 2017,12,2016/2017,64,HHS Region 5,Season onset,52
@@ -17694,11 +17628,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,12,2016/2017,64,HHS Region 5,2 wk ahead,2.1
 2017,12,2016/2017,64,HHS Region 5,3 wk ahead,1.6
 2017,12,2016/2017,64,HHS Region 5,4 wk ahead,1.4
-2017,12,2016/2017,64,HHS Region 6,Season onset,2
+2017,12,2016/2017,64,HHS Region 6,Season onset,52
 2017,12,2016/2017,64,HHS Region 6,Season peak week,6
 2017,12,2016/2017,64,HHS Region 6,Season peak percentage,9.9
 2017,12,2016/2017,64,HHS Region 6,1 wk ahead,3.7
-2017,12,2016/2017,64,HHS Region 6,2 wk ahead,3.3
+2017,12,2016/2017,64,HHS Region 6,2 wk ahead,3.4
 2017,12,2016/2017,64,HHS Region 6,3 wk ahead,3
 2017,12,2016/2017,64,HHS Region 6,4 wk ahead,2.9
 2017,12,2016/2017,64,HHS Region 7,Season onset,51
@@ -17713,14 +17647,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,12,2016/2017,64,HHS Region 8,Season peak percentage,2.7
 2017,12,2016/2017,64,HHS Region 8,1 wk ahead,1.1
 2017,12,2016/2017,64,HHS Region 8,2 wk ahead,1.1
-2017,12,2016/2017,64,HHS Region 8,3 wk ahead,0.8
+2017,12,2016/2017,64,HHS Region 8,3 wk ahead,0.9
 2017,12,2016/2017,64,HHS Region 8,4 wk ahead,0.9
 2017,12,2016/2017,64,HHS Region 9,Season onset,51
 2017,12,2016/2017,64,HHS Region 9,Season peak week,52
 2017,12,2016/2017,64,HHS Region 9,Season peak percentage,3.3
-2017,12,2016/2017,64,HHS Region 9,1 wk ahead,2
-2017,12,2016/2017,64,HHS Region 9,2 wk ahead,1.8
-2017,12,2016/2017,64,HHS Region 9,3 wk ahead,1.6
+2017,12,2016/2017,64,HHS Region 9,1 wk ahead,2.1
+2017,12,2016/2017,64,HHS Region 9,2 wk ahead,1.9
+2017,12,2016/2017,64,HHS Region 9,3 wk ahead,1.7
 2017,12,2016/2017,64,HHS Region 9,4 wk ahead,1.7
 2017,12,2016/2017,64,HHS Region 10,Season onset,50
 2017,12,2016/2017,64,HHS Region 10,Season peak week,52
@@ -17734,7 +17668,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,13,2016/2017,65,US National,Season peak percentage,5.1
 2017,13,2016/2017,65,US National,1 wk ahead,2.4
 2017,13,2016/2017,65,US National,2 wk ahead,2
-2017,13,2016/2017,65,US National,3 wk ahead,1.7
+2017,13,2016/2017,65,US National,3 wk ahead,1.8
 2017,13,2016/2017,65,US National,4 wk ahead,1.6
 2017,13,2016/2017,65,HHS Region 1,Season onset,52
 2017,13,2016/2017,65,HHS Region 1,Season peak week,6
@@ -17761,7 +17695,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,13,2016/2017,65,HHS Region 4,Season peak week,7
 2017,13,2016/2017,65,HHS Region 4,Season peak week,8
 2017,13,2016/2017,65,HHS Region 4,Season peak percentage,5.5
-2017,13,2016/2017,65,HHS Region 4,1 wk ahead,2.7
+2017,13,2016/2017,65,HHS Region 4,1 wk ahead,2.8
 2017,13,2016/2017,65,HHS Region 4,2 wk ahead,2.2
 2017,13,2016/2017,65,HHS Region 4,3 wk ahead,1.8
 2017,13,2016/2017,65,HHS Region 4,4 wk ahead,1.5
@@ -17773,13 +17707,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,13,2016/2017,65,HHS Region 5,2 wk ahead,1.6
 2017,13,2016/2017,65,HHS Region 5,3 wk ahead,1.4
 2017,13,2016/2017,65,HHS Region 5,4 wk ahead,1.3
-2017,13,2016/2017,65,HHS Region 6,Season onset,2
+2017,13,2016/2017,65,HHS Region 6,Season onset,52
 2017,13,2016/2017,65,HHS Region 6,Season peak week,6
 2017,13,2016/2017,65,HHS Region 6,Season peak percentage,9.9
-2017,13,2016/2017,65,HHS Region 6,1 wk ahead,3.3
+2017,13,2016/2017,65,HHS Region 6,1 wk ahead,3.4
 2017,13,2016/2017,65,HHS Region 6,2 wk ahead,3
 2017,13,2016/2017,65,HHS Region 6,3 wk ahead,2.9
-2017,13,2016/2017,65,HHS Region 6,4 wk ahead,2.4
+2017,13,2016/2017,65,HHS Region 6,4 wk ahead,2.5
 2017,13,2016/2017,65,HHS Region 7,Season onset,51
 2017,13,2016/2017,65,HHS Region 7,Season peak week,6
 2017,13,2016/2017,65,HHS Region 7,Season peak percentage,6.4
@@ -17791,14 +17725,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,13,2016/2017,65,HHS Region 8,Season peak week,7
 2017,13,2016/2017,65,HHS Region 8,Season peak percentage,2.7
 2017,13,2016/2017,65,HHS Region 8,1 wk ahead,1.1
-2017,13,2016/2017,65,HHS Region 8,2 wk ahead,0.8
+2017,13,2016/2017,65,HHS Region 8,2 wk ahead,0.9
 2017,13,2016/2017,65,HHS Region 8,3 wk ahead,0.9
 2017,13,2016/2017,65,HHS Region 8,4 wk ahead,1
 2017,13,2016/2017,65,HHS Region 9,Season onset,51
 2017,13,2016/2017,65,HHS Region 9,Season peak week,52
 2017,13,2016/2017,65,HHS Region 9,Season peak percentage,3.3
-2017,13,2016/2017,65,HHS Region 9,1 wk ahead,1.8
-2017,13,2016/2017,65,HHS Region 9,2 wk ahead,1.6
+2017,13,2016/2017,65,HHS Region 9,1 wk ahead,1.9
+2017,13,2016/2017,65,HHS Region 9,2 wk ahead,1.7
 2017,13,2016/2017,65,HHS Region 9,3 wk ahead,1.7
 2017,13,2016/2017,65,HHS Region 9,4 wk ahead,1.8
 2017,13,2016/2017,65,HHS Region 10,Season onset,50
@@ -17812,7 +17746,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,14,2016/2017,66,US National,Season peak week,6
 2017,14,2016/2017,66,US National,Season peak percentage,5.1
 2017,14,2016/2017,66,US National,1 wk ahead,2
-2017,14,2016/2017,66,US National,2 wk ahead,1.7
+2017,14,2016/2017,66,US National,2 wk ahead,1.8
 2017,14,2016/2017,66,US National,3 wk ahead,1.6
 2017,14,2016/2017,66,US National,4 wk ahead,1.4
 2017,14,2016/2017,66,HHS Region 1,Season onset,52
@@ -17835,7 +17769,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,14,2016/2017,66,HHS Region 3,1 wk ahead,1.7
 2017,14,2016/2017,66,HHS Region 3,2 wk ahead,1.4
 2017,14,2016/2017,66,HHS Region 3,3 wk ahead,1.1
-2017,14,2016/2017,66,HHS Region 3,4 wk ahead,1.1
+2017,14,2016/2017,66,HHS Region 3,4 wk ahead,1
 2017,14,2016/2017,66,HHS Region 4,Season onset,45
 2017,14,2016/2017,66,HHS Region 4,Season peak week,7
 2017,14,2016/2017,66,HHS Region 4,Season peak week,8
@@ -17843,7 +17777,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,14,2016/2017,66,HHS Region 4,1 wk ahead,2.2
 2017,14,2016/2017,66,HHS Region 4,2 wk ahead,1.8
 2017,14,2016/2017,66,HHS Region 4,3 wk ahead,1.5
-2017,14,2016/2017,66,HHS Region 4,4 wk ahead,1.2
+2017,14,2016/2017,66,HHS Region 4,4 wk ahead,1.3
 2017,14,2016/2017,66,HHS Region 5,Season onset,52
 2017,14,2016/2017,66,HHS Region 5,Season peak week,7
 2017,14,2016/2017,66,HHS Region 5,Season peak week,8
@@ -17852,34 +17786,34 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,14,2016/2017,66,HHS Region 5,2 wk ahead,1.4
 2017,14,2016/2017,66,HHS Region 5,3 wk ahead,1.3
 2017,14,2016/2017,66,HHS Region 5,4 wk ahead,1.1
-2017,14,2016/2017,66,HHS Region 6,Season onset,2
+2017,14,2016/2017,66,HHS Region 6,Season onset,52
 2017,14,2016/2017,66,HHS Region 6,Season peak week,6
 2017,14,2016/2017,66,HHS Region 6,Season peak percentage,9.9
 2017,14,2016/2017,66,HHS Region 6,1 wk ahead,3
 2017,14,2016/2017,66,HHS Region 6,2 wk ahead,2.9
-2017,14,2016/2017,66,HHS Region 6,3 wk ahead,2.4
-2017,14,2016/2017,66,HHS Region 6,4 wk ahead,2.3
+2017,14,2016/2017,66,HHS Region 6,3 wk ahead,2.5
+2017,14,2016/2017,66,HHS Region 6,4 wk ahead,2.4
 2017,14,2016/2017,66,HHS Region 7,Season onset,51
 2017,14,2016/2017,66,HHS Region 7,Season peak week,6
 2017,14,2016/2017,66,HHS Region 7,Season peak percentage,6.4
 2017,14,2016/2017,66,HHS Region 7,1 wk ahead,1
 2017,14,2016/2017,66,HHS Region 7,2 wk ahead,0.9
 2017,14,2016/2017,66,HHS Region 7,3 wk ahead,0.8
-2017,14,2016/2017,66,HHS Region 7,4 wk ahead,0.7
+2017,14,2016/2017,66,HHS Region 7,4 wk ahead,0.8
 2017,14,2016/2017,66,HHS Region 8,Season onset,51
 2017,14,2016/2017,66,HHS Region 8,Season peak week,7
 2017,14,2016/2017,66,HHS Region 8,Season peak percentage,2.7
-2017,14,2016/2017,66,HHS Region 8,1 wk ahead,0.8
+2017,14,2016/2017,66,HHS Region 8,1 wk ahead,0.9
 2017,14,2016/2017,66,HHS Region 8,2 wk ahead,0.9
 2017,14,2016/2017,66,HHS Region 8,3 wk ahead,1
 2017,14,2016/2017,66,HHS Region 8,4 wk ahead,1
 2017,14,2016/2017,66,HHS Region 9,Season onset,51
 2017,14,2016/2017,66,HHS Region 9,Season peak week,52
 2017,14,2016/2017,66,HHS Region 9,Season peak percentage,3.3
-2017,14,2016/2017,66,HHS Region 9,1 wk ahead,1.6
+2017,14,2016/2017,66,HHS Region 9,1 wk ahead,1.7
 2017,14,2016/2017,66,HHS Region 9,2 wk ahead,1.7
 2017,14,2016/2017,66,HHS Region 9,3 wk ahead,1.8
-2017,14,2016/2017,66,HHS Region 9,4 wk ahead,1.6
+2017,14,2016/2017,66,HHS Region 9,4 wk ahead,1.7
 2017,14,2016/2017,66,HHS Region 10,Season onset,50
 2017,14,2016/2017,66,HHS Region 10,Season peak week,52
 2017,14,2016/2017,66,HHS Region 10,Season peak percentage,3.7
@@ -17890,7 +17824,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,15,2016/2017,67,US National,Season onset,50
 2017,15,2016/2017,67,US National,Season peak week,6
 2017,15,2016/2017,67,US National,Season peak percentage,5.1
-2017,15,2016/2017,67,US National,1 wk ahead,1.7
+2017,15,2016/2017,67,US National,1 wk ahead,1.8
 2017,15,2016/2017,67,US National,2 wk ahead,1.6
 2017,15,2016/2017,67,US National,3 wk ahead,1.4
 2017,15,2016/2017,67,US National,4 wk ahead,1.3
@@ -17913,7 +17847,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,15,2016/2017,67,HHS Region 3,Season peak percentage,5.2
 2017,15,2016/2017,67,HHS Region 3,1 wk ahead,1.4
 2017,15,2016/2017,67,HHS Region 3,2 wk ahead,1.1
-2017,15,2016/2017,67,HHS Region 3,3 wk ahead,1.1
+2017,15,2016/2017,67,HHS Region 3,3 wk ahead,1
 2017,15,2016/2017,67,HHS Region 3,4 wk ahead,0.9
 2017,15,2016/2017,67,HHS Region 4,Season onset,45
 2017,15,2016/2017,67,HHS Region 4,Season peak week,7
@@ -17921,7 +17855,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,15,2016/2017,67,HHS Region 4,Season peak percentage,5.5
 2017,15,2016/2017,67,HHS Region 4,1 wk ahead,1.8
 2017,15,2016/2017,67,HHS Region 4,2 wk ahead,1.5
-2017,15,2016/2017,67,HHS Region 4,3 wk ahead,1.2
+2017,15,2016/2017,67,HHS Region 4,3 wk ahead,1.3
 2017,15,2016/2017,67,HHS Region 4,4 wk ahead,1.4
 2017,15,2016/2017,67,HHS Region 5,Season onset,52
 2017,15,2016/2017,67,HHS Region 5,Season peak week,7
@@ -17931,20 +17865,20 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,15,2016/2017,67,HHS Region 5,2 wk ahead,1.3
 2017,15,2016/2017,67,HHS Region 5,3 wk ahead,1.1
 2017,15,2016/2017,67,HHS Region 5,4 wk ahead,1.1
-2017,15,2016/2017,67,HHS Region 6,Season onset,2
+2017,15,2016/2017,67,HHS Region 6,Season onset,52
 2017,15,2016/2017,67,HHS Region 6,Season peak week,6
 2017,15,2016/2017,67,HHS Region 6,Season peak percentage,9.9
 2017,15,2016/2017,67,HHS Region 6,1 wk ahead,2.9
-2017,15,2016/2017,67,HHS Region 6,2 wk ahead,2.4
-2017,15,2016/2017,67,HHS Region 6,3 wk ahead,2.3
+2017,15,2016/2017,67,HHS Region 6,2 wk ahead,2.5
+2017,15,2016/2017,67,HHS Region 6,3 wk ahead,2.4
 2017,15,2016/2017,67,HHS Region 6,4 wk ahead,1.7
 2017,15,2016/2017,67,HHS Region 7,Season onset,51
 2017,15,2016/2017,67,HHS Region 7,Season peak week,6
 2017,15,2016/2017,67,HHS Region 7,Season peak percentage,6.4
 2017,15,2016/2017,67,HHS Region 7,1 wk ahead,0.9
 2017,15,2016/2017,67,HHS Region 7,2 wk ahead,0.8
-2017,15,2016/2017,67,HHS Region 7,3 wk ahead,0.7
-2017,15,2016/2017,67,HHS Region 7,4 wk ahead,0.4
+2017,15,2016/2017,67,HHS Region 7,3 wk ahead,0.8
+2017,15,2016/2017,67,HHS Region 7,4 wk ahead,0.5
 2017,15,2016/2017,67,HHS Region 8,Season onset,51
 2017,15,2016/2017,67,HHS Region 8,Season peak week,7
 2017,15,2016/2017,67,HHS Region 8,Season peak percentage,2.7
@@ -17957,8 +17891,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,15,2016/2017,67,HHS Region 9,Season peak percentage,3.3
 2017,15,2016/2017,67,HHS Region 9,1 wk ahead,1.7
 2017,15,2016/2017,67,HHS Region 9,2 wk ahead,1.8
-2017,15,2016/2017,67,HHS Region 9,3 wk ahead,1.6
-2017,15,2016/2017,67,HHS Region 9,4 wk ahead,1.5
+2017,15,2016/2017,67,HHS Region 9,3 wk ahead,1.7
+2017,15,2016/2017,67,HHS Region 9,4 wk ahead,1.6
 2017,15,2016/2017,67,HHS Region 10,Season onset,50
 2017,15,2016/2017,67,HHS Region 10,Season peak week,52
 2017,15,2016/2017,67,HHS Region 10,Season peak percentage,3.7
@@ -17991,7 +17925,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,16,2016/2017,68,HHS Region 3,Season peak week,7
 2017,16,2016/2017,68,HHS Region 3,Season peak percentage,5.2
 2017,16,2016/2017,68,HHS Region 3,1 wk ahead,1.1
-2017,16,2016/2017,68,HHS Region 3,2 wk ahead,1.1
+2017,16,2016/2017,68,HHS Region 3,2 wk ahead,1
 2017,16,2016/2017,68,HHS Region 3,3 wk ahead,0.9
 2017,16,2016/2017,68,HHS Region 3,4 wk ahead,1
 2017,16,2016/2017,68,HHS Region 4,Season onset,45
@@ -17999,7 +17933,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,16,2016/2017,68,HHS Region 4,Season peak week,8
 2017,16,2016/2017,68,HHS Region 4,Season peak percentage,5.5
 2017,16,2016/2017,68,HHS Region 4,1 wk ahead,1.5
-2017,16,2016/2017,68,HHS Region 4,2 wk ahead,1.2
+2017,16,2016/2017,68,HHS Region 4,2 wk ahead,1.3
 2017,16,2016/2017,68,HHS Region 4,3 wk ahead,1.4
 2017,16,2016/2017,68,HHS Region 4,4 wk ahead,1.3
 2017,16,2016/2017,68,HHS Region 5,Season onset,52
@@ -18010,19 +17944,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,16,2016/2017,68,HHS Region 5,2 wk ahead,1.1
 2017,16,2016/2017,68,HHS Region 5,3 wk ahead,1.1
 2017,16,2016/2017,68,HHS Region 5,4 wk ahead,0.9
-2017,16,2016/2017,68,HHS Region 6,Season onset,2
+2017,16,2016/2017,68,HHS Region 6,Season onset,52
 2017,16,2016/2017,68,HHS Region 6,Season peak week,6
 2017,16,2016/2017,68,HHS Region 6,Season peak percentage,9.9
-2017,16,2016/2017,68,HHS Region 6,1 wk ahead,2.4
-2017,16,2016/2017,68,HHS Region 6,2 wk ahead,2.3
+2017,16,2016/2017,68,HHS Region 6,1 wk ahead,2.5
+2017,16,2016/2017,68,HHS Region 6,2 wk ahead,2.4
 2017,16,2016/2017,68,HHS Region 6,3 wk ahead,1.7
-2017,16,2016/2017,68,HHS Region 6,4 wk ahead,2.1
+2017,16,2016/2017,68,HHS Region 6,4 wk ahead,2.2
 2017,16,2016/2017,68,HHS Region 7,Season onset,51
 2017,16,2016/2017,68,HHS Region 7,Season peak week,6
 2017,16,2016/2017,68,HHS Region 7,Season peak percentage,6.4
 2017,16,2016/2017,68,HHS Region 7,1 wk ahead,0.8
-2017,16,2016/2017,68,HHS Region 7,2 wk ahead,0.7
-2017,16,2016/2017,68,HHS Region 7,3 wk ahead,0.4
+2017,16,2016/2017,68,HHS Region 7,2 wk ahead,0.8
+2017,16,2016/2017,68,HHS Region 7,3 wk ahead,0.5
 2017,16,2016/2017,68,HHS Region 7,4 wk ahead,0.3
 2017,16,2016/2017,68,HHS Region 8,Season onset,51
 2017,16,2016/2017,68,HHS Region 8,Season peak week,7
@@ -18035,9 +17969,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,16,2016/2017,68,HHS Region 9,Season peak week,52
 2017,16,2016/2017,68,HHS Region 9,Season peak percentage,3.3
 2017,16,2016/2017,68,HHS Region 9,1 wk ahead,1.8
-2017,16,2016/2017,68,HHS Region 9,2 wk ahead,1.6
-2017,16,2016/2017,68,HHS Region 9,3 wk ahead,1.5
-2017,16,2016/2017,68,HHS Region 9,4 wk ahead,1.5
+2017,16,2016/2017,68,HHS Region 9,2 wk ahead,1.7
+2017,16,2016/2017,68,HHS Region 9,3 wk ahead,1.6
+2017,16,2016/2017,68,HHS Region 9,4 wk ahead,1.6
 2017,16,2016/2017,68,HHS Region 10,Season onset,50
 2017,16,2016/2017,68,HHS Region 10,Season peak week,52
 2017,16,2016/2017,68,HHS Region 10,Season peak percentage,3.7
@@ -18069,7 +18003,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,17,2016/2017,69,HHS Region 3,Season onset,51
 2017,17,2016/2017,69,HHS Region 3,Season peak week,7
 2017,17,2016/2017,69,HHS Region 3,Season peak percentage,5.2
-2017,17,2016/2017,69,HHS Region 3,1 wk ahead,1.1
+2017,17,2016/2017,69,HHS Region 3,1 wk ahead,1
 2017,17,2016/2017,69,HHS Region 3,2 wk ahead,0.9
 2017,17,2016/2017,69,HHS Region 3,3 wk ahead,1
 2017,17,2016/2017,69,HHS Region 3,4 wk ahead,0.9
@@ -18077,7 +18011,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,17,2016/2017,69,HHS Region 4,Season peak week,7
 2017,17,2016/2017,69,HHS Region 4,Season peak week,8
 2017,17,2016/2017,69,HHS Region 4,Season peak percentage,5.5
-2017,17,2016/2017,69,HHS Region 4,1 wk ahead,1.2
+2017,17,2016/2017,69,HHS Region 4,1 wk ahead,1.3
 2017,17,2016/2017,69,HHS Region 4,2 wk ahead,1.4
 2017,17,2016/2017,69,HHS Region 4,3 wk ahead,1.3
 2017,17,2016/2017,69,HHS Region 4,4 wk ahead,1.2
@@ -18089,18 +18023,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,17,2016/2017,69,HHS Region 5,2 wk ahead,1.1
 2017,17,2016/2017,69,HHS Region 5,3 wk ahead,0.9
 2017,17,2016/2017,69,HHS Region 5,4 wk ahead,0.8
-2017,17,2016/2017,69,HHS Region 6,Season onset,2
+2017,17,2016/2017,69,HHS Region 6,Season onset,52
 2017,17,2016/2017,69,HHS Region 6,Season peak week,6
 2017,17,2016/2017,69,HHS Region 6,Season peak percentage,9.9
-2017,17,2016/2017,69,HHS Region 6,1 wk ahead,2.3
+2017,17,2016/2017,69,HHS Region 6,1 wk ahead,2.4
 2017,17,2016/2017,69,HHS Region 6,2 wk ahead,1.7
-2017,17,2016/2017,69,HHS Region 6,3 wk ahead,2.1
-2017,17,2016/2017,69,HHS Region 6,4 wk ahead,1.8
+2017,17,2016/2017,69,HHS Region 6,3 wk ahead,2.2
+2017,17,2016/2017,69,HHS Region 6,4 wk ahead,1.9
 2017,17,2016/2017,69,HHS Region 7,Season onset,51
 2017,17,2016/2017,69,HHS Region 7,Season peak week,6
 2017,17,2016/2017,69,HHS Region 7,Season peak percentage,6.4
-2017,17,2016/2017,69,HHS Region 7,1 wk ahead,0.7
-2017,17,2016/2017,69,HHS Region 7,2 wk ahead,0.4
+2017,17,2016/2017,69,HHS Region 7,1 wk ahead,0.8
+2017,17,2016/2017,69,HHS Region 7,2 wk ahead,0.5
 2017,17,2016/2017,69,HHS Region 7,3 wk ahead,0.3
 2017,17,2016/2017,69,HHS Region 7,4 wk ahead,0.2
 2017,17,2016/2017,69,HHS Region 8,Season onset,51
@@ -18113,10 +18047,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,17,2016/2017,69,HHS Region 9,Season onset,51
 2017,17,2016/2017,69,HHS Region 9,Season peak week,52
 2017,17,2016/2017,69,HHS Region 9,Season peak percentage,3.3
-2017,17,2016/2017,69,HHS Region 9,1 wk ahead,1.6
-2017,17,2016/2017,69,HHS Region 9,2 wk ahead,1.5
-2017,17,2016/2017,69,HHS Region 9,3 wk ahead,1.5
-2017,17,2016/2017,69,HHS Region 9,4 wk ahead,1.4
+2017,17,2016/2017,69,HHS Region 9,1 wk ahead,1.7
+2017,17,2016/2017,69,HHS Region 9,2 wk ahead,1.6
+2017,17,2016/2017,69,HHS Region 9,3 wk ahead,1.6
+2017,17,2016/2017,69,HHS Region 9,4 wk ahead,1.5
 2017,17,2016/2017,69,HHS Region 10,Season onset,50
 2017,17,2016/2017,69,HHS Region 10,Season peak week,52
 2017,17,2016/2017,69,HHS Region 10,Season peak percentage,3.7
@@ -18159,7 +18093,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,18,2016/2017,70,HHS Region 4,1 wk ahead,1.4
 2017,18,2016/2017,70,HHS Region 4,2 wk ahead,1.3
 2017,18,2016/2017,70,HHS Region 4,3 wk ahead,1.2
-2017,18,2016/2017,70,HHS Region 4,4 wk ahead,1
+2017,18,2016/2017,70,HHS Region 4,4 wk ahead,0.9
 2017,18,2016/2017,70,HHS Region 5,Season onset,52
 2017,18,2016/2017,70,HHS Region 5,Season peak week,7
 2017,18,2016/2017,70,HHS Region 5,Season peak week,8
@@ -18168,17 +18102,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,18,2016/2017,70,HHS Region 5,2 wk ahead,0.9
 2017,18,2016/2017,70,HHS Region 5,3 wk ahead,0.8
 2017,18,2016/2017,70,HHS Region 5,4 wk ahead,0.8
-2017,18,2016/2017,70,HHS Region 6,Season onset,2
+2017,18,2016/2017,70,HHS Region 6,Season onset,52
 2017,18,2016/2017,70,HHS Region 6,Season peak week,6
 2017,18,2016/2017,70,HHS Region 6,Season peak percentage,9.9
 2017,18,2016/2017,70,HHS Region 6,1 wk ahead,1.7
-2017,18,2016/2017,70,HHS Region 6,2 wk ahead,2.1
-2017,18,2016/2017,70,HHS Region 6,3 wk ahead,1.8
-2017,18,2016/2017,70,HHS Region 6,4 wk ahead,1.6
+2017,18,2016/2017,70,HHS Region 6,2 wk ahead,2.2
+2017,18,2016/2017,70,HHS Region 6,3 wk ahead,1.9
+2017,18,2016/2017,70,HHS Region 6,4 wk ahead,1.7
 2017,18,2016/2017,70,HHS Region 7,Season onset,51
 2017,18,2016/2017,70,HHS Region 7,Season peak week,6
 2017,18,2016/2017,70,HHS Region 7,Season peak percentage,6.4
-2017,18,2016/2017,70,HHS Region 7,1 wk ahead,0.4
+2017,18,2016/2017,70,HHS Region 7,1 wk ahead,0.5
 2017,18,2016/2017,70,HHS Region 7,2 wk ahead,0.3
 2017,18,2016/2017,70,HHS Region 7,3 wk ahead,0.2
 2017,18,2016/2017,70,HHS Region 7,4 wk ahead,0.2
@@ -18188,14 +18122,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,18,2016/2017,70,HHS Region 8,1 wk ahead,0.6
 2017,18,2016/2017,70,HHS Region 8,2 wk ahead,0.8
 2017,18,2016/2017,70,HHS Region 8,3 wk ahead,0.9
-2017,18,2016/2017,70,HHS Region 8,4 wk ahead,0.6
+2017,18,2016/2017,70,HHS Region 8,4 wk ahead,0.5
 2017,18,2016/2017,70,HHS Region 9,Season onset,51
 2017,18,2016/2017,70,HHS Region 9,Season peak week,52
 2017,18,2016/2017,70,HHS Region 9,Season peak percentage,3.3
-2017,18,2016/2017,70,HHS Region 9,1 wk ahead,1.5
-2017,18,2016/2017,70,HHS Region 9,2 wk ahead,1.5
-2017,18,2016/2017,70,HHS Region 9,3 wk ahead,1.4
-2017,18,2016/2017,70,HHS Region 9,4 wk ahead,1.4
+2017,18,2016/2017,70,HHS Region 9,1 wk ahead,1.6
+2017,18,2016/2017,70,HHS Region 9,2 wk ahead,1.6
+2017,18,2016/2017,70,HHS Region 9,3 wk ahead,1.5
+2017,18,2016/2017,70,HHS Region 9,4 wk ahead,1.5
 2017,18,2016/2017,70,HHS Region 10,Season onset,50
 2017,18,2016/2017,70,HHS Region 10,Season peak week,52
 2017,18,2016/2017,70,HHS Region 10,Season peak percentage,3.7
@@ -18209,14 +18143,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,19,2016/2017,71,US National,1 wk ahead,1.3
 2017,19,2016/2017,71,US National,2 wk ahead,1.2
 2017,19,2016/2017,71,US National,3 wk ahead,1.1
-2017,19,2016/2017,71,US National,4 wk ahead,1
+2017,19,2016/2017,71,US National,4 wk ahead,1.1
 2017,19,2016/2017,71,HHS Region 1,Season onset,52
 2017,19,2016/2017,71,HHS Region 1,Season peak week,6
 2017,19,2016/2017,71,HHS Region 1,Season peak percentage,3.2
 2017,19,2016/2017,71,HHS Region 1,1 wk ahead,0.7
 2017,19,2016/2017,71,HHS Region 1,2 wk ahead,0.6
 2017,19,2016/2017,71,HHS Region 1,3 wk ahead,0.7
-2017,19,2016/2017,71,HHS Region 1,4 wk ahead,0.6
+2017,19,2016/2017,71,HHS Region 1,4 wk ahead,0.5
 2017,19,2016/2017,71,HHS Region 2,Season onset,47
 2017,19,2016/2017,71,HHS Region 2,Season peak week,6
 2017,19,2016/2017,71,HHS Region 2,Season peak percentage,6.9
@@ -18237,8 +18171,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,19,2016/2017,71,HHS Region 4,Season peak percentage,5.5
 2017,19,2016/2017,71,HHS Region 4,1 wk ahead,1.3
 2017,19,2016/2017,71,HHS Region 4,2 wk ahead,1.2
-2017,19,2016/2017,71,HHS Region 4,3 wk ahead,1
-2017,19,2016/2017,71,HHS Region 4,4 wk ahead,0.9
+2017,19,2016/2017,71,HHS Region 4,3 wk ahead,0.9
+2017,19,2016/2017,71,HHS Region 4,4 wk ahead,0.8
 2017,19,2016/2017,71,HHS Region 5,Season onset,52
 2017,19,2016/2017,71,HHS Region 5,Season peak week,7
 2017,19,2016/2017,71,HHS Region 5,Season peak week,8
@@ -18247,62 +18181,62 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,19,2016/2017,71,HHS Region 5,2 wk ahead,0.8
 2017,19,2016/2017,71,HHS Region 5,3 wk ahead,0.8
 2017,19,2016/2017,71,HHS Region 5,4 wk ahead,0.7
-2017,19,2016/2017,71,HHS Region 6,Season onset,2
+2017,19,2016/2017,71,HHS Region 6,Season onset,52
 2017,19,2016/2017,71,HHS Region 6,Season peak week,6
 2017,19,2016/2017,71,HHS Region 6,Season peak percentage,9.9
-2017,19,2016/2017,71,HHS Region 6,1 wk ahead,2.1
-2017,19,2016/2017,71,HHS Region 6,2 wk ahead,1.8
-2017,19,2016/2017,71,HHS Region 6,3 wk ahead,1.6
-2017,19,2016/2017,71,HHS Region 6,4 wk ahead,1.5
+2017,19,2016/2017,71,HHS Region 6,1 wk ahead,2.2
+2017,19,2016/2017,71,HHS Region 6,2 wk ahead,1.9
+2017,19,2016/2017,71,HHS Region 6,3 wk ahead,1.7
+2017,19,2016/2017,71,HHS Region 6,4 wk ahead,1.6
 2017,19,2016/2017,71,HHS Region 7,Season onset,51
 2017,19,2016/2017,71,HHS Region 7,Season peak week,6
 2017,19,2016/2017,71,HHS Region 7,Season peak percentage,6.4
 2017,19,2016/2017,71,HHS Region 7,1 wk ahead,0.3
 2017,19,2016/2017,71,HHS Region 7,2 wk ahead,0.2
 2017,19,2016/2017,71,HHS Region 7,3 wk ahead,0.2
-2017,19,2016/2017,71,HHS Region 7,4 wk ahead,0.2
+2017,19,2016/2017,71,HHS Region 7,4 wk ahead,0.3
 2017,19,2016/2017,71,HHS Region 8,Season onset,51
 2017,19,2016/2017,71,HHS Region 8,Season peak week,7
 2017,19,2016/2017,71,HHS Region 8,Season peak percentage,2.7
 2017,19,2016/2017,71,HHS Region 8,1 wk ahead,0.8
 2017,19,2016/2017,71,HHS Region 8,2 wk ahead,0.9
-2017,19,2016/2017,71,HHS Region 8,3 wk ahead,0.6
+2017,19,2016/2017,71,HHS Region 8,3 wk ahead,0.5
 2017,19,2016/2017,71,HHS Region 8,4 wk ahead,0.4
 2017,19,2016/2017,71,HHS Region 9,Season onset,51
 2017,19,2016/2017,71,HHS Region 9,Season peak week,52
 2017,19,2016/2017,71,HHS Region 9,Season peak percentage,3.3
-2017,19,2016/2017,71,HHS Region 9,1 wk ahead,1.5
-2017,19,2016/2017,71,HHS Region 9,2 wk ahead,1.4
-2017,19,2016/2017,71,HHS Region 9,3 wk ahead,1.4
-2017,19,2016/2017,71,HHS Region 9,4 wk ahead,1.5
+2017,19,2016/2017,71,HHS Region 9,1 wk ahead,1.6
+2017,19,2016/2017,71,HHS Region 9,2 wk ahead,1.5
+2017,19,2016/2017,71,HHS Region 9,3 wk ahead,1.5
+2017,19,2016/2017,71,HHS Region 9,4 wk ahead,1.6
 2017,19,2016/2017,71,HHS Region 10,Season onset,50
 2017,19,2016/2017,71,HHS Region 10,Season peak week,52
 2017,19,2016/2017,71,HHS Region 10,Season peak percentage,3.7
 2017,19,2016/2017,71,HHS Region 10,1 wk ahead,0.6
 2017,19,2016/2017,71,HHS Region 10,2 wk ahead,0.3
 2017,19,2016/2017,71,HHS Region 10,3 wk ahead,0.4
-2017,19,2016/2017,71,HHS Region 10,4 wk ahead,0.2
+2017,19,2016/2017,71,HHS Region 10,4 wk ahead,0.3
 2017,20,2016/2017,72,US National,Season onset,50
 2017,20,2016/2017,72,US National,Season peak week,6
 2017,20,2016/2017,72,US National,Season peak percentage,5.1
 2017,20,2016/2017,72,US National,1 wk ahead,1.2
 2017,20,2016/2017,72,US National,2 wk ahead,1.1
-2017,20,2016/2017,72,US National,3 wk ahead,1
+2017,20,2016/2017,72,US National,3 wk ahead,1.1
 2017,20,2016/2017,72,US National,4 wk ahead,0.9
 2017,20,2016/2017,72,HHS Region 1,Season onset,52
 2017,20,2016/2017,72,HHS Region 1,Season peak week,6
 2017,20,2016/2017,72,HHS Region 1,Season peak percentage,3.2
 2017,20,2016/2017,72,HHS Region 1,1 wk ahead,0.6
 2017,20,2016/2017,72,HHS Region 1,2 wk ahead,0.7
-2017,20,2016/2017,72,HHS Region 1,3 wk ahead,0.6
-2017,20,2016/2017,72,HHS Region 1,4 wk ahead,0.5
+2017,20,2016/2017,72,HHS Region 1,3 wk ahead,0.5
+2017,20,2016/2017,72,HHS Region 1,4 wk ahead,0.4
 2017,20,2016/2017,72,HHS Region 2,Season onset,47
 2017,20,2016/2017,72,HHS Region 2,Season peak week,6
 2017,20,2016/2017,72,HHS Region 2,Season peak percentage,6.9
 2017,20,2016/2017,72,HHS Region 2,1 wk ahead,1.8
 2017,20,2016/2017,72,HHS Region 2,2 wk ahead,2
 2017,20,2016/2017,72,HHS Region 2,3 wk ahead,1.9
-2017,20,2016/2017,72,HHS Region 2,4 wk ahead,1.7
+2017,20,2016/2017,72,HHS Region 2,4 wk ahead,1.8
 2017,20,2016/2017,72,HHS Region 3,Season onset,51
 2017,20,2016/2017,72,HHS Region 3,Season peak week,7
 2017,20,2016/2017,72,HHS Region 3,Season peak percentage,5.2
@@ -18315,9 +18249,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,20,2016/2017,72,HHS Region 4,Season peak week,8
 2017,20,2016/2017,72,HHS Region 4,Season peak percentage,5.5
 2017,20,2016/2017,72,HHS Region 4,1 wk ahead,1.2
-2017,20,2016/2017,72,HHS Region 4,2 wk ahead,1
-2017,20,2016/2017,72,HHS Region 4,3 wk ahead,0.9
-2017,20,2016/2017,72,HHS Region 4,4 wk ahead,0.7
+2017,20,2016/2017,72,HHS Region 4,2 wk ahead,0.9
+2017,20,2016/2017,72,HHS Region 4,3 wk ahead,0.8
+2017,20,2016/2017,72,HHS Region 4,4 wk ahead,0.6
 2017,20,2016/2017,72,HHS Region 5,Season onset,52
 2017,20,2016/2017,72,HHS Region 5,Season peak week,7
 2017,20,2016/2017,72,HHS Region 5,Season peak week,8
@@ -18326,40 +18260,40 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,20,2016/2017,72,HHS Region 5,2 wk ahead,0.8
 2017,20,2016/2017,72,HHS Region 5,3 wk ahead,0.7
 2017,20,2016/2017,72,HHS Region 5,4 wk ahead,0.6
-2017,20,2016/2017,72,HHS Region 6,Season onset,2
+2017,20,2016/2017,72,HHS Region 6,Season onset,52
 2017,20,2016/2017,72,HHS Region 6,Season peak week,6
 2017,20,2016/2017,72,HHS Region 6,Season peak percentage,9.9
-2017,20,2016/2017,72,HHS Region 6,1 wk ahead,1.8
-2017,20,2016/2017,72,HHS Region 6,2 wk ahead,1.6
-2017,20,2016/2017,72,HHS Region 6,3 wk ahead,1.5
-2017,20,2016/2017,72,HHS Region 6,4 wk ahead,1.4
+2017,20,2016/2017,72,HHS Region 6,1 wk ahead,1.9
+2017,20,2016/2017,72,HHS Region 6,2 wk ahead,1.7
+2017,20,2016/2017,72,HHS Region 6,3 wk ahead,1.6
+2017,20,2016/2017,72,HHS Region 6,4 wk ahead,1.5
 2017,20,2016/2017,72,HHS Region 7,Season onset,51
 2017,20,2016/2017,72,HHS Region 7,Season peak week,6
 2017,20,2016/2017,72,HHS Region 7,Season peak percentage,6.4
 2017,20,2016/2017,72,HHS Region 7,1 wk ahead,0.2
 2017,20,2016/2017,72,HHS Region 7,2 wk ahead,0.2
-2017,20,2016/2017,72,HHS Region 7,3 wk ahead,0.2
-2017,20,2016/2017,72,HHS Region 7,4 wk ahead,0.2
+2017,20,2016/2017,72,HHS Region 7,3 wk ahead,0.3
+2017,20,2016/2017,72,HHS Region 7,4 wk ahead,0.3
 2017,20,2016/2017,72,HHS Region 8,Season onset,51
 2017,20,2016/2017,72,HHS Region 8,Season peak week,7
 2017,20,2016/2017,72,HHS Region 8,Season peak percentage,2.7
 2017,20,2016/2017,72,HHS Region 8,1 wk ahead,0.9
-2017,20,2016/2017,72,HHS Region 8,2 wk ahead,0.6
+2017,20,2016/2017,72,HHS Region 8,2 wk ahead,0.5
 2017,20,2016/2017,72,HHS Region 8,3 wk ahead,0.4
-2017,20,2016/2017,72,HHS Region 8,4 wk ahead,0.2
+2017,20,2016/2017,72,HHS Region 8,4 wk ahead,0.3
 2017,20,2016/2017,72,HHS Region 9,Season onset,51
 2017,20,2016/2017,72,HHS Region 9,Season peak week,52
 2017,20,2016/2017,72,HHS Region 9,Season peak percentage,3.3
-2017,20,2016/2017,72,HHS Region 9,1 wk ahead,1.4
-2017,20,2016/2017,72,HHS Region 9,2 wk ahead,1.4
-2017,20,2016/2017,72,HHS Region 9,3 wk ahead,1.5
-2017,20,2016/2017,72,HHS Region 9,4 wk ahead,1.2
+2017,20,2016/2017,72,HHS Region 9,1 wk ahead,1.5
+2017,20,2016/2017,72,HHS Region 9,2 wk ahead,1.5
+2017,20,2016/2017,72,HHS Region 9,3 wk ahead,1.6
+2017,20,2016/2017,72,HHS Region 9,4 wk ahead,1.3
 2017,20,2016/2017,72,HHS Region 10,Season onset,50
 2017,20,2016/2017,72,HHS Region 10,Season peak week,52
 2017,20,2016/2017,72,HHS Region 10,Season peak percentage,3.7
 2017,20,2016/2017,72,HHS Region 10,1 wk ahead,0.3
 2017,20,2016/2017,72,HHS Region 10,2 wk ahead,0.4
-2017,20,2016/2017,72,HHS Region 10,3 wk ahead,0.2
+2017,20,2016/2017,72,HHS Region 10,3 wk ahead,0.3
 2017,20,2016/2017,72,HHS Region 10,4 wk ahead,0.3
 2017,40,2017/2018,40,US National,Season onset,47
 2017,40,2017/2018,40,US National,Season peak week,5
@@ -18374,7 +18308,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,40,2017/2018,40,HHS Region 1,1 wk ahead,0.8
 2017,40,2017/2018,40,HHS Region 1,2 wk ahead,0.8
 2017,40,2017/2018,40,HHS Region 1,3 wk ahead,1
-2017,40,2017/2018,40,HHS Region 1,4 wk ahead,0.9
+2017,40,2017/2018,40,HHS Region 1,4 wk ahead,1
 2017,40,2017/2018,40,HHS Region 2,Season onset,49
 2017,40,2017/2018,40,HHS Region 2,Season peak week,6
 2017,40,2017/2018,40,HHS Region 2,Season peak percentage,10.4
@@ -18419,15 +18353,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,40,2017/2018,40,HHS Region 7,4 wk ahead,1.2
 2017,40,2017/2018,40,HHS Region 8,Season onset,50
 2017,40,2017/2018,40,HHS Region 8,Season peak week,5
-2017,40,2017/2018,40,HHS Region 8,Season peak week,6
-2017,40,2017/2018,40,HHS Region 8,Season peak percentage,3.2
+2017,40,2017/2018,40,HHS Region 8,Season peak percentage,3.3
 2017,40,2017/2018,40,HHS Region 8,1 wk ahead,0.6
 2017,40,2017/2018,40,HHS Region 8,2 wk ahead,0.6
 2017,40,2017/2018,40,HHS Region 8,3 wk ahead,0.7
 2017,40,2017/2018,40,HHS Region 8,4 wk ahead,0.7
 2017,40,2017/2018,40,HHS Region 9,Season onset,49
 2017,40,2017/2018,40,HHS Region 9,Season peak week,52
-2017,40,2017/2018,40,HHS Region 9,Season peak percentage,6.9
+2017,40,2017/2018,40,HHS Region 9,Season peak percentage,7
 2017,40,2017/2018,40,HHS Region 9,1 wk ahead,1.6
 2017,40,2017/2018,40,HHS Region 9,2 wk ahead,1.6
 2017,40,2017/2018,40,HHS Region 9,3 wk ahead,1.7
@@ -18451,7 +18384,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,41,2017/2018,41,HHS Region 1,Season peak percentage,5.8
 2017,41,2017/2018,41,HHS Region 1,1 wk ahead,0.8
 2017,41,2017/2018,41,HHS Region 1,2 wk ahead,1
-2017,41,2017/2018,41,HHS Region 1,3 wk ahead,0.9
+2017,41,2017/2018,41,HHS Region 1,3 wk ahead,1
 2017,41,2017/2018,41,HHS Region 1,4 wk ahead,1.1
 2017,41,2017/2018,41,HHS Region 2,Season onset,49
 2017,41,2017/2018,41,HHS Region 2,Season peak week,6
@@ -18497,15 +18430,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,41,2017/2018,41,HHS Region 7,4 wk ahead,1.3
 2017,41,2017/2018,41,HHS Region 8,Season onset,50
 2017,41,2017/2018,41,HHS Region 8,Season peak week,5
-2017,41,2017/2018,41,HHS Region 8,Season peak week,6
-2017,41,2017/2018,41,HHS Region 8,Season peak percentage,3.2
+2017,41,2017/2018,41,HHS Region 8,Season peak percentage,3.3
 2017,41,2017/2018,41,HHS Region 8,1 wk ahead,0.6
 2017,41,2017/2018,41,HHS Region 8,2 wk ahead,0.7
 2017,41,2017/2018,41,HHS Region 8,3 wk ahead,0.7
 2017,41,2017/2018,41,HHS Region 8,4 wk ahead,0.8
 2017,41,2017/2018,41,HHS Region 9,Season onset,49
 2017,41,2017/2018,41,HHS Region 9,Season peak week,52
-2017,41,2017/2018,41,HHS Region 9,Season peak percentage,6.9
+2017,41,2017/2018,41,HHS Region 9,Season peak percentage,7
 2017,41,2017/2018,41,HHS Region 9,1 wk ahead,1.6
 2017,41,2017/2018,41,HHS Region 9,2 wk ahead,1.7
 2017,41,2017/2018,41,HHS Region 9,3 wk ahead,2
@@ -18528,7 +18460,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,42,2017/2018,42,HHS Region 1,Season peak week,6
 2017,42,2017/2018,42,HHS Region 1,Season peak percentage,5.8
 2017,42,2017/2018,42,HHS Region 1,1 wk ahead,1
-2017,42,2017/2018,42,HHS Region 1,2 wk ahead,0.9
+2017,42,2017/2018,42,HHS Region 1,2 wk ahead,1
 2017,42,2017/2018,42,HHS Region 1,3 wk ahead,1.1
 2017,42,2017/2018,42,HHS Region 1,4 wk ahead,1.2
 2017,42,2017/2018,42,HHS Region 2,Season onset,49
@@ -18575,15 +18507,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,42,2017/2018,42,HHS Region 7,4 wk ahead,1.4
 2017,42,2017/2018,42,HHS Region 8,Season onset,50
 2017,42,2017/2018,42,HHS Region 8,Season peak week,5
-2017,42,2017/2018,42,HHS Region 8,Season peak week,6
-2017,42,2017/2018,42,HHS Region 8,Season peak percentage,3.2
+2017,42,2017/2018,42,HHS Region 8,Season peak percentage,3.3
 2017,42,2017/2018,42,HHS Region 8,1 wk ahead,0.7
 2017,42,2017/2018,42,HHS Region 8,2 wk ahead,0.7
 2017,42,2017/2018,42,HHS Region 8,3 wk ahead,0.8
 2017,42,2017/2018,42,HHS Region 8,4 wk ahead,0.8
 2017,42,2017/2018,42,HHS Region 9,Season onset,49
 2017,42,2017/2018,42,HHS Region 9,Season peak week,52
-2017,42,2017/2018,42,HHS Region 9,Season peak percentage,6.9
+2017,42,2017/2018,42,HHS Region 9,Season peak percentage,7
 2017,42,2017/2018,42,HHS Region 9,1 wk ahead,1.7
 2017,42,2017/2018,42,HHS Region 9,2 wk ahead,2
 2017,42,2017/2018,42,HHS Region 9,3 wk ahead,1.9
@@ -18605,7 +18536,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,43,2017/2018,43,HHS Region 1,Season onset,47
 2017,43,2017/2018,43,HHS Region 1,Season peak week,6
 2017,43,2017/2018,43,HHS Region 1,Season peak percentage,5.8
-2017,43,2017/2018,43,HHS Region 1,1 wk ahead,0.9
+2017,43,2017/2018,43,HHS Region 1,1 wk ahead,1
 2017,43,2017/2018,43,HHS Region 1,2 wk ahead,1.1
 2017,43,2017/2018,43,HHS Region 1,3 wk ahead,1.2
 2017,43,2017/2018,43,HHS Region 1,4 wk ahead,1.6
@@ -18653,15 +18584,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,43,2017/2018,43,HHS Region 7,4 wk ahead,1.7
 2017,43,2017/2018,43,HHS Region 8,Season onset,50
 2017,43,2017/2018,43,HHS Region 8,Season peak week,5
-2017,43,2017/2018,43,HHS Region 8,Season peak week,6
-2017,43,2017/2018,43,HHS Region 8,Season peak percentage,3.2
+2017,43,2017/2018,43,HHS Region 8,Season peak percentage,3.3
 2017,43,2017/2018,43,HHS Region 8,1 wk ahead,0.7
 2017,43,2017/2018,43,HHS Region 8,2 wk ahead,0.8
 2017,43,2017/2018,43,HHS Region 8,3 wk ahead,0.8
 2017,43,2017/2018,43,HHS Region 8,4 wk ahead,0.9
 2017,43,2017/2018,43,HHS Region 9,Season onset,49
 2017,43,2017/2018,43,HHS Region 9,Season peak week,52
-2017,43,2017/2018,43,HHS Region 9,Season peak percentage,6.9
+2017,43,2017/2018,43,HHS Region 9,Season peak percentage,7
 2017,43,2017/2018,43,HHS Region 9,1 wk ahead,2
 2017,43,2017/2018,43,HHS Region 9,2 wk ahead,1.9
 2017,43,2017/2018,43,HHS Region 9,3 wk ahead,2
@@ -18731,15 +18661,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,44,2017/2018,44,HHS Region 7,4 wk ahead,1.5
 2017,44,2017/2018,44,HHS Region 8,Season onset,50
 2017,44,2017/2018,44,HHS Region 8,Season peak week,5
-2017,44,2017/2018,44,HHS Region 8,Season peak week,6
-2017,44,2017/2018,44,HHS Region 8,Season peak percentage,3.2
+2017,44,2017/2018,44,HHS Region 8,Season peak percentage,3.3
 2017,44,2017/2018,44,HHS Region 8,1 wk ahead,0.8
 2017,44,2017/2018,44,HHS Region 8,2 wk ahead,0.8
 2017,44,2017/2018,44,HHS Region 8,3 wk ahead,0.9
 2017,44,2017/2018,44,HHS Region 8,4 wk ahead,0.9
 2017,44,2017/2018,44,HHS Region 9,Season onset,49
 2017,44,2017/2018,44,HHS Region 9,Season peak week,52
-2017,44,2017/2018,44,HHS Region 9,Season peak percentage,6.9
+2017,44,2017/2018,44,HHS Region 9,Season peak percentage,7
 2017,44,2017/2018,44,HHS Region 9,1 wk ahead,1.9
 2017,44,2017/2018,44,HHS Region 9,2 wk ahead,2
 2017,44,2017/2018,44,HHS Region 9,3 wk ahead,2.2
@@ -18809,15 +18738,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,45,2017/2018,45,HHS Region 7,4 wk ahead,2.1
 2017,45,2017/2018,45,HHS Region 8,Season onset,50
 2017,45,2017/2018,45,HHS Region 8,Season peak week,5
-2017,45,2017/2018,45,HHS Region 8,Season peak week,6
-2017,45,2017/2018,45,HHS Region 8,Season peak percentage,3.2
+2017,45,2017/2018,45,HHS Region 8,Season peak percentage,3.3
 2017,45,2017/2018,45,HHS Region 8,1 wk ahead,0.8
 2017,45,2017/2018,45,HHS Region 8,2 wk ahead,0.9
 2017,45,2017/2018,45,HHS Region 8,3 wk ahead,0.9
 2017,45,2017/2018,45,HHS Region 8,4 wk ahead,1.1
 2017,45,2017/2018,45,HHS Region 9,Season onset,49
 2017,45,2017/2018,45,HHS Region 9,Season peak week,52
-2017,45,2017/2018,45,HHS Region 9,Season peak percentage,6.9
+2017,45,2017/2018,45,HHS Region 9,Season peak percentage,7
 2017,45,2017/2018,45,HHS Region 9,1 wk ahead,2
 2017,45,2017/2018,45,HHS Region 9,2 wk ahead,2.2
 2017,45,2017/2018,45,HHS Region 9,3 wk ahead,2.2
@@ -18887,15 +18815,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,46,2017/2018,46,HHS Region 7,4 wk ahead,2.8
 2017,46,2017/2018,46,HHS Region 8,Season onset,50
 2017,46,2017/2018,46,HHS Region 8,Season peak week,5
-2017,46,2017/2018,46,HHS Region 8,Season peak week,6
-2017,46,2017/2018,46,HHS Region 8,Season peak percentage,3.2
+2017,46,2017/2018,46,HHS Region 8,Season peak percentage,3.3
 2017,46,2017/2018,46,HHS Region 8,1 wk ahead,0.9
 2017,46,2017/2018,46,HHS Region 8,2 wk ahead,0.9
 2017,46,2017/2018,46,HHS Region 8,3 wk ahead,1.1
 2017,46,2017/2018,46,HHS Region 8,4 wk ahead,1.3
 2017,46,2017/2018,46,HHS Region 9,Season onset,49
 2017,46,2017/2018,46,HHS Region 9,Season peak week,52
-2017,46,2017/2018,46,HHS Region 9,Season peak percentage,6.9
+2017,46,2017/2018,46,HHS Region 9,Season peak percentage,7
 2017,46,2017/2018,46,HHS Region 9,1 wk ahead,2.2
 2017,46,2017/2018,46,HHS Region 9,2 wk ahead,2.2
 2017,46,2017/2018,46,HHS Region 9,3 wk ahead,2.6
@@ -18920,7 +18847,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,47,2017/2018,47,HHS Region 1,1 wk ahead,1.5
 2017,47,2017/2018,47,HHS Region 1,2 wk ahead,1.7
 2017,47,2017/2018,47,HHS Region 1,3 wk ahead,1.8
-2017,47,2017/2018,47,HHS Region 1,4 wk ahead,2.2
+2017,47,2017/2018,47,HHS Region 1,4 wk ahead,2.3
 2017,47,2017/2018,47,HHS Region 2,Season onset,49
 2017,47,2017/2018,47,HHS Region 2,Season peak week,6
 2017,47,2017/2018,47,HHS Region 2,Season peak percentage,10.4
@@ -18965,19 +18892,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,47,2017/2018,47,HHS Region 7,4 wk ahead,4.3
 2017,47,2017/2018,47,HHS Region 8,Season onset,50
 2017,47,2017/2018,47,HHS Region 8,Season peak week,5
-2017,47,2017/2018,47,HHS Region 8,Season peak week,6
-2017,47,2017/2018,47,HHS Region 8,Season peak percentage,3.2
+2017,47,2017/2018,47,HHS Region 8,Season peak percentage,3.3
 2017,47,2017/2018,47,HHS Region 8,1 wk ahead,0.9
 2017,47,2017/2018,47,HHS Region 8,2 wk ahead,1.1
 2017,47,2017/2018,47,HHS Region 8,3 wk ahead,1.3
 2017,47,2017/2018,47,HHS Region 8,4 wk ahead,1.9
 2017,47,2017/2018,47,HHS Region 9,Season onset,49
 2017,47,2017/2018,47,HHS Region 9,Season peak week,52
-2017,47,2017/2018,47,HHS Region 9,Season peak percentage,6.9
+2017,47,2017/2018,47,HHS Region 9,Season peak percentage,7
 2017,47,2017/2018,47,HHS Region 9,1 wk ahead,2.2
 2017,47,2017/2018,47,HHS Region 9,2 wk ahead,2.6
 2017,47,2017/2018,47,HHS Region 9,3 wk ahead,3.6
-2017,47,2017/2018,47,HHS Region 9,4 wk ahead,4.7
+2017,47,2017/2018,47,HHS Region 9,4 wk ahead,4.8
 2017,47,2017/2018,47,HHS Region 10,Season onset,51
 2017,47,2017/2018,47,HHS Region 10,Season peak week,1
 2017,47,2017/2018,47,HHS Region 10,Season peak percentage,4.8
@@ -18997,7 +18923,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,48,2017/2018,48,HHS Region 1,Season peak percentage,5.8
 2017,48,2017/2018,48,HHS Region 1,1 wk ahead,1.7
 2017,48,2017/2018,48,HHS Region 1,2 wk ahead,1.8
-2017,48,2017/2018,48,HHS Region 1,3 wk ahead,2.2
+2017,48,2017/2018,48,HHS Region 1,3 wk ahead,2.3
 2017,48,2017/2018,48,HHS Region 1,4 wk ahead,2.8
 2017,48,2017/2018,48,HHS Region 2,Season onset,49
 2017,48,2017/2018,48,HHS Region 2,Season peak week,6
@@ -19043,19 +18969,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,48,2017/2018,48,HHS Region 7,4 wk ahead,7.3
 2017,48,2017/2018,48,HHS Region 8,Season onset,50
 2017,48,2017/2018,48,HHS Region 8,Season peak week,5
-2017,48,2017/2018,48,HHS Region 8,Season peak week,6
-2017,48,2017/2018,48,HHS Region 8,Season peak percentage,3.2
+2017,48,2017/2018,48,HHS Region 8,Season peak percentage,3.3
 2017,48,2017/2018,48,HHS Region 8,1 wk ahead,1.1
 2017,48,2017/2018,48,HHS Region 8,2 wk ahead,1.3
 2017,48,2017/2018,48,HHS Region 8,3 wk ahead,1.9
 2017,48,2017/2018,48,HHS Region 8,4 wk ahead,2.4
 2017,48,2017/2018,48,HHS Region 9,Season onset,49
 2017,48,2017/2018,48,HHS Region 9,Season peak week,52
-2017,48,2017/2018,48,HHS Region 9,Season peak percentage,6.9
+2017,48,2017/2018,48,HHS Region 9,Season peak percentage,7
 2017,48,2017/2018,48,HHS Region 9,1 wk ahead,2.6
 2017,48,2017/2018,48,HHS Region 9,2 wk ahead,3.6
-2017,48,2017/2018,48,HHS Region 9,3 wk ahead,4.7
-2017,48,2017/2018,48,HHS Region 9,4 wk ahead,6.9
+2017,48,2017/2018,48,HHS Region 9,3 wk ahead,4.8
+2017,48,2017/2018,48,HHS Region 9,4 wk ahead,7
 2017,48,2017/2018,48,HHS Region 10,Season onset,51
 2017,48,2017/2018,48,HHS Region 10,Season peak week,1
 2017,48,2017/2018,48,HHS Region 10,Season peak percentage,4.8
@@ -19069,12 +18994,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,49,2017/2018,49,US National,1 wk ahead,3.4
 2017,49,2017/2018,49,US National,2 wk ahead,4.7
 2017,49,2017/2018,49,US National,3 wk ahead,5.7
-2017,49,2017/2018,49,US National,4 wk ahead,5.7
+2017,49,2017/2018,49,US National,4 wk ahead,5.8
 2017,49,2017/2018,49,HHS Region 1,Season onset,47
 2017,49,2017/2018,49,HHS Region 1,Season peak week,6
 2017,49,2017/2018,49,HHS Region 1,Season peak percentage,5.8
 2017,49,2017/2018,49,HHS Region 1,1 wk ahead,1.8
-2017,49,2017/2018,49,HHS Region 1,2 wk ahead,2.2
+2017,49,2017/2018,49,HHS Region 1,2 wk ahead,2.3
 2017,49,2017/2018,49,HHS Region 1,3 wk ahead,2.8
 2017,49,2017/2018,49,HHS Region 1,4 wk ahead,2.9
 2017,49,2017/2018,49,HHS Region 2,Season onset,49
@@ -19121,18 +19046,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,49,2017/2018,49,HHS Region 7,4 wk ahead,7.6
 2017,49,2017/2018,49,HHS Region 8,Season onset,50
 2017,49,2017/2018,49,HHS Region 8,Season peak week,5
-2017,49,2017/2018,49,HHS Region 8,Season peak week,6
-2017,49,2017/2018,49,HHS Region 8,Season peak percentage,3.2
+2017,49,2017/2018,49,HHS Region 8,Season peak percentage,3.3
 2017,49,2017/2018,49,HHS Region 8,1 wk ahead,1.3
 2017,49,2017/2018,49,HHS Region 8,2 wk ahead,1.9
 2017,49,2017/2018,49,HHS Region 8,3 wk ahead,2.4
 2017,49,2017/2018,49,HHS Region 8,4 wk ahead,2.6
 2017,49,2017/2018,49,HHS Region 9,Season onset,49
 2017,49,2017/2018,49,HHS Region 9,Season peak week,52
-2017,49,2017/2018,49,HHS Region 9,Season peak percentage,6.9
+2017,49,2017/2018,49,HHS Region 9,Season peak percentage,7
 2017,49,2017/2018,49,HHS Region 9,1 wk ahead,3.6
-2017,49,2017/2018,49,HHS Region 9,2 wk ahead,4.7
-2017,49,2017/2018,49,HHS Region 9,3 wk ahead,6.9
+2017,49,2017/2018,49,HHS Region 9,2 wk ahead,4.8
+2017,49,2017/2018,49,HHS Region 9,3 wk ahead,7
 2017,49,2017/2018,49,HHS Region 9,4 wk ahead,6.5
 2017,49,2017/2018,49,HHS Region 10,Season onset,51
 2017,49,2017/2018,49,HHS Region 10,Season peak week,1
@@ -19146,12 +19070,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,50,2017/2018,50,US National,Season peak percentage,7.5
 2017,50,2017/2018,50,US National,1 wk ahead,4.7
 2017,50,2017/2018,50,US National,2 wk ahead,5.7
-2017,50,2017/2018,50,US National,3 wk ahead,5.7
+2017,50,2017/2018,50,US National,3 wk ahead,5.8
 2017,50,2017/2018,50,US National,4 wk ahead,5.9
 2017,50,2017/2018,50,HHS Region 1,Season onset,47
 2017,50,2017/2018,50,HHS Region 1,Season peak week,6
 2017,50,2017/2018,50,HHS Region 1,Season peak percentage,5.8
-2017,50,2017/2018,50,HHS Region 1,1 wk ahead,2.2
+2017,50,2017/2018,50,HHS Region 1,1 wk ahead,2.3
 2017,50,2017/2018,50,HHS Region 1,2 wk ahead,2.8
 2017,50,2017/2018,50,HHS Region 1,3 wk ahead,2.9
 2017,50,2017/2018,50,HHS Region 1,4 wk ahead,2.9
@@ -19175,7 +19099,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,50,2017/2018,50,HHS Region 4,1 wk ahead,4.6
 2017,50,2017/2018,50,HHS Region 4,2 wk ahead,5.3
 2017,50,2017/2018,50,HHS Region 4,3 wk ahead,5.4
-2017,50,2017/2018,50,HHS Region 4,4 wk ahead,6.6
+2017,50,2017/2018,50,HHS Region 4,4 wk ahead,6.7
 2017,50,2017/2018,50,HHS Region 5,Season onset,49
 2017,50,2017/2018,50,HHS Region 5,Season peak week,6
 2017,50,2017/2018,50,HHS Region 5,Season peak percentage,5.8
@@ -19199,17 +19123,16 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,50,2017/2018,50,HHS Region 7,4 wk ahead,6.7
 2017,50,2017/2018,50,HHS Region 8,Season onset,50
 2017,50,2017/2018,50,HHS Region 8,Season peak week,5
-2017,50,2017/2018,50,HHS Region 8,Season peak week,6
-2017,50,2017/2018,50,HHS Region 8,Season peak percentage,3.2
+2017,50,2017/2018,50,HHS Region 8,Season peak percentage,3.3
 2017,50,2017/2018,50,HHS Region 8,1 wk ahead,1.9
 2017,50,2017/2018,50,HHS Region 8,2 wk ahead,2.4
 2017,50,2017/2018,50,HHS Region 8,3 wk ahead,2.6
 2017,50,2017/2018,50,HHS Region 8,4 wk ahead,2.6
 2017,50,2017/2018,50,HHS Region 9,Season onset,49
 2017,50,2017/2018,50,HHS Region 9,Season peak week,52
-2017,50,2017/2018,50,HHS Region 9,Season peak percentage,6.9
-2017,50,2017/2018,50,HHS Region 9,1 wk ahead,4.7
-2017,50,2017/2018,50,HHS Region 9,2 wk ahead,6.9
+2017,50,2017/2018,50,HHS Region 9,Season peak percentage,7
+2017,50,2017/2018,50,HHS Region 9,1 wk ahead,4.8
+2017,50,2017/2018,50,HHS Region 9,2 wk ahead,7
 2017,50,2017/2018,50,HHS Region 9,3 wk ahead,6.5
 2017,50,2017/2018,50,HHS Region 9,4 wk ahead,4.8
 2017,50,2017/2018,50,HHS Region 10,Season onset,51
@@ -19223,7 +19146,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,51,2017/2018,51,US National,Season peak week,5
 2017,51,2017/2018,51,US National,Season peak percentage,7.5
 2017,51,2017/2018,51,US National,1 wk ahead,5.7
-2017,51,2017/2018,51,US National,2 wk ahead,5.7
+2017,51,2017/2018,51,US National,2 wk ahead,5.8
 2017,51,2017/2018,51,US National,3 wk ahead,5.9
 2017,51,2017/2018,51,US National,4 wk ahead,6.5
 2017,51,2017/2018,51,HHS Region 1,Season onset,47
@@ -19252,7 +19175,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,51,2017/2018,51,HHS Region 4,Season peak percentage,9.3
 2017,51,2017/2018,51,HHS Region 4,1 wk ahead,5.3
 2017,51,2017/2018,51,HHS Region 4,2 wk ahead,5.4
-2017,51,2017/2018,51,HHS Region 4,3 wk ahead,6.6
+2017,51,2017/2018,51,HHS Region 4,3 wk ahead,6.7
 2017,51,2017/2018,51,HHS Region 4,4 wk ahead,8.4
 2017,51,2017/2018,51,HHS Region 5,Season onset,49
 2017,51,2017/2018,51,HHS Region 5,Season peak week,6
@@ -19277,16 +19200,15 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,51,2017/2018,51,HHS Region 7,4 wk ahead,8.3
 2017,51,2017/2018,51,HHS Region 8,Season onset,50
 2017,51,2017/2018,51,HHS Region 8,Season peak week,5
-2017,51,2017/2018,51,HHS Region 8,Season peak week,6
-2017,51,2017/2018,51,HHS Region 8,Season peak percentage,3.2
+2017,51,2017/2018,51,HHS Region 8,Season peak percentage,3.3
 2017,51,2017/2018,51,HHS Region 8,1 wk ahead,2.4
 2017,51,2017/2018,51,HHS Region 8,2 wk ahead,2.6
 2017,51,2017/2018,51,HHS Region 8,3 wk ahead,2.6
 2017,51,2017/2018,51,HHS Region 8,4 wk ahead,2.8
 2017,51,2017/2018,51,HHS Region 9,Season onset,49
 2017,51,2017/2018,51,HHS Region 9,Season peak week,52
-2017,51,2017/2018,51,HHS Region 9,Season peak percentage,6.9
-2017,51,2017/2018,51,HHS Region 9,1 wk ahead,6.9
+2017,51,2017/2018,51,HHS Region 9,Season peak percentage,7
+2017,51,2017/2018,51,HHS Region 9,1 wk ahead,7
 2017,51,2017/2018,51,HHS Region 9,2 wk ahead,6.5
 2017,51,2017/2018,51,HHS Region 9,3 wk ahead,4.8
 2017,51,2017/2018,51,HHS Region 9,4 wk ahead,4.2
@@ -19300,7 +19222,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,52,2017/2018,52,US National,Season onset,47
 2017,52,2017/2018,52,US National,Season peak week,5
 2017,52,2017/2018,52,US National,Season peak percentage,7.5
-2017,52,2017/2018,52,US National,1 wk ahead,5.7
+2017,52,2017/2018,52,US National,1 wk ahead,5.8
 2017,52,2017/2018,52,US National,2 wk ahead,5.9
 2017,52,2017/2018,52,US National,3 wk ahead,6.5
 2017,52,2017/2018,52,US National,4 wk ahead,7.2
@@ -19329,7 +19251,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,52,2017/2018,52,HHS Region 4,Season peak week,5
 2017,52,2017/2018,52,HHS Region 4,Season peak percentage,9.3
 2017,52,2017/2018,52,HHS Region 4,1 wk ahead,5.4
-2017,52,2017/2018,52,HHS Region 4,2 wk ahead,6.6
+2017,52,2017/2018,52,HHS Region 4,2 wk ahead,6.7
 2017,52,2017/2018,52,HHS Region 4,3 wk ahead,8.4
 2017,52,2017/2018,52,HHS Region 4,4 wk ahead,9.2
 2017,52,2017/2018,52,HHS Region 5,Season onset,49
@@ -19355,19 +19277,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2017,52,2017/2018,52,HHS Region 7,4 wk ahead,8.9
 2017,52,2017/2018,52,HHS Region 8,Season onset,50
 2017,52,2017/2018,52,HHS Region 8,Season peak week,5
-2017,52,2017/2018,52,HHS Region 8,Season peak week,6
-2017,52,2017/2018,52,HHS Region 8,Season peak percentage,3.2
+2017,52,2017/2018,52,HHS Region 8,Season peak percentage,3.3
 2017,52,2017/2018,52,HHS Region 8,1 wk ahead,2.6
 2017,52,2017/2018,52,HHS Region 8,2 wk ahead,2.6
 2017,52,2017/2018,52,HHS Region 8,3 wk ahead,2.8
 2017,52,2017/2018,52,HHS Region 8,4 wk ahead,2.8
 2017,52,2017/2018,52,HHS Region 9,Season onset,49
 2017,52,2017/2018,52,HHS Region 9,Season peak week,52
-2017,52,2017/2018,52,HHS Region 9,Season peak percentage,6.9
+2017,52,2017/2018,52,HHS Region 9,Season peak percentage,7
 2017,52,2017/2018,52,HHS Region 9,1 wk ahead,6.5
 2017,52,2017/2018,52,HHS Region 9,2 wk ahead,4.8
 2017,52,2017/2018,52,HHS Region 9,3 wk ahead,4.2
-2017,52,2017/2018,52,HHS Region 9,4 wk ahead,4
+2017,52,2017/2018,52,HHS Region 9,4 wk ahead,4.1
 2017,52,2017/2018,52,HHS Region 10,Season onset,51
 2017,52,2017/2018,52,HHS Region 10,Season peak week,1
 2017,52,2017/2018,52,HHS Region 10,Season peak percentage,4.8
@@ -19406,7 +19327,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,1,2017/2018,53,HHS Region 4,Season onset,45
 2018,1,2017/2018,53,HHS Region 4,Season peak week,5
 2018,1,2017/2018,53,HHS Region 4,Season peak percentage,9.3
-2018,1,2017/2018,53,HHS Region 4,1 wk ahead,6.6
+2018,1,2017/2018,53,HHS Region 4,1 wk ahead,6.7
 2018,1,2017/2018,53,HHS Region 4,2 wk ahead,8.4
 2018,1,2017/2018,53,HHS Region 4,3 wk ahead,9.2
 2018,1,2017/2018,53,HHS Region 4,4 wk ahead,9.3
@@ -19433,18 +19354,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,1,2017/2018,53,HHS Region 7,4 wk ahead,8.8
 2018,1,2017/2018,53,HHS Region 8,Season onset,50
 2018,1,2017/2018,53,HHS Region 8,Season peak week,5
-2018,1,2017/2018,53,HHS Region 8,Season peak week,6
-2018,1,2017/2018,53,HHS Region 8,Season peak percentage,3.2
+2018,1,2017/2018,53,HHS Region 8,Season peak percentage,3.3
 2018,1,2017/2018,53,HHS Region 8,1 wk ahead,2.6
 2018,1,2017/2018,53,HHS Region 8,2 wk ahead,2.8
 2018,1,2017/2018,53,HHS Region 8,3 wk ahead,2.8
-2018,1,2017/2018,53,HHS Region 8,4 wk ahead,3.2
+2018,1,2017/2018,53,HHS Region 8,4 wk ahead,3.3
 2018,1,2017/2018,53,HHS Region 9,Season onset,49
 2018,1,2017/2018,53,HHS Region 9,Season peak week,52
-2018,1,2017/2018,53,HHS Region 9,Season peak percentage,6.9
+2018,1,2017/2018,53,HHS Region 9,Season peak percentage,7
 2018,1,2017/2018,53,HHS Region 9,1 wk ahead,4.8
 2018,1,2017/2018,53,HHS Region 9,2 wk ahead,4.2
-2018,1,2017/2018,53,HHS Region 9,3 wk ahead,4
+2018,1,2017/2018,53,HHS Region 9,3 wk ahead,4.1
 2018,1,2017/2018,53,HHS Region 9,4 wk ahead,4.3
 2018,1,2017/2018,53,HHS Region 10,Season onset,51
 2018,1,2017/2018,53,HHS Region 10,Season peak week,1
@@ -19511,17 +19431,16 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,2,2017/2018,54,HHS Region 7,4 wk ahead,8.7
 2018,2,2017/2018,54,HHS Region 8,Season onset,50
 2018,2,2017/2018,54,HHS Region 8,Season peak week,5
-2018,2,2017/2018,54,HHS Region 8,Season peak week,6
-2018,2,2017/2018,54,HHS Region 8,Season peak percentage,3.2
+2018,2,2017/2018,54,HHS Region 8,Season peak percentage,3.3
 2018,2,2017/2018,54,HHS Region 8,1 wk ahead,2.8
 2018,2,2017/2018,54,HHS Region 8,2 wk ahead,2.8
-2018,2,2017/2018,54,HHS Region 8,3 wk ahead,3.2
+2018,2,2017/2018,54,HHS Region 8,3 wk ahead,3.3
 2018,2,2017/2018,54,HHS Region 8,4 wk ahead,3.2
 2018,2,2017/2018,54,HHS Region 9,Season onset,49
 2018,2,2017/2018,54,HHS Region 9,Season peak week,52
-2018,2,2017/2018,54,HHS Region 9,Season peak percentage,6.9
+2018,2,2017/2018,54,HHS Region 9,Season peak percentage,7
 2018,2,2017/2018,54,HHS Region 9,1 wk ahead,4.2
-2018,2,2017/2018,54,HHS Region 9,2 wk ahead,4
+2018,2,2017/2018,54,HHS Region 9,2 wk ahead,4.1
 2018,2,2017/2018,54,HHS Region 9,3 wk ahead,4.3
 2018,2,2017/2018,54,HHS Region 9,4 wk ahead,4
 2018,2,2017/2018,54,HHS Region 10,Season onset,51
@@ -19537,7 +19456,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,3,2017/2018,55,US National,1 wk ahead,7.2
 2018,3,2017/2018,55,US National,2 wk ahead,7.5
 2018,3,2017/2018,55,US National,3 wk ahead,7.4
-2018,3,2017/2018,55,US National,4 wk ahead,6.4
+2018,3,2017/2018,55,US National,4 wk ahead,6.5
 2018,3,2017/2018,55,HHS Region 1,Season onset,47
 2018,3,2017/2018,55,HHS Region 1,Season peak week,6
 2018,3,2017/2018,55,HHS Region 1,Season peak percentage,5.8
@@ -19589,16 +19508,15 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,3,2017/2018,55,HHS Region 7,4 wk ahead,7.8
 2018,3,2017/2018,55,HHS Region 8,Season onset,50
 2018,3,2017/2018,55,HHS Region 8,Season peak week,5
-2018,3,2017/2018,55,HHS Region 8,Season peak week,6
-2018,3,2017/2018,55,HHS Region 8,Season peak percentage,3.2
+2018,3,2017/2018,55,HHS Region 8,Season peak percentage,3.3
 2018,3,2017/2018,55,HHS Region 8,1 wk ahead,2.8
-2018,3,2017/2018,55,HHS Region 8,2 wk ahead,3.2
+2018,3,2017/2018,55,HHS Region 8,2 wk ahead,3.3
 2018,3,2017/2018,55,HHS Region 8,3 wk ahead,3.2
 2018,3,2017/2018,55,HHS Region 8,4 wk ahead,3
 2018,3,2017/2018,55,HHS Region 9,Season onset,49
 2018,3,2017/2018,55,HHS Region 9,Season peak week,52
-2018,3,2017/2018,55,HHS Region 9,Season peak percentage,6.9
-2018,3,2017/2018,55,HHS Region 9,1 wk ahead,4
+2018,3,2017/2018,55,HHS Region 9,Season peak percentage,7
+2018,3,2017/2018,55,HHS Region 9,1 wk ahead,4.1
 2018,3,2017/2018,55,HHS Region 9,2 wk ahead,4.3
 2018,3,2017/2018,55,HHS Region 9,3 wk ahead,4
 2018,3,2017/2018,55,HHS Region 9,4 wk ahead,3.9
@@ -19614,7 +19532,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,4,2017/2018,56,US National,Season peak percentage,7.5
 2018,4,2017/2018,56,US National,1 wk ahead,7.5
 2018,4,2017/2018,56,US National,2 wk ahead,7.4
-2018,4,2017/2018,56,US National,3 wk ahead,6.4
+2018,4,2017/2018,56,US National,3 wk ahead,6.5
 2018,4,2017/2018,56,US National,4 wk ahead,5
 2018,4,2017/2018,56,HHS Region 1,Season onset,47
 2018,4,2017/2018,56,HHS Region 1,Season peak week,6
@@ -19667,15 +19585,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,4,2017/2018,56,HHS Region 7,4 wk ahead,5.6
 2018,4,2017/2018,56,HHS Region 8,Season onset,50
 2018,4,2017/2018,56,HHS Region 8,Season peak week,5
-2018,4,2017/2018,56,HHS Region 8,Season peak week,6
-2018,4,2017/2018,56,HHS Region 8,Season peak percentage,3.2
-2018,4,2017/2018,56,HHS Region 8,1 wk ahead,3.2
+2018,4,2017/2018,56,HHS Region 8,Season peak percentage,3.3
+2018,4,2017/2018,56,HHS Region 8,1 wk ahead,3.3
 2018,4,2017/2018,56,HHS Region 8,2 wk ahead,3.2
 2018,4,2017/2018,56,HHS Region 8,3 wk ahead,3
 2018,4,2017/2018,56,HHS Region 8,4 wk ahead,2.9
 2018,4,2017/2018,56,HHS Region 9,Season onset,49
 2018,4,2017/2018,56,HHS Region 9,Season peak week,52
-2018,4,2017/2018,56,HHS Region 9,Season peak percentage,6.9
+2018,4,2017/2018,56,HHS Region 9,Season peak percentage,7
 2018,4,2017/2018,56,HHS Region 9,1 wk ahead,4.3
 2018,4,2017/2018,56,HHS Region 9,2 wk ahead,4
 2018,4,2017/2018,56,HHS Region 9,3 wk ahead,3.9
@@ -19691,7 +19608,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,5,2017/2018,57,US National,Season peak week,5
 2018,5,2017/2018,57,US National,Season peak percentage,7.5
 2018,5,2017/2018,57,US National,1 wk ahead,7.4
-2018,5,2017/2018,57,US National,2 wk ahead,6.4
+2018,5,2017/2018,57,US National,2 wk ahead,6.5
 2018,5,2017/2018,57,US National,3 wk ahead,5
 2018,5,2017/2018,57,US National,4 wk ahead,3.7
 2018,5,2017/2018,57,HHS Region 1,Season onset,47
@@ -19745,15 +19662,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,5,2017/2018,57,HHS Region 7,4 wk ahead,4
 2018,5,2017/2018,57,HHS Region 8,Season onset,50
 2018,5,2017/2018,57,HHS Region 8,Season peak week,5
-2018,5,2017/2018,57,HHS Region 8,Season peak week,6
-2018,5,2017/2018,57,HHS Region 8,Season peak percentage,3.2
+2018,5,2017/2018,57,HHS Region 8,Season peak percentage,3.3
 2018,5,2017/2018,57,HHS Region 8,1 wk ahead,3.2
 2018,5,2017/2018,57,HHS Region 8,2 wk ahead,3
 2018,5,2017/2018,57,HHS Region 8,3 wk ahead,2.9
 2018,5,2017/2018,57,HHS Region 8,4 wk ahead,2.2
 2018,5,2017/2018,57,HHS Region 9,Season onset,49
 2018,5,2017/2018,57,HHS Region 9,Season peak week,52
-2018,5,2017/2018,57,HHS Region 9,Season peak percentage,6.9
+2018,5,2017/2018,57,HHS Region 9,Season peak percentage,7
 2018,5,2017/2018,57,HHS Region 9,1 wk ahead,4
 2018,5,2017/2018,57,HHS Region 9,2 wk ahead,3.9
 2018,5,2017/2018,57,HHS Region 9,3 wk ahead,3.7
@@ -19768,7 +19684,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,6,2017/2018,58,US National,Season onset,47
 2018,6,2017/2018,58,US National,Season peak week,5
 2018,6,2017/2018,58,US National,Season peak percentage,7.5
-2018,6,2017/2018,58,US National,1 wk ahead,6.4
+2018,6,2017/2018,58,US National,1 wk ahead,6.5
 2018,6,2017/2018,58,US National,2 wk ahead,5
 2018,6,2017/2018,58,US National,3 wk ahead,3.7
 2018,6,2017/2018,58,US National,4 wk ahead,3.2
@@ -19823,19 +19739,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,6,2017/2018,58,HHS Region 7,4 wk ahead,3.6
 2018,6,2017/2018,58,HHS Region 8,Season onset,50
 2018,6,2017/2018,58,HHS Region 8,Season peak week,5
-2018,6,2017/2018,58,HHS Region 8,Season peak week,6
-2018,6,2017/2018,58,HHS Region 8,Season peak percentage,3.2
+2018,6,2017/2018,58,HHS Region 8,Season peak percentage,3.3
 2018,6,2017/2018,58,HHS Region 8,1 wk ahead,3
 2018,6,2017/2018,58,HHS Region 8,2 wk ahead,2.9
 2018,6,2017/2018,58,HHS Region 8,3 wk ahead,2.2
 2018,6,2017/2018,58,HHS Region 8,4 wk ahead,1.9
 2018,6,2017/2018,58,HHS Region 9,Season onset,49
 2018,6,2017/2018,58,HHS Region 9,Season peak week,52
-2018,6,2017/2018,58,HHS Region 9,Season peak percentage,6.9
+2018,6,2017/2018,58,HHS Region 9,Season peak percentage,7
 2018,6,2017/2018,58,HHS Region 9,1 wk ahead,3.9
 2018,6,2017/2018,58,HHS Region 9,2 wk ahead,3.7
 2018,6,2017/2018,58,HHS Region 9,3 wk ahead,3.7
-2018,6,2017/2018,58,HHS Region 9,4 wk ahead,3.4
+2018,6,2017/2018,58,HHS Region 9,4 wk ahead,3.5
 2018,6,2017/2018,58,HHS Region 10,Season onset,51
 2018,6,2017/2018,58,HHS Region 10,Season peak week,1
 2018,6,2017/2018,58,HHS Region 10,Season peak percentage,4.8
@@ -19901,19 +19816,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,7,2017/2018,59,HHS Region 7,4 wk ahead,2.5
 2018,7,2017/2018,59,HHS Region 8,Season onset,50
 2018,7,2017/2018,59,HHS Region 8,Season peak week,5
-2018,7,2017/2018,59,HHS Region 8,Season peak week,6
-2018,7,2017/2018,59,HHS Region 8,Season peak percentage,3.2
+2018,7,2017/2018,59,HHS Region 8,Season peak percentage,3.3
 2018,7,2017/2018,59,HHS Region 8,1 wk ahead,2.9
 2018,7,2017/2018,59,HHS Region 8,2 wk ahead,2.2
 2018,7,2017/2018,59,HHS Region 8,3 wk ahead,1.9
 2018,7,2017/2018,59,HHS Region 8,4 wk ahead,1.6
 2018,7,2017/2018,59,HHS Region 9,Season onset,49
 2018,7,2017/2018,59,HHS Region 9,Season peak week,52
-2018,7,2017/2018,59,HHS Region 9,Season peak percentage,6.9
+2018,7,2017/2018,59,HHS Region 9,Season peak percentage,7
 2018,7,2017/2018,59,HHS Region 9,1 wk ahead,3.7
 2018,7,2017/2018,59,HHS Region 9,2 wk ahead,3.7
-2018,7,2017/2018,59,HHS Region 9,3 wk ahead,3.4
-2018,7,2017/2018,59,HHS Region 9,4 wk ahead,3.2
+2018,7,2017/2018,59,HHS Region 9,3 wk ahead,3.5
+2018,7,2017/2018,59,HHS Region 9,4 wk ahead,3.3
 2018,7,2017/2018,59,HHS Region 10,Season onset,51
 2018,7,2017/2018,59,HHS Region 10,Season peak week,1
 2018,7,2017/2018,59,HHS Region 10,Season peak percentage,4.8
@@ -19979,18 +19893,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,8,2017/2018,60,HHS Region 7,4 wk ahead,2.7
 2018,8,2017/2018,60,HHS Region 8,Season onset,50
 2018,8,2017/2018,60,HHS Region 8,Season peak week,5
-2018,8,2017/2018,60,HHS Region 8,Season peak week,6
-2018,8,2017/2018,60,HHS Region 8,Season peak percentage,3.2
+2018,8,2017/2018,60,HHS Region 8,Season peak percentage,3.3
 2018,8,2017/2018,60,HHS Region 8,1 wk ahead,2.2
 2018,8,2017/2018,60,HHS Region 8,2 wk ahead,1.9
 2018,8,2017/2018,60,HHS Region 8,3 wk ahead,1.6
 2018,8,2017/2018,60,HHS Region 8,4 wk ahead,1.3
 2018,8,2017/2018,60,HHS Region 9,Season onset,49
 2018,8,2017/2018,60,HHS Region 9,Season peak week,52
-2018,8,2017/2018,60,HHS Region 9,Season peak percentage,6.9
+2018,8,2017/2018,60,HHS Region 9,Season peak percentage,7
 2018,8,2017/2018,60,HHS Region 9,1 wk ahead,3.7
-2018,8,2017/2018,60,HHS Region 9,2 wk ahead,3.4
-2018,8,2017/2018,60,HHS Region 9,3 wk ahead,3.2
+2018,8,2017/2018,60,HHS Region 9,2 wk ahead,3.5
+2018,8,2017/2018,60,HHS Region 9,3 wk ahead,3.3
 2018,8,2017/2018,60,HHS Region 9,4 wk ahead,3
 2018,8,2017/2018,60,HHS Region 10,Season onset,51
 2018,8,2017/2018,60,HHS Region 10,Season peak week,1
@@ -20057,19 +19970,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,9,2017/2018,61,HHS Region 7,4 wk ahead,2
 2018,9,2017/2018,61,HHS Region 8,Season onset,50
 2018,9,2017/2018,61,HHS Region 8,Season peak week,5
-2018,9,2017/2018,61,HHS Region 8,Season peak week,6
-2018,9,2017/2018,61,HHS Region 8,Season peak percentage,3.2
+2018,9,2017/2018,61,HHS Region 8,Season peak percentage,3.3
 2018,9,2017/2018,61,HHS Region 8,1 wk ahead,1.9
 2018,9,2017/2018,61,HHS Region 8,2 wk ahead,1.6
 2018,9,2017/2018,61,HHS Region 8,3 wk ahead,1.3
 2018,9,2017/2018,61,HHS Region 8,4 wk ahead,1.1
 2018,9,2017/2018,61,HHS Region 9,Season onset,49
 2018,9,2017/2018,61,HHS Region 9,Season peak week,52
-2018,9,2017/2018,61,HHS Region 9,Season peak percentage,6.9
-2018,9,2017/2018,61,HHS Region 9,1 wk ahead,3.4
-2018,9,2017/2018,61,HHS Region 9,2 wk ahead,3.2
+2018,9,2017/2018,61,HHS Region 9,Season peak percentage,7
+2018,9,2017/2018,61,HHS Region 9,1 wk ahead,3.5
+2018,9,2017/2018,61,HHS Region 9,2 wk ahead,3.3
 2018,9,2017/2018,61,HHS Region 9,3 wk ahead,3
-2018,9,2017/2018,61,HHS Region 9,4 wk ahead,2.7
+2018,9,2017/2018,61,HHS Region 9,4 wk ahead,2.8
 2018,9,2017/2018,61,HHS Region 10,Season onset,51
 2018,9,2017/2018,61,HHS Region 10,Season peak week,1
 2018,9,2017/2018,61,HHS Region 10,Season peak percentage,4.8
@@ -20135,19 +20047,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,10,2017/2018,62,HHS Region 7,4 wk ahead,1.7
 2018,10,2017/2018,62,HHS Region 8,Season onset,50
 2018,10,2017/2018,62,HHS Region 8,Season peak week,5
-2018,10,2017/2018,62,HHS Region 8,Season peak week,6
-2018,10,2017/2018,62,HHS Region 8,Season peak percentage,3.2
+2018,10,2017/2018,62,HHS Region 8,Season peak percentage,3.3
 2018,10,2017/2018,62,HHS Region 8,1 wk ahead,1.6
 2018,10,2017/2018,62,HHS Region 8,2 wk ahead,1.3
 2018,10,2017/2018,62,HHS Region 8,3 wk ahead,1.1
 2018,10,2017/2018,62,HHS Region 8,4 wk ahead,1.1
 2018,10,2017/2018,62,HHS Region 9,Season onset,49
 2018,10,2017/2018,62,HHS Region 9,Season peak week,52
-2018,10,2017/2018,62,HHS Region 9,Season peak percentage,6.9
-2018,10,2017/2018,62,HHS Region 9,1 wk ahead,3.2
+2018,10,2017/2018,62,HHS Region 9,Season peak percentage,7
+2018,10,2017/2018,62,HHS Region 9,1 wk ahead,3.3
 2018,10,2017/2018,62,HHS Region 9,2 wk ahead,3
-2018,10,2017/2018,62,HHS Region 9,3 wk ahead,2.7
-2018,10,2017/2018,62,HHS Region 9,4 wk ahead,2.4
+2018,10,2017/2018,62,HHS Region 9,3 wk ahead,2.8
+2018,10,2017/2018,62,HHS Region 9,4 wk ahead,2.5
 2018,10,2017/2018,62,HHS Region 10,Season onset,51
 2018,10,2017/2018,62,HHS Region 10,Season peak week,1
 2018,10,2017/2018,62,HHS Region 10,Season peak percentage,4.8
@@ -20213,18 +20124,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,11,2017/2018,63,HHS Region 7,4 wk ahead,1.3
 2018,11,2017/2018,63,HHS Region 8,Season onset,50
 2018,11,2017/2018,63,HHS Region 8,Season peak week,5
-2018,11,2017/2018,63,HHS Region 8,Season peak week,6
-2018,11,2017/2018,63,HHS Region 8,Season peak percentage,3.2
+2018,11,2017/2018,63,HHS Region 8,Season peak percentage,3.3
 2018,11,2017/2018,63,HHS Region 8,1 wk ahead,1.3
 2018,11,2017/2018,63,HHS Region 8,2 wk ahead,1.1
 2018,11,2017/2018,63,HHS Region 8,3 wk ahead,1.1
 2018,11,2017/2018,63,HHS Region 8,4 wk ahead,0.8
 2018,11,2017/2018,63,HHS Region 9,Season onset,49
 2018,11,2017/2018,63,HHS Region 9,Season peak week,52
-2018,11,2017/2018,63,HHS Region 9,Season peak percentage,6.9
+2018,11,2017/2018,63,HHS Region 9,Season peak percentage,7
 2018,11,2017/2018,63,HHS Region 9,1 wk ahead,3
-2018,11,2017/2018,63,HHS Region 9,2 wk ahead,2.7
-2018,11,2017/2018,63,HHS Region 9,3 wk ahead,2.4
+2018,11,2017/2018,63,HHS Region 9,2 wk ahead,2.8
+2018,11,2017/2018,63,HHS Region 9,3 wk ahead,2.5
 2018,11,2017/2018,63,HHS Region 9,4 wk ahead,2
 2018,11,2017/2018,63,HHS Region 10,Season onset,51
 2018,11,2017/2018,63,HHS Region 10,Season peak week,1
@@ -20246,7 +20156,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,12,2017/2018,64,HHS Region 1,1 wk ahead,2.2
 2018,12,2017/2018,64,HHS Region 1,2 wk ahead,2
 2018,12,2017/2018,64,HHS Region 1,3 wk ahead,1.9
-2018,12,2017/2018,64,HHS Region 1,4 wk ahead,1.8
+2018,12,2017/2018,64,HHS Region 1,4 wk ahead,1.7
 2018,12,2017/2018,64,HHS Region 2,Season onset,49
 2018,12,2017/2018,64,HHS Region 2,Season peak week,6
 2018,12,2017/2018,64,HHS Region 2,Season peak percentage,10.4
@@ -20274,7 +20184,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,12,2017/2018,64,HHS Region 5,1 wk ahead,2.2
 2018,12,2017/2018,64,HHS Region 5,2 wk ahead,1.8
 2018,12,2017/2018,64,HHS Region 5,3 wk ahead,1.7
-2018,12,2017/2018,64,HHS Region 5,4 wk ahead,1.4
+2018,12,2017/2018,64,HHS Region 5,4 wk ahead,1.5
 2018,12,2017/2018,64,HHS Region 6,Season onset,48
 2018,12,2017/2018,64,HHS Region 6,Season peak week,4
 2018,12,2017/2018,64,HHS Region 6,Season peak percentage,12.7
@@ -20291,17 +20201,16 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,12,2017/2018,64,HHS Region 7,4 wk ahead,0.9
 2018,12,2017/2018,64,HHS Region 8,Season onset,50
 2018,12,2017/2018,64,HHS Region 8,Season peak week,5
-2018,12,2017/2018,64,HHS Region 8,Season peak week,6
-2018,12,2017/2018,64,HHS Region 8,Season peak percentage,3.2
+2018,12,2017/2018,64,HHS Region 8,Season peak percentage,3.3
 2018,12,2017/2018,64,HHS Region 8,1 wk ahead,1.1
 2018,12,2017/2018,64,HHS Region 8,2 wk ahead,1.1
 2018,12,2017/2018,64,HHS Region 8,3 wk ahead,0.8
 2018,12,2017/2018,64,HHS Region 8,4 wk ahead,0.7
 2018,12,2017/2018,64,HHS Region 9,Season onset,49
 2018,12,2017/2018,64,HHS Region 9,Season peak week,52
-2018,12,2017/2018,64,HHS Region 9,Season peak percentage,6.9
-2018,12,2017/2018,64,HHS Region 9,1 wk ahead,2.7
-2018,12,2017/2018,64,HHS Region 9,2 wk ahead,2.4
+2018,12,2017/2018,64,HHS Region 9,Season peak percentage,7
+2018,12,2017/2018,64,HHS Region 9,1 wk ahead,2.8
+2018,12,2017/2018,64,HHS Region 9,2 wk ahead,2.5
 2018,12,2017/2018,64,HHS Region 9,3 wk ahead,2
 2018,12,2017/2018,64,HHS Region 9,4 wk ahead,2
 2018,12,2017/2018,64,HHS Region 10,Season onset,51
@@ -20323,7 +20232,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,13,2017/2018,65,HHS Region 1,Season peak percentage,5.8
 2018,13,2017/2018,65,HHS Region 1,1 wk ahead,2
 2018,13,2017/2018,65,HHS Region 1,2 wk ahead,1.9
-2018,13,2017/2018,65,HHS Region 1,3 wk ahead,1.8
+2018,13,2017/2018,65,HHS Region 1,3 wk ahead,1.7
 2018,13,2017/2018,65,HHS Region 1,4 wk ahead,1.5
 2018,13,2017/2018,65,HHS Region 2,Season onset,49
 2018,13,2017/2018,65,HHS Region 2,Season peak week,6
@@ -20351,7 +20260,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,13,2017/2018,65,HHS Region 5,Season peak percentage,5.8
 2018,13,2017/2018,65,HHS Region 5,1 wk ahead,1.8
 2018,13,2017/2018,65,HHS Region 5,2 wk ahead,1.7
-2018,13,2017/2018,65,HHS Region 5,3 wk ahead,1.4
+2018,13,2017/2018,65,HHS Region 5,3 wk ahead,1.5
 2018,13,2017/2018,65,HHS Region 5,4 wk ahead,1.4
 2018,13,2017/2018,65,HHS Region 6,Season onset,48
 2018,13,2017/2018,65,HHS Region 6,Season peak week,4
@@ -20369,19 +20278,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,13,2017/2018,65,HHS Region 7,4 wk ahead,1
 2018,13,2017/2018,65,HHS Region 8,Season onset,50
 2018,13,2017/2018,65,HHS Region 8,Season peak week,5
-2018,13,2017/2018,65,HHS Region 8,Season peak week,6
-2018,13,2017/2018,65,HHS Region 8,Season peak percentage,3.2
+2018,13,2017/2018,65,HHS Region 8,Season peak percentage,3.3
 2018,13,2017/2018,65,HHS Region 8,1 wk ahead,1.1
 2018,13,2017/2018,65,HHS Region 8,2 wk ahead,0.8
 2018,13,2017/2018,65,HHS Region 8,3 wk ahead,0.7
 2018,13,2017/2018,65,HHS Region 8,4 wk ahead,0.8
 2018,13,2017/2018,65,HHS Region 9,Season onset,49
 2018,13,2017/2018,65,HHS Region 9,Season peak week,52
-2018,13,2017/2018,65,HHS Region 9,Season peak percentage,6.9
-2018,13,2017/2018,65,HHS Region 9,1 wk ahead,2.4
+2018,13,2017/2018,65,HHS Region 9,Season peak percentage,7
+2018,13,2017/2018,65,HHS Region 9,1 wk ahead,2.5
 2018,13,2017/2018,65,HHS Region 9,2 wk ahead,2
 2018,13,2017/2018,65,HHS Region 9,3 wk ahead,2
-2018,13,2017/2018,65,HHS Region 9,4 wk ahead,2
+2018,13,2017/2018,65,HHS Region 9,4 wk ahead,2.1
 2018,13,2017/2018,65,HHS Region 10,Season onset,51
 2018,13,2017/2018,65,HHS Region 10,Season peak week,1
 2018,13,2017/2018,65,HHS Region 10,Season peak percentage,4.8
@@ -20400,7 +20308,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,14,2017/2018,66,HHS Region 1,Season peak week,6
 2018,14,2017/2018,66,HHS Region 1,Season peak percentage,5.8
 2018,14,2017/2018,66,HHS Region 1,1 wk ahead,1.9
-2018,14,2017/2018,66,HHS Region 1,2 wk ahead,1.8
+2018,14,2017/2018,66,HHS Region 1,2 wk ahead,1.7
 2018,14,2017/2018,66,HHS Region 1,3 wk ahead,1.5
 2018,14,2017/2018,66,HHS Region 1,4 wk ahead,1.3
 2018,14,2017/2018,66,HHS Region 2,Season onset,49
@@ -20428,9 +20336,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,14,2017/2018,66,HHS Region 5,Season peak week,6
 2018,14,2017/2018,66,HHS Region 5,Season peak percentage,5.8
 2018,14,2017/2018,66,HHS Region 5,1 wk ahead,1.7
-2018,14,2017/2018,66,HHS Region 5,2 wk ahead,1.4
+2018,14,2017/2018,66,HHS Region 5,2 wk ahead,1.5
 2018,14,2017/2018,66,HHS Region 5,3 wk ahead,1.4
-2018,14,2017/2018,66,HHS Region 5,4 wk ahead,1.1
+2018,14,2017/2018,66,HHS Region 5,4 wk ahead,1.2
 2018,14,2017/2018,66,HHS Region 6,Season onset,48
 2018,14,2017/2018,66,HHS Region 6,Season peak week,4
 2018,14,2017/2018,66,HHS Region 6,Season peak percentage,12.7
@@ -20447,18 +20355,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,14,2017/2018,66,HHS Region 7,4 wk ahead,0.5
 2018,14,2017/2018,66,HHS Region 8,Season onset,50
 2018,14,2017/2018,66,HHS Region 8,Season peak week,5
-2018,14,2017/2018,66,HHS Region 8,Season peak week,6
-2018,14,2017/2018,66,HHS Region 8,Season peak percentage,3.2
+2018,14,2017/2018,66,HHS Region 8,Season peak percentage,3.3
 2018,14,2017/2018,66,HHS Region 8,1 wk ahead,0.8
 2018,14,2017/2018,66,HHS Region 8,2 wk ahead,0.7
 2018,14,2017/2018,66,HHS Region 8,3 wk ahead,0.8
 2018,14,2017/2018,66,HHS Region 8,4 wk ahead,0.6
 2018,14,2017/2018,66,HHS Region 9,Season onset,49
 2018,14,2017/2018,66,HHS Region 9,Season peak week,52
-2018,14,2017/2018,66,HHS Region 9,Season peak percentage,6.9
+2018,14,2017/2018,66,HHS Region 9,Season peak percentage,7
 2018,14,2017/2018,66,HHS Region 9,1 wk ahead,2
 2018,14,2017/2018,66,HHS Region 9,2 wk ahead,2
-2018,14,2017/2018,66,HHS Region 9,3 wk ahead,2
+2018,14,2017/2018,66,HHS Region 9,3 wk ahead,2.1
 2018,14,2017/2018,66,HHS Region 9,4 wk ahead,2
 2018,14,2017/2018,66,HHS Region 10,Season onset,51
 2018,14,2017/2018,66,HHS Region 10,Season peak week,1
@@ -20477,7 +20384,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,15,2017/2018,67,HHS Region 1,Season onset,47
 2018,15,2017/2018,67,HHS Region 1,Season peak week,6
 2018,15,2017/2018,67,HHS Region 1,Season peak percentage,5.8
-2018,15,2017/2018,67,HHS Region 1,1 wk ahead,1.8
+2018,15,2017/2018,67,HHS Region 1,1 wk ahead,1.7
 2018,15,2017/2018,67,HHS Region 1,2 wk ahead,1.5
 2018,15,2017/2018,67,HHS Region 1,3 wk ahead,1.3
 2018,15,2017/2018,67,HHS Region 1,4 wk ahead,1
@@ -20505,9 +20412,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,15,2017/2018,67,HHS Region 5,Season onset,49
 2018,15,2017/2018,67,HHS Region 5,Season peak week,6
 2018,15,2017/2018,67,HHS Region 5,Season peak percentage,5.8
-2018,15,2017/2018,67,HHS Region 5,1 wk ahead,1.4
+2018,15,2017/2018,67,HHS Region 5,1 wk ahead,1.5
 2018,15,2017/2018,67,HHS Region 5,2 wk ahead,1.4
-2018,15,2017/2018,67,HHS Region 5,3 wk ahead,1.1
+2018,15,2017/2018,67,HHS Region 5,3 wk ahead,1.2
 2018,15,2017/2018,67,HHS Region 5,4 wk ahead,1
 2018,15,2017/2018,67,HHS Region 6,Season onset,48
 2018,15,2017/2018,67,HHS Region 6,Season peak week,4
@@ -20525,19 +20432,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,15,2017/2018,67,HHS Region 7,4 wk ahead,0.5
 2018,15,2017/2018,67,HHS Region 8,Season onset,50
 2018,15,2017/2018,67,HHS Region 8,Season peak week,5
-2018,15,2017/2018,67,HHS Region 8,Season peak week,6
-2018,15,2017/2018,67,HHS Region 8,Season peak percentage,3.2
+2018,15,2017/2018,67,HHS Region 8,Season peak percentage,3.3
 2018,15,2017/2018,67,HHS Region 8,1 wk ahead,0.7
 2018,15,2017/2018,67,HHS Region 8,2 wk ahead,0.8
 2018,15,2017/2018,67,HHS Region 8,3 wk ahead,0.6
 2018,15,2017/2018,67,HHS Region 8,4 wk ahead,0.5
 2018,15,2017/2018,67,HHS Region 9,Season onset,49
 2018,15,2017/2018,67,HHS Region 9,Season peak week,52
-2018,15,2017/2018,67,HHS Region 9,Season peak percentage,6.9
+2018,15,2017/2018,67,HHS Region 9,Season peak percentage,7
 2018,15,2017/2018,67,HHS Region 9,1 wk ahead,2
-2018,15,2017/2018,67,HHS Region 9,2 wk ahead,2
+2018,15,2017/2018,67,HHS Region 9,2 wk ahead,2.1
 2018,15,2017/2018,67,HHS Region 9,3 wk ahead,2
-2018,15,2017/2018,67,HHS Region 9,4 wk ahead,1.8
+2018,15,2017/2018,67,HHS Region 9,4 wk ahead,1.9
 2018,15,2017/2018,67,HHS Region 10,Season onset,51
 2018,15,2017/2018,67,HHS Region 10,Season peak week,1
 2018,15,2017/2018,67,HHS Region 10,Season peak percentage,4.8
@@ -20558,7 +20464,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,16,2017/2018,68,HHS Region 1,1 wk ahead,1.5
 2018,16,2017/2018,68,HHS Region 1,2 wk ahead,1.3
 2018,16,2017/2018,68,HHS Region 1,3 wk ahead,1
-2018,16,2017/2018,68,HHS Region 1,4 wk ahead,1
+2018,16,2017/2018,68,HHS Region 1,4 wk ahead,0.9
 2018,16,2017/2018,68,HHS Region 2,Season onset,49
 2018,16,2017/2018,68,HHS Region 2,Season peak week,6
 2018,16,2017/2018,68,HHS Region 2,Season peak percentage,10.4
@@ -20584,7 +20490,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,16,2017/2018,68,HHS Region 5,Season peak week,6
 2018,16,2017/2018,68,HHS Region 5,Season peak percentage,5.8
 2018,16,2017/2018,68,HHS Region 5,1 wk ahead,1.4
-2018,16,2017/2018,68,HHS Region 5,2 wk ahead,1.1
+2018,16,2017/2018,68,HHS Region 5,2 wk ahead,1.2
 2018,16,2017/2018,68,HHS Region 5,3 wk ahead,1
 2018,16,2017/2018,68,HHS Region 5,4 wk ahead,0.9
 2018,16,2017/2018,68,HHS Region 6,Season onset,48
@@ -20593,7 +20499,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,16,2017/2018,68,HHS Region 6,1 wk ahead,2
 2018,16,2017/2018,68,HHS Region 6,2 wk ahead,2
 2018,16,2017/2018,68,HHS Region 6,3 wk ahead,1.9
-2018,16,2017/2018,68,HHS Region 6,4 wk ahead,1.5
+2018,16,2017/2018,68,HHS Region 6,4 wk ahead,1.6
 2018,16,2017/2018,68,HHS Region 7,Season onset,49
 2018,16,2017/2018,68,HHS Region 7,Season peak week,4
 2018,16,2017/2018,68,HHS Region 7,Season peak percentage,8.9
@@ -20603,18 +20509,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,16,2017/2018,68,HHS Region 7,4 wk ahead,0.6
 2018,16,2017/2018,68,HHS Region 8,Season onset,50
 2018,16,2017/2018,68,HHS Region 8,Season peak week,5
-2018,16,2017/2018,68,HHS Region 8,Season peak week,6
-2018,16,2017/2018,68,HHS Region 8,Season peak percentage,3.2
+2018,16,2017/2018,68,HHS Region 8,Season peak percentage,3.3
 2018,16,2017/2018,68,HHS Region 8,1 wk ahead,0.8
 2018,16,2017/2018,68,HHS Region 8,2 wk ahead,0.6
 2018,16,2017/2018,68,HHS Region 8,3 wk ahead,0.5
 2018,16,2017/2018,68,HHS Region 8,4 wk ahead,0.5
 2018,16,2017/2018,68,HHS Region 9,Season onset,49
 2018,16,2017/2018,68,HHS Region 9,Season peak week,52
-2018,16,2017/2018,68,HHS Region 9,Season peak percentage,6.9
-2018,16,2017/2018,68,HHS Region 9,1 wk ahead,2
+2018,16,2017/2018,68,HHS Region 9,Season peak percentage,7
+2018,16,2017/2018,68,HHS Region 9,1 wk ahead,2.1
 2018,16,2017/2018,68,HHS Region 9,2 wk ahead,2
-2018,16,2017/2018,68,HHS Region 9,3 wk ahead,1.8
+2018,16,2017/2018,68,HHS Region 9,3 wk ahead,1.9
 2018,16,2017/2018,68,HHS Region 9,4 wk ahead,1.7
 2018,16,2017/2018,68,HHS Region 10,Season onset,51
 2018,16,2017/2018,68,HHS Region 10,Season peak week,1
@@ -20635,8 +20540,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,17,2017/2018,69,HHS Region 1,Season peak percentage,5.8
 2018,17,2017/2018,69,HHS Region 1,1 wk ahead,1.3
 2018,17,2017/2018,69,HHS Region 1,2 wk ahead,1
-2018,17,2017/2018,69,HHS Region 1,3 wk ahead,1
-2018,17,2017/2018,69,HHS Region 1,4 wk ahead,1.4
+2018,17,2017/2018,69,HHS Region 1,3 wk ahead,0.9
+2018,17,2017/2018,69,HHS Region 1,4 wk ahead,0.8
 2018,17,2017/2018,69,HHS Region 2,Season onset,49
 2018,17,2017/2018,69,HHS Region 2,Season peak week,6
 2018,17,2017/2018,69,HHS Region 2,Season peak percentage,10.4
@@ -20657,11 +20562,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,17,2017/2018,69,HHS Region 4,1 wk ahead,1.2
 2018,17,2017/2018,69,HHS Region 4,2 wk ahead,1
 2018,17,2017/2018,69,HHS Region 4,3 wk ahead,1
-2018,17,2017/2018,69,HHS Region 4,4 wk ahead,0.9
+2018,17,2017/2018,69,HHS Region 4,4 wk ahead,1
 2018,17,2017/2018,69,HHS Region 5,Season onset,49
 2018,17,2017/2018,69,HHS Region 5,Season peak week,6
 2018,17,2017/2018,69,HHS Region 5,Season peak percentage,5.8
-2018,17,2017/2018,69,HHS Region 5,1 wk ahead,1.1
+2018,17,2017/2018,69,HHS Region 5,1 wk ahead,1.2
 2018,17,2017/2018,69,HHS Region 5,2 wk ahead,1
 2018,17,2017/2018,69,HHS Region 5,3 wk ahead,0.9
 2018,17,2017/2018,69,HHS Region 5,4 wk ahead,1
@@ -20670,7 +20575,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,17,2017/2018,69,HHS Region 6,Season peak percentage,12.7
 2018,17,2017/2018,69,HHS Region 6,1 wk ahead,2
 2018,17,2017/2018,69,HHS Region 6,2 wk ahead,1.9
-2018,17,2017/2018,69,HHS Region 6,3 wk ahead,1.5
+2018,17,2017/2018,69,HHS Region 6,3 wk ahead,1.6
 2018,17,2017/2018,69,HHS Region 6,4 wk ahead,1.7
 2018,17,2017/2018,69,HHS Region 7,Season onset,49
 2018,17,2017/2018,69,HHS Region 7,Season peak week,4
@@ -20678,22 +20583,21 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,17,2017/2018,69,HHS Region 7,1 wk ahead,0.5
 2018,17,2017/2018,69,HHS Region 7,2 wk ahead,0.5
 2018,17,2017/2018,69,HHS Region 7,3 wk ahead,0.6
-2018,17,2017/2018,69,HHS Region 7,4 wk ahead,0.7
+2018,17,2017/2018,69,HHS Region 7,4 wk ahead,0.6
 2018,17,2017/2018,69,HHS Region 8,Season onset,50
 2018,17,2017/2018,69,HHS Region 8,Season peak week,5
-2018,17,2017/2018,69,HHS Region 8,Season peak week,6
-2018,17,2017/2018,69,HHS Region 8,Season peak percentage,3.2
+2018,17,2017/2018,69,HHS Region 8,Season peak percentage,3.3
 2018,17,2017/2018,69,HHS Region 8,1 wk ahead,0.6
 2018,17,2017/2018,69,HHS Region 8,2 wk ahead,0.5
 2018,17,2017/2018,69,HHS Region 8,3 wk ahead,0.5
 2018,17,2017/2018,69,HHS Region 8,4 wk ahead,0.5
 2018,17,2017/2018,69,HHS Region 9,Season onset,49
 2018,17,2017/2018,69,HHS Region 9,Season peak week,52
-2018,17,2017/2018,69,HHS Region 9,Season peak percentage,6.9
+2018,17,2017/2018,69,HHS Region 9,Season peak percentage,7
 2018,17,2017/2018,69,HHS Region 9,1 wk ahead,2
-2018,17,2017/2018,69,HHS Region 9,2 wk ahead,1.8
+2018,17,2017/2018,69,HHS Region 9,2 wk ahead,1.9
 2018,17,2017/2018,69,HHS Region 9,3 wk ahead,1.7
-2018,17,2017/2018,69,HHS Region 9,4 wk ahead,1.7
+2018,17,2017/2018,69,HHS Region 9,4 wk ahead,1.8
 2018,17,2017/2018,69,HHS Region 10,Season onset,51
 2018,17,2017/2018,69,HHS Region 10,Season peak week,1
 2018,17,2017/2018,69,HHS Region 10,Season peak percentage,4.8
@@ -20707,13 +20611,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,18,2017/2018,70,US National,1 wk ahead,1.3
 2018,18,2017/2018,70,US National,2 wk ahead,1.2
 2018,18,2017/2018,70,US National,3 wk ahead,1.2
-2018,18,2017/2018,70,US National,4 wk ahead,1.1
+2018,18,2017/2018,70,US National,4 wk ahead,1.2
 2018,18,2017/2018,70,HHS Region 1,Season onset,47
 2018,18,2017/2018,70,HHS Region 1,Season peak week,6
 2018,18,2017/2018,70,HHS Region 1,Season peak percentage,5.8
 2018,18,2017/2018,70,HHS Region 1,1 wk ahead,1
-2018,18,2017/2018,70,HHS Region 1,2 wk ahead,1
-2018,18,2017/2018,70,HHS Region 1,3 wk ahead,1.4
+2018,18,2017/2018,70,HHS Region 1,2 wk ahead,0.9
+2018,18,2017/2018,70,HHS Region 1,3 wk ahead,0.8
 2018,18,2017/2018,70,HHS Region 1,4 wk ahead,0.7
 2018,18,2017/2018,70,HHS Region 2,Season onset,49
 2018,18,2017/2018,70,HHS Region 2,Season peak week,6
@@ -20734,7 +20638,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,18,2017/2018,70,HHS Region 4,Season peak percentage,9.3
 2018,18,2017/2018,70,HHS Region 4,1 wk ahead,1
 2018,18,2017/2018,70,HHS Region 4,2 wk ahead,1
-2018,18,2017/2018,70,HHS Region 4,3 wk ahead,0.9
+2018,18,2017/2018,70,HHS Region 4,3 wk ahead,1
 2018,18,2017/2018,70,HHS Region 4,4 wk ahead,0.9
 2018,18,2017/2018,70,HHS Region 5,Season onset,49
 2018,18,2017/2018,70,HHS Region 5,Season peak week,6
@@ -20747,7 +20651,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,18,2017/2018,70,HHS Region 6,Season peak week,4
 2018,18,2017/2018,70,HHS Region 6,Season peak percentage,12.7
 2018,18,2017/2018,70,HHS Region 6,1 wk ahead,1.9
-2018,18,2017/2018,70,HHS Region 6,2 wk ahead,1.5
+2018,18,2017/2018,70,HHS Region 6,2 wk ahead,1.6
 2018,18,2017/2018,70,HHS Region 6,3 wk ahead,1.7
 2018,18,2017/2018,70,HHS Region 6,4 wk ahead,1.5
 2018,18,2017/2018,70,HHS Region 7,Season onset,49
@@ -20755,23 +20659,22 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,18,2017/2018,70,HHS Region 7,Season peak percentage,8.9
 2018,18,2017/2018,70,HHS Region 7,1 wk ahead,0.5
 2018,18,2017/2018,70,HHS Region 7,2 wk ahead,0.6
-2018,18,2017/2018,70,HHS Region 7,3 wk ahead,0.7
+2018,18,2017/2018,70,HHS Region 7,3 wk ahead,0.6
 2018,18,2017/2018,70,HHS Region 7,4 wk ahead,0.6
 2018,18,2017/2018,70,HHS Region 8,Season onset,50
 2018,18,2017/2018,70,HHS Region 8,Season peak week,5
-2018,18,2017/2018,70,HHS Region 8,Season peak week,6
-2018,18,2017/2018,70,HHS Region 8,Season peak percentage,3.2
+2018,18,2017/2018,70,HHS Region 8,Season peak percentage,3.3
 2018,18,2017/2018,70,HHS Region 8,1 wk ahead,0.5
 2018,18,2017/2018,70,HHS Region 8,2 wk ahead,0.5
 2018,18,2017/2018,70,HHS Region 8,3 wk ahead,0.5
 2018,18,2017/2018,70,HHS Region 8,4 wk ahead,0.7
 2018,18,2017/2018,70,HHS Region 9,Season onset,49
 2018,18,2017/2018,70,HHS Region 9,Season peak week,52
-2018,18,2017/2018,70,HHS Region 9,Season peak percentage,6.9
-2018,18,2017/2018,70,HHS Region 9,1 wk ahead,1.8
+2018,18,2017/2018,70,HHS Region 9,Season peak percentage,7
+2018,18,2017/2018,70,HHS Region 9,1 wk ahead,1.9
 2018,18,2017/2018,70,HHS Region 9,2 wk ahead,1.7
-2018,18,2017/2018,70,HHS Region 9,3 wk ahead,1.7
-2018,18,2017/2018,70,HHS Region 9,4 wk ahead,1.6
+2018,18,2017/2018,70,HHS Region 9,3 wk ahead,1.8
+2018,18,2017/2018,70,HHS Region 9,4 wk ahead,1.7
 2018,18,2017/2018,70,HHS Region 10,Season onset,51
 2018,18,2017/2018,70,HHS Region 10,Season peak week,1
 2018,18,2017/2018,70,HHS Region 10,Season peak percentage,4.8
@@ -20784,13 +20687,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,19,2017/2018,71,US National,Season peak percentage,7.5
 2018,19,2017/2018,71,US National,1 wk ahead,1.2
 2018,19,2017/2018,71,US National,2 wk ahead,1.2
-2018,19,2017/2018,71,US National,3 wk ahead,1.1
+2018,19,2017/2018,71,US National,3 wk ahead,1.2
 2018,19,2017/2018,71,US National,4 wk ahead,1
 2018,19,2017/2018,71,HHS Region 1,Season onset,47
 2018,19,2017/2018,71,HHS Region 1,Season peak week,6
 2018,19,2017/2018,71,HHS Region 1,Season peak percentage,5.8
-2018,19,2017/2018,71,HHS Region 1,1 wk ahead,1
-2018,19,2017/2018,71,HHS Region 1,2 wk ahead,1.4
+2018,19,2017/2018,71,HHS Region 1,1 wk ahead,0.9
+2018,19,2017/2018,71,HHS Region 1,2 wk ahead,0.8
 2018,19,2017/2018,71,HHS Region 1,3 wk ahead,0.7
 2018,19,2017/2018,71,HHS Region 1,4 wk ahead,0.6
 2018,19,2017/2018,71,HHS Region 2,Season onset,49
@@ -20811,7 +20714,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,19,2017/2018,71,HHS Region 4,Season peak week,5
 2018,19,2017/2018,71,HHS Region 4,Season peak percentage,9.3
 2018,19,2017/2018,71,HHS Region 4,1 wk ahead,1
-2018,19,2017/2018,71,HHS Region 4,2 wk ahead,0.9
+2018,19,2017/2018,71,HHS Region 4,2 wk ahead,1
 2018,19,2017/2018,71,HHS Region 4,3 wk ahead,0.9
 2018,19,2017/2018,71,HHS Region 4,4 wk ahead,0.8
 2018,19,2017/2018,71,HHS Region 5,Season onset,49
@@ -20824,7 +20727,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,19,2017/2018,71,HHS Region 6,Season onset,48
 2018,19,2017/2018,71,HHS Region 6,Season peak week,4
 2018,19,2017/2018,71,HHS Region 6,Season peak percentage,12.7
-2018,19,2017/2018,71,HHS Region 6,1 wk ahead,1.5
+2018,19,2017/2018,71,HHS Region 6,1 wk ahead,1.6
 2018,19,2017/2018,71,HHS Region 6,2 wk ahead,1.7
 2018,19,2017/2018,71,HHS Region 6,3 wk ahead,1.5
 2018,19,2017/2018,71,HHS Region 6,4 wk ahead,1.4
@@ -20832,24 +20735,23 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,19,2017/2018,71,HHS Region 7,Season peak week,4
 2018,19,2017/2018,71,HHS Region 7,Season peak percentage,8.9
 2018,19,2017/2018,71,HHS Region 7,1 wk ahead,0.6
-2018,19,2017/2018,71,HHS Region 7,2 wk ahead,0.7
+2018,19,2017/2018,71,HHS Region 7,2 wk ahead,0.6
 2018,19,2017/2018,71,HHS Region 7,3 wk ahead,0.6
 2018,19,2017/2018,71,HHS Region 7,4 wk ahead,0.4
 2018,19,2017/2018,71,HHS Region 8,Season onset,50
 2018,19,2017/2018,71,HHS Region 8,Season peak week,5
-2018,19,2017/2018,71,HHS Region 8,Season peak week,6
-2018,19,2017/2018,71,HHS Region 8,Season peak percentage,3.2
+2018,19,2017/2018,71,HHS Region 8,Season peak percentage,3.3
 2018,19,2017/2018,71,HHS Region 8,1 wk ahead,0.5
 2018,19,2017/2018,71,HHS Region 8,2 wk ahead,0.5
 2018,19,2017/2018,71,HHS Region 8,3 wk ahead,0.7
 2018,19,2017/2018,71,HHS Region 8,4 wk ahead,0.4
 2018,19,2017/2018,71,HHS Region 9,Season onset,49
 2018,19,2017/2018,71,HHS Region 9,Season peak week,52
-2018,19,2017/2018,71,HHS Region 9,Season peak percentage,6.9
+2018,19,2017/2018,71,HHS Region 9,Season peak percentage,7
 2018,19,2017/2018,71,HHS Region 9,1 wk ahead,1.7
-2018,19,2017/2018,71,HHS Region 9,2 wk ahead,1.7
-2018,19,2017/2018,71,HHS Region 9,3 wk ahead,1.6
-2018,19,2017/2018,71,HHS Region 9,4 wk ahead,1.3
+2018,19,2017/2018,71,HHS Region 9,2 wk ahead,1.8
+2018,19,2017/2018,71,HHS Region 9,3 wk ahead,1.7
+2018,19,2017/2018,71,HHS Region 9,4 wk ahead,1.2
 2018,19,2017/2018,71,HHS Region 10,Season onset,51
 2018,19,2017/2018,71,HHS Region 10,Season peak week,1
 2018,19,2017/2018,71,HHS Region 10,Season peak percentage,4.8
@@ -20861,16 +20763,16 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,20,2017/2018,72,US National,Season peak week,5
 2018,20,2017/2018,72,US National,Season peak percentage,7.5
 2018,20,2017/2018,72,US National,1 wk ahead,1.2
-2018,20,2017/2018,72,US National,2 wk ahead,1.1
+2018,20,2017/2018,72,US National,2 wk ahead,1.2
 2018,20,2017/2018,72,US National,3 wk ahead,1
 2018,20,2017/2018,72,US National,4 wk ahead,0.9
 2018,20,2017/2018,72,HHS Region 1,Season onset,47
 2018,20,2017/2018,72,HHS Region 1,Season peak week,6
 2018,20,2017/2018,72,HHS Region 1,Season peak percentage,5.8
-2018,20,2017/2018,72,HHS Region 1,1 wk ahead,1.4
+2018,20,2017/2018,72,HHS Region 1,1 wk ahead,0.8
 2018,20,2017/2018,72,HHS Region 1,2 wk ahead,0.7
 2018,20,2017/2018,72,HHS Region 1,3 wk ahead,0.6
-2018,20,2017/2018,72,HHS Region 1,4 wk ahead,0.7
+2018,20,2017/2018,72,HHS Region 1,4 wk ahead,0.5
 2018,20,2017/2018,72,HHS Region 2,Season onset,49
 2018,20,2017/2018,72,HHS Region 2,Season peak week,6
 2018,20,2017/2018,72,HHS Region 2,Season peak percentage,10.4
@@ -20888,7 +20790,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,20,2017/2018,72,HHS Region 4,Season onset,45
 2018,20,2017/2018,72,HHS Region 4,Season peak week,5
 2018,20,2017/2018,72,HHS Region 4,Season peak percentage,9.3
-2018,20,2017/2018,72,HHS Region 4,1 wk ahead,0.9
+2018,20,2017/2018,72,HHS Region 4,1 wk ahead,1
 2018,20,2017/2018,72,HHS Region 4,2 wk ahead,0.9
 2018,20,2017/2018,72,HHS Region 4,3 wk ahead,0.8
 2018,20,2017/2018,72,HHS Region 4,4 wk ahead,0.6
@@ -20909,24 +20811,23 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,20,2017/2018,72,HHS Region 7,Season onset,49
 2018,20,2017/2018,72,HHS Region 7,Season peak week,4
 2018,20,2017/2018,72,HHS Region 7,Season peak percentage,8.9
-2018,20,2017/2018,72,HHS Region 7,1 wk ahead,0.7
+2018,20,2017/2018,72,HHS Region 7,1 wk ahead,0.6
 2018,20,2017/2018,72,HHS Region 7,2 wk ahead,0.6
 2018,20,2017/2018,72,HHS Region 7,3 wk ahead,0.4
 2018,20,2017/2018,72,HHS Region 7,4 wk ahead,0.4
 2018,20,2017/2018,72,HHS Region 8,Season onset,50
 2018,20,2017/2018,72,HHS Region 8,Season peak week,5
-2018,20,2017/2018,72,HHS Region 8,Season peak week,6
-2018,20,2017/2018,72,HHS Region 8,Season peak percentage,3.2
+2018,20,2017/2018,72,HHS Region 8,Season peak percentage,3.3
 2018,20,2017/2018,72,HHS Region 8,1 wk ahead,0.5
 2018,20,2017/2018,72,HHS Region 8,2 wk ahead,0.7
 2018,20,2017/2018,72,HHS Region 8,3 wk ahead,0.4
-2018,20,2017/2018,72,HHS Region 8,4 wk ahead,0.3
+2018,20,2017/2018,72,HHS Region 8,4 wk ahead,0.4
 2018,20,2017/2018,72,HHS Region 9,Season onset,49
 2018,20,2017/2018,72,HHS Region 9,Season peak week,52
-2018,20,2017/2018,72,HHS Region 9,Season peak percentage,6.9
-2018,20,2017/2018,72,HHS Region 9,1 wk ahead,1.7
-2018,20,2017/2018,72,HHS Region 9,2 wk ahead,1.6
-2018,20,2017/2018,72,HHS Region 9,3 wk ahead,1.3
+2018,20,2017/2018,72,HHS Region 9,Season peak percentage,7
+2018,20,2017/2018,72,HHS Region 9,1 wk ahead,1.8
+2018,20,2017/2018,72,HHS Region 9,2 wk ahead,1.7
+2018,20,2017/2018,72,HHS Region 9,3 wk ahead,1.2
 2018,20,2017/2018,72,HHS Region 9,4 wk ahead,1.3
 2018,20,2017/2018,72,HHS Region 10,Season onset,51
 2018,20,2017/2018,72,HHS Region 10,Season peak week,1
@@ -20934,8 +20835,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,20,2017/2018,72,HHS Region 10,1 wk ahead,0.5
 2018,20,2017/2018,72,HHS Region 10,2 wk ahead,0.4
 2018,20,2017/2018,72,HHS Region 10,3 wk ahead,0.4
-2018,20,2017/2018,72,HHS Region 10,4 wk ahead,0.5
-2018,40,2018/2019,40,US National,Season onset,47
+2018,20,2017/2018,72,HHS Region 10,4 wk ahead,0.4
+2018,40,2018/2019,40,US National,Season onset,49
 2018,40,2018/2019,40,US National,Season peak week,7
 2018,40,2018/2019,40,US National,Season peak percentage,5.1
 2018,40,2018/2019,40,US National,1 wk ahead,1.4
@@ -21014,7 +20915,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,40,2018/2019,40,HHS Region 10,2 wk ahead,0.6
 2018,40,2018/2019,40,HHS Region 10,3 wk ahead,0.6
 2018,40,2018/2019,40,HHS Region 10,4 wk ahead,0.7
-2018,41,2018/2019,41,US National,Season onset,47
+2018,41,2018/2019,41,US National,Season onset,49
 2018,41,2018/2019,41,US National,Season peak week,7
 2018,41,2018/2019,41,US National,Season peak percentage,5.1
 2018,41,2018/2019,41,US National,1 wk ahead,1.5
@@ -21093,7 +20994,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,41,2018/2019,41,HHS Region 10,2 wk ahead,0.6
 2018,41,2018/2019,41,HHS Region 10,3 wk ahead,0.7
 2018,41,2018/2019,41,HHS Region 10,4 wk ahead,0.7
-2018,42,2018/2019,42,US National,Season onset,47
+2018,42,2018/2019,42,US National,Season onset,49
 2018,42,2018/2019,42,US National,Season peak week,7
 2018,42,2018/2019,42,US National,Season peak percentage,5.1
 2018,42,2018/2019,42,US National,1 wk ahead,1.6
@@ -21172,7 +21073,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,42,2018/2019,42,HHS Region 10,2 wk ahead,0.7
 2018,42,2018/2019,42,HHS Region 10,3 wk ahead,0.7
 2018,42,2018/2019,42,HHS Region 10,4 wk ahead,0.9
-2018,43,2018/2019,43,US National,Season onset,47
+2018,43,2018/2019,43,US National,Season onset,49
 2018,43,2018/2019,43,US National,Season peak week,7
 2018,43,2018/2019,43,US National,Season peak percentage,5.1
 2018,43,2018/2019,43,US National,1 wk ahead,1.8
@@ -21251,13 +21152,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,43,2018/2019,43,HHS Region 10,2 wk ahead,0.7
 2018,43,2018/2019,43,HHS Region 10,3 wk ahead,0.9
 2018,43,2018/2019,43,HHS Region 10,4 wk ahead,1
-2018,44,2018/2019,44,US National,Season onset,47
+2018,44,2018/2019,44,US National,Season onset,49
 2018,44,2018/2019,44,US National,Season peak week,7
 2018,44,2018/2019,44,US National,Season peak percentage,5.1
 2018,44,2018/2019,44,US National,1 wk ahead,1.9
 2018,44,2018/2019,44,US National,2 wk ahead,2
 2018,44,2018/2019,44,US National,3 wk ahead,2.2
-2018,44,2018/2019,44,US National,4 wk ahead,2.2
+2018,44,2018/2019,44,US National,4 wk ahead,2.1
 2018,44,2018/2019,44,HHS Region 1,Season onset,49
 2018,44,2018/2019,44,HHS Region 1,Season peak week,6
 2018,44,2018/2019,44,HHS Region 1,Season peak percentage,3.9
@@ -21330,12 +21231,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,44,2018/2019,44,HHS Region 10,2 wk ahead,0.9
 2018,44,2018/2019,44,HHS Region 10,3 wk ahead,1
 2018,44,2018/2019,44,HHS Region 10,4 wk ahead,0.9
-2018,45,2018/2019,45,US National,Season onset,47
+2018,45,2018/2019,45,US National,Season onset,49
 2018,45,2018/2019,45,US National,Season peak week,7
 2018,45,2018/2019,45,US National,Season peak percentage,5.1
 2018,45,2018/2019,45,US National,1 wk ahead,2
 2018,45,2018/2019,45,US National,2 wk ahead,2.2
-2018,45,2018/2019,45,US National,3 wk ahead,2.2
+2018,45,2018/2019,45,US National,3 wk ahead,2.1
 2018,45,2018/2019,45,US National,4 wk ahead,2.3
 2018,45,2018/2019,45,HHS Region 1,Season onset,49
 2018,45,2018/2019,45,HHS Region 1,Season peak week,6
@@ -21401,7 +21302,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,45,2018/2019,45,HHS Region 9,1 wk ahead,2
 2018,45,2018/2019,45,HHS Region 9,2 wk ahead,2.1
 2018,45,2018/2019,45,HHS Region 9,3 wk ahead,2.3
-2018,45,2018/2019,45,HHS Region 9,4 wk ahead,2.5
+2018,45,2018/2019,45,HHS Region 9,4 wk ahead,2.4
 2018,45,2018/2019,45,HHS Region 10,Season onset,50
 2018,45,2018/2019,45,HHS Region 10,Season peak week,11
 2018,45,2018/2019,45,HHS Region 10,Season peak percentage,4.3
@@ -21409,11 +21310,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,45,2018/2019,45,HHS Region 10,2 wk ahead,1
 2018,45,2018/2019,45,HHS Region 10,3 wk ahead,0.9
 2018,45,2018/2019,45,HHS Region 10,4 wk ahead,0.9
-2018,46,2018/2019,46,US National,Season onset,47
+2018,46,2018/2019,46,US National,Season onset,49
 2018,46,2018/2019,46,US National,Season peak week,7
 2018,46,2018/2019,46,US National,Season peak percentage,5.1
 2018,46,2018/2019,46,US National,1 wk ahead,2.2
-2018,46,2018/2019,46,US National,2 wk ahead,2.2
+2018,46,2018/2019,46,US National,2 wk ahead,2.1
 2018,46,2018/2019,46,US National,3 wk ahead,2.3
 2018,46,2018/2019,46,US National,4 wk ahead,2.6
 2018,46,2018/2019,46,HHS Region 1,Season onset,49
@@ -21479,7 +21380,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,46,2018/2019,46,HHS Region 9,Season peak percentage,3.7
 2018,46,2018/2019,46,HHS Region 9,1 wk ahead,2.1
 2018,46,2018/2019,46,HHS Region 9,2 wk ahead,2.3
-2018,46,2018/2019,46,HHS Region 9,3 wk ahead,2.5
+2018,46,2018/2019,46,HHS Region 9,3 wk ahead,2.4
 2018,46,2018/2019,46,HHS Region 9,4 wk ahead,2.8
 2018,46,2018/2019,46,HHS Region 10,Season onset,50
 2018,46,2018/2019,46,HHS Region 10,Season peak week,11
@@ -21488,10 +21389,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,46,2018/2019,46,HHS Region 10,2 wk ahead,0.9
 2018,46,2018/2019,46,HHS Region 10,3 wk ahead,0.9
 2018,46,2018/2019,46,HHS Region 10,4 wk ahead,1.1
-2018,47,2018/2019,47,US National,Season onset,47
+2018,47,2018/2019,47,US National,Season onset,49
 2018,47,2018/2019,47,US National,Season peak week,7
 2018,47,2018/2019,47,US National,Season peak percentage,5.1
-2018,47,2018/2019,47,US National,1 wk ahead,2.2
+2018,47,2018/2019,47,US National,1 wk ahead,2.1
 2018,47,2018/2019,47,US National,2 wk ahead,2.3
 2018,47,2018/2019,47,US National,3 wk ahead,2.6
 2018,47,2018/2019,47,US National,4 wk ahead,3.1
@@ -21557,9 +21458,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,47,2018/2019,47,HHS Region 9,Season peak week,9
 2018,47,2018/2019,47,HHS Region 9,Season peak percentage,3.7
 2018,47,2018/2019,47,HHS Region 9,1 wk ahead,2.3
-2018,47,2018/2019,47,HHS Region 9,2 wk ahead,2.5
+2018,47,2018/2019,47,HHS Region 9,2 wk ahead,2.4
 2018,47,2018/2019,47,HHS Region 9,3 wk ahead,2.8
-2018,47,2018/2019,47,HHS Region 9,4 wk ahead,3.1
+2018,47,2018/2019,47,HHS Region 9,4 wk ahead,3
 2018,47,2018/2019,47,HHS Region 10,Season onset,50
 2018,47,2018/2019,47,HHS Region 10,Season peak week,11
 2018,47,2018/2019,47,HHS Region 10,Season peak percentage,4.3
@@ -21567,7 +21468,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,47,2018/2019,47,HHS Region 10,2 wk ahead,0.9
 2018,47,2018/2019,47,HHS Region 10,3 wk ahead,1.1
 2018,47,2018/2019,47,HHS Region 10,4 wk ahead,1.2
-2018,48,2018/2019,48,US National,Season onset,47
+2018,48,2018/2019,48,US National,Season onset,49
 2018,48,2018/2019,48,US National,Season peak week,7
 2018,48,2018/2019,48,US National,Season peak percentage,5.1
 2018,48,2018/2019,48,US National,1 wk ahead,2.3
@@ -21635,10 +21536,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,48,2018/2019,48,HHS Region 9,Season peak week,7
 2018,48,2018/2019,48,HHS Region 9,Season peak week,9
 2018,48,2018/2019,48,HHS Region 9,Season peak percentage,3.7
-2018,48,2018/2019,48,HHS Region 9,1 wk ahead,2.5
+2018,48,2018/2019,48,HHS Region 9,1 wk ahead,2.4
 2018,48,2018/2019,48,HHS Region 9,2 wk ahead,2.8
-2018,48,2018/2019,48,HHS Region 9,3 wk ahead,3.1
-2018,48,2018/2019,48,HHS Region 9,4 wk ahead,3.4
+2018,48,2018/2019,48,HHS Region 9,3 wk ahead,3
+2018,48,2018/2019,48,HHS Region 9,4 wk ahead,3.3
 2018,48,2018/2019,48,HHS Region 10,Season onset,50
 2018,48,2018/2019,48,HHS Region 10,Season peak week,11
 2018,48,2018/2019,48,HHS Region 10,Season peak percentage,4.3
@@ -21646,7 +21547,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,48,2018/2019,48,HHS Region 10,2 wk ahead,1.1
 2018,48,2018/2019,48,HHS Region 10,3 wk ahead,1.2
 2018,48,2018/2019,48,HHS Region 10,4 wk ahead,1.6
-2018,49,2018/2019,49,US National,Season onset,47
+2018,49,2018/2019,49,US National,Season onset,49
 2018,49,2018/2019,49,US National,Season peak week,7
 2018,49,2018/2019,49,US National,Season peak percentage,5.1
 2018,49,2018/2019,49,US National,1 wk ahead,2.6
@@ -21715,9 +21616,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,49,2018/2019,49,HHS Region 9,Season peak week,9
 2018,49,2018/2019,49,HHS Region 9,Season peak percentage,3.7
 2018,49,2018/2019,49,HHS Region 9,1 wk ahead,2.8
-2018,49,2018/2019,49,HHS Region 9,2 wk ahead,3.1
-2018,49,2018/2019,49,HHS Region 9,3 wk ahead,3.4
-2018,49,2018/2019,49,HHS Region 9,4 wk ahead,3.4
+2018,49,2018/2019,49,HHS Region 9,2 wk ahead,3
+2018,49,2018/2019,49,HHS Region 9,3 wk ahead,3.3
+2018,49,2018/2019,49,HHS Region 9,4 wk ahead,3.3
 2018,49,2018/2019,49,HHS Region 10,Season onset,50
 2018,49,2018/2019,49,HHS Region 10,Season peak week,11
 2018,49,2018/2019,49,HHS Region 10,Season peak percentage,4.3
@@ -21725,7 +21626,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,49,2018/2019,49,HHS Region 10,2 wk ahead,1.2
 2018,49,2018/2019,49,HHS Region 10,3 wk ahead,1.6
 2018,49,2018/2019,49,HHS Region 10,4 wk ahead,1.7
-2018,50,2018/2019,50,US National,Season onset,47
+2018,50,2018/2019,50,US National,Season onset,49
 2018,50,2018/2019,50,US National,Season peak week,7
 2018,50,2018/2019,50,US National,Season peak percentage,5.1
 2018,50,2018/2019,50,US National,1 wk ahead,3.1
@@ -21793,10 +21694,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,50,2018/2019,50,HHS Region 9,Season peak week,7
 2018,50,2018/2019,50,HHS Region 9,Season peak week,9
 2018,50,2018/2019,50,HHS Region 9,Season peak percentage,3.7
-2018,50,2018/2019,50,HHS Region 9,1 wk ahead,3.1
-2018,50,2018/2019,50,HHS Region 9,2 wk ahead,3.4
-2018,50,2018/2019,50,HHS Region 9,3 wk ahead,3.4
-2018,50,2018/2019,50,HHS Region 9,4 wk ahead,3.3
+2018,50,2018/2019,50,HHS Region 9,1 wk ahead,3
+2018,50,2018/2019,50,HHS Region 9,2 wk ahead,3.3
+2018,50,2018/2019,50,HHS Region 9,3 wk ahead,3.3
+2018,50,2018/2019,50,HHS Region 9,4 wk ahead,3.2
 2018,50,2018/2019,50,HHS Region 10,Season onset,50
 2018,50,2018/2019,50,HHS Region 10,Season peak week,11
 2018,50,2018/2019,50,HHS Region 10,Season peak percentage,4.3
@@ -21804,7 +21705,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,50,2018/2019,50,HHS Region 10,2 wk ahead,1.6
 2018,50,2018/2019,50,HHS Region 10,3 wk ahead,1.7
 2018,50,2018/2019,50,HHS Region 10,4 wk ahead,1.6
-2018,51,2018/2019,51,US National,Season onset,47
+2018,51,2018/2019,51,US National,Season onset,49
 2018,51,2018/2019,51,US National,Season peak week,7
 2018,51,2018/2019,51,US National,Season peak percentage,5.1
 2018,51,2018/2019,51,US National,1 wk ahead,4
@@ -21872,9 +21773,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,51,2018/2019,51,HHS Region 9,Season peak week,7
 2018,51,2018/2019,51,HHS Region 9,Season peak week,9
 2018,51,2018/2019,51,HHS Region 9,Season peak percentage,3.7
-2018,51,2018/2019,51,HHS Region 9,1 wk ahead,3.4
-2018,51,2018/2019,51,HHS Region 9,2 wk ahead,3.4
-2018,51,2018/2019,51,HHS Region 9,3 wk ahead,3.3
+2018,51,2018/2019,51,HHS Region 9,1 wk ahead,3.3
+2018,51,2018/2019,51,HHS Region 9,2 wk ahead,3.3
+2018,51,2018/2019,51,HHS Region 9,3 wk ahead,3.2
 2018,51,2018/2019,51,HHS Region 9,4 wk ahead,2.9
 2018,51,2018/2019,51,HHS Region 10,Season onset,50
 2018,51,2018/2019,51,HHS Region 10,Season peak week,11
@@ -21883,7 +21784,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,51,2018/2019,51,HHS Region 10,2 wk ahead,1.7
 2018,51,2018/2019,51,HHS Region 10,3 wk ahead,1.6
 2018,51,2018/2019,51,HHS Region 10,4 wk ahead,1.8
-2018,52,2018/2019,52,US National,Season onset,47
+2018,52,2018/2019,52,US National,Season onset,49
 2018,52,2018/2019,52,US National,Season peak week,7
 2018,52,2018/2019,52,US National,Season peak percentage,5.1
 2018,52,2018/2019,52,US National,1 wk ahead,3.5
@@ -21951,8 +21852,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,52,2018/2019,52,HHS Region 9,Season peak week,7
 2018,52,2018/2019,52,HHS Region 9,Season peak week,9
 2018,52,2018/2019,52,HHS Region 9,Season peak percentage,3.7
-2018,52,2018/2019,52,HHS Region 9,1 wk ahead,3.4
-2018,52,2018/2019,52,HHS Region 9,2 wk ahead,3.3
+2018,52,2018/2019,52,HHS Region 9,1 wk ahead,3.3
+2018,52,2018/2019,52,HHS Region 9,2 wk ahead,3.2
 2018,52,2018/2019,52,HHS Region 9,3 wk ahead,2.9
 2018,52,2018/2019,52,HHS Region 9,4 wk ahead,2.9
 2018,52,2018/2019,52,HHS Region 10,Season onset,50
@@ -21962,7 +21863,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2018,52,2018/2019,52,HHS Region 10,2 wk ahead,1.6
 2018,52,2018/2019,52,HHS Region 10,3 wk ahead,1.8
 2018,52,2018/2019,52,HHS Region 10,4 wk ahead,2.2
-2019,1,2018/2019,53,US National,Season onset,47
+2019,1,2018/2019,53,US National,Season onset,49
 2019,1,2018/2019,53,US National,Season peak week,7
 2019,1,2018/2019,53,US National,Season peak percentage,5.1
 2019,1,2018/2019,53,US National,1 wk ahead,3.1
@@ -21997,7 +21898,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,1,2018/2019,53,HHS Region 4,1 wk ahead,2.8
 2019,1,2018/2019,53,HHS Region 4,2 wk ahead,3
 2019,1,2018/2019,53,HHS Region 4,3 wk ahead,4
-2019,1,2018/2019,53,HHS Region 4,4 wk ahead,4.8
+2019,1,2018/2019,53,HHS Region 4,4 wk ahead,4.9
 2019,1,2018/2019,53,HHS Region 5,Season onset,51
 2019,1,2018/2019,53,HHS Region 5,Season peak week,11
 2019,1,2018/2019,53,HHS Region 5,Season peak percentage,3.6
@@ -22030,7 +21931,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,1,2018/2019,53,HHS Region 9,Season peak week,7
 2019,1,2018/2019,53,HHS Region 9,Season peak week,9
 2019,1,2018/2019,53,HHS Region 9,Season peak percentage,3.7
-2019,1,2018/2019,53,HHS Region 9,1 wk ahead,3.3
+2019,1,2018/2019,53,HHS Region 9,1 wk ahead,3.2
 2019,1,2018/2019,53,HHS Region 9,2 wk ahead,2.9
 2019,1,2018/2019,53,HHS Region 9,3 wk ahead,2.9
 2019,1,2018/2019,53,HHS Region 9,4 wk ahead,3.3
@@ -22041,7 +21942,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,1,2018/2019,53,HHS Region 10,2 wk ahead,1.8
 2019,1,2018/2019,53,HHS Region 10,3 wk ahead,2.2
 2019,1,2018/2019,53,HHS Region 10,4 wk ahead,2.5
-2019,2,2018/2019,54,US National,Season onset,47
+2019,2,2018/2019,54,US National,Season onset,49
 2019,2,2018/2019,54,US National,Season peak week,7
 2019,2,2018/2019,54,US National,Season peak percentage,5.1
 2019,2,2018/2019,54,US National,1 wk ahead,3.3
@@ -22075,7 +21976,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,2,2018/2019,54,HHS Region 4,Season peak percentage,5.9
 2019,2,2018/2019,54,HHS Region 4,1 wk ahead,3
 2019,2,2018/2019,54,HHS Region 4,2 wk ahead,4
-2019,2,2018/2019,54,HHS Region 4,3 wk ahead,4.8
+2019,2,2018/2019,54,HHS Region 4,3 wk ahead,4.9
 2019,2,2018/2019,54,HHS Region 4,4 wk ahead,5.9
 2019,2,2018/2019,54,HHS Region 5,Season onset,51
 2019,2,2018/2019,54,HHS Region 5,Season peak week,11
@@ -22120,7 +22021,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,2,2018/2019,54,HHS Region 10,2 wk ahead,2.2
 2019,2,2018/2019,54,HHS Region 10,3 wk ahead,2.5
 2019,2,2018/2019,54,HHS Region 10,4 wk ahead,3
-2019,3,2018/2019,55,US National,Season onset,47
+2019,3,2018/2019,55,US National,Season onset,49
 2019,3,2018/2019,55,US National,Season peak week,7
 2019,3,2018/2019,55,US National,Season peak percentage,5.1
 2019,3,2018/2019,55,US National,1 wk ahead,3.8
@@ -22153,7 +22054,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,3,2018/2019,55,HHS Region 4,Season peak week,7
 2019,3,2018/2019,55,HHS Region 4,Season peak percentage,5.9
 2019,3,2018/2019,55,HHS Region 4,1 wk ahead,4
-2019,3,2018/2019,55,HHS Region 4,2 wk ahead,4.8
+2019,3,2018/2019,55,HHS Region 4,2 wk ahead,4.9
 2019,3,2018/2019,55,HHS Region 4,3 wk ahead,5.9
 2019,3,2018/2019,55,HHS Region 4,4 wk ahead,5.9
 2019,3,2018/2019,55,HHS Region 5,Season onset,51
@@ -22199,7 +22100,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,3,2018/2019,55,HHS Region 10,2 wk ahead,2.5
 2019,3,2018/2019,55,HHS Region 10,3 wk ahead,3
 2019,3,2018/2019,55,HHS Region 10,4 wk ahead,3.5
-2019,4,2018/2019,56,US National,Season onset,47
+2019,4,2018/2019,56,US National,Season onset,49
 2019,4,2018/2019,56,US National,Season peak week,7
 2019,4,2018/2019,56,US National,Season peak percentage,5.1
 2019,4,2018/2019,56,US National,1 wk ahead,4.3
@@ -22231,7 +22132,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,4,2018/2019,56,HHS Region 4,Season peak week,6
 2019,4,2018/2019,56,HHS Region 4,Season peak week,7
 2019,4,2018/2019,56,HHS Region 4,Season peak percentage,5.9
-2019,4,2018/2019,56,HHS Region 4,1 wk ahead,4.8
+2019,4,2018/2019,56,HHS Region 4,1 wk ahead,4.9
 2019,4,2018/2019,56,HHS Region 4,2 wk ahead,5.9
 2019,4,2018/2019,56,HHS Region 4,3 wk ahead,5.9
 2019,4,2018/2019,56,HHS Region 4,4 wk ahead,5.3
@@ -22278,7 +22179,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,4,2018/2019,56,HHS Region 10,2 wk ahead,3
 2019,4,2018/2019,56,HHS Region 10,3 wk ahead,3.5
 2019,4,2018/2019,56,HHS Region 10,4 wk ahead,3.2
-2019,5,2018/2019,57,US National,Season onset,47
+2019,5,2018/2019,57,US National,Season onset,49
 2019,5,2018/2019,57,US National,Season peak week,7
 2019,5,2018/2019,57,US National,Season peak percentage,5.1
 2019,5,2018/2019,57,US National,1 wk ahead,4.9
@@ -22357,7 +22258,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,5,2018/2019,57,HHS Region 10,2 wk ahead,3.5
 2019,5,2018/2019,57,HHS Region 10,3 wk ahead,3.2
 2019,5,2018/2019,57,HHS Region 10,4 wk ahead,3
-2019,6,2018/2019,58,US National,Season onset,47
+2019,6,2018/2019,58,US National,Season onset,49
 2019,6,2018/2019,58,US National,Season peak week,7
 2019,6,2018/2019,58,US National,Season peak percentage,5.1
 2019,6,2018/2019,58,US National,1 wk ahead,5.1
@@ -22436,7 +22337,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,6,2018/2019,58,HHS Region 10,2 wk ahead,3.2
 2019,6,2018/2019,58,HHS Region 10,3 wk ahead,3
 2019,6,2018/2019,58,HHS Region 10,4 wk ahead,3.5
-2019,7,2018/2019,59,US National,Season onset,47
+2019,7,2018/2019,59,US National,Season onset,49
 2019,7,2018/2019,59,US National,Season peak week,7
 2019,7,2018/2019,59,US National,Season peak percentage,5.1
 2019,7,2018/2019,59,US National,1 wk ahead,4.9
@@ -22515,7 +22416,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,7,2018/2019,59,HHS Region 10,2 wk ahead,3
 2019,7,2018/2019,59,HHS Region 10,3 wk ahead,3.5
 2019,7,2018/2019,59,HHS Region 10,4 wk ahead,4.3
-2019,8,2018/2019,60,US National,Season onset,47
+2019,8,2018/2019,60,US National,Season onset,49
 2019,8,2018/2019,60,US National,Season peak week,7
 2019,8,2018/2019,60,US National,Season peak percentage,5.1
 2019,8,2018/2019,60,US National,1 wk ahead,4.6
@@ -22594,7 +22495,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,8,2018/2019,60,HHS Region 10,2 wk ahead,3.5
 2019,8,2018/2019,60,HHS Region 10,3 wk ahead,4.3
 2019,8,2018/2019,60,HHS Region 10,4 wk ahead,3.8
-2019,9,2018/2019,61,US National,Season onset,47
+2019,9,2018/2019,61,US National,Season onset,49
 2019,9,2018/2019,61,US National,Season peak week,7
 2019,9,2018/2019,61,US National,Season peak percentage,5.1
 2019,9,2018/2019,61,US National,1 wk ahead,4.4
@@ -22650,7 +22551,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,9,2018/2019,61,HHS Region 7,1 wk ahead,5.1
 2019,9,2018/2019,61,HHS Region 7,2 wk ahead,5.7
 2019,9,2018/2019,61,HHS Region 7,3 wk ahead,4.8
-2019,9,2018/2019,61,HHS Region 7,4 wk ahead,3.8
+2019,9,2018/2019,61,HHS Region 7,4 wk ahead,3.9
 2019,9,2018/2019,61,HHS Region 8,Season onset,46
 2019,9,2018/2019,61,HHS Region 8,Season peak week,8
 2019,9,2018/2019,61,HHS Region 8,Season peak percentage,5.9
@@ -22673,7 +22574,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,9,2018/2019,61,HHS Region 10,2 wk ahead,4.3
 2019,9,2018/2019,61,HHS Region 10,3 wk ahead,3.8
 2019,9,2018/2019,61,HHS Region 10,4 wk ahead,2.4
-2019,10,2018/2019,62,US National,Season onset,47
+2019,10,2018/2019,62,US National,Season onset,49
 2019,10,2018/2019,62,US National,Season peak week,7
 2019,10,2018/2019,62,US National,Season peak percentage,5.1
 2019,10,2018/2019,62,US National,1 wk ahead,4.2
@@ -22728,8 +22629,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,10,2018/2019,62,HHS Region 7,Season peak percentage,5.7
 2019,10,2018/2019,62,HHS Region 7,1 wk ahead,5.7
 2019,10,2018/2019,62,HHS Region 7,2 wk ahead,4.8
-2019,10,2018/2019,62,HHS Region 7,3 wk ahead,3.8
-2019,10,2018/2019,62,HHS Region 7,4 wk ahead,2.2
+2019,10,2018/2019,62,HHS Region 7,3 wk ahead,3.9
+2019,10,2018/2019,62,HHS Region 7,4 wk ahead,2.3
 2019,10,2018/2019,62,HHS Region 8,Season onset,46
 2019,10,2018/2019,62,HHS Region 8,Season peak week,8
 2019,10,2018/2019,62,HHS Region 8,Season peak percentage,5.9
@@ -22752,7 +22653,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,10,2018/2019,62,HHS Region 10,2 wk ahead,3.8
 2019,10,2018/2019,62,HHS Region 10,3 wk ahead,2.4
 2019,10,2018/2019,62,HHS Region 10,4 wk ahead,1.6
-2019,11,2018/2019,63,US National,Season onset,47
+2019,11,2018/2019,63,US National,Season onset,49
 2019,11,2018/2019,63,US National,Season peak week,7
 2019,11,2018/2019,63,US National,Season peak percentage,5.1
 2019,11,2018/2019,63,US National,1 wk ahead,3.7
@@ -22806,8 +22707,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,11,2018/2019,63,HHS Region 7,Season peak week,11
 2019,11,2018/2019,63,HHS Region 7,Season peak percentage,5.7
 2019,11,2018/2019,63,HHS Region 7,1 wk ahead,4.8
-2019,11,2018/2019,63,HHS Region 7,2 wk ahead,3.8
-2019,11,2018/2019,63,HHS Region 7,3 wk ahead,2.2
+2019,11,2018/2019,63,HHS Region 7,2 wk ahead,3.9
+2019,11,2018/2019,63,HHS Region 7,3 wk ahead,2.3
 2019,11,2018/2019,63,HHS Region 7,4 wk ahead,1.9
 2019,11,2018/2019,63,HHS Region 8,Season onset,46
 2019,11,2018/2019,63,HHS Region 8,Season peak week,8
@@ -22831,7 +22732,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,11,2018/2019,63,HHS Region 10,2 wk ahead,2.4
 2019,11,2018/2019,63,HHS Region 10,3 wk ahead,1.6
 2019,11,2018/2019,63,HHS Region 10,4 wk ahead,1
-2019,12,2018/2019,64,US National,Season onset,47
+2019,12,2018/2019,64,US National,Season onset,49
 2019,12,2018/2019,64,US National,Season peak week,7
 2019,12,2018/2019,64,US National,Season peak percentage,5.1
 2019,12,2018/2019,64,US National,1 wk ahead,3.1
@@ -22880,21 +22781,21 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,12,2018/2019,64,HHS Region 6,1 wk ahead,4.5
 2019,12,2018/2019,64,HHS Region 6,2 wk ahead,4
 2019,12,2018/2019,64,HHS Region 6,3 wk ahead,3.5
-2019,12,2018/2019,64,HHS Region 6,4 wk ahead,3.1
+2019,12,2018/2019,64,HHS Region 6,4 wk ahead,3
 2019,12,2018/2019,64,HHS Region 7,Season onset,50
 2019,12,2018/2019,64,HHS Region 7,Season peak week,11
 2019,12,2018/2019,64,HHS Region 7,Season peak percentage,5.7
-2019,12,2018/2019,64,HHS Region 7,1 wk ahead,3.8
-2019,12,2018/2019,64,HHS Region 7,2 wk ahead,2.2
+2019,12,2018/2019,64,HHS Region 7,1 wk ahead,3.9
+2019,12,2018/2019,64,HHS Region 7,2 wk ahead,2.3
 2019,12,2018/2019,64,HHS Region 7,3 wk ahead,1.9
-2019,12,2018/2019,64,HHS Region 7,4 wk ahead,1.1
+2019,12,2018/2019,64,HHS Region 7,4 wk ahead,1.2
 2019,12,2018/2019,64,HHS Region 8,Season onset,46
 2019,12,2018/2019,64,HHS Region 8,Season peak week,8
 2019,12,2018/2019,64,HHS Region 8,Season peak percentage,5.9
 2019,12,2018/2019,64,HHS Region 8,1 wk ahead,3.1
 2019,12,2018/2019,64,HHS Region 8,2 wk ahead,3
 2019,12,2018/2019,64,HHS Region 8,3 wk ahead,2.4
-2019,12,2018/2019,64,HHS Region 8,4 wk ahead,2.3
+2019,12,2018/2019,64,HHS Region 8,4 wk ahead,2.4
 2019,12,2018/2019,64,HHS Region 9,Season onset,48
 2019,12,2018/2019,64,HHS Region 9,Season peak week,7
 2019,12,2018/2019,64,HHS Region 9,Season peak week,9
@@ -22910,7 +22811,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,12,2018/2019,64,HHS Region 10,2 wk ahead,1.6
 2019,12,2018/2019,64,HHS Region 10,3 wk ahead,1
 2019,12,2018/2019,64,HHS Region 10,4 wk ahead,1
-2019,13,2018/2019,65,US National,Season onset,47
+2019,13,2018/2019,65,US National,Season onset,49
 2019,13,2018/2019,65,US National,Season peak week,7
 2019,13,2018/2019,65,US National,Season peak percentage,5.1
 2019,13,2018/2019,65,US National,1 wk ahead,2.7
@@ -22958,21 +22859,21 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,13,2018/2019,65,HHS Region 6,Season peak percentage,10.1
 2019,13,2018/2019,65,HHS Region 6,1 wk ahead,4
 2019,13,2018/2019,65,HHS Region 6,2 wk ahead,3.5
-2019,13,2018/2019,65,HHS Region 6,3 wk ahead,3.1
+2019,13,2018/2019,65,HHS Region 6,3 wk ahead,3
 2019,13,2018/2019,65,HHS Region 6,4 wk ahead,2.5
 2019,13,2018/2019,65,HHS Region 7,Season onset,50
 2019,13,2018/2019,65,HHS Region 7,Season peak week,11
 2019,13,2018/2019,65,HHS Region 7,Season peak percentage,5.7
-2019,13,2018/2019,65,HHS Region 7,1 wk ahead,2.2
+2019,13,2018/2019,65,HHS Region 7,1 wk ahead,2.3
 2019,13,2018/2019,65,HHS Region 7,2 wk ahead,1.9
-2019,13,2018/2019,65,HHS Region 7,3 wk ahead,1.1
+2019,13,2018/2019,65,HHS Region 7,3 wk ahead,1.2
 2019,13,2018/2019,65,HHS Region 7,4 wk ahead,1
 2019,13,2018/2019,65,HHS Region 8,Season onset,46
 2019,13,2018/2019,65,HHS Region 8,Season peak week,8
 2019,13,2018/2019,65,HHS Region 8,Season peak percentage,5.9
 2019,13,2018/2019,65,HHS Region 8,1 wk ahead,3
 2019,13,2018/2019,65,HHS Region 8,2 wk ahead,2.4
-2019,13,2018/2019,65,HHS Region 8,3 wk ahead,2.3
+2019,13,2018/2019,65,HHS Region 8,3 wk ahead,2.4
 2019,13,2018/2019,65,HHS Region 8,4 wk ahead,2.1
 2019,13,2018/2019,65,HHS Region 9,Season onset,48
 2019,13,2018/2019,65,HHS Region 9,Season peak week,7
@@ -22989,7 +22890,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,13,2018/2019,65,HHS Region 10,2 wk ahead,1
 2019,13,2018/2019,65,HHS Region 10,3 wk ahead,1
 2019,13,2018/2019,65,HHS Region 10,4 wk ahead,0.9
-2019,14,2018/2019,66,US National,Season onset,47
+2019,14,2018/2019,66,US National,Season onset,49
 2019,14,2018/2019,66,US National,Season peak week,7
 2019,14,2018/2019,66,US National,Season peak percentage,5.1
 2019,14,2018/2019,66,US National,1 wk ahead,2.3
@@ -23036,21 +22937,21 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,14,2018/2019,66,HHS Region 6,Season peak week,7
 2019,14,2018/2019,66,HHS Region 6,Season peak percentage,10.1
 2019,14,2018/2019,66,HHS Region 6,1 wk ahead,3.5
-2019,14,2018/2019,66,HHS Region 6,2 wk ahead,3.1
+2019,14,2018/2019,66,HHS Region 6,2 wk ahead,3
 2019,14,2018/2019,66,HHS Region 6,3 wk ahead,2.5
 2019,14,2018/2019,66,HHS Region 6,4 wk ahead,2.3
 2019,14,2018/2019,66,HHS Region 7,Season onset,50
 2019,14,2018/2019,66,HHS Region 7,Season peak week,11
 2019,14,2018/2019,66,HHS Region 7,Season peak percentage,5.7
 2019,14,2018/2019,66,HHS Region 7,1 wk ahead,1.9
-2019,14,2018/2019,66,HHS Region 7,2 wk ahead,1.1
+2019,14,2018/2019,66,HHS Region 7,2 wk ahead,1.2
 2019,14,2018/2019,66,HHS Region 7,3 wk ahead,1
 2019,14,2018/2019,66,HHS Region 7,4 wk ahead,0.9
 2019,14,2018/2019,66,HHS Region 8,Season onset,46
 2019,14,2018/2019,66,HHS Region 8,Season peak week,8
 2019,14,2018/2019,66,HHS Region 8,Season peak percentage,5.9
 2019,14,2018/2019,66,HHS Region 8,1 wk ahead,2.4
-2019,14,2018/2019,66,HHS Region 8,2 wk ahead,2.3
+2019,14,2018/2019,66,HHS Region 8,2 wk ahead,2.4
 2019,14,2018/2019,66,HHS Region 8,3 wk ahead,2.1
 2019,14,2018/2019,66,HHS Region 8,4 wk ahead,2.2
 2019,14,2018/2019,66,HHS Region 9,Season onset,48
@@ -23068,7 +22969,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,14,2018/2019,66,HHS Region 10,2 wk ahead,1
 2019,14,2018/2019,66,HHS Region 10,3 wk ahead,0.9
 2019,14,2018/2019,66,HHS Region 10,4 wk ahead,0.9
-2019,15,2018/2019,67,US National,Season onset,47
+2019,15,2018/2019,67,US National,Season onset,49
 2019,15,2018/2019,67,US National,Season peak week,7
 2019,15,2018/2019,67,US National,Season peak percentage,5.1
 2019,15,2018/2019,67,US National,1 wk ahead,2
@@ -23114,21 +23015,21 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,15,2018/2019,67,HHS Region 6,Season onset,51
 2019,15,2018/2019,67,HHS Region 6,Season peak week,7
 2019,15,2018/2019,67,HHS Region 6,Season peak percentage,10.1
-2019,15,2018/2019,67,HHS Region 6,1 wk ahead,3.1
+2019,15,2018/2019,67,HHS Region 6,1 wk ahead,3
 2019,15,2018/2019,67,HHS Region 6,2 wk ahead,2.5
 2019,15,2018/2019,67,HHS Region 6,3 wk ahead,2.3
 2019,15,2018/2019,67,HHS Region 6,4 wk ahead,2.2
 2019,15,2018/2019,67,HHS Region 7,Season onset,50
 2019,15,2018/2019,67,HHS Region 7,Season peak week,11
 2019,15,2018/2019,67,HHS Region 7,Season peak percentage,5.7
-2019,15,2018/2019,67,HHS Region 7,1 wk ahead,1.1
+2019,15,2018/2019,67,HHS Region 7,1 wk ahead,1.2
 2019,15,2018/2019,67,HHS Region 7,2 wk ahead,1
 2019,15,2018/2019,67,HHS Region 7,3 wk ahead,0.9
 2019,15,2018/2019,67,HHS Region 7,4 wk ahead,0.8
 2019,15,2018/2019,67,HHS Region 8,Season onset,46
 2019,15,2018/2019,67,HHS Region 8,Season peak week,8
 2019,15,2018/2019,67,HHS Region 8,Season peak percentage,5.9
-2019,15,2018/2019,67,HHS Region 8,1 wk ahead,2.3
+2019,15,2018/2019,67,HHS Region 8,1 wk ahead,2.4
 2019,15,2018/2019,67,HHS Region 8,2 wk ahead,2.1
 2019,15,2018/2019,67,HHS Region 8,3 wk ahead,2.2
 2019,15,2018/2019,67,HHS Region 8,4 wk ahead,2
@@ -23147,7 +23048,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,15,2018/2019,67,HHS Region 10,2 wk ahead,0.9
 2019,15,2018/2019,67,HHS Region 10,3 wk ahead,0.9
 2019,15,2018/2019,67,HHS Region 10,4 wk ahead,0.8
-2019,16,2018/2019,68,US National,Season onset,47
+2019,16,2018/2019,68,US National,Season onset,49
 2019,16,2018/2019,68,US National,Season peak week,7
 2019,16,2018/2019,68,US National,Season peak percentage,5.1
 2019,16,2018/2019,68,US National,1 wk ahead,1.7
@@ -23203,7 +23104,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,16,2018/2019,68,HHS Region 7,1 wk ahead,1
 2019,16,2018/2019,68,HHS Region 7,2 wk ahead,0.9
 2019,16,2018/2019,68,HHS Region 7,3 wk ahead,0.8
-2019,16,2018/2019,68,HHS Region 7,4 wk ahead,0.7
+2019,16,2018/2019,68,HHS Region 7,4 wk ahead,0.8
 2019,16,2018/2019,68,HHS Region 8,Season onset,46
 2019,16,2018/2019,68,HHS Region 8,Season peak week,8
 2019,16,2018/2019,68,HHS Region 8,Season peak percentage,5.9
@@ -23226,7 +23127,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,16,2018/2019,68,HHS Region 10,2 wk ahead,0.9
 2019,16,2018/2019,68,HHS Region 10,3 wk ahead,0.8
 2019,16,2018/2019,68,HHS Region 10,4 wk ahead,0.7
-2019,17,2018/2019,69,US National,Season onset,47
+2019,17,2018/2019,69,US National,Season onset,49
 2019,17,2018/2019,69,US National,Season peak week,7
 2019,17,2018/2019,69,US National,Season peak percentage,5.1
 2019,17,2018/2019,69,US National,1 wk ahead,1.6
@@ -23246,7 +23147,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,17,2018/2019,69,HHS Region 2,1 wk ahead,2.2
 2019,17,2018/2019,69,HHS Region 2,2 wk ahead,2.2
 2019,17,2018/2019,69,HHS Region 2,3 wk ahead,2.4
-2019,17,2018/2019,69,HHS Region 2,4 wk ahead,2.1
+2019,17,2018/2019,69,HHS Region 2,4 wk ahead,2.2
 2019,17,2018/2019,69,HHS Region 3,Season onset,50
 2019,17,2018/2019,69,HHS Region 3,Season peak week,8
 2019,17,2018/2019,69,HHS Region 3,Season peak percentage,4.6
@@ -23281,8 +23182,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,17,2018/2019,69,HHS Region 7,Season peak percentage,5.7
 2019,17,2018/2019,69,HHS Region 7,1 wk ahead,0.9
 2019,17,2018/2019,69,HHS Region 7,2 wk ahead,0.8
-2019,17,2018/2019,69,HHS Region 7,3 wk ahead,0.7
-2019,17,2018/2019,69,HHS Region 7,4 wk ahead,0.7
+2019,17,2018/2019,69,HHS Region 7,3 wk ahead,0.8
+2019,17,2018/2019,69,HHS Region 7,4 wk ahead,0.8
 2019,17,2018/2019,69,HHS Region 8,Season onset,46
 2019,17,2018/2019,69,HHS Region 8,Season peak week,8
 2019,17,2018/2019,69,HHS Region 8,Season peak percentage,5.9
@@ -23305,7 +23206,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,17,2018/2019,69,HHS Region 10,2 wk ahead,0.8
 2019,17,2018/2019,69,HHS Region 10,3 wk ahead,0.7
 2019,17,2018/2019,69,HHS Region 10,4 wk ahead,0.6
-2019,18,2018/2019,70,US National,Season onset,47
+2019,18,2018/2019,70,US National,Season onset,49
 2019,18,2018/2019,70,US National,Season peak week,7
 2019,18,2018/2019,70,US National,Season peak percentage,5.1
 2019,18,2018/2019,70,US National,1 wk ahead,1.5
@@ -23324,7 +23225,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,18,2018/2019,70,HHS Region 2,Season peak percentage,5.2
 2019,18,2018/2019,70,HHS Region 2,1 wk ahead,2.2
 2019,18,2018/2019,70,HHS Region 2,2 wk ahead,2.4
-2019,18,2018/2019,70,HHS Region 2,3 wk ahead,2.1
+2019,18,2018/2019,70,HHS Region 2,3 wk ahead,2.2
 2019,18,2018/2019,70,HHS Region 2,4 wk ahead,2.1
 2019,18,2018/2019,70,HHS Region 3,Season onset,50
 2019,18,2018/2019,70,HHS Region 3,Season peak week,8
@@ -23332,7 +23233,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,18,2018/2019,70,HHS Region 3,1 wk ahead,1
 2019,18,2018/2019,70,HHS Region 3,2 wk ahead,0.9
 2019,18,2018/2019,70,HHS Region 3,3 wk ahead,1
-2019,18,2018/2019,70,HHS Region 3,4 wk ahead,1
+2019,18,2018/2019,70,HHS Region 3,4 wk ahead,0.9
 2019,18,2018/2019,70,HHS Region 4,Season onset,47
 2019,18,2018/2019,70,HHS Region 4,Season peak week,6
 2019,18,2018/2019,70,HHS Region 4,Season peak week,7
@@ -23359,8 +23260,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,18,2018/2019,70,HHS Region 7,Season peak week,11
 2019,18,2018/2019,70,HHS Region 7,Season peak percentage,5.7
 2019,18,2018/2019,70,HHS Region 7,1 wk ahead,0.8
-2019,18,2018/2019,70,HHS Region 7,2 wk ahead,0.7
-2019,18,2018/2019,70,HHS Region 7,3 wk ahead,0.7
+2019,18,2018/2019,70,HHS Region 7,2 wk ahead,0.8
+2019,18,2018/2019,70,HHS Region 7,3 wk ahead,0.8
 2019,18,2018/2019,70,HHS Region 7,4 wk ahead,0.6
 2019,18,2018/2019,70,HHS Region 8,Season onset,46
 2019,18,2018/2019,70,HHS Region 8,Season peak week,8
@@ -23384,7 +23285,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,18,2018/2019,70,HHS Region 10,2 wk ahead,0.7
 2019,18,2018/2019,70,HHS Region 10,3 wk ahead,0.6
 2019,18,2018/2019,70,HHS Region 10,4 wk ahead,0.8
-2019,19,2018/2019,71,US National,Season onset,47
+2019,19,2018/2019,71,US National,Season onset,49
 2019,19,2018/2019,71,US National,Season peak week,7
 2019,19,2018/2019,71,US National,Season peak percentage,5.1
 2019,19,2018/2019,71,US National,1 wk ahead,1.5
@@ -23402,7 +23303,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,19,2018/2019,71,HHS Region 2,Season peak week,7
 2019,19,2018/2019,71,HHS Region 2,Season peak percentage,5.2
 2019,19,2018/2019,71,HHS Region 2,1 wk ahead,2.4
-2019,19,2018/2019,71,HHS Region 2,2 wk ahead,2.1
+2019,19,2018/2019,71,HHS Region 2,2 wk ahead,2.2
 2019,19,2018/2019,71,HHS Region 2,3 wk ahead,2.1
 2019,19,2018/2019,71,HHS Region 2,4 wk ahead,1.8
 2019,19,2018/2019,71,HHS Region 3,Season onset,50
@@ -23410,7 +23311,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,19,2018/2019,71,HHS Region 3,Season peak percentage,4.6
 2019,19,2018/2019,71,HHS Region 3,1 wk ahead,0.9
 2019,19,2018/2019,71,HHS Region 3,2 wk ahead,1
-2019,19,2018/2019,71,HHS Region 3,3 wk ahead,1
+2019,19,2018/2019,71,HHS Region 3,3 wk ahead,0.9
 2019,19,2018/2019,71,HHS Region 3,4 wk ahead,0.9
 2019,19,2018/2019,71,HHS Region 4,Season onset,47
 2019,19,2018/2019,71,HHS Region 4,Season peak week,6
@@ -23437,8 +23338,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,19,2018/2019,71,HHS Region 7,Season onset,50
 2019,19,2018/2019,71,HHS Region 7,Season peak week,11
 2019,19,2018/2019,71,HHS Region 7,Season peak percentage,5.7
-2019,19,2018/2019,71,HHS Region 7,1 wk ahead,0.7
-2019,19,2018/2019,71,HHS Region 7,2 wk ahead,0.7
+2019,19,2018/2019,71,HHS Region 7,1 wk ahead,0.8
+2019,19,2018/2019,71,HHS Region 7,2 wk ahead,0.8
 2019,19,2018/2019,71,HHS Region 7,3 wk ahead,0.6
 2019,19,2018/2019,71,HHS Region 7,4 wk ahead,0.5
 2019,19,2018/2019,71,HHS Region 8,Season onset,46
@@ -23463,7 +23364,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,19,2018/2019,71,HHS Region 10,2 wk ahead,0.6
 2019,19,2018/2019,71,HHS Region 10,3 wk ahead,0.8
 2019,19,2018/2019,71,HHS Region 10,4 wk ahead,0.6
-2019,20,2018/2019,72,US National,Season onset,47
+2019,20,2018/2019,72,US National,Season onset,49
 2019,20,2018/2019,72,US National,Season peak week,7
 2019,20,2018/2019,72,US National,Season peak percentage,5.1
 2019,20,2018/2019,72,US National,1 wk ahead,1.4
@@ -23476,11 +23377,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,20,2018/2019,72,HHS Region 1,1 wk ahead,0.9
 2019,20,2018/2019,72,HHS Region 1,2 wk ahead,0.9
 2019,20,2018/2019,72,HHS Region 1,3 wk ahead,0.7
-2019,20,2018/2019,72,HHS Region 1,4 wk ahead,0.5
+2019,20,2018/2019,72,HHS Region 1,4 wk ahead,0.6
 2019,20,2018/2019,72,HHS Region 2,Season onset,49
 2019,20,2018/2019,72,HHS Region 2,Season peak week,7
 2019,20,2018/2019,72,HHS Region 2,Season peak percentage,5.2
-2019,20,2018/2019,72,HHS Region 2,1 wk ahead,2.1
+2019,20,2018/2019,72,HHS Region 2,1 wk ahead,2.2
 2019,20,2018/2019,72,HHS Region 2,2 wk ahead,2.1
 2019,20,2018/2019,72,HHS Region 2,3 wk ahead,1.8
 2019,20,2018/2019,72,HHS Region 2,4 wk ahead,1.9
@@ -23488,7 +23389,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,20,2018/2019,72,HHS Region 3,Season peak week,8
 2019,20,2018/2019,72,HHS Region 3,Season peak percentage,4.6
 2019,20,2018/2019,72,HHS Region 3,1 wk ahead,1
-2019,20,2018/2019,72,HHS Region 3,2 wk ahead,1
+2019,20,2018/2019,72,HHS Region 3,2 wk ahead,0.9
 2019,20,2018/2019,72,HHS Region 3,3 wk ahead,0.9
 2019,20,2018/2019,72,HHS Region 3,4 wk ahead,0.8
 2019,20,2018/2019,72,HHS Region 4,Season onset,47
@@ -23516,7 +23417,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2019,20,2018/2019,72,HHS Region 7,Season onset,50
 2019,20,2018/2019,72,HHS Region 7,Season peak week,11
 2019,20,2018/2019,72,HHS Region 7,Season peak percentage,5.7
-2019,20,2018/2019,72,HHS Region 7,1 wk ahead,0.7
+2019,20,2018/2019,72,HHS Region 7,1 wk ahead,0.8
 2019,20,2018/2019,72,HHS Region 7,2 wk ahead,0.6
 2019,20,2018/2019,72,HHS Region 7,3 wk ahead,0.5
 2019,20,2018/2019,72,HHS Region 7,4 wk ahead,0.4


### PR DESCRIPTION
Fix ground truth target calculations to use data from issue week 28; or close to
it for seasons before 2013 when backfill records may not be fully available.

For seasons 2013/2014 on: in-season data are always from issue week 28.

For seasons 2010/2011--2013/2014: in-season data end up being either from issue
week 28 or issue week 20, as issue weeks 21..28 were not recorded in at least
the HHS Regions. (Another way would be to try to look ahead and grab data from
the closest issue week >= 28 (probably around the following issue week 40)
instead; this is not implemented, though.)

This updated calculate-targets.R file may require an update to the installed version of epiforecast.

Resolves #203.