### PR TITLE
Use issue week 28 or next available issue as ground truth

### DIFF
--- a/scores/target-multivals.csv
+++ b/scores/target-multivals.csv
@@ -30,11 +30,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,40,2010/2011,40,HHS Region 3,2 wk ahead,1.1
 2010,40,2010/2011,40,HHS Region 3,3 wk ahead,1.1
 2010,40,2010/2011,40,HHS Region 3,4 wk ahead,1.2
-2010,40,2010/2011,40,HHS Region 4,Season onset,49
+2010,40,2010/2011,40,HHS Region 4,Season onset,50
 2010,40,2010/2011,40,HHS Region 4,Season peak week,5
-2010,40,2010/2011,40,HHS Region 4,Season peak percentage,5.6
-2010,40,2010/2011,40,HHS Region 4,1 wk ahead,1
-2010,40,2010/2011,40,HHS Region 4,2 wk ahead,1.1
+2010,40,2010/2011,40,HHS Region 4,Season peak percentage,5.5
+2010,40,2010/2011,40,HHS Region 4,1 wk ahead,1.1
+2010,40,2010/2011,40,HHS Region 4,2 wk ahead,1
 2010,40,2010/2011,40,HHS Region 4,3 wk ahead,1.2
 2010,40,2010/2011,40,HHS Region 4,4 wk ahead,1.4
 2010,40,2010/2011,40,HHS Region 5,Season onset,3
@@ -50,7 +50,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,40,2010/2011,40,HHS Region 6,1 wk ahead,1.9
 2010,40,2010/2011,40,HHS Region 6,2 wk ahead,2
 2010,40,2010/2011,40,HHS Region 6,3 wk ahead,2
-2010,40,2010/2011,40,HHS Region 6,4 wk ahead,2.3
+2010,40,2010/2011,40,HHS Region 6,4 wk ahead,2.2
 2010,40,2010/2011,40,HHS Region 7,Season onset,4
 2010,40,2010/2011,40,HHS Region 7,Season peak week,8
 2010,40,2010/2011,40,HHS Region 7,Season peak percentage,4.7
@@ -65,8 +65,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,40,2010/2011,40,HHS Region 8,2 wk ahead,0.6
 2010,40,2010/2011,40,HHS Region 8,3 wk ahead,0.7
 2010,40,2010/2011,40,HHS Region 8,4 wk ahead,0.8
-2010,40,2010/2011,40,HHS Region 9,Season onset,none
+2010,40,2010/2011,40,HHS Region 9,Season onset,6
 2010,40,2010/2011,40,HHS Region 9,Season peak week,7
+2010,40,2010/2011,40,HHS Region 9,Season peak week,8
 2010,40,2010/2011,40,HHS Region 9,Season peak percentage,4.7
 2010,40,2010/2011,40,HHS Region 9,1 wk ahead,1.9
 2010,40,2010/2011,40,HHS Region 9,2 wk ahead,2
@@ -110,10 +111,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,41,2010/2011,41,HHS Region 3,2 wk ahead,1.1
 2010,41,2010/2011,41,HHS Region 3,3 wk ahead,1.2
 2010,41,2010/2011,41,HHS Region 3,4 wk ahead,1.3
-2010,41,2010/2011,41,HHS Region 4,Season onset,49
+2010,41,2010/2011,41,HHS Region 4,Season onset,50
 2010,41,2010/2011,41,HHS Region 4,Season peak week,5
-2010,41,2010/2011,41,HHS Region 4,Season peak percentage,5.6
-2010,41,2010/2011,41,HHS Region 4,1 wk ahead,1.1
+2010,41,2010/2011,41,HHS Region 4,Season peak percentage,5.5
+2010,41,2010/2011,41,HHS Region 4,1 wk ahead,1
 2010,41,2010/2011,41,HHS Region 4,2 wk ahead,1.2
 2010,41,2010/2011,41,HHS Region 4,3 wk ahead,1.4
 2010,41,2010/2011,41,HHS Region 4,4 wk ahead,1.6
@@ -129,7 +130,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,41,2010/2011,41,HHS Region 6,Season peak percentage,7.9
 2010,41,2010/2011,41,HHS Region 6,1 wk ahead,2
 2010,41,2010/2011,41,HHS Region 6,2 wk ahead,2
-2010,41,2010/2011,41,HHS Region 6,3 wk ahead,2.3
+2010,41,2010/2011,41,HHS Region 6,3 wk ahead,2.2
 2010,41,2010/2011,41,HHS Region 6,4 wk ahead,2.4
 2010,41,2010/2011,41,HHS Region 7,Season onset,4
 2010,41,2010/2011,41,HHS Region 7,Season peak week,8
@@ -145,8 +146,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,41,2010/2011,41,HHS Region 8,2 wk ahead,0.7
 2010,41,2010/2011,41,HHS Region 8,3 wk ahead,0.8
 2010,41,2010/2011,41,HHS Region 8,4 wk ahead,0.7
-2010,41,2010/2011,41,HHS Region 9,Season onset,none
+2010,41,2010/2011,41,HHS Region 9,Season onset,6
 2010,41,2010/2011,41,HHS Region 9,Season peak week,7
+2010,41,2010/2011,41,HHS Region 9,Season peak week,8
 2010,41,2010/2011,41,HHS Region 9,Season peak percentage,4.7
 2010,41,2010/2011,41,HHS Region 9,1 wk ahead,2
 2010,41,2010/2011,41,HHS Region 9,2 wk ahead,1.8
@@ -190,25 +192,25 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,42,2010/2011,42,HHS Region 3,2 wk ahead,1.2
 2010,42,2010/2011,42,HHS Region 3,3 wk ahead,1.3
 2010,42,2010/2011,42,HHS Region 3,4 wk ahead,1.3
-2010,42,2010/2011,42,HHS Region 4,Season onset,49
+2010,42,2010/2011,42,HHS Region 4,Season onset,50
 2010,42,2010/2011,42,HHS Region 4,Season peak week,5
-2010,42,2010/2011,42,HHS Region 4,Season peak percentage,5.6
+2010,42,2010/2011,42,HHS Region 4,Season peak percentage,5.5
 2010,42,2010/2011,42,HHS Region 4,1 wk ahead,1.2
 2010,42,2010/2011,42,HHS Region 4,2 wk ahead,1.4
 2010,42,2010/2011,42,HHS Region 4,3 wk ahead,1.6
-2010,42,2010/2011,42,HHS Region 4,4 wk ahead,1.9
+2010,42,2010/2011,42,HHS Region 4,4 wk ahead,1.8
 2010,42,2010/2011,42,HHS Region 5,Season onset,3
 2010,42,2010/2011,42,HHS Region 5,Season peak week,5
 2010,42,2010/2011,42,HHS Region 5,Season peak percentage,3.8
 2010,42,2010/2011,42,HHS Region 5,1 wk ahead,0.9
 2010,42,2010/2011,42,HHS Region 5,2 wk ahead,1
 2010,42,2010/2011,42,HHS Region 5,3 wk ahead,0.9
-2010,42,2010/2011,42,HHS Region 5,4 wk ahead,1
+2010,42,2010/2011,42,HHS Region 5,4 wk ahead,0.9
 2010,42,2010/2011,42,HHS Region 6,Season onset,3
 2010,42,2010/2011,42,HHS Region 6,Season peak week,7
 2010,42,2010/2011,42,HHS Region 6,Season peak percentage,7.9
 2010,42,2010/2011,42,HHS Region 6,1 wk ahead,2
-2010,42,2010/2011,42,HHS Region 6,2 wk ahead,2.3
+2010,42,2010/2011,42,HHS Region 6,2 wk ahead,2.2
 2010,42,2010/2011,42,HHS Region 6,3 wk ahead,2.4
 2010,42,2010/2011,42,HHS Region 6,4 wk ahead,2.4
 2010,42,2010/2011,42,HHS Region 7,Season onset,4
@@ -225,8 +227,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,42,2010/2011,42,HHS Region 8,2 wk ahead,0.8
 2010,42,2010/2011,42,HHS Region 8,3 wk ahead,0.7
 2010,42,2010/2011,42,HHS Region 8,4 wk ahead,0.7
-2010,42,2010/2011,42,HHS Region 9,Season onset,none
+2010,42,2010/2011,42,HHS Region 9,Season onset,6
 2010,42,2010/2011,42,HHS Region 9,Season peak week,7
+2010,42,2010/2011,42,HHS Region 9,Season peak week,8
 2010,42,2010/2011,42,HHS Region 9,Season peak percentage,4.7
 2010,42,2010/2011,42,HHS Region 9,1 wk ahead,1.8
 2010,42,2010/2011,42,HHS Region 9,2 wk ahead,2.3
@@ -270,24 +273,24 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,43,2010/2011,43,HHS Region 3,2 wk ahead,1.3
 2010,43,2010/2011,43,HHS Region 3,3 wk ahead,1.3
 2010,43,2010/2011,43,HHS Region 3,4 wk ahead,1.5
-2010,43,2010/2011,43,HHS Region 4,Season onset,49
+2010,43,2010/2011,43,HHS Region 4,Season onset,50
 2010,43,2010/2011,43,HHS Region 4,Season peak week,5
-2010,43,2010/2011,43,HHS Region 4,Season peak percentage,5.6
+2010,43,2010/2011,43,HHS Region 4,Season peak percentage,5.5
 2010,43,2010/2011,43,HHS Region 4,1 wk ahead,1.4
 2010,43,2010/2011,43,HHS Region 4,2 wk ahead,1.6
-2010,43,2010/2011,43,HHS Region 4,3 wk ahead,1.9
+2010,43,2010/2011,43,HHS Region 4,3 wk ahead,1.8
 2010,43,2010/2011,43,HHS Region 4,4 wk ahead,2.2
 2010,43,2010/2011,43,HHS Region 5,Season onset,3
 2010,43,2010/2011,43,HHS Region 5,Season peak week,5
 2010,43,2010/2011,43,HHS Region 5,Season peak percentage,3.8
 2010,43,2010/2011,43,HHS Region 5,1 wk ahead,1
 2010,43,2010/2011,43,HHS Region 5,2 wk ahead,0.9
-2010,43,2010/2011,43,HHS Region 5,3 wk ahead,1
+2010,43,2010/2011,43,HHS Region 5,3 wk ahead,0.9
 2010,43,2010/2011,43,HHS Region 5,4 wk ahead,1
 2010,43,2010/2011,43,HHS Region 6,Season onset,3
 2010,43,2010/2011,43,HHS Region 6,Season peak week,7
 2010,43,2010/2011,43,HHS Region 6,Season peak percentage,7.9
-2010,43,2010/2011,43,HHS Region 6,1 wk ahead,2.3
+2010,43,2010/2011,43,HHS Region 6,1 wk ahead,2.2
 2010,43,2010/2011,43,HHS Region 6,2 wk ahead,2.4
 2010,43,2010/2011,43,HHS Region 6,3 wk ahead,2.4
 2010,43,2010/2011,43,HHS Region 6,4 wk ahead,2.6
@@ -305,8 +308,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,43,2010/2011,43,HHS Region 8,2 wk ahead,0.7
 2010,43,2010/2011,43,HHS Region 8,3 wk ahead,0.7
 2010,43,2010/2011,43,HHS Region 8,4 wk ahead,0.7
-2010,43,2010/2011,43,HHS Region 9,Season onset,none
+2010,43,2010/2011,43,HHS Region 9,Season onset,6
 2010,43,2010/2011,43,HHS Region 9,Season peak week,7
+2010,43,2010/2011,43,HHS Region 9,Season peak week,8
 2010,43,2010/2011,43,HHS Region 9,Season peak percentage,4.7
 2010,43,2010/2011,43,HHS Region 9,1 wk ahead,2.3
 2010,43,2010/2011,43,HHS Region 9,2 wk ahead,2.3
@@ -350,18 +354,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,44,2010/2011,44,HHS Region 3,2 wk ahead,1.3
 2010,44,2010/2011,44,HHS Region 3,3 wk ahead,1.5
 2010,44,2010/2011,44,HHS Region 3,4 wk ahead,1.5
-2010,44,2010/2011,44,HHS Region 4,Season onset,49
+2010,44,2010/2011,44,HHS Region 4,Season onset,50
 2010,44,2010/2011,44,HHS Region 4,Season peak week,5
-2010,44,2010/2011,44,HHS Region 4,Season peak percentage,5.6
+2010,44,2010/2011,44,HHS Region 4,Season peak percentage,5.5
 2010,44,2010/2011,44,HHS Region 4,1 wk ahead,1.6
-2010,44,2010/2011,44,HHS Region 4,2 wk ahead,1.9
+2010,44,2010/2011,44,HHS Region 4,2 wk ahead,1.8
 2010,44,2010/2011,44,HHS Region 4,3 wk ahead,2.2
-2010,44,2010/2011,44,HHS Region 4,4 wk ahead,2
+2010,44,2010/2011,44,HHS Region 4,4 wk ahead,1.9
 2010,44,2010/2011,44,HHS Region 5,Season onset,3
 2010,44,2010/2011,44,HHS Region 5,Season peak week,5
 2010,44,2010/2011,44,HHS Region 5,Season peak percentage,3.8
 2010,44,2010/2011,44,HHS Region 5,1 wk ahead,0.9
-2010,44,2010/2011,44,HHS Region 5,2 wk ahead,1
+2010,44,2010/2011,44,HHS Region 5,2 wk ahead,0.9
 2010,44,2010/2011,44,HHS Region 5,3 wk ahead,1
 2010,44,2010/2011,44,HHS Region 5,4 wk ahead,0.9
 2010,44,2010/2011,44,HHS Region 6,Season onset,3
@@ -385,8 +389,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,44,2010/2011,44,HHS Region 8,2 wk ahead,0.7
 2010,44,2010/2011,44,HHS Region 8,3 wk ahead,0.7
 2010,44,2010/2011,44,HHS Region 8,4 wk ahead,0.7
-2010,44,2010/2011,44,HHS Region 9,Season onset,none
+2010,44,2010/2011,44,HHS Region 9,Season onset,6
 2010,44,2010/2011,44,HHS Region 9,Season peak week,7
+2010,44,2010/2011,44,HHS Region 9,Season peak week,8
 2010,44,2010/2011,44,HHS Region 9,Season peak percentage,4.7
 2010,44,2010/2011,44,HHS Region 9,1 wk ahead,2.3
 2010,44,2010/2011,44,HHS Region 9,2 wk ahead,2.5
@@ -430,17 +435,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,45,2010/2011,45,HHS Region 3,2 wk ahead,1.5
 2010,45,2010/2011,45,HHS Region 3,3 wk ahead,1.5
 2010,45,2010/2011,45,HHS Region 3,4 wk ahead,1.5
-2010,45,2010/2011,45,HHS Region 4,Season onset,49
+2010,45,2010/2011,45,HHS Region 4,Season onset,50
 2010,45,2010/2011,45,HHS Region 4,Season peak week,5
-2010,45,2010/2011,45,HHS Region 4,Season peak percentage,5.6
-2010,45,2010/2011,45,HHS Region 4,1 wk ahead,1.9
+2010,45,2010/2011,45,HHS Region 4,Season peak percentage,5.5
+2010,45,2010/2011,45,HHS Region 4,1 wk ahead,1.8
 2010,45,2010/2011,45,HHS Region 4,2 wk ahead,2.2
-2010,45,2010/2011,45,HHS Region 4,3 wk ahead,2
-2010,45,2010/2011,45,HHS Region 4,4 wk ahead,2.3
+2010,45,2010/2011,45,HHS Region 4,3 wk ahead,1.9
+2010,45,2010/2011,45,HHS Region 4,4 wk ahead,2.2
 2010,45,2010/2011,45,HHS Region 5,Season onset,3
 2010,45,2010/2011,45,HHS Region 5,Season peak week,5
 2010,45,2010/2011,45,HHS Region 5,Season peak percentage,3.8
-2010,45,2010/2011,45,HHS Region 5,1 wk ahead,1
+2010,45,2010/2011,45,HHS Region 5,1 wk ahead,0.9
 2010,45,2010/2011,45,HHS Region 5,2 wk ahead,1
 2010,45,2010/2011,45,HHS Region 5,3 wk ahead,0.9
 2010,45,2010/2011,45,HHS Region 5,4 wk ahead,1
@@ -465,8 +470,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,45,2010/2011,45,HHS Region 8,2 wk ahead,0.7
 2010,45,2010/2011,45,HHS Region 8,3 wk ahead,0.7
 2010,45,2010/2011,45,HHS Region 8,4 wk ahead,0.8
-2010,45,2010/2011,45,HHS Region 9,Season onset,none
+2010,45,2010/2011,45,HHS Region 9,Season onset,6
 2010,45,2010/2011,45,HHS Region 9,Season peak week,7
+2010,45,2010/2011,45,HHS Region 9,Season peak week,8
 2010,45,2010/2011,45,HHS Region 9,Season peak percentage,4.7
 2010,45,2010/2011,45,HHS Region 9,1 wk ahead,2.5
 2010,45,2010/2011,45,HHS Region 9,2 wk ahead,2.8
@@ -510,13 +516,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,46,2010/2011,46,HHS Region 3,2 wk ahead,1.5
 2010,46,2010/2011,46,HHS Region 3,3 wk ahead,1.5
 2010,46,2010/2011,46,HHS Region 3,4 wk ahead,1.6
-2010,46,2010/2011,46,HHS Region 4,Season onset,49
+2010,46,2010/2011,46,HHS Region 4,Season onset,50
 2010,46,2010/2011,46,HHS Region 4,Season peak week,5
-2010,46,2010/2011,46,HHS Region 4,Season peak percentage,5.6
+2010,46,2010/2011,46,HHS Region 4,Season peak percentage,5.5
 2010,46,2010/2011,46,HHS Region 4,1 wk ahead,2.2
-2010,46,2010/2011,46,HHS Region 4,2 wk ahead,2
-2010,46,2010/2011,46,HHS Region 4,3 wk ahead,2.3
-2010,46,2010/2011,46,HHS Region 4,4 wk ahead,3.4
+2010,46,2010/2011,46,HHS Region 4,2 wk ahead,1.9
+2010,46,2010/2011,46,HHS Region 4,3 wk ahead,2.2
+2010,46,2010/2011,46,HHS Region 4,4 wk ahead,3.3
 2010,46,2010/2011,46,HHS Region 5,Season onset,3
 2010,46,2010/2011,46,HHS Region 5,Season peak week,5
 2010,46,2010/2011,46,HHS Region 5,Season peak percentage,3.8
@@ -545,13 +551,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,46,2010/2011,46,HHS Region 8,2 wk ahead,0.7
 2010,46,2010/2011,46,HHS Region 8,3 wk ahead,0.8
 2010,46,2010/2011,46,HHS Region 8,4 wk ahead,0.8
-2010,46,2010/2011,46,HHS Region 9,Season onset,none
+2010,46,2010/2011,46,HHS Region 9,Season onset,6
 2010,46,2010/2011,46,HHS Region 9,Season peak week,7
+2010,46,2010/2011,46,HHS Region 9,Season peak week,8
 2010,46,2010/2011,46,HHS Region 9,Season peak percentage,4.7
 2010,46,2010/2011,46,HHS Region 9,1 wk ahead,2.8
 2010,46,2010/2011,46,HHS Region 9,2 wk ahead,2.4
 2010,46,2010/2011,46,HHS Region 9,3 wk ahead,2.9
-2010,46,2010/2011,46,HHS Region 9,4 wk ahead,3.6
+2010,46,2010/2011,46,HHS Region 9,4 wk ahead,3.4
 2010,46,2010/2011,46,HHS Region 10,Season onset,5
 2010,46,2010/2011,46,HHS Region 10,Season peak week,7
 2010,46,2010/2011,46,HHS Region 10,Season peak percentage,3.9
@@ -590,12 +597,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,47,2010/2011,47,HHS Region 3,2 wk ahead,1.5
 2010,47,2010/2011,47,HHS Region 3,3 wk ahead,1.6
 2010,47,2010/2011,47,HHS Region 3,4 wk ahead,2.2
-2010,47,2010/2011,47,HHS Region 4,Season onset,49
+2010,47,2010/2011,47,HHS Region 4,Season onset,50
 2010,47,2010/2011,47,HHS Region 4,Season peak week,5
-2010,47,2010/2011,47,HHS Region 4,Season peak percentage,5.6
-2010,47,2010/2011,47,HHS Region 4,1 wk ahead,2
-2010,47,2010/2011,47,HHS Region 4,2 wk ahead,2.3
-2010,47,2010/2011,47,HHS Region 4,3 wk ahead,3.4
+2010,47,2010/2011,47,HHS Region 4,Season peak percentage,5.5
+2010,47,2010/2011,47,HHS Region 4,1 wk ahead,1.9
+2010,47,2010/2011,47,HHS Region 4,2 wk ahead,2.2
+2010,47,2010/2011,47,HHS Region 4,3 wk ahead,3.3
 2010,47,2010/2011,47,HHS Region 4,4 wk ahead,4.4
 2010,47,2010/2011,47,HHS Region 5,Season onset,3
 2010,47,2010/2011,47,HHS Region 5,Season peak week,5
@@ -625,13 +632,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,47,2010/2011,47,HHS Region 8,2 wk ahead,0.8
 2010,47,2010/2011,47,HHS Region 8,3 wk ahead,0.8
 2010,47,2010/2011,47,HHS Region 8,4 wk ahead,0.9
-2010,47,2010/2011,47,HHS Region 9,Season onset,none
+2010,47,2010/2011,47,HHS Region 9,Season onset,6
 2010,47,2010/2011,47,HHS Region 9,Season peak week,7
+2010,47,2010/2011,47,HHS Region 9,Season peak week,8
 2010,47,2010/2011,47,HHS Region 9,Season peak percentage,4.7
 2010,47,2010/2011,47,HHS Region 9,1 wk ahead,2.4
 2010,47,2010/2011,47,HHS Region 9,2 wk ahead,2.9
-2010,47,2010/2011,47,HHS Region 9,3 wk ahead,3.6
-2010,47,2010/2011,47,HHS Region 9,4 wk ahead,4.6
+2010,47,2010/2011,47,HHS Region 9,3 wk ahead,3.4
+2010,47,2010/2011,47,HHS Region 9,4 wk ahead,4.2
 2010,47,2010/2011,47,HHS Region 10,Season onset,5
 2010,47,2010/2011,47,HHS Region 10,Season peak week,7
 2010,47,2010/2011,47,HHS Region 10,Season peak percentage,3.9
@@ -670,11 +678,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,48,2010/2011,48,HHS Region 3,2 wk ahead,1.6
 2010,48,2010/2011,48,HHS Region 3,3 wk ahead,2.2
 2010,48,2010/2011,48,HHS Region 3,4 wk ahead,2.6
-2010,48,2010/2011,48,HHS Region 4,Season onset,49
+2010,48,2010/2011,48,HHS Region 4,Season onset,50
 2010,48,2010/2011,48,HHS Region 4,Season peak week,5
-2010,48,2010/2011,48,HHS Region 4,Season peak percentage,5.6
-2010,48,2010/2011,48,HHS Region 4,1 wk ahead,2.3
-2010,48,2010/2011,48,HHS Region 4,2 wk ahead,3.4
+2010,48,2010/2011,48,HHS Region 4,Season peak percentage,5.5
+2010,48,2010/2011,48,HHS Region 4,1 wk ahead,2.2
+2010,48,2010/2011,48,HHS Region 4,2 wk ahead,3.3
 2010,48,2010/2011,48,HHS Region 4,3 wk ahead,4.4
 2010,48,2010/2011,48,HHS Region 4,4 wk ahead,4
 2010,48,2010/2011,48,HHS Region 5,Season onset,3
@@ -705,12 +713,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,48,2010/2011,48,HHS Region 8,2 wk ahead,0.8
 2010,48,2010/2011,48,HHS Region 8,3 wk ahead,0.9
 2010,48,2010/2011,48,HHS Region 8,4 wk ahead,1
-2010,48,2010/2011,48,HHS Region 9,Season onset,none
+2010,48,2010/2011,48,HHS Region 9,Season onset,6
 2010,48,2010/2011,48,HHS Region 9,Season peak week,7
+2010,48,2010/2011,48,HHS Region 9,Season peak week,8
 2010,48,2010/2011,48,HHS Region 9,Season peak percentage,4.7
 2010,48,2010/2011,48,HHS Region 9,1 wk ahead,2.9
-2010,48,2010/2011,48,HHS Region 9,2 wk ahead,3.6
-2010,48,2010/2011,48,HHS Region 9,3 wk ahead,4.6
+2010,48,2010/2011,48,HHS Region 9,2 wk ahead,3.4
+2010,48,2010/2011,48,HHS Region 9,3 wk ahead,4.2
 2010,48,2010/2011,48,HHS Region 9,4 wk ahead,4.2
 2010,48,2010/2011,48,HHS Region 10,Season onset,5
 2010,48,2010/2011,48,HHS Region 10,Season peak week,7
@@ -750,13 +759,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,49,2010/2011,49,HHS Region 3,2 wk ahead,2.2
 2010,49,2010/2011,49,HHS Region 3,3 wk ahead,2.6
 2010,49,2010/2011,49,HHS Region 3,4 wk ahead,2.2
-2010,49,2010/2011,49,HHS Region 4,Season onset,49
+2010,49,2010/2011,49,HHS Region 4,Season onset,50
 2010,49,2010/2011,49,HHS Region 4,Season peak week,5
-2010,49,2010/2011,49,HHS Region 4,Season peak percentage,5.6
-2010,49,2010/2011,49,HHS Region 4,1 wk ahead,3.4
+2010,49,2010/2011,49,HHS Region 4,Season peak percentage,5.5
+2010,49,2010/2011,49,HHS Region 4,1 wk ahead,3.3
 2010,49,2010/2011,49,HHS Region 4,2 wk ahead,4.4
 2010,49,2010/2011,49,HHS Region 4,3 wk ahead,4
-2010,49,2010/2011,49,HHS Region 4,4 wk ahead,3.2
+2010,49,2010/2011,49,HHS Region 4,4 wk ahead,3.3
 2010,49,2010/2011,49,HHS Region 5,Season onset,3
 2010,49,2010/2011,49,HHS Region 5,Season peak week,5
 2010,49,2010/2011,49,HHS Region 5,Season peak percentage,3.8
@@ -785,11 +794,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,49,2010/2011,49,HHS Region 8,2 wk ahead,0.9
 2010,49,2010/2011,49,HHS Region 8,3 wk ahead,1
 2010,49,2010/2011,49,HHS Region 8,4 wk ahead,0.7
-2010,49,2010/2011,49,HHS Region 9,Season onset,none
+2010,49,2010/2011,49,HHS Region 9,Season onset,6
 2010,49,2010/2011,49,HHS Region 9,Season peak week,7
+2010,49,2010/2011,49,HHS Region 9,Season peak week,8
 2010,49,2010/2011,49,HHS Region 9,Season peak percentage,4.7
-2010,49,2010/2011,49,HHS Region 9,1 wk ahead,3.6
-2010,49,2010/2011,49,HHS Region 9,2 wk ahead,4.6
+2010,49,2010/2011,49,HHS Region 9,1 wk ahead,3.4
+2010,49,2010/2011,49,HHS Region 9,2 wk ahead,4.2
 2010,49,2010/2011,49,HHS Region 9,3 wk ahead,4.2
 2010,49,2010/2011,49,HHS Region 9,4 wk ahead,3.2
 2010,49,2010/2011,49,HHS Region 10,Season onset,5
@@ -830,12 +840,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,50,2010/2011,50,HHS Region 3,2 wk ahead,2.6
 2010,50,2010/2011,50,HHS Region 3,3 wk ahead,2.2
 2010,50,2010/2011,50,HHS Region 3,4 wk ahead,2.5
-2010,50,2010/2011,50,HHS Region 4,Season onset,49
+2010,50,2010/2011,50,HHS Region 4,Season onset,50
 2010,50,2010/2011,50,HHS Region 4,Season peak week,5
-2010,50,2010/2011,50,HHS Region 4,Season peak percentage,5.6
+2010,50,2010/2011,50,HHS Region 4,Season peak percentage,5.5
 2010,50,2010/2011,50,HHS Region 4,1 wk ahead,4.4
 2010,50,2010/2011,50,HHS Region 4,2 wk ahead,4
-2010,50,2010/2011,50,HHS Region 4,3 wk ahead,3.2
+2010,50,2010/2011,50,HHS Region 4,3 wk ahead,3.3
 2010,50,2010/2011,50,HHS Region 4,4 wk ahead,3.6
 2010,50,2010/2011,50,HHS Region 5,Season onset,3
 2010,50,2010/2011,50,HHS Region 5,Season peak week,5
@@ -865,10 +875,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,50,2010/2011,50,HHS Region 8,2 wk ahead,1
 2010,50,2010/2011,50,HHS Region 8,3 wk ahead,0.7
 2010,50,2010/2011,50,HHS Region 8,4 wk ahead,1.4
-2010,50,2010/2011,50,HHS Region 9,Season onset,none
+2010,50,2010/2011,50,HHS Region 9,Season onset,6
 2010,50,2010/2011,50,HHS Region 9,Season peak week,7
+2010,50,2010/2011,50,HHS Region 9,Season peak week,8
 2010,50,2010/2011,50,HHS Region 9,Season peak percentage,4.7
-2010,50,2010/2011,50,HHS Region 9,1 wk ahead,4.6
+2010,50,2010/2011,50,HHS Region 9,1 wk ahead,4.2
 2010,50,2010/2011,50,HHS Region 9,2 wk ahead,4.2
 2010,50,2010/2011,50,HHS Region 9,3 wk ahead,3.2
 2010,50,2010/2011,50,HHS Region 9,4 wk ahead,3.4
@@ -910,11 +921,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,51,2010/2011,51,HHS Region 3,2 wk ahead,2.2
 2010,51,2010/2011,51,HHS Region 3,3 wk ahead,2.5
 2010,51,2010/2011,51,HHS Region 3,4 wk ahead,3.3
-2010,51,2010/2011,51,HHS Region 4,Season onset,49
+2010,51,2010/2011,51,HHS Region 4,Season onset,50
 2010,51,2010/2011,51,HHS Region 4,Season peak week,5
-2010,51,2010/2011,51,HHS Region 4,Season peak percentage,5.6
+2010,51,2010/2011,51,HHS Region 4,Season peak percentage,5.5
 2010,51,2010/2011,51,HHS Region 4,1 wk ahead,4
-2010,51,2010/2011,51,HHS Region 4,2 wk ahead,3.2
+2010,51,2010/2011,51,HHS Region 4,2 wk ahead,3.3
 2010,51,2010/2011,51,HHS Region 4,3 wk ahead,3.6
 2010,51,2010/2011,51,HHS Region 4,4 wk ahead,4.2
 2010,51,2010/2011,51,HHS Region 5,Season onset,3
@@ -930,7 +941,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,51,2010/2011,51,HHS Region 6,1 wk ahead,3.8
 2010,51,2010/2011,51,HHS Region 6,2 wk ahead,3.3
 2010,51,2010/2011,51,HHS Region 6,3 wk ahead,4.4
-2010,51,2010/2011,51,HHS Region 6,4 wk ahead,5.8
+2010,51,2010/2011,51,HHS Region 6,4 wk ahead,5.7
 2010,51,2010/2011,51,HHS Region 7,Season onset,4
 2010,51,2010/2011,51,HHS Region 7,Season peak week,8
 2010,51,2010/2011,51,HHS Region 7,Season peak percentage,4.7
@@ -945,8 +956,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,51,2010/2011,51,HHS Region 8,2 wk ahead,0.7
 2010,51,2010/2011,51,HHS Region 8,3 wk ahead,1.4
 2010,51,2010/2011,51,HHS Region 8,4 wk ahead,1.4
-2010,51,2010/2011,51,HHS Region 9,Season onset,none
+2010,51,2010/2011,51,HHS Region 9,Season onset,6
 2010,51,2010/2011,51,HHS Region 9,Season peak week,7
+2010,51,2010/2011,51,HHS Region 9,Season peak week,8
 2010,51,2010/2011,51,HHS Region 9,Season peak percentage,4.7
 2010,51,2010/2011,51,HHS Region 9,1 wk ahead,4.2
 2010,51,2010/2011,51,HHS Region 9,2 wk ahead,3.2
@@ -990,10 +1002,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,52,2010/2011,52,HHS Region 3,2 wk ahead,2.5
 2010,52,2010/2011,52,HHS Region 3,3 wk ahead,3.3
 2010,52,2010/2011,52,HHS Region 3,4 wk ahead,4
-2010,52,2010/2011,52,HHS Region 4,Season onset,49
+2010,52,2010/2011,52,HHS Region 4,Season onset,50
 2010,52,2010/2011,52,HHS Region 4,Season peak week,5
-2010,52,2010/2011,52,HHS Region 4,Season peak percentage,5.6
-2010,52,2010/2011,52,HHS Region 4,1 wk ahead,3.2
+2010,52,2010/2011,52,HHS Region 4,Season peak percentage,5.5
+2010,52,2010/2011,52,HHS Region 4,1 wk ahead,3.3
 2010,52,2010/2011,52,HHS Region 4,2 wk ahead,3.6
 2010,52,2010/2011,52,HHS Region 4,3 wk ahead,4.2
 2010,52,2010/2011,52,HHS Region 4,4 wk ahead,5
@@ -1009,8 +1021,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,52,2010/2011,52,HHS Region 6,Season peak percentage,7.9
 2010,52,2010/2011,52,HHS Region 6,1 wk ahead,3.3
 2010,52,2010/2011,52,HHS Region 6,2 wk ahead,4.4
-2010,52,2010/2011,52,HHS Region 6,3 wk ahead,5.8
-2010,52,2010/2011,52,HHS Region 6,4 wk ahead,7
+2010,52,2010/2011,52,HHS Region 6,3 wk ahead,5.7
+2010,52,2010/2011,52,HHS Region 6,4 wk ahead,6.9
 2010,52,2010/2011,52,HHS Region 7,Season onset,4
 2010,52,2010/2011,52,HHS Region 7,Season peak week,8
 2010,52,2010/2011,52,HHS Region 7,Season peak percentage,4.7
@@ -1025,8 +1037,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2010,52,2010/2011,52,HHS Region 8,2 wk ahead,1.4
 2010,52,2010/2011,52,HHS Region 8,3 wk ahead,1.4
 2010,52,2010/2011,52,HHS Region 8,4 wk ahead,1.5
-2010,52,2010/2011,52,HHS Region 9,Season onset,none
+2010,52,2010/2011,52,HHS Region 9,Season onset,6
 2010,52,2010/2011,52,HHS Region 9,Season peak week,7
+2010,52,2010/2011,52,HHS Region 9,Season peak week,8
 2010,52,2010/2011,52,HHS Region 9,Season peak percentage,4.7
 2010,52,2010/2011,52,HHS Region 9,1 wk ahead,3.2
 2010,52,2010/2011,52,HHS Region 9,2 wk ahead,3.4
@@ -1062,7 +1075,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,1,2010/2011,53,HHS Region 2,1 wk ahead,3.8
 2011,1,2010/2011,53,HHS Region 2,2 wk ahead,3.7
 2011,1,2010/2011,53,HHS Region 2,3 wk ahead,3.9
-2011,1,2010/2011,53,HHS Region 2,4 wk ahead,3.8
+2011,1,2010/2011,53,HHS Region 2,4 wk ahead,4.1
 2011,1,2010/2011,53,HHS Region 3,Season onset,3
 2011,1,2010/2011,53,HHS Region 3,Season peak week,5
 2011,1,2010/2011,53,HHS Region 3,Season peak percentage,4.4
@@ -1070,13 +1083,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,1,2010/2011,53,HHS Region 3,2 wk ahead,3.3
 2011,1,2010/2011,53,HHS Region 3,3 wk ahead,4
 2011,1,2010/2011,53,HHS Region 3,4 wk ahead,4.4
-2011,1,2010/2011,53,HHS Region 4,Season onset,49
+2011,1,2010/2011,53,HHS Region 4,Season onset,50
 2011,1,2010/2011,53,HHS Region 4,Season peak week,5
-2011,1,2010/2011,53,HHS Region 4,Season peak percentage,5.6
+2011,1,2010/2011,53,HHS Region 4,Season peak percentage,5.5
 2011,1,2010/2011,53,HHS Region 4,1 wk ahead,3.6
 2011,1,2010/2011,53,HHS Region 4,2 wk ahead,4.2
 2011,1,2010/2011,53,HHS Region 4,3 wk ahead,5
-2011,1,2010/2011,53,HHS Region 4,4 wk ahead,5.6
+2011,1,2010/2011,53,HHS Region 4,4 wk ahead,5.5
 2011,1,2010/2011,53,HHS Region 5,Season onset,3
 2011,1,2010/2011,53,HHS Region 5,Season peak week,5
 2011,1,2010/2011,53,HHS Region 5,Season peak percentage,3.8
@@ -1088,8 +1101,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,1,2010/2011,53,HHS Region 6,Season peak week,7
 2011,1,2010/2011,53,HHS Region 6,Season peak percentage,7.9
 2011,1,2010/2011,53,HHS Region 6,1 wk ahead,4.4
-2011,1,2010/2011,53,HHS Region 6,2 wk ahead,5.8
-2011,1,2010/2011,53,HHS Region 6,3 wk ahead,7
+2011,1,2010/2011,53,HHS Region 6,2 wk ahead,5.7
+2011,1,2010/2011,53,HHS Region 6,3 wk ahead,6.9
 2011,1,2010/2011,53,HHS Region 6,4 wk ahead,7.6
 2011,1,2010/2011,53,HHS Region 7,Season onset,4
 2011,1,2010/2011,53,HHS Region 7,Season peak week,8
@@ -1105,8 +1118,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,1,2010/2011,53,HHS Region 8,2 wk ahead,1.4
 2011,1,2010/2011,53,HHS Region 8,3 wk ahead,1.5
 2011,1,2010/2011,53,HHS Region 8,4 wk ahead,2.2
-2011,1,2010/2011,53,HHS Region 9,Season onset,none
+2011,1,2010/2011,53,HHS Region 9,Season onset,6
 2011,1,2010/2011,53,HHS Region 9,Season peak week,7
+2011,1,2010/2011,53,HHS Region 9,Season peak week,8
 2011,1,2010/2011,53,HHS Region 9,Season peak percentage,4.7
 2011,1,2010/2011,53,HHS Region 9,1 wk ahead,3.4
 2011,1,2010/2011,53,HHS Region 9,2 wk ahead,3.8
@@ -1141,7 +1155,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,2,2010/2011,54,HHS Region 2,Season peak percentage,4.5
 2011,2,2010/2011,54,HHS Region 2,1 wk ahead,3.7
 2011,2,2010/2011,54,HHS Region 2,2 wk ahead,3.9
-2011,2,2010/2011,54,HHS Region 2,3 wk ahead,3.8
+2011,2,2010/2011,54,HHS Region 2,3 wk ahead,4.1
 2011,2,2010/2011,54,HHS Region 2,4 wk ahead,4.1
 2011,2,2010/2011,54,HHS Region 3,Season onset,3
 2011,2,2010/2011,54,HHS Region 3,Season peak week,5
@@ -1149,14 +1163,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,2,2010/2011,54,HHS Region 3,1 wk ahead,3.3
 2011,2,2010/2011,54,HHS Region 3,2 wk ahead,4
 2011,2,2010/2011,54,HHS Region 3,3 wk ahead,4.4
-2011,2,2010/2011,54,HHS Region 3,4 wk ahead,4
-2011,2,2010/2011,54,HHS Region 4,Season onset,49
+2011,2,2010/2011,54,HHS Region 3,4 wk ahead,4.1
+2011,2,2010/2011,54,HHS Region 4,Season onset,50
 2011,2,2010/2011,54,HHS Region 4,Season peak week,5
-2011,2,2010/2011,54,HHS Region 4,Season peak percentage,5.6
+2011,2,2010/2011,54,HHS Region 4,Season peak percentage,5.5
 2011,2,2010/2011,54,HHS Region 4,1 wk ahead,4.2
 2011,2,2010/2011,54,HHS Region 4,2 wk ahead,5
-2011,2,2010/2011,54,HHS Region 4,3 wk ahead,5.6
-2011,2,2010/2011,54,HHS Region 4,4 wk ahead,5.3
+2011,2,2010/2011,54,HHS Region 4,3 wk ahead,5.5
+2011,2,2010/2011,54,HHS Region 4,4 wk ahead,5.2
 2011,2,2010/2011,54,HHS Region 5,Season onset,3
 2011,2,2010/2011,54,HHS Region 5,Season peak week,5
 2011,2,2010/2011,54,HHS Region 5,Season peak percentage,3.8
@@ -1167,8 +1181,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,2,2010/2011,54,HHS Region 6,Season onset,3
 2011,2,2010/2011,54,HHS Region 6,Season peak week,7
 2011,2,2010/2011,54,HHS Region 6,Season peak percentage,7.9
-2011,2,2010/2011,54,HHS Region 6,1 wk ahead,5.8
-2011,2,2010/2011,54,HHS Region 6,2 wk ahead,7
+2011,2,2010/2011,54,HHS Region 6,1 wk ahead,5.7
+2011,2,2010/2011,54,HHS Region 6,2 wk ahead,6.9
 2011,2,2010/2011,54,HHS Region 6,3 wk ahead,7.6
 2011,2,2010/2011,54,HHS Region 6,4 wk ahead,7.8
 2011,2,2010/2011,54,HHS Region 7,Season onset,4
@@ -1185,8 +1199,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,2,2010/2011,54,HHS Region 8,2 wk ahead,1.5
 2011,2,2010/2011,54,HHS Region 8,3 wk ahead,2.2
 2011,2,2010/2011,54,HHS Region 8,4 wk ahead,2.5
-2011,2,2010/2011,54,HHS Region 9,Season onset,none
+2011,2,2010/2011,54,HHS Region 9,Season onset,6
 2011,2,2010/2011,54,HHS Region 9,Season peak week,7
+2011,2,2010/2011,54,HHS Region 9,Season peak week,8
 2011,2,2010/2011,54,HHS Region 9,Season peak percentage,4.7
 2011,2,2010/2011,54,HHS Region 9,1 wk ahead,3.8
 2011,2,2010/2011,54,HHS Region 9,2 wk ahead,4.2
@@ -1220,7 +1235,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,3,2010/2011,55,HHS Region 2,Season peak week,52
 2011,3,2010/2011,55,HHS Region 2,Season peak percentage,4.5
 2011,3,2010/2011,55,HHS Region 2,1 wk ahead,3.9
-2011,3,2010/2011,55,HHS Region 2,2 wk ahead,3.8
+2011,3,2010/2011,55,HHS Region 2,2 wk ahead,4.1
 2011,3,2010/2011,55,HHS Region 2,3 wk ahead,4.1
 2011,3,2010/2011,55,HHS Region 2,4 wk ahead,4.3
 2011,3,2010/2011,55,HHS Region 3,Season onset,3
@@ -1228,14 +1243,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,3,2010/2011,55,HHS Region 3,Season peak percentage,4.4
 2011,3,2010/2011,55,HHS Region 3,1 wk ahead,4
 2011,3,2010/2011,55,HHS Region 3,2 wk ahead,4.4
-2011,3,2010/2011,55,HHS Region 3,3 wk ahead,4
+2011,3,2010/2011,55,HHS Region 3,3 wk ahead,4.1
 2011,3,2010/2011,55,HHS Region 3,4 wk ahead,4
-2011,3,2010/2011,55,HHS Region 4,Season onset,49
+2011,3,2010/2011,55,HHS Region 4,Season onset,50
 2011,3,2010/2011,55,HHS Region 4,Season peak week,5
-2011,3,2010/2011,55,HHS Region 4,Season peak percentage,5.6
+2011,3,2010/2011,55,HHS Region 4,Season peak percentage,5.5
 2011,3,2010/2011,55,HHS Region 4,1 wk ahead,5
-2011,3,2010/2011,55,HHS Region 4,2 wk ahead,5.6
-2011,3,2010/2011,55,HHS Region 4,3 wk ahead,5.3
+2011,3,2010/2011,55,HHS Region 4,2 wk ahead,5.5
+2011,3,2010/2011,55,HHS Region 4,3 wk ahead,5.2
 2011,3,2010/2011,55,HHS Region 4,4 wk ahead,4.8
 2011,3,2010/2011,55,HHS Region 5,Season onset,3
 2011,3,2010/2011,55,HHS Region 5,Season peak week,5
@@ -1247,7 +1262,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,3,2010/2011,55,HHS Region 6,Season onset,3
 2011,3,2010/2011,55,HHS Region 6,Season peak week,7
 2011,3,2010/2011,55,HHS Region 6,Season peak percentage,7.9
-2011,3,2010/2011,55,HHS Region 6,1 wk ahead,7
+2011,3,2010/2011,55,HHS Region 6,1 wk ahead,6.9
 2011,3,2010/2011,55,HHS Region 6,2 wk ahead,7.6
 2011,3,2010/2011,55,HHS Region 6,3 wk ahead,7.8
 2011,3,2010/2011,55,HHS Region 6,4 wk ahead,7.9
@@ -1265,8 +1280,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,3,2010/2011,55,HHS Region 8,2 wk ahead,2.2
 2011,3,2010/2011,55,HHS Region 8,3 wk ahead,2.5
 2011,3,2010/2011,55,HHS Region 8,4 wk ahead,2.7
-2011,3,2010/2011,55,HHS Region 9,Season onset,none
+2011,3,2010/2011,55,HHS Region 9,Season onset,6
 2011,3,2010/2011,55,HHS Region 9,Season peak week,7
+2011,3,2010/2011,55,HHS Region 9,Season peak week,8
 2011,3,2010/2011,55,HHS Region 9,Season peak percentage,4.7
 2011,3,2010/2011,55,HHS Region 9,1 wk ahead,4.2
 2011,3,2010/2011,55,HHS Region 9,2 wk ahead,4
@@ -1299,7 +1315,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,4,2010/2011,56,HHS Region 2,Season onset,49
 2011,4,2010/2011,56,HHS Region 2,Season peak week,52
 2011,4,2010/2011,56,HHS Region 2,Season peak percentage,4.5
-2011,4,2010/2011,56,HHS Region 2,1 wk ahead,3.8
+2011,4,2010/2011,56,HHS Region 2,1 wk ahead,4.1
 2011,4,2010/2011,56,HHS Region 2,2 wk ahead,4.1
 2011,4,2010/2011,56,HHS Region 2,3 wk ahead,4.3
 2011,4,2010/2011,56,HHS Region 2,4 wk ahead,4.3
@@ -1307,14 +1323,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,4,2010/2011,56,HHS Region 3,Season peak week,5
 2011,4,2010/2011,56,HHS Region 3,Season peak percentage,4.4
 2011,4,2010/2011,56,HHS Region 3,1 wk ahead,4.4
-2011,4,2010/2011,56,HHS Region 3,2 wk ahead,4
+2011,4,2010/2011,56,HHS Region 3,2 wk ahead,4.1
 2011,4,2010/2011,56,HHS Region 3,3 wk ahead,4
 2011,4,2010/2011,56,HHS Region 3,4 wk ahead,3.6
-2011,4,2010/2011,56,HHS Region 4,Season onset,49
+2011,4,2010/2011,56,HHS Region 4,Season onset,50
 2011,4,2010/2011,56,HHS Region 4,Season peak week,5
-2011,4,2010/2011,56,HHS Region 4,Season peak percentage,5.6
-2011,4,2010/2011,56,HHS Region 4,1 wk ahead,5.6
-2011,4,2010/2011,56,HHS Region 4,2 wk ahead,5.3
+2011,4,2010/2011,56,HHS Region 4,Season peak percentage,5.5
+2011,4,2010/2011,56,HHS Region 4,1 wk ahead,5.5
+2011,4,2010/2011,56,HHS Region 4,2 wk ahead,5.2
 2011,4,2010/2011,56,HHS Region 4,3 wk ahead,4.8
 2011,4,2010/2011,56,HHS Region 4,4 wk ahead,3.9
 2011,4,2010/2011,56,HHS Region 5,Season onset,3
@@ -1330,7 +1346,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,4,2010/2011,56,HHS Region 6,1 wk ahead,7.6
 2011,4,2010/2011,56,HHS Region 6,2 wk ahead,7.8
 2011,4,2010/2011,56,HHS Region 6,3 wk ahead,7.9
-2011,4,2010/2011,56,HHS Region 6,4 wk ahead,6.2
+2011,4,2010/2011,56,HHS Region 6,4 wk ahead,6.3
 2011,4,2010/2011,56,HHS Region 7,Season onset,4
 2011,4,2010/2011,56,HHS Region 7,Season peak week,8
 2011,4,2010/2011,56,HHS Region 7,Season peak percentage,4.7
@@ -1344,14 +1360,15 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,4,2010/2011,56,HHS Region 8,1 wk ahead,2.2
 2011,4,2010/2011,56,HHS Region 8,2 wk ahead,2.5
 2011,4,2010/2011,56,HHS Region 8,3 wk ahead,2.7
-2011,4,2010/2011,56,HHS Region 8,4 wk ahead,2.6
-2011,4,2010/2011,56,HHS Region 9,Season onset,none
+2011,4,2010/2011,56,HHS Region 8,4 wk ahead,2.5
+2011,4,2010/2011,56,HHS Region 9,Season onset,6
 2011,4,2010/2011,56,HHS Region 9,Season peak week,7
+2011,4,2010/2011,56,HHS Region 9,Season peak week,8
 2011,4,2010/2011,56,HHS Region 9,Season peak percentage,4.7
 2011,4,2010/2011,56,HHS Region 9,1 wk ahead,4
 2011,4,2010/2011,56,HHS Region 9,2 wk ahead,4.5
 2011,4,2010/2011,56,HHS Region 9,3 wk ahead,4.7
-2011,4,2010/2011,56,HHS Region 9,4 wk ahead,3.9
+2011,4,2010/2011,56,HHS Region 9,4 wk ahead,4.7
 2011,4,2010/2011,56,HHS Region 10,Season onset,5
 2011,4,2010/2011,56,HHS Region 10,Season peak week,7
 2011,4,2010/2011,56,HHS Region 10,Season peak percentage,3.9
@@ -1386,14 +1403,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,5,2010/2011,57,HHS Region 3,Season onset,3
 2011,5,2010/2011,57,HHS Region 3,Season peak week,5
 2011,5,2010/2011,57,HHS Region 3,Season peak percentage,4.4
-2011,5,2010/2011,57,HHS Region 3,1 wk ahead,4
+2011,5,2010/2011,57,HHS Region 3,1 wk ahead,4.1
 2011,5,2010/2011,57,HHS Region 3,2 wk ahead,4
 2011,5,2010/2011,57,HHS Region 3,3 wk ahead,3.6
 2011,5,2010/2011,57,HHS Region 3,4 wk ahead,3
-2011,5,2010/2011,57,HHS Region 4,Season onset,49
+2011,5,2010/2011,57,HHS Region 4,Season onset,50
 2011,5,2010/2011,57,HHS Region 4,Season peak week,5
-2011,5,2010/2011,57,HHS Region 4,Season peak percentage,5.6
-2011,5,2010/2011,57,HHS Region 4,1 wk ahead,5.3
+2011,5,2010/2011,57,HHS Region 4,Season peak percentage,5.5
+2011,5,2010/2011,57,HHS Region 4,1 wk ahead,5.2
 2011,5,2010/2011,57,HHS Region 4,2 wk ahead,4.8
 2011,5,2010/2011,57,HHS Region 4,3 wk ahead,3.9
 2011,5,2010/2011,57,HHS Region 4,4 wk ahead,2.8
@@ -1403,14 +1420,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,5,2010/2011,57,HHS Region 5,1 wk ahead,3.3
 2011,5,2010/2011,57,HHS Region 5,2 wk ahead,3.3
 2011,5,2010/2011,57,HHS Region 5,3 wk ahead,3.1
-2011,5,2010/2011,57,HHS Region 5,4 wk ahead,2.8
+2011,5,2010/2011,57,HHS Region 5,4 wk ahead,2.9
 2011,5,2010/2011,57,HHS Region 6,Season onset,3
 2011,5,2010/2011,57,HHS Region 6,Season peak week,7
 2011,5,2010/2011,57,HHS Region 6,Season peak percentage,7.9
 2011,5,2010/2011,57,HHS Region 6,1 wk ahead,7.8
 2011,5,2010/2011,57,HHS Region 6,2 wk ahead,7.9
-2011,5,2010/2011,57,HHS Region 6,3 wk ahead,6.2
-2011,5,2010/2011,57,HHS Region 6,4 wk ahead,4.8
+2011,5,2010/2011,57,HHS Region 6,3 wk ahead,6.3
+2011,5,2010/2011,57,HHS Region 6,4 wk ahead,4.7
 2011,5,2010/2011,57,HHS Region 7,Season onset,4
 2011,5,2010/2011,57,HHS Region 7,Season peak week,8
 2011,5,2010/2011,57,HHS Region 7,Season peak percentage,4.7
@@ -1423,15 +1440,16 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,5,2010/2011,57,HHS Region 8,Season peak percentage,2.7
 2011,5,2010/2011,57,HHS Region 8,1 wk ahead,2.5
 2011,5,2010/2011,57,HHS Region 8,2 wk ahead,2.7
-2011,5,2010/2011,57,HHS Region 8,3 wk ahead,2.6
-2011,5,2010/2011,57,HHS Region 8,4 wk ahead,2.3
-2011,5,2010/2011,57,HHS Region 9,Season onset,none
+2011,5,2010/2011,57,HHS Region 8,3 wk ahead,2.5
+2011,5,2010/2011,57,HHS Region 8,4 wk ahead,2.2
+2011,5,2010/2011,57,HHS Region 9,Season onset,6
 2011,5,2010/2011,57,HHS Region 9,Season peak week,7
+2011,5,2010/2011,57,HHS Region 9,Season peak week,8
 2011,5,2010/2011,57,HHS Region 9,Season peak percentage,4.7
 2011,5,2010/2011,57,HHS Region 9,1 wk ahead,4.5
 2011,5,2010/2011,57,HHS Region 9,2 wk ahead,4.7
-2011,5,2010/2011,57,HHS Region 9,3 wk ahead,3.9
-2011,5,2010/2011,57,HHS Region 9,4 wk ahead,4.6
+2011,5,2010/2011,57,HHS Region 9,3 wk ahead,4.7
+2011,5,2010/2011,57,HHS Region 9,4 wk ahead,4.5
 2011,5,2010/2011,57,HHS Region 10,Season onset,5
 2011,5,2010/2011,57,HHS Region 10,Season peak week,7
 2011,5,2010/2011,57,HHS Region 10,Season peak percentage,3.9
@@ -1470,26 +1488,26 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,6,2010/2011,58,HHS Region 3,2 wk ahead,3.6
 2011,6,2010/2011,58,HHS Region 3,3 wk ahead,3
 2011,6,2010/2011,58,HHS Region 3,4 wk ahead,2.6
-2011,6,2010/2011,58,HHS Region 4,Season onset,49
+2011,6,2010/2011,58,HHS Region 4,Season onset,50
 2011,6,2010/2011,58,HHS Region 4,Season peak week,5
-2011,6,2010/2011,58,HHS Region 4,Season peak percentage,5.6
+2011,6,2010/2011,58,HHS Region 4,Season peak percentage,5.5
 2011,6,2010/2011,58,HHS Region 4,1 wk ahead,4.8
 2011,6,2010/2011,58,HHS Region 4,2 wk ahead,3.9
 2011,6,2010/2011,58,HHS Region 4,3 wk ahead,2.8
-2011,6,2010/2011,58,HHS Region 4,4 wk ahead,2.6
+2011,6,2010/2011,58,HHS Region 4,4 wk ahead,2.5
 2011,6,2010/2011,58,HHS Region 5,Season onset,3
 2011,6,2010/2011,58,HHS Region 5,Season peak week,5
 2011,6,2010/2011,58,HHS Region 5,Season peak percentage,3.8
 2011,6,2010/2011,58,HHS Region 5,1 wk ahead,3.3
 2011,6,2010/2011,58,HHS Region 5,2 wk ahead,3.1
-2011,6,2010/2011,58,HHS Region 5,3 wk ahead,2.8
-2011,6,2010/2011,58,HHS Region 5,4 wk ahead,2.4
+2011,6,2010/2011,58,HHS Region 5,3 wk ahead,2.9
+2011,6,2010/2011,58,HHS Region 5,4 wk ahead,2.5
 2011,6,2010/2011,58,HHS Region 6,Season onset,3
 2011,6,2010/2011,58,HHS Region 6,Season peak week,7
 2011,6,2010/2011,58,HHS Region 6,Season peak percentage,7.9
 2011,6,2010/2011,58,HHS Region 6,1 wk ahead,7.9
-2011,6,2010/2011,58,HHS Region 6,2 wk ahead,6.2
-2011,6,2010/2011,58,HHS Region 6,3 wk ahead,4.8
+2011,6,2010/2011,58,HHS Region 6,2 wk ahead,6.3
+2011,6,2010/2011,58,HHS Region 6,3 wk ahead,4.7
 2011,6,2010/2011,58,HHS Region 6,4 wk ahead,3.6
 2011,6,2010/2011,58,HHS Region 7,Season onset,4
 2011,6,2010/2011,58,HHS Region 7,Season peak week,8
@@ -1502,16 +1520,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,6,2010/2011,58,HHS Region 8,Season peak week,7
 2011,6,2010/2011,58,HHS Region 8,Season peak percentage,2.7
 2011,6,2010/2011,58,HHS Region 8,1 wk ahead,2.7
-2011,6,2010/2011,58,HHS Region 8,2 wk ahead,2.6
-2011,6,2010/2011,58,HHS Region 8,3 wk ahead,2.3
-2011,6,2010/2011,58,HHS Region 8,4 wk ahead,2.2
-2011,6,2010/2011,58,HHS Region 9,Season onset,none
+2011,6,2010/2011,58,HHS Region 8,2 wk ahead,2.5
+2011,6,2010/2011,58,HHS Region 8,3 wk ahead,2.2
+2011,6,2010/2011,58,HHS Region 8,4 wk ahead,2.1
+2011,6,2010/2011,58,HHS Region 9,Season onset,6
 2011,6,2010/2011,58,HHS Region 9,Season peak week,7
+2011,6,2010/2011,58,HHS Region 9,Season peak week,8
 2011,6,2010/2011,58,HHS Region 9,Season peak percentage,4.7
 2011,6,2010/2011,58,HHS Region 9,1 wk ahead,4.7
-2011,6,2010/2011,58,HHS Region 9,2 wk ahead,3.9
-2011,6,2010/2011,58,HHS Region 9,3 wk ahead,4.6
-2011,6,2010/2011,58,HHS Region 9,4 wk ahead,4.3
+2011,6,2010/2011,58,HHS Region 9,2 wk ahead,4.7
+2011,6,2010/2011,58,HHS Region 9,3 wk ahead,4.5
+2011,6,2010/2011,58,HHS Region 9,4 wk ahead,4.2
 2011,6,2010/2011,58,HHS Region 10,Season onset,5
 2011,6,2010/2011,58,HHS Region 10,Season peak week,7
 2011,6,2010/2011,58,HHS Region 10,Season peak percentage,3.9
@@ -1542,7 +1561,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,7,2010/2011,59,HHS Region 2,1 wk ahead,4.3
 2011,7,2010/2011,59,HHS Region 2,2 wk ahead,3.4
 2011,7,2010/2011,59,HHS Region 2,3 wk ahead,3.2
-2011,7,2010/2011,59,HHS Region 2,4 wk ahead,3.1
+2011,7,2010/2011,59,HHS Region 2,4 wk ahead,3.2
 2011,7,2010/2011,59,HHS Region 3,Season onset,3
 2011,7,2010/2011,59,HHS Region 3,Season peak week,5
 2011,7,2010/2011,59,HHS Region 3,Season peak percentage,4.4
@@ -1550,25 +1569,25 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,7,2010/2011,59,HHS Region 3,2 wk ahead,3
 2011,7,2010/2011,59,HHS Region 3,3 wk ahead,2.6
 2011,7,2010/2011,59,HHS Region 3,4 wk ahead,2
-2011,7,2010/2011,59,HHS Region 4,Season onset,49
+2011,7,2010/2011,59,HHS Region 4,Season onset,50
 2011,7,2010/2011,59,HHS Region 4,Season peak week,5
-2011,7,2010/2011,59,HHS Region 4,Season peak percentage,5.6
+2011,7,2010/2011,59,HHS Region 4,Season peak percentage,5.5
 2011,7,2010/2011,59,HHS Region 4,1 wk ahead,3.9
 2011,7,2010/2011,59,HHS Region 4,2 wk ahead,2.8
-2011,7,2010/2011,59,HHS Region 4,3 wk ahead,2.6
+2011,7,2010/2011,59,HHS Region 4,3 wk ahead,2.5
 2011,7,2010/2011,59,HHS Region 4,4 wk ahead,2
 2011,7,2010/2011,59,HHS Region 5,Season onset,3
 2011,7,2010/2011,59,HHS Region 5,Season peak week,5
 2011,7,2010/2011,59,HHS Region 5,Season peak percentage,3.8
 2011,7,2010/2011,59,HHS Region 5,1 wk ahead,3.1
-2011,7,2010/2011,59,HHS Region 5,2 wk ahead,2.8
-2011,7,2010/2011,59,HHS Region 5,3 wk ahead,2.4
+2011,7,2010/2011,59,HHS Region 5,2 wk ahead,2.9
+2011,7,2010/2011,59,HHS Region 5,3 wk ahead,2.5
 2011,7,2010/2011,59,HHS Region 5,4 wk ahead,2.4
 2011,7,2010/2011,59,HHS Region 6,Season onset,3
 2011,7,2010/2011,59,HHS Region 6,Season peak week,7
 2011,7,2010/2011,59,HHS Region 6,Season peak percentage,7.9
-2011,7,2010/2011,59,HHS Region 6,1 wk ahead,6.2
-2011,7,2010/2011,59,HHS Region 6,2 wk ahead,4.8
+2011,7,2010/2011,59,HHS Region 6,1 wk ahead,6.3
+2011,7,2010/2011,59,HHS Region 6,2 wk ahead,4.7
 2011,7,2010/2011,59,HHS Region 6,3 wk ahead,3.6
 2011,7,2010/2011,59,HHS Region 6,4 wk ahead,3
 2011,7,2010/2011,59,HHS Region 7,Season onset,4
@@ -1581,17 +1600,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,7,2010/2011,59,HHS Region 8,Season onset,5
 2011,7,2010/2011,59,HHS Region 8,Season peak week,7
 2011,7,2010/2011,59,HHS Region 8,Season peak percentage,2.7
-2011,7,2010/2011,59,HHS Region 8,1 wk ahead,2.6
-2011,7,2010/2011,59,HHS Region 8,2 wk ahead,2.3
-2011,7,2010/2011,59,HHS Region 8,3 wk ahead,2.2
+2011,7,2010/2011,59,HHS Region 8,1 wk ahead,2.5
+2011,7,2010/2011,59,HHS Region 8,2 wk ahead,2.2
+2011,7,2010/2011,59,HHS Region 8,3 wk ahead,2.1
 2011,7,2010/2011,59,HHS Region 8,4 wk ahead,1.7
-2011,7,2010/2011,59,HHS Region 9,Season onset,none
+2011,7,2010/2011,59,HHS Region 9,Season onset,6
 2011,7,2010/2011,59,HHS Region 9,Season peak week,7
+2011,7,2010/2011,59,HHS Region 9,Season peak week,8
 2011,7,2010/2011,59,HHS Region 9,Season peak percentage,4.7
-2011,7,2010/2011,59,HHS Region 9,1 wk ahead,3.9
-2011,7,2010/2011,59,HHS Region 9,2 wk ahead,4.6
-2011,7,2010/2011,59,HHS Region 9,3 wk ahead,4.3
-2011,7,2010/2011,59,HHS Region 9,4 wk ahead,4
+2011,7,2010/2011,59,HHS Region 9,1 wk ahead,4.7
+2011,7,2010/2011,59,HHS Region 9,2 wk ahead,4.5
+2011,7,2010/2011,59,HHS Region 9,3 wk ahead,4.2
+2011,7,2010/2011,59,HHS Region 9,4 wk ahead,3.9
 2011,7,2010/2011,59,HHS Region 10,Season onset,5
 2011,7,2010/2011,59,HHS Region 10,Season peak week,7
 2011,7,2010/2011,59,HHS Region 10,Season peak percentage,3.9
@@ -1621,7 +1641,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,8,2010/2011,60,HHS Region 2,Season peak percentage,4.5
 2011,8,2010/2011,60,HHS Region 2,1 wk ahead,3.4
 2011,8,2010/2011,60,HHS Region 2,2 wk ahead,3.2
-2011,8,2010/2011,60,HHS Region 2,3 wk ahead,3.1
+2011,8,2010/2011,60,HHS Region 2,3 wk ahead,3.2
 2011,8,2010/2011,60,HHS Region 2,4 wk ahead,2.5
 2011,8,2010/2011,60,HHS Region 3,Season onset,3
 2011,8,2010/2011,60,HHS Region 3,Season peak week,5
@@ -1630,24 +1650,24 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,8,2010/2011,60,HHS Region 3,2 wk ahead,2.6
 2011,8,2010/2011,60,HHS Region 3,3 wk ahead,2
 2011,8,2010/2011,60,HHS Region 3,4 wk ahead,1.7
-2011,8,2010/2011,60,HHS Region 4,Season onset,49
+2011,8,2010/2011,60,HHS Region 4,Season onset,50
 2011,8,2010/2011,60,HHS Region 4,Season peak week,5
-2011,8,2010/2011,60,HHS Region 4,Season peak percentage,5.6
+2011,8,2010/2011,60,HHS Region 4,Season peak percentage,5.5
 2011,8,2010/2011,60,HHS Region 4,1 wk ahead,2.8
-2011,8,2010/2011,60,HHS Region 4,2 wk ahead,2.6
+2011,8,2010/2011,60,HHS Region 4,2 wk ahead,2.5
 2011,8,2010/2011,60,HHS Region 4,3 wk ahead,2
 2011,8,2010/2011,60,HHS Region 4,4 wk ahead,1.6
 2011,8,2010/2011,60,HHS Region 5,Season onset,3
 2011,8,2010/2011,60,HHS Region 5,Season peak week,5
 2011,8,2010/2011,60,HHS Region 5,Season peak percentage,3.8
-2011,8,2010/2011,60,HHS Region 5,1 wk ahead,2.8
-2011,8,2010/2011,60,HHS Region 5,2 wk ahead,2.4
+2011,8,2010/2011,60,HHS Region 5,1 wk ahead,2.9
+2011,8,2010/2011,60,HHS Region 5,2 wk ahead,2.5
 2011,8,2010/2011,60,HHS Region 5,3 wk ahead,2.4
 2011,8,2010/2011,60,HHS Region 5,4 wk ahead,1.6
 2011,8,2010/2011,60,HHS Region 6,Season onset,3
 2011,8,2010/2011,60,HHS Region 6,Season peak week,7
 2011,8,2010/2011,60,HHS Region 6,Season peak percentage,7.9
-2011,8,2010/2011,60,HHS Region 6,1 wk ahead,4.8
+2011,8,2010/2011,60,HHS Region 6,1 wk ahead,4.7
 2011,8,2010/2011,60,HHS Region 6,2 wk ahead,3.6
 2011,8,2010/2011,60,HHS Region 6,3 wk ahead,3
 2011,8,2010/2011,60,HHS Region 6,4 wk ahead,2.9
@@ -1661,17 +1681,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,8,2010/2011,60,HHS Region 8,Season onset,5
 2011,8,2010/2011,60,HHS Region 8,Season peak week,7
 2011,8,2010/2011,60,HHS Region 8,Season peak percentage,2.7
-2011,8,2010/2011,60,HHS Region 8,1 wk ahead,2.3
-2011,8,2010/2011,60,HHS Region 8,2 wk ahead,2.2
+2011,8,2010/2011,60,HHS Region 8,1 wk ahead,2.2
+2011,8,2010/2011,60,HHS Region 8,2 wk ahead,2.1
 2011,8,2010/2011,60,HHS Region 8,3 wk ahead,1.7
 2011,8,2010/2011,60,HHS Region 8,4 wk ahead,1.4
-2011,8,2010/2011,60,HHS Region 9,Season onset,none
+2011,8,2010/2011,60,HHS Region 9,Season onset,6
 2011,8,2010/2011,60,HHS Region 9,Season peak week,7
+2011,8,2010/2011,60,HHS Region 9,Season peak week,8
 2011,8,2010/2011,60,HHS Region 9,Season peak percentage,4.7
-2011,8,2010/2011,60,HHS Region 9,1 wk ahead,4.6
-2011,8,2010/2011,60,HHS Region 9,2 wk ahead,4.3
-2011,8,2010/2011,60,HHS Region 9,3 wk ahead,4
-2011,8,2010/2011,60,HHS Region 9,4 wk ahead,3.1
+2011,8,2010/2011,60,HHS Region 9,1 wk ahead,4.5
+2011,8,2010/2011,60,HHS Region 9,2 wk ahead,4.2
+2011,8,2010/2011,60,HHS Region 9,3 wk ahead,3.9
+2011,8,2010/2011,60,HHS Region 9,4 wk ahead,3
 2011,8,2010/2011,60,HHS Region 10,Season onset,5
 2011,8,2010/2011,60,HHS Region 10,Season peak week,7
 2011,8,2010/2011,60,HHS Region 10,Season peak percentage,3.9
@@ -1700,7 +1721,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,9,2010/2011,61,HHS Region 2,Season peak week,52
 2011,9,2010/2011,61,HHS Region 2,Season peak percentage,4.5
 2011,9,2010/2011,61,HHS Region 2,1 wk ahead,3.2
-2011,9,2010/2011,61,HHS Region 2,2 wk ahead,3.1
+2011,9,2010/2011,61,HHS Region 2,2 wk ahead,3.2
 2011,9,2010/2011,61,HHS Region 2,3 wk ahead,2.5
 2011,9,2010/2011,61,HHS Region 2,4 wk ahead,2.7
 2011,9,2010/2011,61,HHS Region 3,Season onset,3
@@ -1710,17 +1731,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,9,2010/2011,61,HHS Region 3,2 wk ahead,2
 2011,9,2010/2011,61,HHS Region 3,3 wk ahead,1.7
 2011,9,2010/2011,61,HHS Region 3,4 wk ahead,1.5
-2011,9,2010/2011,61,HHS Region 4,Season onset,49
+2011,9,2010/2011,61,HHS Region 4,Season onset,50
 2011,9,2010/2011,61,HHS Region 4,Season peak week,5
-2011,9,2010/2011,61,HHS Region 4,Season peak percentage,5.6
-2011,9,2010/2011,61,HHS Region 4,1 wk ahead,2.6
+2011,9,2010/2011,61,HHS Region 4,Season peak percentage,5.5
+2011,9,2010/2011,61,HHS Region 4,1 wk ahead,2.5
 2011,9,2010/2011,61,HHS Region 4,2 wk ahead,2
 2011,9,2010/2011,61,HHS Region 4,3 wk ahead,1.6
 2011,9,2010/2011,61,HHS Region 4,4 wk ahead,1.5
 2011,9,2010/2011,61,HHS Region 5,Season onset,3
 2011,9,2010/2011,61,HHS Region 5,Season peak week,5
 2011,9,2010/2011,61,HHS Region 5,Season peak percentage,3.8
-2011,9,2010/2011,61,HHS Region 5,1 wk ahead,2.4
+2011,9,2010/2011,61,HHS Region 5,1 wk ahead,2.5
 2011,9,2010/2011,61,HHS Region 5,2 wk ahead,2.4
 2011,9,2010/2011,61,HHS Region 5,3 wk ahead,1.6
 2011,9,2010/2011,61,HHS Region 5,4 wk ahead,1.5
@@ -1737,28 +1758,29 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,9,2010/2011,61,HHS Region 7,1 wk ahead,3.5
 2011,9,2010/2011,61,HHS Region 7,2 wk ahead,2.3
 2011,9,2010/2011,61,HHS Region 7,3 wk ahead,1.7
-2011,9,2010/2011,61,HHS Region 7,4 wk ahead,1.5
+2011,9,2010/2011,61,HHS Region 7,4 wk ahead,1.4
 2011,9,2010/2011,61,HHS Region 8,Season onset,5
 2011,9,2010/2011,61,HHS Region 8,Season peak week,7
 2011,9,2010/2011,61,HHS Region 8,Season peak percentage,2.7
-2011,9,2010/2011,61,HHS Region 8,1 wk ahead,2.2
+2011,9,2010/2011,61,HHS Region 8,1 wk ahead,2.1
 2011,9,2010/2011,61,HHS Region 8,2 wk ahead,1.7
 2011,9,2010/2011,61,HHS Region 8,3 wk ahead,1.4
 2011,9,2010/2011,61,HHS Region 8,4 wk ahead,1.1
-2011,9,2010/2011,61,HHS Region 9,Season onset,none
+2011,9,2010/2011,61,HHS Region 9,Season onset,6
 2011,9,2010/2011,61,HHS Region 9,Season peak week,7
+2011,9,2010/2011,61,HHS Region 9,Season peak week,8
 2011,9,2010/2011,61,HHS Region 9,Season peak percentage,4.7
-2011,9,2010/2011,61,HHS Region 9,1 wk ahead,4.3
-2011,9,2010/2011,61,HHS Region 9,2 wk ahead,4
-2011,9,2010/2011,61,HHS Region 9,3 wk ahead,3.1
-2011,9,2010/2011,61,HHS Region 9,4 wk ahead,2.9
+2011,9,2010/2011,61,HHS Region 9,1 wk ahead,4.2
+2011,9,2010/2011,61,HHS Region 9,2 wk ahead,3.9
+2011,9,2010/2011,61,HHS Region 9,3 wk ahead,3
+2011,9,2010/2011,61,HHS Region 9,4 wk ahead,2.8
 2011,9,2010/2011,61,HHS Region 10,Season onset,5
 2011,9,2010/2011,61,HHS Region 10,Season peak week,7
 2011,9,2010/2011,61,HHS Region 10,Season peak percentage,3.9
 2011,9,2010/2011,61,HHS Region 10,1 wk ahead,3.2
 2011,9,2010/2011,61,HHS Region 10,2 wk ahead,3.1
 2011,9,2010/2011,61,HHS Region 10,3 wk ahead,2.8
-2011,9,2010/2011,61,HHS Region 10,4 wk ahead,1.5
+2011,9,2010/2011,61,HHS Region 10,4 wk ahead,1.7
 2011,10,2010/2011,62,US National,Season onset,51
 2011,10,2010/2011,62,US National,Season peak week,5
 2011,10,2010/2011,62,US National,Season peak week,6
@@ -1779,7 +1801,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,10,2010/2011,62,HHS Region 2,Season onset,49
 2011,10,2010/2011,62,HHS Region 2,Season peak week,52
 2011,10,2010/2011,62,HHS Region 2,Season peak percentage,4.5
-2011,10,2010/2011,62,HHS Region 2,1 wk ahead,3.1
+2011,10,2010/2011,62,HHS Region 2,1 wk ahead,3.2
 2011,10,2010/2011,62,HHS Region 2,2 wk ahead,2.5
 2011,10,2010/2011,62,HHS Region 2,3 wk ahead,2.7
 2011,10,2010/2011,62,HHS Region 2,4 wk ahead,2.5
@@ -1790,9 +1812,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,10,2010/2011,62,HHS Region 3,2 wk ahead,1.7
 2011,10,2010/2011,62,HHS Region 3,3 wk ahead,1.5
 2011,10,2010/2011,62,HHS Region 3,4 wk ahead,1.5
-2011,10,2010/2011,62,HHS Region 4,Season onset,49
+2011,10,2010/2011,62,HHS Region 4,Season onset,50
 2011,10,2010/2011,62,HHS Region 4,Season peak week,5
-2011,10,2010/2011,62,HHS Region 4,Season peak percentage,5.6
+2011,10,2010/2011,62,HHS Region 4,Season peak percentage,5.5
 2011,10,2010/2011,62,HHS Region 4,1 wk ahead,2
 2011,10,2010/2011,62,HHS Region 4,2 wk ahead,1.6
 2011,10,2010/2011,62,HHS Region 4,3 wk ahead,1.5
@@ -1803,20 +1825,20 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,10,2010/2011,62,HHS Region 5,1 wk ahead,2.4
 2011,10,2010/2011,62,HHS Region 5,2 wk ahead,1.6
 2011,10,2010/2011,62,HHS Region 5,3 wk ahead,1.5
-2011,10,2010/2011,62,HHS Region 5,4 wk ahead,1.2
+2011,10,2010/2011,62,HHS Region 5,4 wk ahead,1.3
 2011,10,2010/2011,62,HHS Region 6,Season onset,3
 2011,10,2010/2011,62,HHS Region 6,Season peak week,7
 2011,10,2010/2011,62,HHS Region 6,Season peak percentage,7.9
 2011,10,2010/2011,62,HHS Region 6,1 wk ahead,3
 2011,10,2010/2011,62,HHS Region 6,2 wk ahead,2.9
 2011,10,2010/2011,62,HHS Region 6,3 wk ahead,2
-2011,10,2010/2011,62,HHS Region 6,4 wk ahead,1.9
+2011,10,2010/2011,62,HHS Region 6,4 wk ahead,1.8
 2011,10,2010/2011,62,HHS Region 7,Season onset,4
 2011,10,2010/2011,62,HHS Region 7,Season peak week,8
 2011,10,2010/2011,62,HHS Region 7,Season peak percentage,4.7
 2011,10,2010/2011,62,HHS Region 7,1 wk ahead,2.3
 2011,10,2010/2011,62,HHS Region 7,2 wk ahead,1.7
-2011,10,2010/2011,62,HHS Region 7,3 wk ahead,1.5
+2011,10,2010/2011,62,HHS Region 7,3 wk ahead,1.4
 2011,10,2010/2011,62,HHS Region 7,4 wk ahead,1.2
 2011,10,2010/2011,62,HHS Region 8,Season onset,5
 2011,10,2010/2011,62,HHS Region 8,Season peak week,7
@@ -1825,19 +1847,20 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,10,2010/2011,62,HHS Region 8,2 wk ahead,1.4
 2011,10,2010/2011,62,HHS Region 8,3 wk ahead,1.1
 2011,10,2010/2011,62,HHS Region 8,4 wk ahead,0.8
-2011,10,2010/2011,62,HHS Region 9,Season onset,none
+2011,10,2010/2011,62,HHS Region 9,Season onset,6
 2011,10,2010/2011,62,HHS Region 9,Season peak week,7
+2011,10,2010/2011,62,HHS Region 9,Season peak week,8
 2011,10,2010/2011,62,HHS Region 9,Season peak percentage,4.7
-2011,10,2010/2011,62,HHS Region 9,1 wk ahead,4
-2011,10,2010/2011,62,HHS Region 9,2 wk ahead,3.1
-2011,10,2010/2011,62,HHS Region 9,3 wk ahead,2.9
-2011,10,2010/2011,62,HHS Region 9,4 wk ahead,2.5
+2011,10,2010/2011,62,HHS Region 9,1 wk ahead,3.9
+2011,10,2010/2011,62,HHS Region 9,2 wk ahead,3
+2011,10,2010/2011,62,HHS Region 9,3 wk ahead,2.8
+2011,10,2010/2011,62,HHS Region 9,4 wk ahead,2.4
 2011,10,2010/2011,62,HHS Region 10,Season onset,5
 2011,10,2010/2011,62,HHS Region 10,Season peak week,7
 2011,10,2010/2011,62,HHS Region 10,Season peak percentage,3.9
 2011,10,2010/2011,62,HHS Region 10,1 wk ahead,3.1
 2011,10,2010/2011,62,HHS Region 10,2 wk ahead,2.8
-2011,10,2010/2011,62,HHS Region 10,3 wk ahead,1.5
+2011,10,2010/2011,62,HHS Region 10,3 wk ahead,1.7
 2011,10,2010/2011,62,HHS Region 10,4 wk ahead,1.2
 2011,11,2010/2011,63,US National,Season onset,51
 2011,11,2010/2011,63,US National,Season peak week,5
@@ -1862,7 +1885,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,11,2010/2011,63,HHS Region 2,1 wk ahead,2.5
 2011,11,2010/2011,63,HHS Region 2,2 wk ahead,2.7
 2011,11,2010/2011,63,HHS Region 2,3 wk ahead,2.5
-2011,11,2010/2011,63,HHS Region 2,4 wk ahead,2.3
+2011,11,2010/2011,63,HHS Region 2,4 wk ahead,2.2
 2011,11,2010/2011,63,HHS Region 3,Season onset,3
 2011,11,2010/2011,63,HHS Region 3,Season peak week,5
 2011,11,2010/2011,63,HHS Region 3,Season peak percentage,4.4
@@ -1870,9 +1893,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,11,2010/2011,63,HHS Region 3,2 wk ahead,1.5
 2011,11,2010/2011,63,HHS Region 3,3 wk ahead,1.5
 2011,11,2010/2011,63,HHS Region 3,4 wk ahead,1.4
-2011,11,2010/2011,63,HHS Region 4,Season onset,49
+2011,11,2010/2011,63,HHS Region 4,Season onset,50
 2011,11,2010/2011,63,HHS Region 4,Season peak week,5
-2011,11,2010/2011,63,HHS Region 4,Season peak percentage,5.6
+2011,11,2010/2011,63,HHS Region 4,Season peak percentage,5.5
 2011,11,2010/2011,63,HHS Region 4,1 wk ahead,1.6
 2011,11,2010/2011,63,HHS Region 4,2 wk ahead,1.5
 2011,11,2010/2011,63,HHS Region 4,3 wk ahead,1.3
@@ -1882,20 +1905,20 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,11,2010/2011,63,HHS Region 5,Season peak percentage,3.8
 2011,11,2010/2011,63,HHS Region 5,1 wk ahead,1.6
 2011,11,2010/2011,63,HHS Region 5,2 wk ahead,1.5
-2011,11,2010/2011,63,HHS Region 5,3 wk ahead,1.2
+2011,11,2010/2011,63,HHS Region 5,3 wk ahead,1.3
 2011,11,2010/2011,63,HHS Region 5,4 wk ahead,0.9
 2011,11,2010/2011,63,HHS Region 6,Season onset,3
 2011,11,2010/2011,63,HHS Region 6,Season peak week,7
 2011,11,2010/2011,63,HHS Region 6,Season peak percentage,7.9
 2011,11,2010/2011,63,HHS Region 6,1 wk ahead,2.9
 2011,11,2010/2011,63,HHS Region 6,2 wk ahead,2
-2011,11,2010/2011,63,HHS Region 6,3 wk ahead,1.9
+2011,11,2010/2011,63,HHS Region 6,3 wk ahead,1.8
 2011,11,2010/2011,63,HHS Region 6,4 wk ahead,1.5
 2011,11,2010/2011,63,HHS Region 7,Season onset,4
 2011,11,2010/2011,63,HHS Region 7,Season peak week,8
 2011,11,2010/2011,63,HHS Region 7,Season peak percentage,4.7
 2011,11,2010/2011,63,HHS Region 7,1 wk ahead,1.7
-2011,11,2010/2011,63,HHS Region 7,2 wk ahead,1.5
+2011,11,2010/2011,63,HHS Region 7,2 wk ahead,1.4
 2011,11,2010/2011,63,HHS Region 7,3 wk ahead,1.2
 2011,11,2010/2011,63,HHS Region 7,4 wk ahead,1
 2011,11,2010/2011,63,HHS Region 8,Season onset,5
@@ -1905,18 +1928,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,11,2010/2011,63,HHS Region 8,2 wk ahead,1.1
 2011,11,2010/2011,63,HHS Region 8,3 wk ahead,0.8
 2011,11,2010/2011,63,HHS Region 8,4 wk ahead,0.8
-2011,11,2010/2011,63,HHS Region 9,Season onset,none
+2011,11,2010/2011,63,HHS Region 9,Season onset,6
 2011,11,2010/2011,63,HHS Region 9,Season peak week,7
+2011,11,2010/2011,63,HHS Region 9,Season peak week,8
 2011,11,2010/2011,63,HHS Region 9,Season peak percentage,4.7
-2011,11,2010/2011,63,HHS Region 9,1 wk ahead,3.1
-2011,11,2010/2011,63,HHS Region 9,2 wk ahead,2.9
-2011,11,2010/2011,63,HHS Region 9,3 wk ahead,2.5
-2011,11,2010/2011,63,HHS Region 9,4 wk ahead,2.2
+2011,11,2010/2011,63,HHS Region 9,1 wk ahead,3
+2011,11,2010/2011,63,HHS Region 9,2 wk ahead,2.8
+2011,11,2010/2011,63,HHS Region 9,3 wk ahead,2.4
+2011,11,2010/2011,63,HHS Region 9,4 wk ahead,2.3
 2011,11,2010/2011,63,HHS Region 10,Season onset,5
 2011,11,2010/2011,63,HHS Region 10,Season peak week,7
 2011,11,2010/2011,63,HHS Region 10,Season peak percentage,3.9
 2011,11,2010/2011,63,HHS Region 10,1 wk ahead,2.8
-2011,11,2010/2011,63,HHS Region 10,2 wk ahead,1.5
+2011,11,2010/2011,63,HHS Region 10,2 wk ahead,1.7
 2011,11,2010/2011,63,HHS Region 10,3 wk ahead,1.2
 2011,11,2010/2011,63,HHS Region 10,4 wk ahead,1.2
 2011,12,2010/2011,64,US National,Season onset,51
@@ -1941,8 +1965,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,12,2010/2011,64,HHS Region 2,Season peak percentage,4.5
 2011,12,2010/2011,64,HHS Region 2,1 wk ahead,2.7
 2011,12,2010/2011,64,HHS Region 2,2 wk ahead,2.5
-2011,12,2010/2011,64,HHS Region 2,3 wk ahead,2.3
-2011,12,2010/2011,64,HHS Region 2,4 wk ahead,2.4
+2011,12,2010/2011,64,HHS Region 2,3 wk ahead,2.2
+2011,12,2010/2011,64,HHS Region 2,4 wk ahead,2.2
 2011,12,2010/2011,64,HHS Region 3,Season onset,3
 2011,12,2010/2011,64,HHS Region 3,Season peak week,5
 2011,12,2010/2011,64,HHS Region 3,Season peak percentage,4.4
@@ -1950,9 +1974,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,12,2010/2011,64,HHS Region 3,2 wk ahead,1.5
 2011,12,2010/2011,64,HHS Region 3,3 wk ahead,1.4
 2011,12,2010/2011,64,HHS Region 3,4 wk ahead,1.2
-2011,12,2010/2011,64,HHS Region 4,Season onset,49
+2011,12,2010/2011,64,HHS Region 4,Season onset,50
 2011,12,2010/2011,64,HHS Region 4,Season peak week,5
-2011,12,2010/2011,64,HHS Region 4,Season peak percentage,5.6
+2011,12,2010/2011,64,HHS Region 4,Season peak percentage,5.5
 2011,12,2010/2011,64,HHS Region 4,1 wk ahead,1.5
 2011,12,2010/2011,64,HHS Region 4,2 wk ahead,1.3
 2011,12,2010/2011,64,HHS Region 4,3 wk ahead,1.2
@@ -1961,20 +1985,20 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,12,2010/2011,64,HHS Region 5,Season peak week,5
 2011,12,2010/2011,64,HHS Region 5,Season peak percentage,3.8
 2011,12,2010/2011,64,HHS Region 5,1 wk ahead,1.5
-2011,12,2010/2011,64,HHS Region 5,2 wk ahead,1.2
+2011,12,2010/2011,64,HHS Region 5,2 wk ahead,1.3
 2011,12,2010/2011,64,HHS Region 5,3 wk ahead,0.9
 2011,12,2010/2011,64,HHS Region 5,4 wk ahead,0.9
 2011,12,2010/2011,64,HHS Region 6,Season onset,3
 2011,12,2010/2011,64,HHS Region 6,Season peak week,7
 2011,12,2010/2011,64,HHS Region 6,Season peak percentage,7.9
 2011,12,2010/2011,64,HHS Region 6,1 wk ahead,2
-2011,12,2010/2011,64,HHS Region 6,2 wk ahead,1.9
+2011,12,2010/2011,64,HHS Region 6,2 wk ahead,1.8
 2011,12,2010/2011,64,HHS Region 6,3 wk ahead,1.5
 2011,12,2010/2011,64,HHS Region 6,4 wk ahead,1.5
 2011,12,2010/2011,64,HHS Region 7,Season onset,4
 2011,12,2010/2011,64,HHS Region 7,Season peak week,8
 2011,12,2010/2011,64,HHS Region 7,Season peak percentage,4.7
-2011,12,2010/2011,64,HHS Region 7,1 wk ahead,1.5
+2011,12,2010/2011,64,HHS Region 7,1 wk ahead,1.4
 2011,12,2010/2011,64,HHS Region 7,2 wk ahead,1.2
 2011,12,2010/2011,64,HHS Region 7,3 wk ahead,1
 2011,12,2010/2011,64,HHS Region 7,4 wk ahead,0.8
@@ -1985,20 +2009,21 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,12,2010/2011,64,HHS Region 8,2 wk ahead,0.8
 2011,12,2010/2011,64,HHS Region 8,3 wk ahead,0.8
 2011,12,2010/2011,64,HHS Region 8,4 wk ahead,0.6
-2011,12,2010/2011,64,HHS Region 9,Season onset,none
+2011,12,2010/2011,64,HHS Region 9,Season onset,6
 2011,12,2010/2011,64,HHS Region 9,Season peak week,7
+2011,12,2010/2011,64,HHS Region 9,Season peak week,8
 2011,12,2010/2011,64,HHS Region 9,Season peak percentage,4.7
-2011,12,2010/2011,64,HHS Region 9,1 wk ahead,2.9
-2011,12,2010/2011,64,HHS Region 9,2 wk ahead,2.5
-2011,12,2010/2011,64,HHS Region 9,3 wk ahead,2.2
-2011,12,2010/2011,64,HHS Region 9,4 wk ahead,2.2
+2011,12,2010/2011,64,HHS Region 9,1 wk ahead,2.8
+2011,12,2010/2011,64,HHS Region 9,2 wk ahead,2.4
+2011,12,2010/2011,64,HHS Region 9,3 wk ahead,2.3
+2011,12,2010/2011,64,HHS Region 9,4 wk ahead,2.1
 2011,12,2010/2011,64,HHS Region 10,Season onset,5
 2011,12,2010/2011,64,HHS Region 10,Season peak week,7
 2011,12,2010/2011,64,HHS Region 10,Season peak percentage,3.9
-2011,12,2010/2011,64,HHS Region 10,1 wk ahead,1.5
+2011,12,2010/2011,64,HHS Region 10,1 wk ahead,1.7
 2011,12,2010/2011,64,HHS Region 10,2 wk ahead,1.2
 2011,12,2010/2011,64,HHS Region 10,3 wk ahead,1.2
-2011,12,2010/2011,64,HHS Region 10,4 wk ahead,1.2
+2011,12,2010/2011,64,HHS Region 10,4 wk ahead,1.3
 2011,13,2010/2011,65,US National,Season onset,51
 2011,13,2010/2011,65,US National,Season peak week,5
 2011,13,2010/2011,65,US National,Season peak week,6
@@ -2020,9 +2045,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,13,2010/2011,65,HHS Region 2,Season peak week,52
 2011,13,2010/2011,65,HHS Region 2,Season peak percentage,4.5
 2011,13,2010/2011,65,HHS Region 2,1 wk ahead,2.5
-2011,13,2010/2011,65,HHS Region 2,2 wk ahead,2.3
-2011,13,2010/2011,65,HHS Region 2,3 wk ahead,2.4
-2011,13,2010/2011,65,HHS Region 2,4 wk ahead,1.8
+2011,13,2010/2011,65,HHS Region 2,2 wk ahead,2.2
+2011,13,2010/2011,65,HHS Region 2,3 wk ahead,2.2
+2011,13,2010/2011,65,HHS Region 2,4 wk ahead,1.7
 2011,13,2010/2011,65,HHS Region 3,Season onset,3
 2011,13,2010/2011,65,HHS Region 3,Season peak week,5
 2011,13,2010/2011,65,HHS Region 3,Season peak percentage,4.4
@@ -2030,9 +2055,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,13,2010/2011,65,HHS Region 3,2 wk ahead,1.4
 2011,13,2010/2011,65,HHS Region 3,3 wk ahead,1.2
 2011,13,2010/2011,65,HHS Region 3,4 wk ahead,0.9
-2011,13,2010/2011,65,HHS Region 4,Season onset,49
+2011,13,2010/2011,65,HHS Region 4,Season onset,50
 2011,13,2010/2011,65,HHS Region 4,Season peak week,5
-2011,13,2010/2011,65,HHS Region 4,Season peak percentage,5.6
+2011,13,2010/2011,65,HHS Region 4,Season peak percentage,5.5
 2011,13,2010/2011,65,HHS Region 4,1 wk ahead,1.3
 2011,13,2010/2011,65,HHS Region 4,2 wk ahead,1.2
 2011,13,2010/2011,65,HHS Region 4,3 wk ahead,1.1
@@ -2040,14 +2065,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,13,2010/2011,65,HHS Region 5,Season onset,3
 2011,13,2010/2011,65,HHS Region 5,Season peak week,5
 2011,13,2010/2011,65,HHS Region 5,Season peak percentage,3.8
-2011,13,2010/2011,65,HHS Region 5,1 wk ahead,1.2
+2011,13,2010/2011,65,HHS Region 5,1 wk ahead,1.3
 2011,13,2010/2011,65,HHS Region 5,2 wk ahead,0.9
 2011,13,2010/2011,65,HHS Region 5,3 wk ahead,0.9
 2011,13,2010/2011,65,HHS Region 5,4 wk ahead,0.8
 2011,13,2010/2011,65,HHS Region 6,Season onset,3
 2011,13,2010/2011,65,HHS Region 6,Season peak week,7
 2011,13,2010/2011,65,HHS Region 6,Season peak percentage,7.9
-2011,13,2010/2011,65,HHS Region 6,1 wk ahead,1.9
+2011,13,2010/2011,65,HHS Region 6,1 wk ahead,1.8
 2011,13,2010/2011,65,HHS Region 6,2 wk ahead,1.5
 2011,13,2010/2011,65,HHS Region 6,3 wk ahead,1.5
 2011,13,2010/2011,65,HHS Region 6,4 wk ahead,1.3
@@ -2057,7 +2082,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,13,2010/2011,65,HHS Region 7,1 wk ahead,1.2
 2011,13,2010/2011,65,HHS Region 7,2 wk ahead,1
 2011,13,2010/2011,65,HHS Region 7,3 wk ahead,0.8
-2011,13,2010/2011,65,HHS Region 7,4 wk ahead,0.7
+2011,13,2010/2011,65,HHS Region 7,4 wk ahead,0.6
 2011,13,2010/2011,65,HHS Region 8,Season onset,5
 2011,13,2010/2011,65,HHS Region 8,Season peak week,7
 2011,13,2010/2011,65,HHS Region 8,Season peak percentage,2.7
@@ -2065,20 +2090,21 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,13,2010/2011,65,HHS Region 8,2 wk ahead,0.8
 2011,13,2010/2011,65,HHS Region 8,3 wk ahead,0.6
 2011,13,2010/2011,65,HHS Region 8,4 wk ahead,0.6
-2011,13,2010/2011,65,HHS Region 9,Season onset,none
+2011,13,2010/2011,65,HHS Region 9,Season onset,6
 2011,13,2010/2011,65,HHS Region 9,Season peak week,7
+2011,13,2010/2011,65,HHS Region 9,Season peak week,8
 2011,13,2010/2011,65,HHS Region 9,Season peak percentage,4.7
-2011,13,2010/2011,65,HHS Region 9,1 wk ahead,2.5
-2011,13,2010/2011,65,HHS Region 9,2 wk ahead,2.2
-2011,13,2010/2011,65,HHS Region 9,3 wk ahead,2.2
-2011,13,2010/2011,65,HHS Region 9,4 wk ahead,2.2
+2011,13,2010/2011,65,HHS Region 9,1 wk ahead,2.4
+2011,13,2010/2011,65,HHS Region 9,2 wk ahead,2.3
+2011,13,2010/2011,65,HHS Region 9,3 wk ahead,2.1
+2011,13,2010/2011,65,HHS Region 9,4 wk ahead,2.1
 2011,13,2010/2011,65,HHS Region 10,Season onset,5
 2011,13,2010/2011,65,HHS Region 10,Season peak week,7
 2011,13,2010/2011,65,HHS Region 10,Season peak percentage,3.9
 2011,13,2010/2011,65,HHS Region 10,1 wk ahead,1.2
 2011,13,2010/2011,65,HHS Region 10,2 wk ahead,1.2
-2011,13,2010/2011,65,HHS Region 10,3 wk ahead,1.2
-2011,13,2010/2011,65,HHS Region 10,4 wk ahead,0.8
+2011,13,2010/2011,65,HHS Region 10,3 wk ahead,1.3
+2011,13,2010/2011,65,HHS Region 10,4 wk ahead,0.9
 2011,14,2010/2011,66,US National,Season onset,51
 2011,14,2010/2011,66,US National,Season peak week,5
 2011,14,2010/2011,66,US National,Season peak week,6
@@ -2099,20 +2125,20 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,14,2010/2011,66,HHS Region 2,Season onset,49
 2011,14,2010/2011,66,HHS Region 2,Season peak week,52
 2011,14,2010/2011,66,HHS Region 2,Season peak percentage,4.5
-2011,14,2010/2011,66,HHS Region 2,1 wk ahead,2.3
-2011,14,2010/2011,66,HHS Region 2,2 wk ahead,2.4
-2011,14,2010/2011,66,HHS Region 2,3 wk ahead,1.8
-2011,14,2010/2011,66,HHS Region 2,4 wk ahead,1.8
+2011,14,2010/2011,66,HHS Region 2,1 wk ahead,2.2
+2011,14,2010/2011,66,HHS Region 2,2 wk ahead,2.2
+2011,14,2010/2011,66,HHS Region 2,3 wk ahead,1.7
+2011,14,2010/2011,66,HHS Region 2,4 wk ahead,1.6
 2011,14,2010/2011,66,HHS Region 3,Season onset,3
 2011,14,2010/2011,66,HHS Region 3,Season peak week,5
 2011,14,2010/2011,66,HHS Region 3,Season peak percentage,4.4
 2011,14,2010/2011,66,HHS Region 3,1 wk ahead,1.4
 2011,14,2010/2011,66,HHS Region 3,2 wk ahead,1.2
 2011,14,2010/2011,66,HHS Region 3,3 wk ahead,0.9
-2011,14,2010/2011,66,HHS Region 3,4 wk ahead,1.1
-2011,14,2010/2011,66,HHS Region 4,Season onset,49
+2011,14,2010/2011,66,HHS Region 3,4 wk ahead,1
+2011,14,2010/2011,66,HHS Region 4,Season onset,50
 2011,14,2010/2011,66,HHS Region 4,Season peak week,5
-2011,14,2010/2011,66,HHS Region 4,Season peak percentage,5.6
+2011,14,2010/2011,66,HHS Region 4,Season peak percentage,5.5
 2011,14,2010/2011,66,HHS Region 4,1 wk ahead,1.2
 2011,14,2010/2011,66,HHS Region 4,2 wk ahead,1.1
 2011,14,2010/2011,66,HHS Region 4,3 wk ahead,1.1
@@ -2130,13 +2156,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,14,2010/2011,66,HHS Region 6,1 wk ahead,1.5
 2011,14,2010/2011,66,HHS Region 6,2 wk ahead,1.5
 2011,14,2010/2011,66,HHS Region 6,3 wk ahead,1.3
-2011,14,2010/2011,66,HHS Region 6,4 wk ahead,1.3
+2011,14,2010/2011,66,HHS Region 6,4 wk ahead,1.4
 2011,14,2010/2011,66,HHS Region 7,Season onset,4
 2011,14,2010/2011,66,HHS Region 7,Season peak week,8
 2011,14,2010/2011,66,HHS Region 7,Season peak percentage,4.7
 2011,14,2010/2011,66,HHS Region 7,1 wk ahead,1
 2011,14,2010/2011,66,HHS Region 7,2 wk ahead,0.8
-2011,14,2010/2011,66,HHS Region 7,3 wk ahead,0.7
+2011,14,2010/2011,66,HHS Region 7,3 wk ahead,0.6
 2011,14,2010/2011,66,HHS Region 7,4 wk ahead,0.5
 2011,14,2010/2011,66,HHS Region 8,Season onset,5
 2011,14,2010/2011,66,HHS Region 8,Season peak week,7
@@ -2145,19 +2171,20 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,14,2010/2011,66,HHS Region 8,2 wk ahead,0.6
 2011,14,2010/2011,66,HHS Region 8,3 wk ahead,0.6
 2011,14,2010/2011,66,HHS Region 8,4 wk ahead,0.5
-2011,14,2010/2011,66,HHS Region 9,Season onset,none
+2011,14,2010/2011,66,HHS Region 9,Season onset,6
 2011,14,2010/2011,66,HHS Region 9,Season peak week,7
+2011,14,2010/2011,66,HHS Region 9,Season peak week,8
 2011,14,2010/2011,66,HHS Region 9,Season peak percentage,4.7
-2011,14,2010/2011,66,HHS Region 9,1 wk ahead,2.2
-2011,14,2010/2011,66,HHS Region 9,2 wk ahead,2.2
-2011,14,2010/2011,66,HHS Region 9,3 wk ahead,2.2
-2011,14,2010/2011,66,HHS Region 9,4 wk ahead,2
+2011,14,2010/2011,66,HHS Region 9,1 wk ahead,2.3
+2011,14,2010/2011,66,HHS Region 9,2 wk ahead,2.1
+2011,14,2010/2011,66,HHS Region 9,3 wk ahead,2.1
+2011,14,2010/2011,66,HHS Region 9,4 wk ahead,1.9
 2011,14,2010/2011,66,HHS Region 10,Season onset,5
 2011,14,2010/2011,66,HHS Region 10,Season peak week,7
 2011,14,2010/2011,66,HHS Region 10,Season peak percentage,3.9
 2011,14,2010/2011,66,HHS Region 10,1 wk ahead,1.2
-2011,14,2010/2011,66,HHS Region 10,2 wk ahead,1.2
-2011,14,2010/2011,66,HHS Region 10,3 wk ahead,0.8
+2011,14,2010/2011,66,HHS Region 10,2 wk ahead,1.3
+2011,14,2010/2011,66,HHS Region 10,3 wk ahead,0.9
 2011,14,2010/2011,66,HHS Region 10,4 wk ahead,0.9
 2011,15,2010/2011,67,US National,Season onset,51
 2011,15,2010/2011,67,US National,Season peak week,5
@@ -2179,24 +2206,24 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,15,2010/2011,67,HHS Region 2,Season onset,49
 2011,15,2010/2011,67,HHS Region 2,Season peak week,52
 2011,15,2010/2011,67,HHS Region 2,Season peak percentage,4.5
-2011,15,2010/2011,67,HHS Region 2,1 wk ahead,2.4
-2011,15,2010/2011,67,HHS Region 2,2 wk ahead,1.8
-2011,15,2010/2011,67,HHS Region 2,3 wk ahead,1.8
+2011,15,2010/2011,67,HHS Region 2,1 wk ahead,2.2
+2011,15,2010/2011,67,HHS Region 2,2 wk ahead,1.7
+2011,15,2010/2011,67,HHS Region 2,3 wk ahead,1.6
 2011,15,2010/2011,67,HHS Region 2,4 wk ahead,1.7
 2011,15,2010/2011,67,HHS Region 3,Season onset,3
 2011,15,2010/2011,67,HHS Region 3,Season peak week,5
 2011,15,2010/2011,67,HHS Region 3,Season peak percentage,4.4
 2011,15,2010/2011,67,HHS Region 3,1 wk ahead,1.2
 2011,15,2010/2011,67,HHS Region 3,2 wk ahead,0.9
-2011,15,2010/2011,67,HHS Region 3,3 wk ahead,1.1
-2011,15,2010/2011,67,HHS Region 3,4 wk ahead,1.1
-2011,15,2010/2011,67,HHS Region 4,Season onset,49
+2011,15,2010/2011,67,HHS Region 3,3 wk ahead,1
+2011,15,2010/2011,67,HHS Region 3,4 wk ahead,0.9
+2011,15,2010/2011,67,HHS Region 4,Season onset,50
 2011,15,2010/2011,67,HHS Region 4,Season peak week,5
-2011,15,2010/2011,67,HHS Region 4,Season peak percentage,5.6
+2011,15,2010/2011,67,HHS Region 4,Season peak percentage,5.5
 2011,15,2010/2011,67,HHS Region 4,1 wk ahead,1.1
 2011,15,2010/2011,67,HHS Region 4,2 wk ahead,1.1
 2011,15,2010/2011,67,HHS Region 4,3 wk ahead,1
-2011,15,2010/2011,67,HHS Region 4,4 wk ahead,1
+2011,15,2010/2011,67,HHS Region 4,4 wk ahead,0.9
 2011,15,2010/2011,67,HHS Region 5,Season onset,3
 2011,15,2010/2011,67,HHS Region 5,Season peak week,5
 2011,15,2010/2011,67,HHS Region 5,Season peak percentage,3.8
@@ -2209,13 +2236,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,15,2010/2011,67,HHS Region 6,Season peak percentage,7.9
 2011,15,2010/2011,67,HHS Region 6,1 wk ahead,1.5
 2011,15,2010/2011,67,HHS Region 6,2 wk ahead,1.3
-2011,15,2010/2011,67,HHS Region 6,3 wk ahead,1.3
+2011,15,2010/2011,67,HHS Region 6,3 wk ahead,1.4
 2011,15,2010/2011,67,HHS Region 6,4 wk ahead,1.4
 2011,15,2010/2011,67,HHS Region 7,Season onset,4
 2011,15,2010/2011,67,HHS Region 7,Season peak week,8
 2011,15,2010/2011,67,HHS Region 7,Season peak percentage,4.7
 2011,15,2010/2011,67,HHS Region 7,1 wk ahead,0.8
-2011,15,2010/2011,67,HHS Region 7,2 wk ahead,0.7
+2011,15,2010/2011,67,HHS Region 7,2 wk ahead,0.6
 2011,15,2010/2011,67,HHS Region 7,3 wk ahead,0.5
 2011,15,2010/2011,67,HHS Region 7,4 wk ahead,0.6
 2011,15,2010/2011,67,HHS Region 8,Season onset,5
@@ -2224,21 +2251,22 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,15,2010/2011,67,HHS Region 8,1 wk ahead,0.6
 2011,15,2010/2011,67,HHS Region 8,2 wk ahead,0.6
 2011,15,2010/2011,67,HHS Region 8,3 wk ahead,0.5
-2011,15,2010/2011,67,HHS Region 8,4 wk ahead,0.4
-2011,15,2010/2011,67,HHS Region 9,Season onset,none
+2011,15,2010/2011,67,HHS Region 8,4 wk ahead,0.5
+2011,15,2010/2011,67,HHS Region 9,Season onset,6
 2011,15,2010/2011,67,HHS Region 9,Season peak week,7
+2011,15,2010/2011,67,HHS Region 9,Season peak week,8
 2011,15,2010/2011,67,HHS Region 9,Season peak percentage,4.7
-2011,15,2010/2011,67,HHS Region 9,1 wk ahead,2.2
-2011,15,2010/2011,67,HHS Region 9,2 wk ahead,2.2
-2011,15,2010/2011,67,HHS Region 9,3 wk ahead,2
-2011,15,2010/2011,67,HHS Region 9,4 wk ahead,1
+2011,15,2010/2011,67,HHS Region 9,1 wk ahead,2.1
+2011,15,2010/2011,67,HHS Region 9,2 wk ahead,2.1
+2011,15,2010/2011,67,HHS Region 9,3 wk ahead,1.9
+2011,15,2010/2011,67,HHS Region 9,4 wk ahead,1.9
 2011,15,2010/2011,67,HHS Region 10,Season onset,5
 2011,15,2010/2011,67,HHS Region 10,Season peak week,7
 2011,15,2010/2011,67,HHS Region 10,Season peak percentage,3.9
-2011,15,2010/2011,67,HHS Region 10,1 wk ahead,1.2
-2011,15,2010/2011,67,HHS Region 10,2 wk ahead,0.8
+2011,15,2010/2011,67,HHS Region 10,1 wk ahead,1.3
+2011,15,2010/2011,67,HHS Region 10,2 wk ahead,0.9
 2011,15,2010/2011,67,HHS Region 10,3 wk ahead,0.9
-2011,15,2010/2011,67,HHS Region 10,4 wk ahead,0.9
+2011,15,2010/2011,67,HHS Region 10,4 wk ahead,0.8
 2011,16,2010/2011,68,US National,Season onset,51
 2011,16,2010/2011,68,US National,Season peak week,5
 2011,16,2010/2011,68,US National,Season peak week,6
@@ -2255,28 +2283,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,16,2010/2011,68,HHS Region 1,1 wk ahead,0.7
 2011,16,2010/2011,68,HHS Region 1,2 wk ahead,0.6
 2011,16,2010/2011,68,HHS Region 1,3 wk ahead,0.5
-2011,16,2010/2011,68,HHS Region 1,4 wk ahead,0.4
+2011,16,2010/2011,68,HHS Region 1,4 wk ahead,0.5
 2011,16,2010/2011,68,HHS Region 2,Season onset,49
 2011,16,2010/2011,68,HHS Region 2,Season peak week,52
 2011,16,2010/2011,68,HHS Region 2,Season peak percentage,4.5
-2011,16,2010/2011,68,HHS Region 2,1 wk ahead,1.8
-2011,16,2010/2011,68,HHS Region 2,2 wk ahead,1.8
+2011,16,2010/2011,68,HHS Region 2,1 wk ahead,1.7
+2011,16,2010/2011,68,HHS Region 2,2 wk ahead,1.6
 2011,16,2010/2011,68,HHS Region 2,3 wk ahead,1.7
-2011,16,2010/2011,68,HHS Region 2,4 wk ahead,1.3
+2011,16,2010/2011,68,HHS Region 2,4 wk ahead,1.4
 2011,16,2010/2011,68,HHS Region 3,Season onset,3
 2011,16,2010/2011,68,HHS Region 3,Season peak week,5
 2011,16,2010/2011,68,HHS Region 3,Season peak percentage,4.4
 2011,16,2010/2011,68,HHS Region 3,1 wk ahead,0.9
-2011,16,2010/2011,68,HHS Region 3,2 wk ahead,1.1
-2011,16,2010/2011,68,HHS Region 3,3 wk ahead,1.1
-2011,16,2010/2011,68,HHS Region 3,4 wk ahead,1.2
-2011,16,2010/2011,68,HHS Region 4,Season onset,49
+2011,16,2010/2011,68,HHS Region 3,2 wk ahead,1
+2011,16,2010/2011,68,HHS Region 3,3 wk ahead,0.9
+2011,16,2010/2011,68,HHS Region 3,4 wk ahead,1
+2011,16,2010/2011,68,HHS Region 4,Season onset,50
 2011,16,2010/2011,68,HHS Region 4,Season peak week,5
-2011,16,2010/2011,68,HHS Region 4,Season peak percentage,5.6
+2011,16,2010/2011,68,HHS Region 4,Season peak percentage,5.5
 2011,16,2010/2011,68,HHS Region 4,1 wk ahead,1.1
 2011,16,2010/2011,68,HHS Region 4,2 wk ahead,1
-2011,16,2010/2011,68,HHS Region 4,3 wk ahead,1
-2011,16,2010/2011,68,HHS Region 4,4 wk ahead,1
+2011,16,2010/2011,68,HHS Region 4,3 wk ahead,0.9
+2011,16,2010/2011,68,HHS Region 4,4 wk ahead,0.9
 2011,16,2010/2011,68,HHS Region 5,Season onset,3
 2011,16,2010/2011,68,HHS Region 5,Season peak week,5
 2011,16,2010/2011,68,HHS Region 5,Season peak percentage,3.8
@@ -2288,37 +2316,38 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,16,2010/2011,68,HHS Region 6,Season peak week,7
 2011,16,2010/2011,68,HHS Region 6,Season peak percentage,7.9
 2011,16,2010/2011,68,HHS Region 6,1 wk ahead,1.3
-2011,16,2010/2011,68,HHS Region 6,2 wk ahead,1.3
+2011,16,2010/2011,68,HHS Region 6,2 wk ahead,1.4
 2011,16,2010/2011,68,HHS Region 6,3 wk ahead,1.4
-2011,16,2010/2011,68,HHS Region 6,4 wk ahead,1.1
+2011,16,2010/2011,68,HHS Region 6,4 wk ahead,1.2
 2011,16,2010/2011,68,HHS Region 7,Season onset,4
 2011,16,2010/2011,68,HHS Region 7,Season peak week,8
 2011,16,2010/2011,68,HHS Region 7,Season peak percentage,4.7
-2011,16,2010/2011,68,HHS Region 7,1 wk ahead,0.7
+2011,16,2010/2011,68,HHS Region 7,1 wk ahead,0.6
 2011,16,2010/2011,68,HHS Region 7,2 wk ahead,0.5
 2011,16,2010/2011,68,HHS Region 7,3 wk ahead,0.6
-2011,16,2010/2011,68,HHS Region 7,4 wk ahead,0.6
+2011,16,2010/2011,68,HHS Region 7,4 wk ahead,0.5
 2011,16,2010/2011,68,HHS Region 8,Season onset,5
 2011,16,2010/2011,68,HHS Region 8,Season peak week,7
 2011,16,2010/2011,68,HHS Region 8,Season peak percentage,2.7
 2011,16,2010/2011,68,HHS Region 8,1 wk ahead,0.6
 2011,16,2010/2011,68,HHS Region 8,2 wk ahead,0.5
-2011,16,2010/2011,68,HHS Region 8,3 wk ahead,0.4
+2011,16,2010/2011,68,HHS Region 8,3 wk ahead,0.5
 2011,16,2010/2011,68,HHS Region 8,4 wk ahead,0.5
-2011,16,2010/2011,68,HHS Region 9,Season onset,none
+2011,16,2010/2011,68,HHS Region 9,Season onset,6
 2011,16,2010/2011,68,HHS Region 9,Season peak week,7
+2011,16,2010/2011,68,HHS Region 9,Season peak week,8
 2011,16,2010/2011,68,HHS Region 9,Season peak percentage,4.7
-2011,16,2010/2011,68,HHS Region 9,1 wk ahead,2.2
-2011,16,2010/2011,68,HHS Region 9,2 wk ahead,2
-2011,16,2010/2011,68,HHS Region 9,3 wk ahead,1
-2011,16,2010/2011,68,HHS Region 9,4 wk ahead,0.7
+2011,16,2010/2011,68,HHS Region 9,1 wk ahead,2.1
+2011,16,2010/2011,68,HHS Region 9,2 wk ahead,1.9
+2011,16,2010/2011,68,HHS Region 9,3 wk ahead,1.9
+2011,16,2010/2011,68,HHS Region 9,4 wk ahead,1.8
 2011,16,2010/2011,68,HHS Region 10,Season onset,5
 2011,16,2010/2011,68,HHS Region 10,Season peak week,7
 2011,16,2010/2011,68,HHS Region 10,Season peak percentage,3.9
-2011,16,2010/2011,68,HHS Region 10,1 wk ahead,0.8
+2011,16,2010/2011,68,HHS Region 10,1 wk ahead,0.9
 2011,16,2010/2011,68,HHS Region 10,2 wk ahead,0.9
-2011,16,2010/2011,68,HHS Region 10,3 wk ahead,0.9
-2011,16,2010/2011,68,HHS Region 10,4 wk ahead,1
+2011,16,2010/2011,68,HHS Region 10,3 wk ahead,0.8
+2011,16,2010/2011,68,HHS Region 10,4 wk ahead,0.8
 2011,17,2010/2011,69,US National,Season onset,51
 2011,17,2010/2011,69,US National,Season peak week,5
 2011,17,2010/2011,69,US National,Season peak week,6
@@ -2334,28 +2363,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,17,2010/2011,69,HHS Region 1,Season peak percentage,2.3
 2011,17,2010/2011,69,HHS Region 1,1 wk ahead,0.6
 2011,17,2010/2011,69,HHS Region 1,2 wk ahead,0.5
-2011,17,2010/2011,69,HHS Region 1,3 wk ahead,0.4
+2011,17,2010/2011,69,HHS Region 1,3 wk ahead,0.5
 2011,17,2010/2011,69,HHS Region 1,4 wk ahead,0.6
 2011,17,2010/2011,69,HHS Region 2,Season onset,49
 2011,17,2010/2011,69,HHS Region 2,Season peak week,52
 2011,17,2010/2011,69,HHS Region 2,Season peak percentage,4.5
-2011,17,2010/2011,69,HHS Region 2,1 wk ahead,1.8
+2011,17,2010/2011,69,HHS Region 2,1 wk ahead,1.6
 2011,17,2010/2011,69,HHS Region 2,2 wk ahead,1.7
-2011,17,2010/2011,69,HHS Region 2,3 wk ahead,1.3
+2011,17,2010/2011,69,HHS Region 2,3 wk ahead,1.4
 2011,17,2010/2011,69,HHS Region 2,4 wk ahead,1.9
 2011,17,2010/2011,69,HHS Region 3,Season onset,3
 2011,17,2010/2011,69,HHS Region 3,Season peak week,5
 2011,17,2010/2011,69,HHS Region 3,Season peak percentage,4.4
-2011,17,2010/2011,69,HHS Region 3,1 wk ahead,1.1
-2011,17,2010/2011,69,HHS Region 3,2 wk ahead,1.1
-2011,17,2010/2011,69,HHS Region 3,3 wk ahead,1.2
+2011,17,2010/2011,69,HHS Region 3,1 wk ahead,1
+2011,17,2010/2011,69,HHS Region 3,2 wk ahead,0.9
+2011,17,2010/2011,69,HHS Region 3,3 wk ahead,1
 2011,17,2010/2011,69,HHS Region 3,4 wk ahead,0.9
-2011,17,2010/2011,69,HHS Region 4,Season onset,49
+2011,17,2010/2011,69,HHS Region 4,Season onset,50
 2011,17,2010/2011,69,HHS Region 4,Season peak week,5
-2011,17,2010/2011,69,HHS Region 4,Season peak percentage,5.6
+2011,17,2010/2011,69,HHS Region 4,Season peak percentage,5.5
 2011,17,2010/2011,69,HHS Region 4,1 wk ahead,1
-2011,17,2010/2011,69,HHS Region 4,2 wk ahead,1
-2011,17,2010/2011,69,HHS Region 4,3 wk ahead,1
+2011,17,2010/2011,69,HHS Region 4,2 wk ahead,0.9
+2011,17,2010/2011,69,HHS Region 4,3 wk ahead,0.9
 2011,17,2010/2011,69,HHS Region 4,4 wk ahead,0.9
 2011,17,2010/2011,69,HHS Region 5,Season onset,3
 2011,17,2010/2011,69,HHS Region 5,Season peak week,5
@@ -2367,37 +2396,38 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,17,2010/2011,69,HHS Region 6,Season onset,3
 2011,17,2010/2011,69,HHS Region 6,Season peak week,7
 2011,17,2010/2011,69,HHS Region 6,Season peak percentage,7.9
-2011,17,2010/2011,69,HHS Region 6,1 wk ahead,1.3
+2011,17,2010/2011,69,HHS Region 6,1 wk ahead,1.4
 2011,17,2010/2011,69,HHS Region 6,2 wk ahead,1.4
-2011,17,2010/2011,69,HHS Region 6,3 wk ahead,1.1
+2011,17,2010/2011,69,HHS Region 6,3 wk ahead,1.2
 2011,17,2010/2011,69,HHS Region 6,4 wk ahead,1.1
 2011,17,2010/2011,69,HHS Region 7,Season onset,4
 2011,17,2010/2011,69,HHS Region 7,Season peak week,8
 2011,17,2010/2011,69,HHS Region 7,Season peak percentage,4.7
 2011,17,2010/2011,69,HHS Region 7,1 wk ahead,0.5
 2011,17,2010/2011,69,HHS Region 7,2 wk ahead,0.6
-2011,17,2010/2011,69,HHS Region 7,3 wk ahead,0.6
+2011,17,2010/2011,69,HHS Region 7,3 wk ahead,0.5
 2011,17,2010/2011,69,HHS Region 7,4 wk ahead,0.5
 2011,17,2010/2011,69,HHS Region 8,Season onset,5
 2011,17,2010/2011,69,HHS Region 8,Season peak week,7
 2011,17,2010/2011,69,HHS Region 8,Season peak percentage,2.7
 2011,17,2010/2011,69,HHS Region 8,1 wk ahead,0.5
-2011,17,2010/2011,69,HHS Region 8,2 wk ahead,0.4
+2011,17,2010/2011,69,HHS Region 8,2 wk ahead,0.5
 2011,17,2010/2011,69,HHS Region 8,3 wk ahead,0.5
 2011,17,2010/2011,69,HHS Region 8,4 wk ahead,0.4
-2011,17,2010/2011,69,HHS Region 9,Season onset,none
+2011,17,2010/2011,69,HHS Region 9,Season onset,6
 2011,17,2010/2011,69,HHS Region 9,Season peak week,7
+2011,17,2010/2011,69,HHS Region 9,Season peak week,8
 2011,17,2010/2011,69,HHS Region 9,Season peak percentage,4.7
-2011,17,2010/2011,69,HHS Region 9,1 wk ahead,2
-2011,17,2010/2011,69,HHS Region 9,2 wk ahead,1
-2011,17,2010/2011,69,HHS Region 9,3 wk ahead,0.7
+2011,17,2010/2011,69,HHS Region 9,1 wk ahead,1.9
+2011,17,2010/2011,69,HHS Region 9,2 wk ahead,1.9
+2011,17,2010/2011,69,HHS Region 9,3 wk ahead,1.8
 2011,17,2010/2011,69,HHS Region 9,4 wk ahead,1.8
 2011,17,2010/2011,69,HHS Region 10,Season onset,5
 2011,17,2010/2011,69,HHS Region 10,Season peak week,7
 2011,17,2010/2011,69,HHS Region 10,Season peak percentage,3.9
 2011,17,2010/2011,69,HHS Region 10,1 wk ahead,0.9
-2011,17,2010/2011,69,HHS Region 10,2 wk ahead,0.9
-2011,17,2010/2011,69,HHS Region 10,3 wk ahead,1
+2011,17,2010/2011,69,HHS Region 10,2 wk ahead,0.8
+2011,17,2010/2011,69,HHS Region 10,3 wk ahead,0.8
 2011,17,2010/2011,69,HHS Region 10,4 wk ahead,0.5
 2011,18,2010/2011,70,US National,Season onset,51
 2011,18,2010/2011,70,US National,Season peak week,5
@@ -2413,28 +2443,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,18,2010/2011,70,HHS Region 1,Season peak week,8
 2011,18,2010/2011,70,HHS Region 1,Season peak percentage,2.3
 2011,18,2010/2011,70,HHS Region 1,1 wk ahead,0.5
-2011,18,2010/2011,70,HHS Region 1,2 wk ahead,0.4
+2011,18,2010/2011,70,HHS Region 1,2 wk ahead,0.5
 2011,18,2010/2011,70,HHS Region 1,3 wk ahead,0.6
 2011,18,2010/2011,70,HHS Region 1,4 wk ahead,0.6
 2011,18,2010/2011,70,HHS Region 2,Season onset,49
 2011,18,2010/2011,70,HHS Region 2,Season peak week,52
 2011,18,2010/2011,70,HHS Region 2,Season peak percentage,4.5
 2011,18,2010/2011,70,HHS Region 2,1 wk ahead,1.7
-2011,18,2010/2011,70,HHS Region 2,2 wk ahead,1.3
+2011,18,2010/2011,70,HHS Region 2,2 wk ahead,1.4
 2011,18,2010/2011,70,HHS Region 2,3 wk ahead,1.9
 2011,18,2010/2011,70,HHS Region 2,4 wk ahead,1.8
 2011,18,2010/2011,70,HHS Region 3,Season onset,3
 2011,18,2010/2011,70,HHS Region 3,Season peak week,5
 2011,18,2010/2011,70,HHS Region 3,Season peak percentage,4.4
-2011,18,2010/2011,70,HHS Region 3,1 wk ahead,1.1
-2011,18,2010/2011,70,HHS Region 3,2 wk ahead,1.2
+2011,18,2010/2011,70,HHS Region 3,1 wk ahead,0.9
+2011,18,2010/2011,70,HHS Region 3,2 wk ahead,1
 2011,18,2010/2011,70,HHS Region 3,3 wk ahead,0.9
 2011,18,2010/2011,70,HHS Region 3,4 wk ahead,0.9
-2011,18,2010/2011,70,HHS Region 4,Season onset,49
+2011,18,2010/2011,70,HHS Region 4,Season onset,50
 2011,18,2010/2011,70,HHS Region 4,Season peak week,5
-2011,18,2010/2011,70,HHS Region 4,Season peak percentage,5.6
-2011,18,2010/2011,70,HHS Region 4,1 wk ahead,1
-2011,18,2010/2011,70,HHS Region 4,2 wk ahead,1
+2011,18,2010/2011,70,HHS Region 4,Season peak percentage,5.5
+2011,18,2010/2011,70,HHS Region 4,1 wk ahead,0.9
+2011,18,2010/2011,70,HHS Region 4,2 wk ahead,0.9
 2011,18,2010/2011,70,HHS Region 4,3 wk ahead,0.9
 2011,18,2010/2011,70,HHS Region 4,4 wk ahead,1
 2011,18,2010/2011,70,HHS Region 5,Season onset,3
@@ -2448,35 +2478,36 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,18,2010/2011,70,HHS Region 6,Season peak week,7
 2011,18,2010/2011,70,HHS Region 6,Season peak percentage,7.9
 2011,18,2010/2011,70,HHS Region 6,1 wk ahead,1.4
-2011,18,2010/2011,70,HHS Region 6,2 wk ahead,1.1
+2011,18,2010/2011,70,HHS Region 6,2 wk ahead,1.2
 2011,18,2010/2011,70,HHS Region 6,3 wk ahead,1.1
 2011,18,2010/2011,70,HHS Region 6,4 wk ahead,1.2
 2011,18,2010/2011,70,HHS Region 7,Season onset,4
 2011,18,2010/2011,70,HHS Region 7,Season peak week,8
 2011,18,2010/2011,70,HHS Region 7,Season peak percentage,4.7
 2011,18,2010/2011,70,HHS Region 7,1 wk ahead,0.6
-2011,18,2010/2011,70,HHS Region 7,2 wk ahead,0.6
+2011,18,2010/2011,70,HHS Region 7,2 wk ahead,0.5
 2011,18,2010/2011,70,HHS Region 7,3 wk ahead,0.5
 2011,18,2010/2011,70,HHS Region 7,4 wk ahead,0.2
 2011,18,2010/2011,70,HHS Region 8,Season onset,5
 2011,18,2010/2011,70,HHS Region 8,Season peak week,7
 2011,18,2010/2011,70,HHS Region 8,Season peak percentage,2.7
-2011,18,2010/2011,70,HHS Region 8,1 wk ahead,0.4
+2011,18,2010/2011,70,HHS Region 8,1 wk ahead,0.5
 2011,18,2010/2011,70,HHS Region 8,2 wk ahead,0.5
 2011,18,2010/2011,70,HHS Region 8,3 wk ahead,0.4
 2011,18,2010/2011,70,HHS Region 8,4 wk ahead,0.4
-2011,18,2010/2011,70,HHS Region 9,Season onset,none
+2011,18,2010/2011,70,HHS Region 9,Season onset,6
 2011,18,2010/2011,70,HHS Region 9,Season peak week,7
+2011,18,2010/2011,70,HHS Region 9,Season peak week,8
 2011,18,2010/2011,70,HHS Region 9,Season peak percentage,4.7
-2011,18,2010/2011,70,HHS Region 9,1 wk ahead,1
-2011,18,2010/2011,70,HHS Region 9,2 wk ahead,0.7
+2011,18,2010/2011,70,HHS Region 9,1 wk ahead,1.9
+2011,18,2010/2011,70,HHS Region 9,2 wk ahead,1.8
 2011,18,2010/2011,70,HHS Region 9,3 wk ahead,1.8
 2011,18,2010/2011,70,HHS Region 9,4 wk ahead,2.2
 2011,18,2010/2011,70,HHS Region 10,Season onset,5
 2011,18,2010/2011,70,HHS Region 10,Season peak week,7
 2011,18,2010/2011,70,HHS Region 10,Season peak percentage,3.9
-2011,18,2010/2011,70,HHS Region 10,1 wk ahead,0.9
-2011,18,2010/2011,70,HHS Region 10,2 wk ahead,1
+2011,18,2010/2011,70,HHS Region 10,1 wk ahead,0.8
+2011,18,2010/2011,70,HHS Region 10,2 wk ahead,0.8
 2011,18,2010/2011,70,HHS Region 10,3 wk ahead,0.5
 2011,18,2010/2011,70,HHS Region 10,4 wk ahead,0.7
 2011,19,2010/2011,71,US National,Season onset,51
@@ -2492,28 +2523,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,19,2010/2011,71,HHS Region 1,Season peak week,7
 2011,19,2010/2011,71,HHS Region 1,Season peak week,8
 2011,19,2010/2011,71,HHS Region 1,Season peak percentage,2.3
-2011,19,2010/2011,71,HHS Region 1,1 wk ahead,0.4
+2011,19,2010/2011,71,HHS Region 1,1 wk ahead,0.5
 2011,19,2010/2011,71,HHS Region 1,2 wk ahead,0.6
 2011,19,2010/2011,71,HHS Region 1,3 wk ahead,0.6
 2011,19,2010/2011,71,HHS Region 1,4 wk ahead,0.5
 2011,19,2010/2011,71,HHS Region 2,Season onset,49
 2011,19,2010/2011,71,HHS Region 2,Season peak week,52
 2011,19,2010/2011,71,HHS Region 2,Season peak percentage,4.5
-2011,19,2010/2011,71,HHS Region 2,1 wk ahead,1.3
+2011,19,2010/2011,71,HHS Region 2,1 wk ahead,1.4
 2011,19,2010/2011,71,HHS Region 2,2 wk ahead,1.9
 2011,19,2010/2011,71,HHS Region 2,3 wk ahead,1.8
 2011,19,2010/2011,71,HHS Region 2,4 wk ahead,1.3
 2011,19,2010/2011,71,HHS Region 3,Season onset,3
 2011,19,2010/2011,71,HHS Region 3,Season peak week,5
 2011,19,2010/2011,71,HHS Region 3,Season peak percentage,4.4
-2011,19,2010/2011,71,HHS Region 3,1 wk ahead,1.2
+2011,19,2010/2011,71,HHS Region 3,1 wk ahead,1
 2011,19,2010/2011,71,HHS Region 3,2 wk ahead,0.9
 2011,19,2010/2011,71,HHS Region 3,3 wk ahead,0.9
 2011,19,2010/2011,71,HHS Region 3,4 wk ahead,1.1
-2011,19,2010/2011,71,HHS Region 4,Season onset,49
+2011,19,2010/2011,71,HHS Region 4,Season onset,50
 2011,19,2010/2011,71,HHS Region 4,Season peak week,5
-2011,19,2010/2011,71,HHS Region 4,Season peak percentage,5.6
-2011,19,2010/2011,71,HHS Region 4,1 wk ahead,1
+2011,19,2010/2011,71,HHS Region 4,Season peak percentage,5.5
+2011,19,2010/2011,71,HHS Region 4,1 wk ahead,0.9
 2011,19,2010/2011,71,HHS Region 4,2 wk ahead,0.9
 2011,19,2010/2011,71,HHS Region 4,3 wk ahead,1
 2011,19,2010/2011,71,HHS Region 4,4 wk ahead,0.9
@@ -2527,14 +2558,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,19,2010/2011,71,HHS Region 6,Season onset,3
 2011,19,2010/2011,71,HHS Region 6,Season peak week,7
 2011,19,2010/2011,71,HHS Region 6,Season peak percentage,7.9
-2011,19,2010/2011,71,HHS Region 6,1 wk ahead,1.1
+2011,19,2010/2011,71,HHS Region 6,1 wk ahead,1.2
 2011,19,2010/2011,71,HHS Region 6,2 wk ahead,1.1
 2011,19,2010/2011,71,HHS Region 6,3 wk ahead,1.2
 2011,19,2010/2011,71,HHS Region 6,4 wk ahead,0.9
 2011,19,2010/2011,71,HHS Region 7,Season onset,4
 2011,19,2010/2011,71,HHS Region 7,Season peak week,8
 2011,19,2010/2011,71,HHS Region 7,Season peak percentage,4.7
-2011,19,2010/2011,71,HHS Region 7,1 wk ahead,0.6
+2011,19,2010/2011,71,HHS Region 7,1 wk ahead,0.5
 2011,19,2010/2011,71,HHS Region 7,2 wk ahead,0.5
 2011,19,2010/2011,71,HHS Region 7,3 wk ahead,0.2
 2011,19,2010/2011,71,HHS Region 7,4 wk ahead,0.2
@@ -2545,17 +2576,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,19,2010/2011,71,HHS Region 8,2 wk ahead,0.4
 2011,19,2010/2011,71,HHS Region 8,3 wk ahead,0.4
 2011,19,2010/2011,71,HHS Region 8,4 wk ahead,0.3
-2011,19,2010/2011,71,HHS Region 9,Season onset,none
+2011,19,2010/2011,71,HHS Region 9,Season onset,6
 2011,19,2010/2011,71,HHS Region 9,Season peak week,7
+2011,19,2010/2011,71,HHS Region 9,Season peak week,8
 2011,19,2010/2011,71,HHS Region 9,Season peak percentage,4.7
-2011,19,2010/2011,71,HHS Region 9,1 wk ahead,0.7
+2011,19,2010/2011,71,HHS Region 9,1 wk ahead,1.8
 2011,19,2010/2011,71,HHS Region 9,2 wk ahead,1.8
 2011,19,2010/2011,71,HHS Region 9,3 wk ahead,2.2
 2011,19,2010/2011,71,HHS Region 9,4 wk ahead,1.9
 2011,19,2010/2011,71,HHS Region 10,Season onset,5
 2011,19,2010/2011,71,HHS Region 10,Season peak week,7
 2011,19,2010/2011,71,HHS Region 10,Season peak percentage,3.9
-2011,19,2010/2011,71,HHS Region 10,1 wk ahead,1
+2011,19,2010/2011,71,HHS Region 10,1 wk ahead,0.8
 2011,19,2010/2011,71,HHS Region 10,2 wk ahead,0.5
 2011,19,2010/2011,71,HHS Region 10,3 wk ahead,0.7
 2011,19,2010/2011,71,HHS Region 10,4 wk ahead,0.6
@@ -2590,9 +2622,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,20,2010/2011,72,HHS Region 3,2 wk ahead,0.9
 2011,20,2010/2011,72,HHS Region 3,3 wk ahead,1.1
 2011,20,2010/2011,72,HHS Region 3,4 wk ahead,1
-2011,20,2010/2011,72,HHS Region 4,Season onset,49
+2011,20,2010/2011,72,HHS Region 4,Season onset,50
 2011,20,2010/2011,72,HHS Region 4,Season peak week,5
-2011,20,2010/2011,72,HHS Region 4,Season peak percentage,5.6
+2011,20,2010/2011,72,HHS Region 4,Season peak percentage,5.5
 2011,20,2010/2011,72,HHS Region 4,1 wk ahead,0.9
 2011,20,2010/2011,72,HHS Region 4,2 wk ahead,1
 2011,20,2010/2011,72,HHS Region 4,3 wk ahead,0.9
@@ -2625,8 +2657,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,20,2010/2011,72,HHS Region 8,2 wk ahead,0.4
 2011,20,2010/2011,72,HHS Region 8,3 wk ahead,0.3
 2011,20,2010/2011,72,HHS Region 8,4 wk ahead,0.3
-2011,20,2010/2011,72,HHS Region 9,Season onset,none
+2011,20,2010/2011,72,HHS Region 9,Season onset,6
 2011,20,2010/2011,72,HHS Region 9,Season peak week,7
+2011,20,2010/2011,72,HHS Region 9,Season peak week,8
 2011,20,2010/2011,72,HHS Region 9,Season peak percentage,4.7
 2011,20,2010/2011,72,HHS Region 9,1 wk ahead,1.8
 2011,20,2010/2011,72,HHS Region 9,2 wk ahead,2.2
@@ -2648,7 +2681,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,40,2011/2012,40,US National,4 wk ahead,1.4
 2011,40,2011/2012,40,HHS Region 1,Season onset,none
 2011,40,2011/2012,40,HHS Region 1,Season peak week,52
-2011,40,2011/2012,40,HHS Region 1,Season peak week,8
 2011,40,2011/2012,40,HHS Region 1,Season peak percentage,1
 2011,40,2011/2012,40,HHS Region 1,1 wk ahead,0.7
 2011,40,2011/2012,40,HHS Region 1,2 wk ahead,0.6
@@ -2672,7 +2704,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,40,2011/2012,40,HHS Region 4,Season peak week,52
 2011,40,2011/2012,40,HHS Region 4,Season peak week,10
 2011,40,2011/2012,40,HHS Region 4,Season peak percentage,2.3
-2011,40,2011/2012,40,HHS Region 4,1 wk ahead,1.1
+2011,40,2011/2012,40,HHS Region 4,1 wk ahead,1.2
 2011,40,2011/2012,40,HHS Region 4,2 wk ahead,1.2
 2011,40,2011/2012,40,HHS Region 4,3 wk ahead,1.3
 2011,40,2011/2012,40,HHS Region 4,4 wk ahead,1.5
@@ -2680,19 +2712,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,40,2011/2012,40,HHS Region 5,Season peak week,11
 2011,40,2011/2012,40,HHS Region 5,Season peak percentage,2.4
 2011,40,2011/2012,40,HHS Region 5,1 wk ahead,0.9
-2011,40,2011/2012,40,HHS Region 5,2 wk ahead,1
+2011,40,2011/2012,40,HHS Region 5,2 wk ahead,1.1
 2011,40,2011/2012,40,HHS Region 5,3 wk ahead,1
 2011,40,2011/2012,40,HHS Region 5,4 wk ahead,1.1
 2011,40,2011/2012,40,HHS Region 6,Season onset,none
 2011,40,2011/2012,40,HHS Region 6,Season peak week,11
-2011,40,2011/2012,40,HHS Region 6,Season peak percentage,4.2
+2011,40,2011/2012,40,HHS Region 6,Season peak percentage,4.1
 2011,40,2011/2012,40,HHS Region 6,1 wk ahead,1.7
 2011,40,2011/2012,40,HHS Region 6,2 wk ahead,1.9
 2011,40,2011/2012,40,HHS Region 6,3 wk ahead,1.9
 2011,40,2011/2012,40,HHS Region 6,4 wk ahead,1.9
 2011,40,2011/2012,40,HHS Region 7,Season onset,5
 2011,40,2011/2012,40,HHS Region 7,Season peak week,9
-2011,40,2011/2012,40,HHS Region 7,Season peak percentage,3.5
+2011,40,2011/2012,40,HHS Region 7,Season peak percentage,3.4
 2011,40,2011/2012,40,HHS Region 7,1 wk ahead,0.9
 2011,40,2011/2012,40,HHS Region 7,2 wk ahead,0.8
 2011,40,2011/2012,40,HHS Region 7,3 wk ahead,1
@@ -2706,18 +2738,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,40,2011/2012,40,HHS Region 8,4 wk ahead,0.9
 2011,40,2011/2012,40,HHS Region 9,Season onset,none
 2011,40,2011/2012,40,HHS Region 9,Season peak week,52
+2011,40,2011/2012,40,HHS Region 9,Season peak week,8
 2011,40,2011/2012,40,HHS Region 9,Season peak percentage,3.7
-2011,40,2011/2012,40,HHS Region 9,1 wk ahead,1.6
-2011,40,2011/2012,40,HHS Region 9,2 wk ahead,1.9
-2011,40,2011/2012,40,HHS Region 9,3 wk ahead,1.9
-2011,40,2011/2012,40,HHS Region 9,4 wk ahead,2.1
-2011,40,2011/2012,40,HHS Region 10,Season onset,10
-2011,40,2011/2012,40,HHS Region 10,Season peak week,11
-2011,40,2011/2012,40,HHS Region 10,Season peak percentage,2.7
+2011,40,2011/2012,40,HHS Region 9,1 wk ahead,1.7
+2011,40,2011/2012,40,HHS Region 9,2 wk ahead,2
+2011,40,2011/2012,40,HHS Region 9,3 wk ahead,2
+2011,40,2011/2012,40,HHS Region 9,4 wk ahead,2.2
+2011,40,2011/2012,40,HHS Region 10,Season onset,none
+2011,40,2011/2012,40,HHS Region 10,Season peak week,12
+2011,40,2011/2012,40,HHS Region 10,Season peak percentage,2.2
 2011,40,2011/2012,40,HHS Region 10,1 wk ahead,0.7
-2011,40,2011/2012,40,HHS Region 10,2 wk ahead,0.5
+2011,40,2011/2012,40,HHS Region 10,2 wk ahead,0.6
 2011,40,2011/2012,40,HHS Region 10,3 wk ahead,0.7
-2011,40,2011/2012,40,HHS Region 10,4 wk ahead,1
+2011,40,2011/2012,40,HHS Region 10,4 wk ahead,0.8
 2011,41,2011/2012,41,US National,Season onset,none
 2011,41,2011/2012,41,US National,Season peak week,11
 2011,41,2011/2012,41,US National,Season peak percentage,2.4
@@ -2727,7 +2760,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,41,2011/2012,41,US National,4 wk ahead,1.4
 2011,41,2011/2012,41,HHS Region 1,Season onset,none
 2011,41,2011/2012,41,HHS Region 1,Season peak week,52
-2011,41,2011/2012,41,HHS Region 1,Season peak week,8
 2011,41,2011/2012,41,HHS Region 1,Season peak percentage,1
 2011,41,2011/2012,41,HHS Region 1,1 wk ahead,0.6
 2011,41,2011/2012,41,HHS Region 1,2 wk ahead,0.7
@@ -2758,20 +2790,20 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,41,2011/2012,41,HHS Region 5,Season onset,7
 2011,41,2011/2012,41,HHS Region 5,Season peak week,11
 2011,41,2011/2012,41,HHS Region 5,Season peak percentage,2.4
-2011,41,2011/2012,41,HHS Region 5,1 wk ahead,1
+2011,41,2011/2012,41,HHS Region 5,1 wk ahead,1.1
 2011,41,2011/2012,41,HHS Region 5,2 wk ahead,1
 2011,41,2011/2012,41,HHS Region 5,3 wk ahead,1.1
 2011,41,2011/2012,41,HHS Region 5,4 wk ahead,1.1
 2011,41,2011/2012,41,HHS Region 6,Season onset,none
 2011,41,2011/2012,41,HHS Region 6,Season peak week,11
-2011,41,2011/2012,41,HHS Region 6,Season peak percentage,4.2
+2011,41,2011/2012,41,HHS Region 6,Season peak percentage,4.1
 2011,41,2011/2012,41,HHS Region 6,1 wk ahead,1.9
 2011,41,2011/2012,41,HHS Region 6,2 wk ahead,1.9
 2011,41,2011/2012,41,HHS Region 6,3 wk ahead,1.9
 2011,41,2011/2012,41,HHS Region 6,4 wk ahead,2
 2011,41,2011/2012,41,HHS Region 7,Season onset,5
 2011,41,2011/2012,41,HHS Region 7,Season peak week,9
-2011,41,2011/2012,41,HHS Region 7,Season peak percentage,3.5
+2011,41,2011/2012,41,HHS Region 7,Season peak percentage,3.4
 2011,41,2011/2012,41,HHS Region 7,1 wk ahead,0.8
 2011,41,2011/2012,41,HHS Region 7,2 wk ahead,1
 2011,41,2011/2012,41,HHS Region 7,3 wk ahead,1.1
@@ -2785,18 +2817,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,41,2011/2012,41,HHS Region 8,4 wk ahead,1
 2011,41,2011/2012,41,HHS Region 9,Season onset,none
 2011,41,2011/2012,41,HHS Region 9,Season peak week,52
+2011,41,2011/2012,41,HHS Region 9,Season peak week,8
 2011,41,2011/2012,41,HHS Region 9,Season peak percentage,3.7
-2011,41,2011/2012,41,HHS Region 9,1 wk ahead,1.9
-2011,41,2011/2012,41,HHS Region 9,2 wk ahead,1.9
-2011,41,2011/2012,41,HHS Region 9,3 wk ahead,2.1
-2011,41,2011/2012,41,HHS Region 9,4 wk ahead,1.8
-2011,41,2011/2012,41,HHS Region 10,Season onset,10
-2011,41,2011/2012,41,HHS Region 10,Season peak week,11
-2011,41,2011/2012,41,HHS Region 10,Season peak percentage,2.7
-2011,41,2011/2012,41,HHS Region 10,1 wk ahead,0.5
+2011,41,2011/2012,41,HHS Region 9,1 wk ahead,2
+2011,41,2011/2012,41,HHS Region 9,2 wk ahead,2
+2011,41,2011/2012,41,HHS Region 9,3 wk ahead,2.2
+2011,41,2011/2012,41,HHS Region 9,4 wk ahead,1.9
+2011,41,2011/2012,41,HHS Region 10,Season onset,none
+2011,41,2011/2012,41,HHS Region 10,Season peak week,12
+2011,41,2011/2012,41,HHS Region 10,Season peak percentage,2.2
+2011,41,2011/2012,41,HHS Region 10,1 wk ahead,0.6
 2011,41,2011/2012,41,HHS Region 10,2 wk ahead,0.7
-2011,41,2011/2012,41,HHS Region 10,3 wk ahead,1
-2011,41,2011/2012,41,HHS Region 10,4 wk ahead,0.8
+2011,41,2011/2012,41,HHS Region 10,3 wk ahead,0.8
+2011,41,2011/2012,41,HHS Region 10,4 wk ahead,0.7
 2011,42,2011/2012,42,US National,Season onset,none
 2011,42,2011/2012,42,US National,Season peak week,11
 2011,42,2011/2012,42,US National,Season peak percentage,2.4
@@ -2806,7 +2839,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,42,2011/2012,42,US National,4 wk ahead,1.4
 2011,42,2011/2012,42,HHS Region 1,Season onset,none
 2011,42,2011/2012,42,HHS Region 1,Season peak week,52
-2011,42,2011/2012,42,HHS Region 1,Season peak week,8
 2011,42,2011/2012,42,HHS Region 1,Season peak percentage,1
 2011,42,2011/2012,42,HHS Region 1,1 wk ahead,0.7
 2011,42,2011/2012,42,HHS Region 1,2 wk ahead,0.7
@@ -2843,14 +2875,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,42,2011/2012,42,HHS Region 5,4 wk ahead,1
 2011,42,2011/2012,42,HHS Region 6,Season onset,none
 2011,42,2011/2012,42,HHS Region 6,Season peak week,11
-2011,42,2011/2012,42,HHS Region 6,Season peak percentage,4.2
+2011,42,2011/2012,42,HHS Region 6,Season peak percentage,4.1
 2011,42,2011/2012,42,HHS Region 6,1 wk ahead,1.9
 2011,42,2011/2012,42,HHS Region 6,2 wk ahead,1.9
 2011,42,2011/2012,42,HHS Region 6,3 wk ahead,2
 2011,42,2011/2012,42,HHS Region 6,4 wk ahead,2.2
 2011,42,2011/2012,42,HHS Region 7,Season onset,5
 2011,42,2011/2012,42,HHS Region 7,Season peak week,9
-2011,42,2011/2012,42,HHS Region 7,Season peak percentage,3.5
+2011,42,2011/2012,42,HHS Region 7,Season peak percentage,3.4
 2011,42,2011/2012,42,HHS Region 7,1 wk ahead,1
 2011,42,2011/2012,42,HHS Region 7,2 wk ahead,1.1
 2011,42,2011/2012,42,HHS Region 7,3 wk ahead,0.9
@@ -2864,17 +2896,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,42,2011/2012,42,HHS Region 8,4 wk ahead,1
 2011,42,2011/2012,42,HHS Region 9,Season onset,none
 2011,42,2011/2012,42,HHS Region 9,Season peak week,52
+2011,42,2011/2012,42,HHS Region 9,Season peak week,8
 2011,42,2011/2012,42,HHS Region 9,Season peak percentage,3.7
-2011,42,2011/2012,42,HHS Region 9,1 wk ahead,1.9
-2011,42,2011/2012,42,HHS Region 9,2 wk ahead,2.1
-2011,42,2011/2012,42,HHS Region 9,3 wk ahead,1.8
-2011,42,2011/2012,42,HHS Region 9,4 wk ahead,2.2
-2011,42,2011/2012,42,HHS Region 10,Season onset,10
-2011,42,2011/2012,42,HHS Region 10,Season peak week,11
-2011,42,2011/2012,42,HHS Region 10,Season peak percentage,2.7
+2011,42,2011/2012,42,HHS Region 9,1 wk ahead,2
+2011,42,2011/2012,42,HHS Region 9,2 wk ahead,2.2
+2011,42,2011/2012,42,HHS Region 9,3 wk ahead,1.9
+2011,42,2011/2012,42,HHS Region 9,4 wk ahead,2.3
+2011,42,2011/2012,42,HHS Region 10,Season onset,none
+2011,42,2011/2012,42,HHS Region 10,Season peak week,12
+2011,42,2011/2012,42,HHS Region 10,Season peak percentage,2.2
 2011,42,2011/2012,42,HHS Region 10,1 wk ahead,0.7
-2011,42,2011/2012,42,HHS Region 10,2 wk ahead,1
-2011,42,2011/2012,42,HHS Region 10,3 wk ahead,0.8
+2011,42,2011/2012,42,HHS Region 10,2 wk ahead,0.8
+2011,42,2011/2012,42,HHS Region 10,3 wk ahead,0.7
 2011,42,2011/2012,42,HHS Region 10,4 wk ahead,0.9
 2011,43,2011/2012,43,US National,Season onset,none
 2011,43,2011/2012,43,US National,Season peak week,11
@@ -2885,7 +2918,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,43,2011/2012,43,US National,4 wk ahead,1.6
 2011,43,2011/2012,43,HHS Region 1,Season onset,none
 2011,43,2011/2012,43,HHS Region 1,Season peak week,52
-2011,43,2011/2012,43,HHS Region 1,Season peak week,8
 2011,43,2011/2012,43,HHS Region 1,Season peak percentage,1
 2011,43,2011/2012,43,HHS Region 1,1 wk ahead,0.7
 2011,43,2011/2012,43,HHS Region 1,2 wk ahead,0.7
@@ -2922,14 +2954,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,43,2011/2012,43,HHS Region 5,4 wk ahead,1.2
 2011,43,2011/2012,43,HHS Region 6,Season onset,none
 2011,43,2011/2012,43,HHS Region 6,Season peak week,11
-2011,43,2011/2012,43,HHS Region 6,Season peak percentage,4.2
+2011,43,2011/2012,43,HHS Region 6,Season peak percentage,4.1
 2011,43,2011/2012,43,HHS Region 6,1 wk ahead,1.9
 2011,43,2011/2012,43,HHS Region 6,2 wk ahead,2
 2011,43,2011/2012,43,HHS Region 6,3 wk ahead,2.2
 2011,43,2011/2012,43,HHS Region 6,4 wk ahead,2.1
 2011,43,2011/2012,43,HHS Region 7,Season onset,5
 2011,43,2011/2012,43,HHS Region 7,Season peak week,9
-2011,43,2011/2012,43,HHS Region 7,Season peak percentage,3.5
+2011,43,2011/2012,43,HHS Region 7,Season peak percentage,3.4
 2011,43,2011/2012,43,HHS Region 7,1 wk ahead,1.1
 2011,43,2011/2012,43,HHS Region 7,2 wk ahead,0.9
 2011,43,2011/2012,43,HHS Region 7,3 wk ahead,0.8
@@ -2943,18 +2975,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,43,2011/2012,43,HHS Region 8,4 wk ahead,1.1
 2011,43,2011/2012,43,HHS Region 9,Season onset,none
 2011,43,2011/2012,43,HHS Region 9,Season peak week,52
+2011,43,2011/2012,43,HHS Region 9,Season peak week,8
 2011,43,2011/2012,43,HHS Region 9,Season peak percentage,3.7
-2011,43,2011/2012,43,HHS Region 9,1 wk ahead,2.1
-2011,43,2011/2012,43,HHS Region 9,2 wk ahead,1.8
-2011,43,2011/2012,43,HHS Region 9,3 wk ahead,2.2
-2011,43,2011/2012,43,HHS Region 9,4 wk ahead,2.1
-2011,43,2011/2012,43,HHS Region 10,Season onset,10
-2011,43,2011/2012,43,HHS Region 10,Season peak week,11
-2011,43,2011/2012,43,HHS Region 10,Season peak percentage,2.7
-2011,43,2011/2012,43,HHS Region 10,1 wk ahead,1
-2011,43,2011/2012,43,HHS Region 10,2 wk ahead,0.8
+2011,43,2011/2012,43,HHS Region 9,1 wk ahead,2.2
+2011,43,2011/2012,43,HHS Region 9,2 wk ahead,1.9
+2011,43,2011/2012,43,HHS Region 9,3 wk ahead,2.3
+2011,43,2011/2012,43,HHS Region 9,4 wk ahead,2.2
+2011,43,2011/2012,43,HHS Region 10,Season onset,none
+2011,43,2011/2012,43,HHS Region 10,Season peak week,12
+2011,43,2011/2012,43,HHS Region 10,Season peak percentage,2.2
+2011,43,2011/2012,43,HHS Region 10,1 wk ahead,0.8
+2011,43,2011/2012,43,HHS Region 10,2 wk ahead,0.7
 2011,43,2011/2012,43,HHS Region 10,3 wk ahead,0.9
-2011,43,2011/2012,43,HHS Region 10,4 wk ahead,1.3
+2011,43,2011/2012,43,HHS Region 10,4 wk ahead,1.1
 2011,44,2011/2012,44,US National,Season onset,none
 2011,44,2011/2012,44,US National,Season peak week,11
 2011,44,2011/2012,44,US National,Season peak percentage,2.4
@@ -2964,7 +2997,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,44,2011/2012,44,US National,4 wk ahead,1.3
 2011,44,2011/2012,44,HHS Region 1,Season onset,none
 2011,44,2011/2012,44,HHS Region 1,Season peak week,52
-2011,44,2011/2012,44,HHS Region 1,Season peak week,8
 2011,44,2011/2012,44,HHS Region 1,Season peak percentage,1
 2011,44,2011/2012,44,HHS Region 1,1 wk ahead,0.7
 2011,44,2011/2012,44,HHS Region 1,2 wk ahead,0.6
@@ -3001,14 +3033,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,44,2011/2012,44,HHS Region 5,4 wk ahead,1.1
 2011,44,2011/2012,44,HHS Region 6,Season onset,none
 2011,44,2011/2012,44,HHS Region 6,Season peak week,11
-2011,44,2011/2012,44,HHS Region 6,Season peak percentage,4.2
+2011,44,2011/2012,44,HHS Region 6,Season peak percentage,4.1
 2011,44,2011/2012,44,HHS Region 6,1 wk ahead,2
 2011,44,2011/2012,44,HHS Region 6,2 wk ahead,2.2
 2011,44,2011/2012,44,HHS Region 6,3 wk ahead,2.1
 2011,44,2011/2012,44,HHS Region 6,4 wk ahead,2.2
 2011,44,2011/2012,44,HHS Region 7,Season onset,5
 2011,44,2011/2012,44,HHS Region 7,Season peak week,9
-2011,44,2011/2012,44,HHS Region 7,Season peak percentage,3.5
+2011,44,2011/2012,44,HHS Region 7,Season peak percentage,3.4
 2011,44,2011/2012,44,HHS Region 7,1 wk ahead,0.9
 2011,44,2011/2012,44,HHS Region 7,2 wk ahead,0.8
 2011,44,2011/2012,44,HHS Region 7,3 wk ahead,0.9
@@ -3022,17 +3054,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,44,2011/2012,44,HHS Region 8,4 wk ahead,0.9
 2011,44,2011/2012,44,HHS Region 9,Season onset,none
 2011,44,2011/2012,44,HHS Region 9,Season peak week,52
+2011,44,2011/2012,44,HHS Region 9,Season peak week,8
 2011,44,2011/2012,44,HHS Region 9,Season peak percentage,3.7
-2011,44,2011/2012,44,HHS Region 9,1 wk ahead,1.8
-2011,44,2011/2012,44,HHS Region 9,2 wk ahead,2.2
-2011,44,2011/2012,44,HHS Region 9,3 wk ahead,2.1
-2011,44,2011/2012,44,HHS Region 9,4 wk ahead,1.4
-2011,44,2011/2012,44,HHS Region 10,Season onset,10
-2011,44,2011/2012,44,HHS Region 10,Season peak week,11
-2011,44,2011/2012,44,HHS Region 10,Season peak percentage,2.7
-2011,44,2011/2012,44,HHS Region 10,1 wk ahead,0.8
+2011,44,2011/2012,44,HHS Region 9,1 wk ahead,1.9
+2011,44,2011/2012,44,HHS Region 9,2 wk ahead,2.3
+2011,44,2011/2012,44,HHS Region 9,3 wk ahead,2.2
+2011,44,2011/2012,44,HHS Region 9,4 wk ahead,1.5
+2011,44,2011/2012,44,HHS Region 10,Season onset,none
+2011,44,2011/2012,44,HHS Region 10,Season peak week,12
+2011,44,2011/2012,44,HHS Region 10,Season peak percentage,2.2
+2011,44,2011/2012,44,HHS Region 10,1 wk ahead,0.7
 2011,44,2011/2012,44,HHS Region 10,2 wk ahead,0.9
-2011,44,2011/2012,44,HHS Region 10,3 wk ahead,1.3
+2011,44,2011/2012,44,HHS Region 10,3 wk ahead,1.1
 2011,44,2011/2012,44,HHS Region 10,4 wk ahead,0.8
 2011,45,2011/2012,45,US National,Season onset,none
 2011,45,2011/2012,45,US National,Season peak week,11
@@ -3043,7 +3076,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,45,2011/2012,45,US National,4 wk ahead,1.5
 2011,45,2011/2012,45,HHS Region 1,Season onset,none
 2011,45,2011/2012,45,HHS Region 1,Season peak week,52
-2011,45,2011/2012,45,HHS Region 1,Season peak week,8
 2011,45,2011/2012,45,HHS Region 1,Season peak percentage,1
 2011,45,2011/2012,45,HHS Region 1,1 wk ahead,0.6
 2011,45,2011/2012,45,HHS Region 1,2 wk ahead,0.7
@@ -3080,14 +3112,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,45,2011/2012,45,HHS Region 5,4 wk ahead,1
 2011,45,2011/2012,45,HHS Region 6,Season onset,none
 2011,45,2011/2012,45,HHS Region 6,Season peak week,11
-2011,45,2011/2012,45,HHS Region 6,Season peak percentage,4.2
+2011,45,2011/2012,45,HHS Region 6,Season peak percentage,4.1
 2011,45,2011/2012,45,HHS Region 6,1 wk ahead,2.2
 2011,45,2011/2012,45,HHS Region 6,2 wk ahead,2.1
 2011,45,2011/2012,45,HHS Region 6,3 wk ahead,2.2
 2011,45,2011/2012,45,HHS Region 6,4 wk ahead,2
 2011,45,2011/2012,45,HHS Region 7,Season onset,5
 2011,45,2011/2012,45,HHS Region 7,Season peak week,9
-2011,45,2011/2012,45,HHS Region 7,Season peak percentage,3.5
+2011,45,2011/2012,45,HHS Region 7,Season peak percentage,3.4
 2011,45,2011/2012,45,HHS Region 7,1 wk ahead,0.8
 2011,45,2011/2012,45,HHS Region 7,2 wk ahead,0.9
 2011,45,2011/2012,45,HHS Region 7,3 wk ahead,1
@@ -3101,16 +3133,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,45,2011/2012,45,HHS Region 8,4 wk ahead,0.9
 2011,45,2011/2012,45,HHS Region 9,Season onset,none
 2011,45,2011/2012,45,HHS Region 9,Season peak week,52
+2011,45,2011/2012,45,HHS Region 9,Season peak week,8
 2011,45,2011/2012,45,HHS Region 9,Season peak percentage,3.7
-2011,45,2011/2012,45,HHS Region 9,1 wk ahead,2.2
-2011,45,2011/2012,45,HHS Region 9,2 wk ahead,2.1
-2011,45,2011/2012,45,HHS Region 9,3 wk ahead,1.4
-2011,45,2011/2012,45,HHS Region 9,4 wk ahead,2.2
-2011,45,2011/2012,45,HHS Region 10,Season onset,10
-2011,45,2011/2012,45,HHS Region 10,Season peak week,11
-2011,45,2011/2012,45,HHS Region 10,Season peak percentage,2.7
+2011,45,2011/2012,45,HHS Region 9,1 wk ahead,2.3
+2011,45,2011/2012,45,HHS Region 9,2 wk ahead,2.2
+2011,45,2011/2012,45,HHS Region 9,3 wk ahead,1.5
+2011,45,2011/2012,45,HHS Region 9,4 wk ahead,2.3
+2011,45,2011/2012,45,HHS Region 10,Season onset,none
+2011,45,2011/2012,45,HHS Region 10,Season peak week,12
+2011,45,2011/2012,45,HHS Region 10,Season peak percentage,2.2
 2011,45,2011/2012,45,HHS Region 10,1 wk ahead,0.9
-2011,45,2011/2012,45,HHS Region 10,2 wk ahead,1.3
+2011,45,2011/2012,45,HHS Region 10,2 wk ahead,1.1
 2011,45,2011/2012,45,HHS Region 10,3 wk ahead,0.8
 2011,45,2011/2012,45,HHS Region 10,4 wk ahead,0.6
 2011,46,2011/2012,46,US National,Season onset,none
@@ -3122,7 +3155,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,46,2011/2012,46,US National,4 wk ahead,1.6
 2011,46,2011/2012,46,HHS Region 1,Season onset,none
 2011,46,2011/2012,46,HHS Region 1,Season peak week,52
-2011,46,2011/2012,46,HHS Region 1,Season peak week,8
 2011,46,2011/2012,46,HHS Region 1,Season peak percentage,1
 2011,46,2011/2012,46,HHS Region 1,1 wk ahead,0.7
 2011,46,2011/2012,46,HHS Region 1,2 wk ahead,0.6
@@ -3159,14 +3191,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,46,2011/2012,46,HHS Region 5,4 wk ahead,1.1
 2011,46,2011/2012,46,HHS Region 6,Season onset,none
 2011,46,2011/2012,46,HHS Region 6,Season peak week,11
-2011,46,2011/2012,46,HHS Region 6,Season peak percentage,4.2
+2011,46,2011/2012,46,HHS Region 6,Season peak percentage,4.1
 2011,46,2011/2012,46,HHS Region 6,1 wk ahead,2.1
 2011,46,2011/2012,46,HHS Region 6,2 wk ahead,2.2
 2011,46,2011/2012,46,HHS Region 6,3 wk ahead,2
 2011,46,2011/2012,46,HHS Region 6,4 wk ahead,2.1
 2011,46,2011/2012,46,HHS Region 7,Season onset,5
 2011,46,2011/2012,46,HHS Region 7,Season peak week,9
-2011,46,2011/2012,46,HHS Region 7,Season peak percentage,3.5
+2011,46,2011/2012,46,HHS Region 7,Season peak percentage,3.4
 2011,46,2011/2012,46,HHS Region 7,1 wk ahead,0.9
 2011,46,2011/2012,46,HHS Region 7,2 wk ahead,1
 2011,46,2011/2012,46,HHS Region 7,3 wk ahead,0.8
@@ -3180,18 +3212,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,46,2011/2012,46,HHS Region 8,4 wk ahead,1
 2011,46,2011/2012,46,HHS Region 9,Season onset,none
 2011,46,2011/2012,46,HHS Region 9,Season peak week,52
+2011,46,2011/2012,46,HHS Region 9,Season peak week,8
 2011,46,2011/2012,46,HHS Region 9,Season peak percentage,3.7
-2011,46,2011/2012,46,HHS Region 9,1 wk ahead,2.1
-2011,46,2011/2012,46,HHS Region 9,2 wk ahead,1.4
-2011,46,2011/2012,46,HHS Region 9,3 wk ahead,2.2
+2011,46,2011/2012,46,HHS Region 9,1 wk ahead,2.2
+2011,46,2011/2012,46,HHS Region 9,2 wk ahead,1.5
+2011,46,2011/2012,46,HHS Region 9,3 wk ahead,2.3
 2011,46,2011/2012,46,HHS Region 9,4 wk ahead,2.6
-2011,46,2011/2012,46,HHS Region 10,Season onset,10
-2011,46,2011/2012,46,HHS Region 10,Season peak week,11
-2011,46,2011/2012,46,HHS Region 10,Season peak percentage,2.7
-2011,46,2011/2012,46,HHS Region 10,1 wk ahead,1.3
+2011,46,2011/2012,46,HHS Region 10,Season onset,none
+2011,46,2011/2012,46,HHS Region 10,Season peak week,12
+2011,46,2011/2012,46,HHS Region 10,Season peak percentage,2.2
+2011,46,2011/2012,46,HHS Region 10,1 wk ahead,1.1
 2011,46,2011/2012,46,HHS Region 10,2 wk ahead,0.8
 2011,46,2011/2012,46,HHS Region 10,3 wk ahead,0.6
-2011,46,2011/2012,46,HHS Region 10,4 wk ahead,1.3
+2011,46,2011/2012,46,HHS Region 10,4 wk ahead,1
 2011,47,2011/2012,47,US National,Season onset,none
 2011,47,2011/2012,47,US National,Season peak week,11
 2011,47,2011/2012,47,US National,Season peak percentage,2.4
@@ -3201,7 +3234,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,47,2011/2012,47,US National,4 wk ahead,1.8
 2011,47,2011/2012,47,HHS Region 1,Season onset,none
 2011,47,2011/2012,47,HHS Region 1,Season peak week,52
-2011,47,2011/2012,47,HHS Region 1,Season peak week,8
 2011,47,2011/2012,47,HHS Region 1,Season peak percentage,1
 2011,47,2011/2012,47,HHS Region 1,1 wk ahead,0.6
 2011,47,2011/2012,47,HHS Region 1,2 wk ahead,0.6
@@ -3238,14 +3270,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,47,2011/2012,47,HHS Region 5,4 wk ahead,1.2
 2011,47,2011/2012,47,HHS Region 6,Season onset,none
 2011,47,2011/2012,47,HHS Region 6,Season peak week,11
-2011,47,2011/2012,47,HHS Region 6,Season peak percentage,4.2
+2011,47,2011/2012,47,HHS Region 6,Season peak percentage,4.1
 2011,47,2011/2012,47,HHS Region 6,1 wk ahead,2.2
 2011,47,2011/2012,47,HHS Region 6,2 wk ahead,2
 2011,47,2011/2012,47,HHS Region 6,3 wk ahead,2.1
 2011,47,2011/2012,47,HHS Region 6,4 wk ahead,2.2
 2011,47,2011/2012,47,HHS Region 7,Season onset,5
 2011,47,2011/2012,47,HHS Region 7,Season peak week,9
-2011,47,2011/2012,47,HHS Region 7,Season peak percentage,3.5
+2011,47,2011/2012,47,HHS Region 7,Season peak percentage,3.4
 2011,47,2011/2012,47,HHS Region 7,1 wk ahead,1
 2011,47,2011/2012,47,HHS Region 7,2 wk ahead,0.8
 2011,47,2011/2012,47,HHS Region 7,3 wk ahead,1.4
@@ -3259,18 +3291,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,47,2011/2012,47,HHS Region 8,4 wk ahead,1
 2011,47,2011/2012,47,HHS Region 9,Season onset,none
 2011,47,2011/2012,47,HHS Region 9,Season peak week,52
+2011,47,2011/2012,47,HHS Region 9,Season peak week,8
 2011,47,2011/2012,47,HHS Region 9,Season peak percentage,3.7
-2011,47,2011/2012,47,HHS Region 9,1 wk ahead,1.4
-2011,47,2011/2012,47,HHS Region 9,2 wk ahead,2.2
+2011,47,2011/2012,47,HHS Region 9,1 wk ahead,1.5
+2011,47,2011/2012,47,HHS Region 9,2 wk ahead,2.3
 2011,47,2011/2012,47,HHS Region 9,3 wk ahead,2.6
-2011,47,2011/2012,47,HHS Region 9,4 wk ahead,3
-2011,47,2011/2012,47,HHS Region 10,Season onset,10
-2011,47,2011/2012,47,HHS Region 10,Season peak week,11
-2011,47,2011/2012,47,HHS Region 10,Season peak percentage,2.7
+2011,47,2011/2012,47,HHS Region 9,4 wk ahead,3.1
+2011,47,2011/2012,47,HHS Region 10,Season onset,none
+2011,47,2011/2012,47,HHS Region 10,Season peak week,12
+2011,47,2011/2012,47,HHS Region 10,Season peak percentage,2.2
 2011,47,2011/2012,47,HHS Region 10,1 wk ahead,0.8
 2011,47,2011/2012,47,HHS Region 10,2 wk ahead,0.6
-2011,47,2011/2012,47,HHS Region 10,3 wk ahead,1.3
-2011,47,2011/2012,47,HHS Region 10,4 wk ahead,1.6
+2011,47,2011/2012,47,HHS Region 10,3 wk ahead,1
+2011,47,2011/2012,47,HHS Region 10,4 wk ahead,1.2
 2011,48,2011/2012,48,US National,Season onset,none
 2011,48,2011/2012,48,US National,Season peak week,11
 2011,48,2011/2012,48,US National,Season peak percentage,2.4
@@ -3280,7 +3313,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,48,2011/2012,48,US National,4 wk ahead,2.1
 2011,48,2011/2012,48,HHS Region 1,Season onset,none
 2011,48,2011/2012,48,HHS Region 1,Season peak week,52
-2011,48,2011/2012,48,HHS Region 1,Season peak week,8
 2011,48,2011/2012,48,HHS Region 1,Season peak percentage,1
 2011,48,2011/2012,48,HHS Region 1,1 wk ahead,0.6
 2011,48,2011/2012,48,HHS Region 1,2 wk ahead,0.8
@@ -3317,14 +3349,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,48,2011/2012,48,HHS Region 5,4 wk ahead,1.5
 2011,48,2011/2012,48,HHS Region 6,Season onset,none
 2011,48,2011/2012,48,HHS Region 6,Season peak week,11
-2011,48,2011/2012,48,HHS Region 6,Season peak percentage,4.2
+2011,48,2011/2012,48,HHS Region 6,Season peak percentage,4.1
 2011,48,2011/2012,48,HHS Region 6,1 wk ahead,2
 2011,48,2011/2012,48,HHS Region 6,2 wk ahead,2.1
 2011,48,2011/2012,48,HHS Region 6,3 wk ahead,2.2
 2011,48,2011/2012,48,HHS Region 6,4 wk ahead,2.3
 2011,48,2011/2012,48,HHS Region 7,Season onset,5
 2011,48,2011/2012,48,HHS Region 7,Season peak week,9
-2011,48,2011/2012,48,HHS Region 7,Season peak percentage,3.5
+2011,48,2011/2012,48,HHS Region 7,Season peak percentage,3.4
 2011,48,2011/2012,48,HHS Region 7,1 wk ahead,0.8
 2011,48,2011/2012,48,HHS Region 7,2 wk ahead,1.4
 2011,48,2011/2012,48,HHS Region 7,3 wk ahead,1.4
@@ -3338,18 +3370,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,48,2011/2012,48,HHS Region 8,4 wk ahead,1.1
 2011,48,2011/2012,48,HHS Region 9,Season onset,none
 2011,48,2011/2012,48,HHS Region 9,Season peak week,52
+2011,48,2011/2012,48,HHS Region 9,Season peak week,8
 2011,48,2011/2012,48,HHS Region 9,Season peak percentage,3.7
-2011,48,2011/2012,48,HHS Region 9,1 wk ahead,2.2
+2011,48,2011/2012,48,HHS Region 9,1 wk ahead,2.3
 2011,48,2011/2012,48,HHS Region 9,2 wk ahead,2.6
-2011,48,2011/2012,48,HHS Region 9,3 wk ahead,3
+2011,48,2011/2012,48,HHS Region 9,3 wk ahead,3.1
 2011,48,2011/2012,48,HHS Region 9,4 wk ahead,3.7
-2011,48,2011/2012,48,HHS Region 10,Season onset,10
-2011,48,2011/2012,48,HHS Region 10,Season peak week,11
-2011,48,2011/2012,48,HHS Region 10,Season peak percentage,2.7
+2011,48,2011/2012,48,HHS Region 10,Season onset,none
+2011,48,2011/2012,48,HHS Region 10,Season peak week,12
+2011,48,2011/2012,48,HHS Region 10,Season peak percentage,2.2
 2011,48,2011/2012,48,HHS Region 10,1 wk ahead,0.6
-2011,48,2011/2012,48,HHS Region 10,2 wk ahead,1.3
-2011,48,2011/2012,48,HHS Region 10,3 wk ahead,1.6
-2011,48,2011/2012,48,HHS Region 10,4 wk ahead,2
+2011,48,2011/2012,48,HHS Region 10,2 wk ahead,1
+2011,48,2011/2012,48,HHS Region 10,3 wk ahead,1.2
+2011,48,2011/2012,48,HHS Region 10,4 wk ahead,1.3
 2011,49,2011/2012,49,US National,Season onset,none
 2011,49,2011/2012,49,US National,Season peak week,11
 2011,49,2011/2012,49,US National,Season peak percentage,2.4
@@ -3359,7 +3392,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,49,2011/2012,49,US National,4 wk ahead,1.8
 2011,49,2011/2012,49,HHS Region 1,Season onset,none
 2011,49,2011/2012,49,HHS Region 1,Season peak week,52
-2011,49,2011/2012,49,HHS Region 1,Season peak week,8
 2011,49,2011/2012,49,HHS Region 1,Season peak percentage,1
 2011,49,2011/2012,49,HHS Region 1,1 wk ahead,0.8
 2011,49,2011/2012,49,HHS Region 1,2 wk ahead,0.9
@@ -3396,14 +3428,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,49,2011/2012,49,HHS Region 5,4 wk ahead,1.2
 2011,49,2011/2012,49,HHS Region 6,Season onset,none
 2011,49,2011/2012,49,HHS Region 6,Season peak week,11
-2011,49,2011/2012,49,HHS Region 6,Season peak percentage,4.2
+2011,49,2011/2012,49,HHS Region 6,Season peak percentage,4.1
 2011,49,2011/2012,49,HHS Region 6,1 wk ahead,2.1
 2011,49,2011/2012,49,HHS Region 6,2 wk ahead,2.2
 2011,49,2011/2012,49,HHS Region 6,3 wk ahead,2.3
 2011,49,2011/2012,49,HHS Region 6,4 wk ahead,2.1
 2011,49,2011/2012,49,HHS Region 7,Season onset,5
 2011,49,2011/2012,49,HHS Region 7,Season peak week,9
-2011,49,2011/2012,49,HHS Region 7,Season peak percentage,3.5
+2011,49,2011/2012,49,HHS Region 7,Season peak percentage,3.4
 2011,49,2011/2012,49,HHS Region 7,1 wk ahead,1.4
 2011,49,2011/2012,49,HHS Region 7,2 wk ahead,1.4
 2011,49,2011/2012,49,HHS Region 7,3 wk ahead,1.9
@@ -3417,18 +3449,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,49,2011/2012,49,HHS Region 8,4 wk ahead,1.1
 2011,49,2011/2012,49,HHS Region 9,Season onset,none
 2011,49,2011/2012,49,HHS Region 9,Season peak week,52
+2011,49,2011/2012,49,HHS Region 9,Season peak week,8
 2011,49,2011/2012,49,HHS Region 9,Season peak percentage,3.7
 2011,49,2011/2012,49,HHS Region 9,1 wk ahead,2.6
-2011,49,2011/2012,49,HHS Region 9,2 wk ahead,3
+2011,49,2011/2012,49,HHS Region 9,2 wk ahead,3.1
 2011,49,2011/2012,49,HHS Region 9,3 wk ahead,3.7
 2011,49,2011/2012,49,HHS Region 9,4 wk ahead,3
-2011,49,2011/2012,49,HHS Region 10,Season onset,10
-2011,49,2011/2012,49,HHS Region 10,Season peak week,11
-2011,49,2011/2012,49,HHS Region 10,Season peak percentage,2.7
-2011,49,2011/2012,49,HHS Region 10,1 wk ahead,1.3
-2011,49,2011/2012,49,HHS Region 10,2 wk ahead,1.6
-2011,49,2011/2012,49,HHS Region 10,3 wk ahead,2
-2011,49,2011/2012,49,HHS Region 10,4 wk ahead,1.6
+2011,49,2011/2012,49,HHS Region 10,Season onset,none
+2011,49,2011/2012,49,HHS Region 10,Season peak week,12
+2011,49,2011/2012,49,HHS Region 10,Season peak percentage,2.2
+2011,49,2011/2012,49,HHS Region 10,1 wk ahead,1
+2011,49,2011/2012,49,HHS Region 10,2 wk ahead,1.2
+2011,49,2011/2012,49,HHS Region 10,3 wk ahead,1.3
+2011,49,2011/2012,49,HHS Region 10,4 wk ahead,1.1
 2011,50,2011/2012,50,US National,Season onset,none
 2011,50,2011/2012,50,US National,Season peak week,11
 2011,50,2011/2012,50,US National,Season peak percentage,2.4
@@ -3438,7 +3471,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,50,2011/2012,50,US National,4 wk ahead,1.6
 2011,50,2011/2012,50,HHS Region 1,Season onset,none
 2011,50,2011/2012,50,HHS Region 1,Season peak week,52
-2011,50,2011/2012,50,HHS Region 1,Season peak week,8
 2011,50,2011/2012,50,HHS Region 1,Season peak percentage,1
 2011,50,2011/2012,50,HHS Region 1,1 wk ahead,0.9
 2011,50,2011/2012,50,HHS Region 1,2 wk ahead,1
@@ -3450,7 +3482,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,50,2011/2012,50,HHS Region 2,1 wk ahead,1.2
 2011,50,2011/2012,50,HHS Region 2,2 wk ahead,1.2
 2011,50,2011/2012,50,HHS Region 2,3 wk ahead,1.3
-2011,50,2011/2012,50,HHS Region 2,4 wk ahead,1.1
+2011,50,2011/2012,50,HHS Region 2,4 wk ahead,1
 2011,50,2011/2012,50,HHS Region 3,Season onset,none
 2011,50,2011/2012,50,HHS Region 3,Season peak week,52
 2011,50,2011/2012,50,HHS Region 3,Season peak percentage,2.1
@@ -3475,14 +3507,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,50,2011/2012,50,HHS Region 5,4 wk ahead,1.2
 2011,50,2011/2012,50,HHS Region 6,Season onset,none
 2011,50,2011/2012,50,HHS Region 6,Season peak week,11
-2011,50,2011/2012,50,HHS Region 6,Season peak percentage,4.2
+2011,50,2011/2012,50,HHS Region 6,Season peak percentage,4.1
 2011,50,2011/2012,50,HHS Region 6,1 wk ahead,2.2
 2011,50,2011/2012,50,HHS Region 6,2 wk ahead,2.3
 2011,50,2011/2012,50,HHS Region 6,3 wk ahead,2.1
 2011,50,2011/2012,50,HHS Region 6,4 wk ahead,2.1
 2011,50,2011/2012,50,HHS Region 7,Season onset,5
 2011,50,2011/2012,50,HHS Region 7,Season peak week,9
-2011,50,2011/2012,50,HHS Region 7,Season peak percentage,3.5
+2011,50,2011/2012,50,HHS Region 7,Season peak percentage,3.4
 2011,50,2011/2012,50,HHS Region 7,1 wk ahead,1.4
 2011,50,2011/2012,50,HHS Region 7,2 wk ahead,1.9
 2011,50,2011/2012,50,HHS Region 7,3 wk ahead,1.5
@@ -3496,18 +3528,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,50,2011/2012,50,HHS Region 8,4 wk ahead,1.1
 2011,50,2011/2012,50,HHS Region 9,Season onset,none
 2011,50,2011/2012,50,HHS Region 9,Season peak week,52
+2011,50,2011/2012,50,HHS Region 9,Season peak week,8
 2011,50,2011/2012,50,HHS Region 9,Season peak percentage,3.7
-2011,50,2011/2012,50,HHS Region 9,1 wk ahead,3
+2011,50,2011/2012,50,HHS Region 9,1 wk ahead,3.1
 2011,50,2011/2012,50,HHS Region 9,2 wk ahead,3.7
 2011,50,2011/2012,50,HHS Region 9,3 wk ahead,3
 2011,50,2011/2012,50,HHS Region 9,4 wk ahead,2.5
-2011,50,2011/2012,50,HHS Region 10,Season onset,10
-2011,50,2011/2012,50,HHS Region 10,Season peak week,11
-2011,50,2011/2012,50,HHS Region 10,Season peak percentage,2.7
-2011,50,2011/2012,50,HHS Region 10,1 wk ahead,1.6
-2011,50,2011/2012,50,HHS Region 10,2 wk ahead,2
-2011,50,2011/2012,50,HHS Region 10,3 wk ahead,1.6
-2011,50,2011/2012,50,HHS Region 10,4 wk ahead,1
+2011,50,2011/2012,50,HHS Region 10,Season onset,none
+2011,50,2011/2012,50,HHS Region 10,Season peak week,12
+2011,50,2011/2012,50,HHS Region 10,Season peak percentage,2.2
+2011,50,2011/2012,50,HHS Region 10,1 wk ahead,1.2
+2011,50,2011/2012,50,HHS Region 10,2 wk ahead,1.3
+2011,50,2011/2012,50,HHS Region 10,3 wk ahead,1.1
+2011,50,2011/2012,50,HHS Region 10,4 wk ahead,0.7
 2011,51,2011/2012,51,US National,Season onset,none
 2011,51,2011/2012,51,US National,Season peak week,11
 2011,51,2011/2012,51,US National,Season peak percentage,2.4
@@ -3517,7 +3550,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,51,2011/2012,51,US National,4 wk ahead,1.6
 2011,51,2011/2012,51,HHS Region 1,Season onset,none
 2011,51,2011/2012,51,HHS Region 1,Season peak week,52
-2011,51,2011/2012,51,HHS Region 1,Season peak week,8
 2011,51,2011/2012,51,HHS Region 1,Season peak percentage,1
 2011,51,2011/2012,51,HHS Region 1,1 wk ahead,1
 2011,51,2011/2012,51,HHS Region 1,2 wk ahead,0.9
@@ -3528,8 +3560,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,51,2011/2012,51,HHS Region 2,Season peak percentage,1.4
 2011,51,2011/2012,51,HHS Region 2,1 wk ahead,1.2
 2011,51,2011/2012,51,HHS Region 2,2 wk ahead,1.3
-2011,51,2011/2012,51,HHS Region 2,3 wk ahead,1.1
-2011,51,2011/2012,51,HHS Region 2,4 wk ahead,1.2
+2011,51,2011/2012,51,HHS Region 2,3 wk ahead,1
+2011,51,2011/2012,51,HHS Region 2,4 wk ahead,1.1
 2011,51,2011/2012,51,HHS Region 3,Season onset,none
 2011,51,2011/2012,51,HHS Region 3,Season peak week,52
 2011,51,2011/2012,51,HHS Region 3,Season peak percentage,2.1
@@ -3554,14 +3586,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,51,2011/2012,51,HHS Region 5,4 wk ahead,1.2
 2011,51,2011/2012,51,HHS Region 6,Season onset,none
 2011,51,2011/2012,51,HHS Region 6,Season peak week,11
-2011,51,2011/2012,51,HHS Region 6,Season peak percentage,4.2
+2011,51,2011/2012,51,HHS Region 6,Season peak percentage,4.1
 2011,51,2011/2012,51,HHS Region 6,1 wk ahead,2.3
 2011,51,2011/2012,51,HHS Region 6,2 wk ahead,2.1
 2011,51,2011/2012,51,HHS Region 6,3 wk ahead,2.1
 2011,51,2011/2012,51,HHS Region 6,4 wk ahead,2.2
 2011,51,2011/2012,51,HHS Region 7,Season onset,5
 2011,51,2011/2012,51,HHS Region 7,Season peak week,9
-2011,51,2011/2012,51,HHS Region 7,Season peak percentage,3.5
+2011,51,2011/2012,51,HHS Region 7,Season peak percentage,3.4
 2011,51,2011/2012,51,HHS Region 7,1 wk ahead,1.9
 2011,51,2011/2012,51,HHS Region 7,2 wk ahead,1.5
 2011,51,2011/2012,51,HHS Region 7,3 wk ahead,1.5
@@ -3575,18 +3607,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,51,2011/2012,51,HHS Region 8,4 wk ahead,1.1
 2011,51,2011/2012,51,HHS Region 9,Season onset,none
 2011,51,2011/2012,51,HHS Region 9,Season peak week,52
+2011,51,2011/2012,51,HHS Region 9,Season peak week,8
 2011,51,2011/2012,51,HHS Region 9,Season peak percentage,3.7
 2011,51,2011/2012,51,HHS Region 9,1 wk ahead,3.7
 2011,51,2011/2012,51,HHS Region 9,2 wk ahead,3
 2011,51,2011/2012,51,HHS Region 9,3 wk ahead,2.5
-2011,51,2011/2012,51,HHS Region 9,4 wk ahead,2.3
-2011,51,2011/2012,51,HHS Region 10,Season onset,10
-2011,51,2011/2012,51,HHS Region 10,Season peak week,11
-2011,51,2011/2012,51,HHS Region 10,Season peak percentage,2.7
-2011,51,2011/2012,51,HHS Region 10,1 wk ahead,2
-2011,51,2011/2012,51,HHS Region 10,2 wk ahead,1.6
-2011,51,2011/2012,51,HHS Region 10,3 wk ahead,1
-2011,51,2011/2012,51,HHS Region 10,4 wk ahead,1.5
+2011,51,2011/2012,51,HHS Region 9,4 wk ahead,2.4
+2011,51,2011/2012,51,HHS Region 10,Season onset,none
+2011,51,2011/2012,51,HHS Region 10,Season peak week,12
+2011,51,2011/2012,51,HHS Region 10,Season peak percentage,2.2
+2011,51,2011/2012,51,HHS Region 10,1 wk ahead,1.3
+2011,51,2011/2012,51,HHS Region 10,2 wk ahead,1.1
+2011,51,2011/2012,51,HHS Region 10,3 wk ahead,0.7
+2011,51,2011/2012,51,HHS Region 10,4 wk ahead,1.1
 2011,52,2011/2012,52,US National,Season onset,none
 2011,52,2011/2012,52,US National,Season peak week,11
 2011,52,2011/2012,52,US National,Season peak percentage,2.4
@@ -3596,7 +3629,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,52,2011/2012,52,US National,4 wk ahead,1.8
 2011,52,2011/2012,52,HHS Region 1,Season onset,none
 2011,52,2011/2012,52,HHS Region 1,Season peak week,52
-2011,52,2011/2012,52,HHS Region 1,Season peak week,8
 2011,52,2011/2012,52,HHS Region 1,Season peak percentage,1
 2011,52,2011/2012,52,HHS Region 1,1 wk ahead,0.9
 2011,52,2011/2012,52,HHS Region 1,2 wk ahead,0.8
@@ -3606,8 +3638,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,52,2011/2012,52,HHS Region 2,Season peak week,49
 2011,52,2011/2012,52,HHS Region 2,Season peak percentage,1.4
 2011,52,2011/2012,52,HHS Region 2,1 wk ahead,1.3
-2011,52,2011/2012,52,HHS Region 2,2 wk ahead,1.1
-2011,52,2011/2012,52,HHS Region 2,3 wk ahead,1.2
+2011,52,2011/2012,52,HHS Region 2,2 wk ahead,1
+2011,52,2011/2012,52,HHS Region 2,3 wk ahead,1.1
 2011,52,2011/2012,52,HHS Region 2,4 wk ahead,1
 2011,52,2011/2012,52,HHS Region 3,Season onset,none
 2011,52,2011/2012,52,HHS Region 3,Season peak week,52
@@ -3623,7 +3655,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,52,2011/2012,52,HHS Region 4,1 wk ahead,1.6
 2011,52,2011/2012,52,HHS Region 4,2 wk ahead,1.5
 2011,52,2011/2012,52,HHS Region 4,3 wk ahead,1.7
-2011,52,2011/2012,52,HHS Region 4,4 wk ahead,1.8
+2011,52,2011/2012,52,HHS Region 4,4 wk ahead,1.7
 2011,52,2011/2012,52,HHS Region 5,Season onset,7
 2011,52,2011/2012,52,HHS Region 5,Season peak week,11
 2011,52,2011/2012,52,HHS Region 5,Season peak percentage,2.4
@@ -3633,14 +3665,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,52,2011/2012,52,HHS Region 5,4 wk ahead,1.3
 2011,52,2011/2012,52,HHS Region 6,Season onset,none
 2011,52,2011/2012,52,HHS Region 6,Season peak week,11
-2011,52,2011/2012,52,HHS Region 6,Season peak percentage,4.2
+2011,52,2011/2012,52,HHS Region 6,Season peak percentage,4.1
 2011,52,2011/2012,52,HHS Region 6,1 wk ahead,2.1
 2011,52,2011/2012,52,HHS Region 6,2 wk ahead,2.1
 2011,52,2011/2012,52,HHS Region 6,3 wk ahead,2.2
-2011,52,2011/2012,52,HHS Region 6,4 wk ahead,2.3
+2011,52,2011/2012,52,HHS Region 6,4 wk ahead,2.4
 2011,52,2011/2012,52,HHS Region 7,Season onset,5
 2011,52,2011/2012,52,HHS Region 7,Season peak week,9
-2011,52,2011/2012,52,HHS Region 7,Season peak percentage,3.5
+2011,52,2011/2012,52,HHS Region 7,Season peak percentage,3.4
 2011,52,2011/2012,52,HHS Region 7,1 wk ahead,1.5
 2011,52,2011/2012,52,HHS Region 7,2 wk ahead,1.5
 2011,52,2011/2012,52,HHS Region 7,3 wk ahead,1.6
@@ -3654,18 +3686,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2011,52,2011/2012,52,HHS Region 8,4 wk ahead,1.3
 2011,52,2011/2012,52,HHS Region 9,Season onset,none
 2011,52,2011/2012,52,HHS Region 9,Season peak week,52
+2011,52,2011/2012,52,HHS Region 9,Season peak week,8
 2011,52,2011/2012,52,HHS Region 9,Season peak percentage,3.7
 2011,52,2011/2012,52,HHS Region 9,1 wk ahead,3
 2011,52,2011/2012,52,HHS Region 9,2 wk ahead,2.5
-2011,52,2011/2012,52,HHS Region 9,3 wk ahead,2.3
-2011,52,2011/2012,52,HHS Region 9,4 wk ahead,2.9
-2011,52,2011/2012,52,HHS Region 10,Season onset,10
-2011,52,2011/2012,52,HHS Region 10,Season peak week,11
-2011,52,2011/2012,52,HHS Region 10,Season peak percentage,2.7
-2011,52,2011/2012,52,HHS Region 10,1 wk ahead,1.6
-2011,52,2011/2012,52,HHS Region 10,2 wk ahead,1
-2011,52,2011/2012,52,HHS Region 10,3 wk ahead,1.5
-2011,52,2011/2012,52,HHS Region 10,4 wk ahead,1.3
+2011,52,2011/2012,52,HHS Region 9,3 wk ahead,2.4
+2011,52,2011/2012,52,HHS Region 9,4 wk ahead,3
+2011,52,2011/2012,52,HHS Region 10,Season onset,none
+2011,52,2011/2012,52,HHS Region 10,Season peak week,12
+2011,52,2011/2012,52,HHS Region 10,Season peak percentage,2.2
+2011,52,2011/2012,52,HHS Region 10,1 wk ahead,1.1
+2011,52,2011/2012,52,HHS Region 10,2 wk ahead,0.7
+2011,52,2011/2012,52,HHS Region 10,3 wk ahead,1.1
+2011,52,2011/2012,52,HHS Region 10,4 wk ahead,1.1
 2012,1,2011/2012,53,US National,Season onset,none
 2012,1,2011/2012,53,US National,Season peak week,11
 2012,1,2011/2012,53,US National,Season peak percentage,2.4
@@ -3675,7 +3708,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,1,2011/2012,53,US National,4 wk ahead,2
 2012,1,2011/2012,53,HHS Region 1,Season onset,none
 2012,1,2011/2012,53,HHS Region 1,Season peak week,52
-2012,1,2011/2012,53,HHS Region 1,Season peak week,8
 2012,1,2011/2012,53,HHS Region 1,Season peak percentage,1
 2012,1,2011/2012,53,HHS Region 1,1 wk ahead,0.8
 2012,1,2011/2012,53,HHS Region 1,2 wk ahead,0.8
@@ -3684,8 +3716,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,1,2011/2012,53,HHS Region 2,Season onset,none
 2012,1,2011/2012,53,HHS Region 2,Season peak week,49
 2012,1,2011/2012,53,HHS Region 2,Season peak percentage,1.4
-2012,1,2011/2012,53,HHS Region 2,1 wk ahead,1.1
-2012,1,2011/2012,53,HHS Region 2,2 wk ahead,1.2
+2012,1,2011/2012,53,HHS Region 2,1 wk ahead,1
+2012,1,2011/2012,53,HHS Region 2,2 wk ahead,1.1
 2012,1,2011/2012,53,HHS Region 2,3 wk ahead,1
 2012,1,2011/2012,53,HHS Region 2,4 wk ahead,1.1
 2012,1,2011/2012,53,HHS Region 3,Season onset,none
@@ -3701,8 +3733,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,1,2011/2012,53,HHS Region 4,Season peak percentage,2.3
 2012,1,2011/2012,53,HHS Region 4,1 wk ahead,1.5
 2012,1,2011/2012,53,HHS Region 4,2 wk ahead,1.7
-2012,1,2011/2012,53,HHS Region 4,3 wk ahead,1.8
-2012,1,2011/2012,53,HHS Region 4,4 wk ahead,1.9
+2012,1,2011/2012,53,HHS Region 4,3 wk ahead,1.7
+2012,1,2011/2012,53,HHS Region 4,4 wk ahead,1.8
 2012,1,2011/2012,53,HHS Region 5,Season onset,7
 2012,1,2011/2012,53,HHS Region 5,Season peak week,11
 2012,1,2011/2012,53,HHS Region 5,Season peak percentage,2.4
@@ -3712,14 +3744,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,1,2011/2012,53,HHS Region 5,4 wk ahead,1.5
 2012,1,2011/2012,53,HHS Region 6,Season onset,none
 2012,1,2011/2012,53,HHS Region 6,Season peak week,11
-2012,1,2011/2012,53,HHS Region 6,Season peak percentage,4.2
+2012,1,2011/2012,53,HHS Region 6,Season peak percentage,4.1
 2012,1,2011/2012,53,HHS Region 6,1 wk ahead,2.1
 2012,1,2011/2012,53,HHS Region 6,2 wk ahead,2.2
-2012,1,2011/2012,53,HHS Region 6,3 wk ahead,2.3
-2012,1,2011/2012,53,HHS Region 6,4 wk ahead,2.6
+2012,1,2011/2012,53,HHS Region 6,3 wk ahead,2.4
+2012,1,2011/2012,53,HHS Region 6,4 wk ahead,2.5
 2012,1,2011/2012,53,HHS Region 7,Season onset,5
 2012,1,2011/2012,53,HHS Region 7,Season peak week,9
-2012,1,2011/2012,53,HHS Region 7,Season peak percentage,3.5
+2012,1,2011/2012,53,HHS Region 7,Season peak percentage,3.4
 2012,1,2011/2012,53,HHS Region 7,1 wk ahead,1.5
 2012,1,2011/2012,53,HHS Region 7,2 wk ahead,1.6
 2012,1,2011/2012,53,HHS Region 7,3 wk ahead,1.8
@@ -3733,18 +3765,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,1,2011/2012,53,HHS Region 8,4 wk ahead,1.5
 2012,1,2011/2012,53,HHS Region 9,Season onset,none
 2012,1,2011/2012,53,HHS Region 9,Season peak week,52
+2012,1,2011/2012,53,HHS Region 9,Season peak week,8
 2012,1,2011/2012,53,HHS Region 9,Season peak percentage,3.7
 2012,1,2011/2012,53,HHS Region 9,1 wk ahead,2.5
-2012,1,2011/2012,53,HHS Region 9,2 wk ahead,2.3
-2012,1,2011/2012,53,HHS Region 9,3 wk ahead,2.9
-2012,1,2011/2012,53,HHS Region 9,4 wk ahead,3.2
-2012,1,2011/2012,53,HHS Region 10,Season onset,10
-2012,1,2011/2012,53,HHS Region 10,Season peak week,11
-2012,1,2011/2012,53,HHS Region 10,Season peak percentage,2.7
-2012,1,2011/2012,53,HHS Region 10,1 wk ahead,1
-2012,1,2011/2012,53,HHS Region 10,2 wk ahead,1.5
-2012,1,2011/2012,53,HHS Region 10,3 wk ahead,1.3
-2012,1,2011/2012,53,HHS Region 10,4 wk ahead,1.8
+2012,1,2011/2012,53,HHS Region 9,2 wk ahead,2.4
+2012,1,2011/2012,53,HHS Region 9,3 wk ahead,3
+2012,1,2011/2012,53,HHS Region 9,4 wk ahead,3.3
+2012,1,2011/2012,53,HHS Region 10,Season onset,none
+2012,1,2011/2012,53,HHS Region 10,Season peak week,12
+2012,1,2011/2012,53,HHS Region 10,Season peak percentage,2.2
+2012,1,2011/2012,53,HHS Region 10,1 wk ahead,0.7
+2012,1,2011/2012,53,HHS Region 10,2 wk ahead,1.1
+2012,1,2011/2012,53,HHS Region 10,3 wk ahead,1.1
+2012,1,2011/2012,53,HHS Region 10,4 wk ahead,1.2
 2012,2,2011/2012,54,US National,Season onset,none
 2012,2,2011/2012,54,US National,Season peak week,11
 2012,2,2011/2012,54,US National,Season peak percentage,2.4
@@ -3754,7 +3787,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,2,2011/2012,54,US National,4 wk ahead,1.9
 2012,2,2011/2012,54,HHS Region 1,Season onset,none
 2012,2,2011/2012,54,HHS Region 1,Season peak week,52
-2012,2,2011/2012,54,HHS Region 1,Season peak week,8
 2012,2,2011/2012,54,HHS Region 1,Season peak percentage,1
 2012,2,2011/2012,54,HHS Region 1,1 wk ahead,0.8
 2012,2,2011/2012,54,HHS Region 1,2 wk ahead,0.8
@@ -3763,7 +3795,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,2,2011/2012,54,HHS Region 2,Season onset,none
 2012,2,2011/2012,54,HHS Region 2,Season peak week,49
 2012,2,2011/2012,54,HHS Region 2,Season peak percentage,1.4
-2012,2,2011/2012,54,HHS Region 2,1 wk ahead,1.2
+2012,2,2011/2012,54,HHS Region 2,1 wk ahead,1.1
 2012,2,2011/2012,54,HHS Region 2,2 wk ahead,1
 2012,2,2011/2012,54,HHS Region 2,3 wk ahead,1.1
 2012,2,2011/2012,54,HHS Region 2,4 wk ahead,1
@@ -3779,8 +3811,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,2,2011/2012,54,HHS Region 4,Season peak week,10
 2012,2,2011/2012,54,HHS Region 4,Season peak percentage,2.3
 2012,2,2011/2012,54,HHS Region 4,1 wk ahead,1.7
-2012,2,2011/2012,54,HHS Region 4,2 wk ahead,1.8
-2012,2,2011/2012,54,HHS Region 4,3 wk ahead,1.9
+2012,2,2011/2012,54,HHS Region 4,2 wk ahead,1.7
+2012,2,2011/2012,54,HHS Region 4,3 wk ahead,1.8
 2012,2,2011/2012,54,HHS Region 4,4 wk ahead,1.9
 2012,2,2011/2012,54,HHS Region 5,Season onset,7
 2012,2,2011/2012,54,HHS Region 5,Season peak week,11
@@ -3791,14 +3823,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,2,2011/2012,54,HHS Region 5,4 wk ahead,1.4
 2012,2,2011/2012,54,HHS Region 6,Season onset,none
 2012,2,2011/2012,54,HHS Region 6,Season peak week,11
-2012,2,2011/2012,54,HHS Region 6,Season peak percentage,4.2
+2012,2,2011/2012,54,HHS Region 6,Season peak percentage,4.1
 2012,2,2011/2012,54,HHS Region 6,1 wk ahead,2.2
-2012,2,2011/2012,54,HHS Region 6,2 wk ahead,2.3
-2012,2,2011/2012,54,HHS Region 6,3 wk ahead,2.6
-2012,2,2011/2012,54,HHS Region 6,4 wk ahead,2.6
+2012,2,2011/2012,54,HHS Region 6,2 wk ahead,2.4
+2012,2,2011/2012,54,HHS Region 6,3 wk ahead,2.5
+2012,2,2011/2012,54,HHS Region 6,4 wk ahead,2.7
 2012,2,2011/2012,54,HHS Region 7,Season onset,5
 2012,2,2011/2012,54,HHS Region 7,Season peak week,9
-2012,2,2011/2012,54,HHS Region 7,Season peak percentage,3.5
+2012,2,2011/2012,54,HHS Region 7,Season peak percentage,3.4
 2012,2,2011/2012,54,HHS Region 7,1 wk ahead,1.6
 2012,2,2011/2012,54,HHS Region 7,2 wk ahead,1.8
 2012,2,2011/2012,54,HHS Region 7,3 wk ahead,2.6
@@ -3812,18 +3844,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,2,2011/2012,54,HHS Region 8,4 wk ahead,1.6
 2012,2,2011/2012,54,HHS Region 9,Season onset,none
 2012,2,2011/2012,54,HHS Region 9,Season peak week,52
+2012,2,2011/2012,54,HHS Region 9,Season peak week,8
 2012,2,2011/2012,54,HHS Region 9,Season peak percentage,3.7
-2012,2,2011/2012,54,HHS Region 9,1 wk ahead,2.3
-2012,2,2011/2012,54,HHS Region 9,2 wk ahead,2.9
-2012,2,2011/2012,54,HHS Region 9,3 wk ahead,3.2
-2012,2,2011/2012,54,HHS Region 9,4 wk ahead,2.8
-2012,2,2011/2012,54,HHS Region 10,Season onset,10
-2012,2,2011/2012,54,HHS Region 10,Season peak week,11
-2012,2,2011/2012,54,HHS Region 10,Season peak percentage,2.7
-2012,2,2011/2012,54,HHS Region 10,1 wk ahead,1.5
-2012,2,2011/2012,54,HHS Region 10,2 wk ahead,1.3
-2012,2,2011/2012,54,HHS Region 10,3 wk ahead,1.8
-2012,2,2011/2012,54,HHS Region 10,4 wk ahead,1.7
+2012,2,2011/2012,54,HHS Region 9,1 wk ahead,2.4
+2012,2,2011/2012,54,HHS Region 9,2 wk ahead,3
+2012,2,2011/2012,54,HHS Region 9,3 wk ahead,3.3
+2012,2,2011/2012,54,HHS Region 9,4 wk ahead,2.9
+2012,2,2011/2012,54,HHS Region 10,Season onset,none
+2012,2,2011/2012,54,HHS Region 10,Season peak week,12
+2012,2,2011/2012,54,HHS Region 10,Season peak percentage,2.2
+2012,2,2011/2012,54,HHS Region 10,1 wk ahead,1.1
+2012,2,2011/2012,54,HHS Region 10,2 wk ahead,1.1
+2012,2,2011/2012,54,HHS Region 10,3 wk ahead,1.2
+2012,2,2011/2012,54,HHS Region 10,4 wk ahead,1.2
 2012,3,2011/2012,55,US National,Season onset,none
 2012,3,2011/2012,55,US National,Season peak week,11
 2012,3,2011/2012,55,US National,Season peak percentage,2.4
@@ -3833,7 +3866,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,3,2011/2012,55,US National,4 wk ahead,2.1
 2012,3,2011/2012,55,HHS Region 1,Season onset,none
 2012,3,2011/2012,55,HHS Region 1,Season peak week,52
-2012,3,2011/2012,55,HHS Region 1,Season peak week,8
 2012,3,2011/2012,55,HHS Region 1,Season peak percentage,1
 2012,3,2011/2012,55,HHS Region 1,1 wk ahead,0.8
 2012,3,2011/2012,55,HHS Region 1,2 wk ahead,0.8
@@ -3857,10 +3889,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,3,2011/2012,55,HHS Region 4,Season peak week,52
 2012,3,2011/2012,55,HHS Region 4,Season peak week,10
 2012,3,2011/2012,55,HHS Region 4,Season peak percentage,2.3
-2012,3,2011/2012,55,HHS Region 4,1 wk ahead,1.8
-2012,3,2011/2012,55,HHS Region 4,2 wk ahead,1.9
+2012,3,2011/2012,55,HHS Region 4,1 wk ahead,1.7
+2012,3,2011/2012,55,HHS Region 4,2 wk ahead,1.8
 2012,3,2011/2012,55,HHS Region 4,3 wk ahead,1.9
-2012,3,2011/2012,55,HHS Region 4,4 wk ahead,2.1
+2012,3,2011/2012,55,HHS Region 4,4 wk ahead,2
 2012,3,2011/2012,55,HHS Region 5,Season onset,7
 2012,3,2011/2012,55,HHS Region 5,Season peak week,11
 2012,3,2011/2012,55,HHS Region 5,Season peak percentage,2.4
@@ -3870,18 +3902,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,3,2011/2012,55,HHS Region 5,4 wk ahead,1.6
 2012,3,2011/2012,55,HHS Region 6,Season onset,none
 2012,3,2011/2012,55,HHS Region 6,Season peak week,11
-2012,3,2011/2012,55,HHS Region 6,Season peak percentage,4.2
-2012,3,2011/2012,55,HHS Region 6,1 wk ahead,2.3
-2012,3,2011/2012,55,HHS Region 6,2 wk ahead,2.6
-2012,3,2011/2012,55,HHS Region 6,3 wk ahead,2.6
+2012,3,2011/2012,55,HHS Region 6,Season peak percentage,4.1
+2012,3,2011/2012,55,HHS Region 6,1 wk ahead,2.4
+2012,3,2011/2012,55,HHS Region 6,2 wk ahead,2.5
+2012,3,2011/2012,55,HHS Region 6,3 wk ahead,2.7
 2012,3,2011/2012,55,HHS Region 6,4 wk ahead,3
 2012,3,2011/2012,55,HHS Region 7,Season onset,5
 2012,3,2011/2012,55,HHS Region 7,Season peak week,9
-2012,3,2011/2012,55,HHS Region 7,Season peak percentage,3.5
+2012,3,2011/2012,55,HHS Region 7,Season peak percentage,3.4
 2012,3,2011/2012,55,HHS Region 7,1 wk ahead,1.8
 2012,3,2011/2012,55,HHS Region 7,2 wk ahead,2.6
 2012,3,2011/2012,55,HHS Region 7,3 wk ahead,2.8
-2012,3,2011/2012,55,HHS Region 7,4 wk ahead,3.2
+2012,3,2011/2012,55,HHS Region 7,4 wk ahead,3.1
 2012,3,2011/2012,55,HHS Region 8,Season onset,none
 2012,3,2011/2012,55,HHS Region 8,Season peak week,11
 2012,3,2011/2012,55,HHS Region 8,Season peak percentage,2.2
@@ -3891,18 +3923,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,3,2011/2012,55,HHS Region 8,4 wk ahead,1.6
 2012,3,2011/2012,55,HHS Region 9,Season onset,none
 2012,3,2011/2012,55,HHS Region 9,Season peak week,52
+2012,3,2011/2012,55,HHS Region 9,Season peak week,8
 2012,3,2011/2012,55,HHS Region 9,Season peak percentage,3.7
-2012,3,2011/2012,55,HHS Region 9,1 wk ahead,2.9
-2012,3,2011/2012,55,HHS Region 9,2 wk ahead,3.2
-2012,3,2011/2012,55,HHS Region 9,3 wk ahead,2.8
-2012,3,2011/2012,55,HHS Region 9,4 wk ahead,3.1
-2012,3,2011/2012,55,HHS Region 10,Season onset,10
-2012,3,2011/2012,55,HHS Region 10,Season peak week,11
-2012,3,2011/2012,55,HHS Region 10,Season peak percentage,2.7
-2012,3,2011/2012,55,HHS Region 10,1 wk ahead,1.3
-2012,3,2011/2012,55,HHS Region 10,2 wk ahead,1.8
-2012,3,2011/2012,55,HHS Region 10,3 wk ahead,1.7
-2012,3,2011/2012,55,HHS Region 10,4 wk ahead,2
+2012,3,2011/2012,55,HHS Region 9,1 wk ahead,3
+2012,3,2011/2012,55,HHS Region 9,2 wk ahead,3.3
+2012,3,2011/2012,55,HHS Region 9,3 wk ahead,2.9
+2012,3,2011/2012,55,HHS Region 9,4 wk ahead,3.2
+2012,3,2011/2012,55,HHS Region 10,Season onset,none
+2012,3,2011/2012,55,HHS Region 10,Season peak week,12
+2012,3,2011/2012,55,HHS Region 10,Season peak percentage,2.2
+2012,3,2011/2012,55,HHS Region 10,1 wk ahead,1.1
+2012,3,2011/2012,55,HHS Region 10,2 wk ahead,1.2
+2012,3,2011/2012,55,HHS Region 10,3 wk ahead,1.2
+2012,3,2011/2012,55,HHS Region 10,4 wk ahead,1.5
 2012,4,2011/2012,56,US National,Season onset,none
 2012,4,2011/2012,56,US National,Season peak week,11
 2012,4,2011/2012,56,US National,Season peak percentage,2.4
@@ -3912,12 +3945,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,4,2011/2012,56,US National,4 wk ahead,2.2
 2012,4,2011/2012,56,HHS Region 1,Season onset,none
 2012,4,2011/2012,56,HHS Region 1,Season peak week,52
-2012,4,2011/2012,56,HHS Region 1,Season peak week,8
 2012,4,2011/2012,56,HHS Region 1,Season peak percentage,1
 2012,4,2011/2012,56,HHS Region 1,1 wk ahead,0.8
 2012,4,2011/2012,56,HHS Region 1,2 wk ahead,0.8
 2012,4,2011/2012,56,HHS Region 1,3 wk ahead,0.9
-2012,4,2011/2012,56,HHS Region 1,4 wk ahead,1
+2012,4,2011/2012,56,HHS Region 1,4 wk ahead,0.9
 2012,4,2011/2012,56,HHS Region 2,Season onset,none
 2012,4,2011/2012,56,HHS Region 2,Season peak week,49
 2012,4,2011/2012,56,HHS Region 2,Season peak percentage,1.4
@@ -3936,9 +3968,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,4,2011/2012,56,HHS Region 4,Season peak week,52
 2012,4,2011/2012,56,HHS Region 4,Season peak week,10
 2012,4,2011/2012,56,HHS Region 4,Season peak percentage,2.3
-2012,4,2011/2012,56,HHS Region 4,1 wk ahead,1.9
+2012,4,2011/2012,56,HHS Region 4,1 wk ahead,1.8
 2012,4,2011/2012,56,HHS Region 4,2 wk ahead,1.9
-2012,4,2011/2012,56,HHS Region 4,3 wk ahead,2.1
+2012,4,2011/2012,56,HHS Region 4,3 wk ahead,2
 2012,4,2011/2012,56,HHS Region 4,4 wk ahead,2
 2012,4,2011/2012,56,HHS Region 5,Season onset,7
 2012,4,2011/2012,56,HHS Region 5,Season peak week,11
@@ -3949,17 +3981,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,4,2011/2012,56,HHS Region 5,4 wk ahead,1.8
 2012,4,2011/2012,56,HHS Region 6,Season onset,none
 2012,4,2011/2012,56,HHS Region 6,Season peak week,11
-2012,4,2011/2012,56,HHS Region 6,Season peak percentage,4.2
-2012,4,2011/2012,56,HHS Region 6,1 wk ahead,2.6
-2012,4,2011/2012,56,HHS Region 6,2 wk ahead,2.6
+2012,4,2011/2012,56,HHS Region 6,Season peak percentage,4.1
+2012,4,2011/2012,56,HHS Region 6,1 wk ahead,2.5
+2012,4,2011/2012,56,HHS Region 6,2 wk ahead,2.7
 2012,4,2011/2012,56,HHS Region 6,3 wk ahead,3
 2012,4,2011/2012,56,HHS Region 6,4 wk ahead,3.3
 2012,4,2011/2012,56,HHS Region 7,Season onset,5
 2012,4,2011/2012,56,HHS Region 7,Season peak week,9
-2012,4,2011/2012,56,HHS Region 7,Season peak percentage,3.5
+2012,4,2011/2012,56,HHS Region 7,Season peak percentage,3.4
 2012,4,2011/2012,56,HHS Region 7,1 wk ahead,2.6
 2012,4,2011/2012,56,HHS Region 7,2 wk ahead,2.8
-2012,4,2011/2012,56,HHS Region 7,3 wk ahead,3.2
+2012,4,2011/2012,56,HHS Region 7,3 wk ahead,3.1
 2012,4,2011/2012,56,HHS Region 7,4 wk ahead,3
 2012,4,2011/2012,56,HHS Region 8,Season onset,none
 2012,4,2011/2012,56,HHS Region 8,Season peak week,11
@@ -3970,18 +4002,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,4,2011/2012,56,HHS Region 8,4 wk ahead,1.9
 2012,4,2011/2012,56,HHS Region 9,Season onset,none
 2012,4,2011/2012,56,HHS Region 9,Season peak week,52
+2012,4,2011/2012,56,HHS Region 9,Season peak week,8
 2012,4,2011/2012,56,HHS Region 9,Season peak percentage,3.7
-2012,4,2011/2012,56,HHS Region 9,1 wk ahead,3.2
-2012,4,2011/2012,56,HHS Region 9,2 wk ahead,2.8
-2012,4,2011/2012,56,HHS Region 9,3 wk ahead,3.1
-2012,4,2011/2012,56,HHS Region 9,4 wk ahead,3.6
-2012,4,2011/2012,56,HHS Region 10,Season onset,10
-2012,4,2011/2012,56,HHS Region 10,Season peak week,11
-2012,4,2011/2012,56,HHS Region 10,Season peak percentage,2.7
-2012,4,2011/2012,56,HHS Region 10,1 wk ahead,1.8
-2012,4,2011/2012,56,HHS Region 10,2 wk ahead,1.7
-2012,4,2011/2012,56,HHS Region 10,3 wk ahead,2
-2012,4,2011/2012,56,HHS Region 10,4 wk ahead,1.8
+2012,4,2011/2012,56,HHS Region 9,1 wk ahead,3.3
+2012,4,2011/2012,56,HHS Region 9,2 wk ahead,2.9
+2012,4,2011/2012,56,HHS Region 9,3 wk ahead,3.2
+2012,4,2011/2012,56,HHS Region 9,4 wk ahead,3.7
+2012,4,2011/2012,56,HHS Region 10,Season onset,none
+2012,4,2011/2012,56,HHS Region 10,Season peak week,12
+2012,4,2011/2012,56,HHS Region 10,Season peak percentage,2.2
+2012,4,2011/2012,56,HHS Region 10,1 wk ahead,1.2
+2012,4,2011/2012,56,HHS Region 10,2 wk ahead,1.2
+2012,4,2011/2012,56,HHS Region 10,3 wk ahead,1.5
+2012,4,2011/2012,56,HHS Region 10,4 wk ahead,1.4
 2012,5,2011/2012,57,US National,Season onset,none
 2012,5,2011/2012,57,US National,Season peak week,11
 2012,5,2011/2012,57,US National,Season peak percentage,2.4
@@ -3991,11 +4024,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,5,2011/2012,57,US National,4 wk ahead,2.2
 2012,5,2011/2012,57,HHS Region 1,Season onset,none
 2012,5,2011/2012,57,HHS Region 1,Season peak week,52
-2012,5,2011/2012,57,HHS Region 1,Season peak week,8
 2012,5,2011/2012,57,HHS Region 1,Season peak percentage,1
 2012,5,2011/2012,57,HHS Region 1,1 wk ahead,0.8
 2012,5,2011/2012,57,HHS Region 1,2 wk ahead,0.9
-2012,5,2011/2012,57,HHS Region 1,3 wk ahead,1
+2012,5,2011/2012,57,HHS Region 1,3 wk ahead,0.9
 2012,5,2011/2012,57,HHS Region 1,4 wk ahead,0.8
 2012,5,2011/2012,57,HHS Region 2,Season onset,none
 2012,5,2011/2012,57,HHS Region 2,Season peak week,49
@@ -4016,7 +4048,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,5,2011/2012,57,HHS Region 4,Season peak week,10
 2012,5,2011/2012,57,HHS Region 4,Season peak percentage,2.3
 2012,5,2011/2012,57,HHS Region 4,1 wk ahead,1.9
-2012,5,2011/2012,57,HHS Region 4,2 wk ahead,2.1
+2012,5,2011/2012,57,HHS Region 4,2 wk ahead,2
 2012,5,2011/2012,57,HHS Region 4,3 wk ahead,2
 2012,5,2011/2012,57,HHS Region 4,4 wk ahead,2.1
 2012,5,2011/2012,57,HHS Region 5,Season onset,7
@@ -4028,18 +4060,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,5,2011/2012,57,HHS Region 5,4 wk ahead,1.8
 2012,5,2011/2012,57,HHS Region 6,Season onset,none
 2012,5,2011/2012,57,HHS Region 6,Season peak week,11
-2012,5,2011/2012,57,HHS Region 6,Season peak percentage,4.2
-2012,5,2011/2012,57,HHS Region 6,1 wk ahead,2.6
+2012,5,2011/2012,57,HHS Region 6,Season peak percentage,4.1
+2012,5,2011/2012,57,HHS Region 6,1 wk ahead,2.7
 2012,5,2011/2012,57,HHS Region 6,2 wk ahead,3
 2012,5,2011/2012,57,HHS Region 6,3 wk ahead,3.3
 2012,5,2011/2012,57,HHS Region 6,4 wk ahead,3.5
 2012,5,2011/2012,57,HHS Region 7,Season onset,5
 2012,5,2011/2012,57,HHS Region 7,Season peak week,9
-2012,5,2011/2012,57,HHS Region 7,Season peak percentage,3.5
+2012,5,2011/2012,57,HHS Region 7,Season peak percentage,3.4
 2012,5,2011/2012,57,HHS Region 7,1 wk ahead,2.8
-2012,5,2011/2012,57,HHS Region 7,2 wk ahead,3.2
+2012,5,2011/2012,57,HHS Region 7,2 wk ahead,3.1
 2012,5,2011/2012,57,HHS Region 7,3 wk ahead,3
-2012,5,2011/2012,57,HHS Region 7,4 wk ahead,3.5
+2012,5,2011/2012,57,HHS Region 7,4 wk ahead,3.4
 2012,5,2011/2012,57,HHS Region 8,Season onset,none
 2012,5,2011/2012,57,HHS Region 8,Season peak week,11
 2012,5,2011/2012,57,HHS Region 8,Season peak percentage,2.2
@@ -4049,18 +4081,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,5,2011/2012,57,HHS Region 8,4 wk ahead,1.7
 2012,5,2011/2012,57,HHS Region 9,Season onset,none
 2012,5,2011/2012,57,HHS Region 9,Season peak week,52
+2012,5,2011/2012,57,HHS Region 9,Season peak week,8
 2012,5,2011/2012,57,HHS Region 9,Season peak percentage,3.7
-2012,5,2011/2012,57,HHS Region 9,1 wk ahead,2.8
-2012,5,2011/2012,57,HHS Region 9,2 wk ahead,3.1
-2012,5,2011/2012,57,HHS Region 9,3 wk ahead,3.6
+2012,5,2011/2012,57,HHS Region 9,1 wk ahead,2.9
+2012,5,2011/2012,57,HHS Region 9,2 wk ahead,3.2
+2012,5,2011/2012,57,HHS Region 9,3 wk ahead,3.7
 2012,5,2011/2012,57,HHS Region 9,4 wk ahead,3.1
-2012,5,2011/2012,57,HHS Region 10,Season onset,10
-2012,5,2011/2012,57,HHS Region 10,Season peak week,11
-2012,5,2011/2012,57,HHS Region 10,Season peak percentage,2.7
-2012,5,2011/2012,57,HHS Region 10,1 wk ahead,1.7
-2012,5,2011/2012,57,HHS Region 10,2 wk ahead,2
-2012,5,2011/2012,57,HHS Region 10,3 wk ahead,1.8
-2012,5,2011/2012,57,HHS Region 10,4 wk ahead,1.9
+2012,5,2011/2012,57,HHS Region 10,Season onset,none
+2012,5,2011/2012,57,HHS Region 10,Season peak week,12
+2012,5,2011/2012,57,HHS Region 10,Season peak percentage,2.2
+2012,5,2011/2012,57,HHS Region 10,1 wk ahead,1.2
+2012,5,2011/2012,57,HHS Region 10,2 wk ahead,1.5
+2012,5,2011/2012,57,HHS Region 10,3 wk ahead,1.4
+2012,5,2011/2012,57,HHS Region 10,4 wk ahead,1.5
 2012,6,2011/2012,58,US National,Season onset,none
 2012,6,2011/2012,58,US National,Season peak week,11
 2012,6,2011/2012,58,US National,Season peak percentage,2.4
@@ -4070,10 +4103,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,6,2011/2012,58,US National,4 wk ahead,2.2
 2012,6,2011/2012,58,HHS Region 1,Season onset,none
 2012,6,2011/2012,58,HHS Region 1,Season peak week,52
-2012,6,2011/2012,58,HHS Region 1,Season peak week,8
 2012,6,2011/2012,58,HHS Region 1,Season peak percentage,1
 2012,6,2011/2012,58,HHS Region 1,1 wk ahead,0.9
-2012,6,2011/2012,58,HHS Region 1,2 wk ahead,1
+2012,6,2011/2012,58,HHS Region 1,2 wk ahead,0.9
 2012,6,2011/2012,58,HHS Region 1,3 wk ahead,0.8
 2012,6,2011/2012,58,HHS Region 1,4 wk ahead,0.8
 2012,6,2011/2012,58,HHS Region 2,Season onset,none
@@ -4094,7 +4126,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,6,2011/2012,58,HHS Region 4,Season peak week,52
 2012,6,2011/2012,58,HHS Region 4,Season peak week,10
 2012,6,2011/2012,58,HHS Region 4,Season peak percentage,2.3
-2012,6,2011/2012,58,HHS Region 4,1 wk ahead,2.1
+2012,6,2011/2012,58,HHS Region 4,1 wk ahead,2
 2012,6,2011/2012,58,HHS Region 4,2 wk ahead,2
 2012,6,2011/2012,58,HHS Region 4,3 wk ahead,2.1
 2012,6,2011/2012,58,HHS Region 4,4 wk ahead,2.3
@@ -4104,20 +4136,20 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,6,2011/2012,58,HHS Region 5,1 wk ahead,1.6
 2012,6,2011/2012,58,HHS Region 5,2 wk ahead,1.8
 2012,6,2011/2012,58,HHS Region 5,3 wk ahead,1.8
-2012,6,2011/2012,58,HHS Region 5,4 wk ahead,2.1
+2012,6,2011/2012,58,HHS Region 5,4 wk ahead,2
 2012,6,2011/2012,58,HHS Region 6,Season onset,none
 2012,6,2011/2012,58,HHS Region 6,Season peak week,11
-2012,6,2011/2012,58,HHS Region 6,Season peak percentage,4.2
+2012,6,2011/2012,58,HHS Region 6,Season peak percentage,4.1
 2012,6,2011/2012,58,HHS Region 6,1 wk ahead,3
 2012,6,2011/2012,58,HHS Region 6,2 wk ahead,3.3
 2012,6,2011/2012,58,HHS Region 6,3 wk ahead,3.5
 2012,6,2011/2012,58,HHS Region 6,4 wk ahead,3.4
 2012,6,2011/2012,58,HHS Region 7,Season onset,5
 2012,6,2011/2012,58,HHS Region 7,Season peak week,9
-2012,6,2011/2012,58,HHS Region 7,Season peak percentage,3.5
-2012,6,2011/2012,58,HHS Region 7,1 wk ahead,3.2
+2012,6,2011/2012,58,HHS Region 7,Season peak percentage,3.4
+2012,6,2011/2012,58,HHS Region 7,1 wk ahead,3.1
 2012,6,2011/2012,58,HHS Region 7,2 wk ahead,3
-2012,6,2011/2012,58,HHS Region 7,3 wk ahead,3.5
+2012,6,2011/2012,58,HHS Region 7,3 wk ahead,3.4
 2012,6,2011/2012,58,HHS Region 7,4 wk ahead,3.1
 2012,6,2011/2012,58,HHS Region 8,Season onset,none
 2012,6,2011/2012,58,HHS Region 8,Season peak week,11
@@ -4128,18 +4160,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,6,2011/2012,58,HHS Region 8,4 wk ahead,1.8
 2012,6,2011/2012,58,HHS Region 9,Season onset,none
 2012,6,2011/2012,58,HHS Region 9,Season peak week,52
+2012,6,2011/2012,58,HHS Region 9,Season peak week,8
 2012,6,2011/2012,58,HHS Region 9,Season peak percentage,3.7
-2012,6,2011/2012,58,HHS Region 9,1 wk ahead,3.1
-2012,6,2011/2012,58,HHS Region 9,2 wk ahead,3.6
+2012,6,2011/2012,58,HHS Region 9,1 wk ahead,3.2
+2012,6,2011/2012,58,HHS Region 9,2 wk ahead,3.7
 2012,6,2011/2012,58,HHS Region 9,3 wk ahead,3.1
-2012,6,2011/2012,58,HHS Region 9,4 wk ahead,2.4
-2012,6,2011/2012,58,HHS Region 10,Season onset,10
-2012,6,2011/2012,58,HHS Region 10,Season peak week,11
-2012,6,2011/2012,58,HHS Region 10,Season peak percentage,2.7
-2012,6,2011/2012,58,HHS Region 10,1 wk ahead,2
-2012,6,2011/2012,58,HHS Region 10,2 wk ahead,1.8
-2012,6,2011/2012,58,HHS Region 10,3 wk ahead,1.9
-2012,6,2011/2012,58,HHS Region 10,4 wk ahead,2.2
+2012,6,2011/2012,58,HHS Region 9,4 wk ahead,2.5
+2012,6,2011/2012,58,HHS Region 10,Season onset,none
+2012,6,2011/2012,58,HHS Region 10,Season peak week,12
+2012,6,2011/2012,58,HHS Region 10,Season peak percentage,2.2
+2012,6,2011/2012,58,HHS Region 10,1 wk ahead,1.5
+2012,6,2011/2012,58,HHS Region 10,2 wk ahead,1.4
+2012,6,2011/2012,58,HHS Region 10,3 wk ahead,1.5
+2012,6,2011/2012,58,HHS Region 10,4 wk ahead,1.6
 2012,7,2011/2012,59,US National,Season onset,none
 2012,7,2011/2012,59,US National,Season peak week,11
 2012,7,2011/2012,59,US National,Season peak percentage,2.4
@@ -4149,9 +4182,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,7,2011/2012,59,US National,4 wk ahead,2.4
 2012,7,2011/2012,59,HHS Region 1,Season onset,none
 2012,7,2011/2012,59,HHS Region 1,Season peak week,52
-2012,7,2011/2012,59,HHS Region 1,Season peak week,8
 2012,7,2011/2012,59,HHS Region 1,Season peak percentage,1
-2012,7,2011/2012,59,HHS Region 1,1 wk ahead,1
+2012,7,2011/2012,59,HHS Region 1,1 wk ahead,0.9
 2012,7,2011/2012,59,HHS Region 1,2 wk ahead,0.8
 2012,7,2011/2012,59,HHS Region 1,3 wk ahead,0.8
 2012,7,2011/2012,59,HHS Region 1,4 wk ahead,0.9
@@ -4182,20 +4214,20 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,7,2011/2012,59,HHS Region 5,Season peak percentage,2.4
 2012,7,2011/2012,59,HHS Region 5,1 wk ahead,1.8
 2012,7,2011/2012,59,HHS Region 5,2 wk ahead,1.8
-2012,7,2011/2012,59,HHS Region 5,3 wk ahead,2.1
+2012,7,2011/2012,59,HHS Region 5,3 wk ahead,2
 2012,7,2011/2012,59,HHS Region 5,4 wk ahead,2.4
 2012,7,2011/2012,59,HHS Region 6,Season onset,none
 2012,7,2011/2012,59,HHS Region 6,Season peak week,11
-2012,7,2011/2012,59,HHS Region 6,Season peak percentage,4.2
+2012,7,2011/2012,59,HHS Region 6,Season peak percentage,4.1
 2012,7,2011/2012,59,HHS Region 6,1 wk ahead,3.3
 2012,7,2011/2012,59,HHS Region 6,2 wk ahead,3.5
 2012,7,2011/2012,59,HHS Region 6,3 wk ahead,3.4
-2012,7,2011/2012,59,HHS Region 6,4 wk ahead,4.2
+2012,7,2011/2012,59,HHS Region 6,4 wk ahead,4.1
 2012,7,2011/2012,59,HHS Region 7,Season onset,5
 2012,7,2011/2012,59,HHS Region 7,Season peak week,9
-2012,7,2011/2012,59,HHS Region 7,Season peak percentage,3.5
+2012,7,2011/2012,59,HHS Region 7,Season peak percentage,3.4
 2012,7,2011/2012,59,HHS Region 7,1 wk ahead,3
-2012,7,2011/2012,59,HHS Region 7,2 wk ahead,3.5
+2012,7,2011/2012,59,HHS Region 7,2 wk ahead,3.4
 2012,7,2011/2012,59,HHS Region 7,3 wk ahead,3.1
 2012,7,2011/2012,59,HHS Region 7,4 wk ahead,2.6
 2012,7,2011/2012,59,HHS Region 8,Season onset,none
@@ -4207,18 +4239,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,7,2011/2012,59,HHS Region 8,4 wk ahead,2.2
 2012,7,2011/2012,59,HHS Region 9,Season onset,none
 2012,7,2011/2012,59,HHS Region 9,Season peak week,52
+2012,7,2011/2012,59,HHS Region 9,Season peak week,8
 2012,7,2011/2012,59,HHS Region 9,Season peak percentage,3.7
-2012,7,2011/2012,59,HHS Region 9,1 wk ahead,3.6
+2012,7,2011/2012,59,HHS Region 9,1 wk ahead,3.7
 2012,7,2011/2012,59,HHS Region 9,2 wk ahead,3.1
-2012,7,2011/2012,59,HHS Region 9,3 wk ahead,2.4
-2012,7,2011/2012,59,HHS Region 9,4 wk ahead,2.7
-2012,7,2011/2012,59,HHS Region 10,Season onset,10
-2012,7,2011/2012,59,HHS Region 10,Season peak week,11
-2012,7,2011/2012,59,HHS Region 10,Season peak percentage,2.7
-2012,7,2011/2012,59,HHS Region 10,1 wk ahead,1.8
-2012,7,2011/2012,59,HHS Region 10,2 wk ahead,1.9
-2012,7,2011/2012,59,HHS Region 10,3 wk ahead,2.2
-2012,7,2011/2012,59,HHS Region 10,4 wk ahead,2.7
+2012,7,2011/2012,59,HHS Region 9,3 wk ahead,2.5
+2012,7,2011/2012,59,HHS Region 9,4 wk ahead,2.8
+2012,7,2011/2012,59,HHS Region 10,Season onset,none
+2012,7,2011/2012,59,HHS Region 10,Season peak week,12
+2012,7,2011/2012,59,HHS Region 10,Season peak percentage,2.2
+2012,7,2011/2012,59,HHS Region 10,1 wk ahead,1.4
+2012,7,2011/2012,59,HHS Region 10,2 wk ahead,1.5
+2012,7,2011/2012,59,HHS Region 10,3 wk ahead,1.6
+2012,7,2011/2012,59,HHS Region 10,4 wk ahead,1.9
 2012,8,2011/2012,60,US National,Season onset,none
 2012,8,2011/2012,60,US National,Season peak week,11
 2012,8,2011/2012,60,US National,Season peak percentage,2.4
@@ -4228,12 +4261,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,8,2011/2012,60,US National,4 wk ahead,2
 2012,8,2011/2012,60,HHS Region 1,Season onset,none
 2012,8,2011/2012,60,HHS Region 1,Season peak week,52
-2012,8,2011/2012,60,HHS Region 1,Season peak week,8
 2012,8,2011/2012,60,HHS Region 1,Season peak percentage,1
 2012,8,2011/2012,60,HHS Region 1,1 wk ahead,0.8
 2012,8,2011/2012,60,HHS Region 1,2 wk ahead,0.8
 2012,8,2011/2012,60,HHS Region 1,3 wk ahead,0.9
-2012,8,2011/2012,60,HHS Region 1,4 wk ahead,0.9
+2012,8,2011/2012,60,HHS Region 1,4 wk ahead,0.8
 2012,8,2011/2012,60,HHS Region 2,Season onset,none
 2012,8,2011/2012,60,HHS Region 2,Season peak week,49
 2012,8,2011/2012,60,HHS Region 2,Season peak percentage,1.4
@@ -4247,7 +4279,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,8,2011/2012,60,HHS Region 3,1 wk ahead,1.7
 2012,8,2011/2012,60,HHS Region 3,2 wk ahead,1.6
 2012,8,2011/2012,60,HHS Region 3,3 wk ahead,1.9
-2012,8,2011/2012,60,HHS Region 3,4 wk ahead,1.5
+2012,8,2011/2012,60,HHS Region 3,4 wk ahead,1.4
 2012,8,2011/2012,60,HHS Region 4,Season onset,none
 2012,8,2011/2012,60,HHS Region 4,Season peak week,52
 2012,8,2011/2012,60,HHS Region 4,Season peak week,10
@@ -4260,20 +4292,20 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,8,2011/2012,60,HHS Region 5,Season peak week,11
 2012,8,2011/2012,60,HHS Region 5,Season peak percentage,2.4
 2012,8,2011/2012,60,HHS Region 5,1 wk ahead,1.8
-2012,8,2011/2012,60,HHS Region 5,2 wk ahead,2.1
+2012,8,2011/2012,60,HHS Region 5,2 wk ahead,2
 2012,8,2011/2012,60,HHS Region 5,3 wk ahead,2.4
 2012,8,2011/2012,60,HHS Region 5,4 wk ahead,1.9
 2012,8,2011/2012,60,HHS Region 6,Season onset,none
 2012,8,2011/2012,60,HHS Region 6,Season peak week,11
-2012,8,2011/2012,60,HHS Region 6,Season peak percentage,4.2
+2012,8,2011/2012,60,HHS Region 6,Season peak percentage,4.1
 2012,8,2011/2012,60,HHS Region 6,1 wk ahead,3.5
 2012,8,2011/2012,60,HHS Region 6,2 wk ahead,3.4
-2012,8,2011/2012,60,HHS Region 6,3 wk ahead,4.2
-2012,8,2011/2012,60,HHS Region 6,4 wk ahead,3
+2012,8,2011/2012,60,HHS Region 6,3 wk ahead,4.1
+2012,8,2011/2012,60,HHS Region 6,4 wk ahead,2.9
 2012,8,2011/2012,60,HHS Region 7,Season onset,5
 2012,8,2011/2012,60,HHS Region 7,Season peak week,9
-2012,8,2011/2012,60,HHS Region 7,Season peak percentage,3.5
-2012,8,2011/2012,60,HHS Region 7,1 wk ahead,3.5
+2012,8,2011/2012,60,HHS Region 7,Season peak percentage,3.4
+2012,8,2011/2012,60,HHS Region 7,1 wk ahead,3.4
 2012,8,2011/2012,60,HHS Region 7,2 wk ahead,3.1
 2012,8,2011/2012,60,HHS Region 7,3 wk ahead,2.6
 2012,8,2011/2012,60,HHS Region 7,4 wk ahead,1.7
@@ -4286,18 +4318,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,8,2011/2012,60,HHS Region 8,4 wk ahead,1.6
 2012,8,2011/2012,60,HHS Region 9,Season onset,none
 2012,8,2011/2012,60,HHS Region 9,Season peak week,52
+2012,8,2011/2012,60,HHS Region 9,Season peak week,8
 2012,8,2011/2012,60,HHS Region 9,Season peak percentage,3.7
 2012,8,2011/2012,60,HHS Region 9,1 wk ahead,3.1
-2012,8,2011/2012,60,HHS Region 9,2 wk ahead,2.4
-2012,8,2011/2012,60,HHS Region 9,3 wk ahead,2.7
-2012,8,2011/2012,60,HHS Region 9,4 wk ahead,2.5
-2012,8,2011/2012,60,HHS Region 10,Season onset,10
-2012,8,2011/2012,60,HHS Region 10,Season peak week,11
-2012,8,2011/2012,60,HHS Region 10,Season peak percentage,2.7
-2012,8,2011/2012,60,HHS Region 10,1 wk ahead,1.9
-2012,8,2011/2012,60,HHS Region 10,2 wk ahead,2.2
-2012,8,2011/2012,60,HHS Region 10,3 wk ahead,2.7
-2012,8,2011/2012,60,HHS Region 10,4 wk ahead,2.4
+2012,8,2011/2012,60,HHS Region 9,2 wk ahead,2.5
+2012,8,2011/2012,60,HHS Region 9,3 wk ahead,2.8
+2012,8,2011/2012,60,HHS Region 9,4 wk ahead,2.6
+2012,8,2011/2012,60,HHS Region 10,Season onset,none
+2012,8,2011/2012,60,HHS Region 10,Season peak week,12
+2012,8,2011/2012,60,HHS Region 10,Season peak percentage,2.2
+2012,8,2011/2012,60,HHS Region 10,1 wk ahead,1.5
+2012,8,2011/2012,60,HHS Region 10,2 wk ahead,1.6
+2012,8,2011/2012,60,HHS Region 10,3 wk ahead,1.9
+2012,8,2011/2012,60,HHS Region 10,4 wk ahead,2.2
 2012,9,2011/2012,61,US National,Season onset,none
 2012,9,2011/2012,61,US National,Season peak week,11
 2012,9,2011/2012,61,US National,Season peak percentage,2.4
@@ -4307,11 +4340,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,9,2011/2012,61,US National,4 wk ahead,1.9
 2012,9,2011/2012,61,HHS Region 1,Season onset,none
 2012,9,2011/2012,61,HHS Region 1,Season peak week,52
-2012,9,2011/2012,61,HHS Region 1,Season peak week,8
 2012,9,2011/2012,61,HHS Region 1,Season peak percentage,1
 2012,9,2011/2012,61,HHS Region 1,1 wk ahead,0.8
 2012,9,2011/2012,61,HHS Region 1,2 wk ahead,0.9
-2012,9,2011/2012,61,HHS Region 1,3 wk ahead,0.9
+2012,9,2011/2012,61,HHS Region 1,3 wk ahead,0.8
 2012,9,2011/2012,61,HHS Region 1,4 wk ahead,0.6
 2012,9,2011/2012,61,HHS Region 2,Season onset,none
 2012,9,2011/2012,61,HHS Region 2,Season peak week,49
@@ -4325,7 +4357,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,9,2011/2012,61,HHS Region 3,Season peak percentage,2.1
 2012,9,2011/2012,61,HHS Region 3,1 wk ahead,1.6
 2012,9,2011/2012,61,HHS Region 3,2 wk ahead,1.9
-2012,9,2011/2012,61,HHS Region 3,3 wk ahead,1.5
+2012,9,2011/2012,61,HHS Region 3,3 wk ahead,1.4
 2012,9,2011/2012,61,HHS Region 3,4 wk ahead,1.4
 2012,9,2011/2012,61,HHS Region 4,Season onset,none
 2012,9,2011/2012,61,HHS Region 4,Season peak week,52
@@ -4338,20 +4370,20 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,9,2011/2012,61,HHS Region 5,Season onset,7
 2012,9,2011/2012,61,HHS Region 5,Season peak week,11
 2012,9,2011/2012,61,HHS Region 5,Season peak percentage,2.4
-2012,9,2011/2012,61,HHS Region 5,1 wk ahead,2.1
+2012,9,2011/2012,61,HHS Region 5,1 wk ahead,2
 2012,9,2011/2012,61,HHS Region 5,2 wk ahead,2.4
 2012,9,2011/2012,61,HHS Region 5,3 wk ahead,1.9
-2012,9,2011/2012,61,HHS Region 5,4 wk ahead,1.4
+2012,9,2011/2012,61,HHS Region 5,4 wk ahead,1.3
 2012,9,2011/2012,61,HHS Region 6,Season onset,none
 2012,9,2011/2012,61,HHS Region 6,Season peak week,11
-2012,9,2011/2012,61,HHS Region 6,Season peak percentage,4.2
+2012,9,2011/2012,61,HHS Region 6,Season peak percentage,4.1
 2012,9,2011/2012,61,HHS Region 6,1 wk ahead,3.4
-2012,9,2011/2012,61,HHS Region 6,2 wk ahead,4.2
-2012,9,2011/2012,61,HHS Region 6,3 wk ahead,3
+2012,9,2011/2012,61,HHS Region 6,2 wk ahead,4.1
+2012,9,2011/2012,61,HHS Region 6,3 wk ahead,2.9
 2012,9,2011/2012,61,HHS Region 6,4 wk ahead,2.6
 2012,9,2011/2012,61,HHS Region 7,Season onset,5
 2012,9,2011/2012,61,HHS Region 7,Season peak week,9
-2012,9,2011/2012,61,HHS Region 7,Season peak percentage,3.5
+2012,9,2011/2012,61,HHS Region 7,Season peak percentage,3.4
 2012,9,2011/2012,61,HHS Region 7,1 wk ahead,3.1
 2012,9,2011/2012,61,HHS Region 7,2 wk ahead,2.6
 2012,9,2011/2012,61,HHS Region 7,3 wk ahead,1.7
@@ -4365,18 +4397,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,9,2011/2012,61,HHS Region 8,4 wk ahead,1.5
 2012,9,2011/2012,61,HHS Region 9,Season onset,none
 2012,9,2011/2012,61,HHS Region 9,Season peak week,52
+2012,9,2011/2012,61,HHS Region 9,Season peak week,8
 2012,9,2011/2012,61,HHS Region 9,Season peak percentage,3.7
-2012,9,2011/2012,61,HHS Region 9,1 wk ahead,2.4
-2012,9,2011/2012,61,HHS Region 9,2 wk ahead,2.7
-2012,9,2011/2012,61,HHS Region 9,3 wk ahead,2.5
-2012,9,2011/2012,61,HHS Region 9,4 wk ahead,3.3
-2012,9,2011/2012,61,HHS Region 10,Season onset,10
-2012,9,2011/2012,61,HHS Region 10,Season peak week,11
-2012,9,2011/2012,61,HHS Region 10,Season peak percentage,2.7
-2012,9,2011/2012,61,HHS Region 10,1 wk ahead,2.2
-2012,9,2011/2012,61,HHS Region 10,2 wk ahead,2.7
-2012,9,2011/2012,61,HHS Region 10,3 wk ahead,2.4
-2012,9,2011/2012,61,HHS Region 10,4 wk ahead,1.9
+2012,9,2011/2012,61,HHS Region 9,1 wk ahead,2.5
+2012,9,2011/2012,61,HHS Region 9,2 wk ahead,2.8
+2012,9,2011/2012,61,HHS Region 9,3 wk ahead,2.6
+2012,9,2011/2012,61,HHS Region 9,4 wk ahead,3.4
+2012,9,2011/2012,61,HHS Region 10,Season onset,none
+2012,9,2011/2012,61,HHS Region 10,Season peak week,12
+2012,9,2011/2012,61,HHS Region 10,Season peak percentage,2.2
+2012,9,2011/2012,61,HHS Region 10,1 wk ahead,1.6
+2012,9,2011/2012,61,HHS Region 10,2 wk ahead,1.9
+2012,9,2011/2012,61,HHS Region 10,3 wk ahead,2.2
+2012,9,2011/2012,61,HHS Region 10,4 wk ahead,1.8
 2012,10,2011/2012,62,US National,Season onset,none
 2012,10,2011/2012,62,US National,Season peak week,11
 2012,10,2011/2012,62,US National,Season peak percentage,2.4
@@ -4386,10 +4419,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,10,2011/2012,62,US National,4 wk ahead,1.7
 2012,10,2011/2012,62,HHS Region 1,Season onset,none
 2012,10,2011/2012,62,HHS Region 1,Season peak week,52
-2012,10,2011/2012,62,HHS Region 1,Season peak week,8
 2012,10,2011/2012,62,HHS Region 1,Season peak percentage,1
 2012,10,2011/2012,62,HHS Region 1,1 wk ahead,0.9
-2012,10,2011/2012,62,HHS Region 1,2 wk ahead,0.9
+2012,10,2011/2012,62,HHS Region 1,2 wk ahead,0.8
 2012,10,2011/2012,62,HHS Region 1,3 wk ahead,0.6
 2012,10,2011/2012,62,HHS Region 1,4 wk ahead,0.8
 2012,10,2011/2012,62,HHS Region 2,Season onset,none
@@ -4403,7 +4435,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,10,2011/2012,62,HHS Region 3,Season peak week,52
 2012,10,2011/2012,62,HHS Region 3,Season peak percentage,2.1
 2012,10,2011/2012,62,HHS Region 3,1 wk ahead,1.9
-2012,10,2011/2012,62,HHS Region 3,2 wk ahead,1.5
+2012,10,2011/2012,62,HHS Region 3,2 wk ahead,1.4
 2012,10,2011/2012,62,HHS Region 3,3 wk ahead,1.4
 2012,10,2011/2012,62,HHS Region 3,4 wk ahead,1.3
 2012,10,2011/2012,62,HHS Region 4,Season onset,none
@@ -4419,18 +4451,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,10,2011/2012,62,HHS Region 5,Season peak percentage,2.4
 2012,10,2011/2012,62,HHS Region 5,1 wk ahead,2.4
 2012,10,2011/2012,62,HHS Region 5,2 wk ahead,1.9
-2012,10,2011/2012,62,HHS Region 5,3 wk ahead,1.4
+2012,10,2011/2012,62,HHS Region 5,3 wk ahead,1.3
 2012,10,2011/2012,62,HHS Region 5,4 wk ahead,1.4
 2012,10,2011/2012,62,HHS Region 6,Season onset,none
 2012,10,2011/2012,62,HHS Region 6,Season peak week,11
-2012,10,2011/2012,62,HHS Region 6,Season peak percentage,4.2
-2012,10,2011/2012,62,HHS Region 6,1 wk ahead,4.2
-2012,10,2011/2012,62,HHS Region 6,2 wk ahead,3
+2012,10,2011/2012,62,HHS Region 6,Season peak percentage,4.1
+2012,10,2011/2012,62,HHS Region 6,1 wk ahead,4.1
+2012,10,2011/2012,62,HHS Region 6,2 wk ahead,2.9
 2012,10,2011/2012,62,HHS Region 6,3 wk ahead,2.6
-2012,10,2011/2012,62,HHS Region 6,4 wk ahead,2.3
+2012,10,2011/2012,62,HHS Region 6,4 wk ahead,2.4
 2012,10,2011/2012,62,HHS Region 7,Season onset,5
 2012,10,2011/2012,62,HHS Region 7,Season peak week,9
-2012,10,2011/2012,62,HHS Region 7,Season peak percentage,3.5
+2012,10,2011/2012,62,HHS Region 7,Season peak percentage,3.4
 2012,10,2011/2012,62,HHS Region 7,1 wk ahead,2.6
 2012,10,2011/2012,62,HHS Region 7,2 wk ahead,1.7
 2012,10,2011/2012,62,HHS Region 7,3 wk ahead,1.2
@@ -4444,18 +4476,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,10,2011/2012,62,HHS Region 8,4 wk ahead,1.2
 2012,10,2011/2012,62,HHS Region 9,Season onset,none
 2012,10,2011/2012,62,HHS Region 9,Season peak week,52
+2012,10,2011/2012,62,HHS Region 9,Season peak week,8
 2012,10,2011/2012,62,HHS Region 9,Season peak percentage,3.7
-2012,10,2011/2012,62,HHS Region 9,1 wk ahead,2.7
-2012,10,2011/2012,62,HHS Region 9,2 wk ahead,2.5
-2012,10,2011/2012,62,HHS Region 9,3 wk ahead,3.3
-2012,10,2011/2012,62,HHS Region 9,4 wk ahead,2.6
-2012,10,2011/2012,62,HHS Region 10,Season onset,10
-2012,10,2011/2012,62,HHS Region 10,Season peak week,11
-2012,10,2011/2012,62,HHS Region 10,Season peak percentage,2.7
-2012,10,2011/2012,62,HHS Region 10,1 wk ahead,2.7
-2012,10,2011/2012,62,HHS Region 10,2 wk ahead,2.4
-2012,10,2011/2012,62,HHS Region 10,3 wk ahead,1.9
-2012,10,2011/2012,62,HHS Region 10,4 wk ahead,1.8
+2012,10,2011/2012,62,HHS Region 9,1 wk ahead,2.8
+2012,10,2011/2012,62,HHS Region 9,2 wk ahead,2.6
+2012,10,2011/2012,62,HHS Region 9,3 wk ahead,3.4
+2012,10,2011/2012,62,HHS Region 9,4 wk ahead,2.7
+2012,10,2011/2012,62,HHS Region 10,Season onset,none
+2012,10,2011/2012,62,HHS Region 10,Season peak week,12
+2012,10,2011/2012,62,HHS Region 10,Season peak percentage,2.2
+2012,10,2011/2012,62,HHS Region 10,1 wk ahead,1.9
+2012,10,2011/2012,62,HHS Region 10,2 wk ahead,2.2
+2012,10,2011/2012,62,HHS Region 10,3 wk ahead,1.8
+2012,10,2011/2012,62,HHS Region 10,4 wk ahead,1.6
 2012,11,2011/2012,63,US National,Season onset,none
 2012,11,2011/2012,63,US National,Season peak week,11
 2012,11,2011/2012,63,US National,Season peak percentage,2.4
@@ -4465,9 +4498,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,11,2011/2012,63,US National,4 wk ahead,1.5
 2012,11,2011/2012,63,HHS Region 1,Season onset,none
 2012,11,2011/2012,63,HHS Region 1,Season peak week,52
-2012,11,2011/2012,63,HHS Region 1,Season peak week,8
 2012,11,2011/2012,63,HHS Region 1,Season peak percentage,1
-2012,11,2011/2012,63,HHS Region 1,1 wk ahead,0.9
+2012,11,2011/2012,63,HHS Region 1,1 wk ahead,0.8
 2012,11,2011/2012,63,HHS Region 1,2 wk ahead,0.6
 2012,11,2011/2012,63,HHS Region 1,3 wk ahead,0.8
 2012,11,2011/2012,63,HHS Region 1,4 wk ahead,0.9
@@ -4477,11 +4509,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,11,2011/2012,63,HHS Region 2,1 wk ahead,1.2
 2012,11,2011/2012,63,HHS Region 2,2 wk ahead,1.1
 2012,11,2011/2012,63,HHS Region 2,3 wk ahead,1.3
-2012,11,2011/2012,63,HHS Region 2,4 wk ahead,1.2
+2012,11,2011/2012,63,HHS Region 2,4 wk ahead,1.1
 2012,11,2011/2012,63,HHS Region 3,Season onset,none
 2012,11,2011/2012,63,HHS Region 3,Season peak week,52
 2012,11,2011/2012,63,HHS Region 3,Season peak percentage,2.1
-2012,11,2011/2012,63,HHS Region 3,1 wk ahead,1.5
+2012,11,2011/2012,63,HHS Region 3,1 wk ahead,1.4
 2012,11,2011/2012,63,HHS Region 3,2 wk ahead,1.4
 2012,11,2011/2012,63,HHS Region 3,3 wk ahead,1.3
 2012,11,2011/2012,63,HHS Region 3,4 wk ahead,1.2
@@ -4492,24 +4524,24 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,11,2011/2012,63,HHS Region 4,1 wk ahead,1.9
 2012,11,2011/2012,63,HHS Region 4,2 wk ahead,1.7
 2012,11,2011/2012,63,HHS Region 4,3 wk ahead,1.6
-2012,11,2011/2012,63,HHS Region 4,4 wk ahead,1.5
+2012,11,2011/2012,63,HHS Region 4,4 wk ahead,1.4
 2012,11,2011/2012,63,HHS Region 5,Season onset,7
 2012,11,2011/2012,63,HHS Region 5,Season peak week,11
 2012,11,2011/2012,63,HHS Region 5,Season peak percentage,2.4
 2012,11,2011/2012,63,HHS Region 5,1 wk ahead,1.9
-2012,11,2011/2012,63,HHS Region 5,2 wk ahead,1.4
+2012,11,2011/2012,63,HHS Region 5,2 wk ahead,1.3
 2012,11,2011/2012,63,HHS Region 5,3 wk ahead,1.4
 2012,11,2011/2012,63,HHS Region 5,4 wk ahead,1.2
 2012,11,2011/2012,63,HHS Region 6,Season onset,none
 2012,11,2011/2012,63,HHS Region 6,Season peak week,11
-2012,11,2011/2012,63,HHS Region 6,Season peak percentage,4.2
-2012,11,2011/2012,63,HHS Region 6,1 wk ahead,3
+2012,11,2011/2012,63,HHS Region 6,Season peak percentage,4.1
+2012,11,2011/2012,63,HHS Region 6,1 wk ahead,2.9
 2012,11,2011/2012,63,HHS Region 6,2 wk ahead,2.6
-2012,11,2011/2012,63,HHS Region 6,3 wk ahead,2.3
+2012,11,2011/2012,63,HHS Region 6,3 wk ahead,2.4
 2012,11,2011/2012,63,HHS Region 6,4 wk ahead,1.9
 2012,11,2011/2012,63,HHS Region 7,Season onset,5
 2012,11,2011/2012,63,HHS Region 7,Season peak week,9
-2012,11,2011/2012,63,HHS Region 7,Season peak percentage,3.5
+2012,11,2011/2012,63,HHS Region 7,Season peak percentage,3.4
 2012,11,2011/2012,63,HHS Region 7,1 wk ahead,1.7
 2012,11,2011/2012,63,HHS Region 7,2 wk ahead,1.2
 2012,11,2011/2012,63,HHS Region 7,3 wk ahead,0.9
@@ -4523,18 +4555,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,11,2011/2012,63,HHS Region 8,4 wk ahead,1.1
 2012,11,2011/2012,63,HHS Region 9,Season onset,none
 2012,11,2011/2012,63,HHS Region 9,Season peak week,52
+2012,11,2011/2012,63,HHS Region 9,Season peak week,8
 2012,11,2011/2012,63,HHS Region 9,Season peak percentage,3.7
-2012,11,2011/2012,63,HHS Region 9,1 wk ahead,2.5
-2012,11,2011/2012,63,HHS Region 9,2 wk ahead,3.3
-2012,11,2011/2012,63,HHS Region 9,3 wk ahead,2.6
+2012,11,2011/2012,63,HHS Region 9,1 wk ahead,2.6
+2012,11,2011/2012,63,HHS Region 9,2 wk ahead,3.4
+2012,11,2011/2012,63,HHS Region 9,3 wk ahead,2.7
 2012,11,2011/2012,63,HHS Region 9,4 wk ahead,2.6
-2012,11,2011/2012,63,HHS Region 10,Season onset,10
-2012,11,2011/2012,63,HHS Region 10,Season peak week,11
-2012,11,2011/2012,63,HHS Region 10,Season peak percentage,2.7
-2012,11,2011/2012,63,HHS Region 10,1 wk ahead,2.4
-2012,11,2011/2012,63,HHS Region 10,2 wk ahead,1.9
-2012,11,2011/2012,63,HHS Region 10,3 wk ahead,1.8
-2012,11,2011/2012,63,HHS Region 10,4 wk ahead,2.1
+2012,11,2011/2012,63,HHS Region 10,Season onset,none
+2012,11,2011/2012,63,HHS Region 10,Season peak week,12
+2012,11,2011/2012,63,HHS Region 10,Season peak percentage,2.2
+2012,11,2011/2012,63,HHS Region 10,1 wk ahead,2.2
+2012,11,2011/2012,63,HHS Region 10,2 wk ahead,1.8
+2012,11,2011/2012,63,HHS Region 10,3 wk ahead,1.6
+2012,11,2011/2012,63,HHS Region 10,4 wk ahead,1.9
 2012,12,2011/2012,64,US National,Season onset,none
 2012,12,2011/2012,64,US National,Season peak week,11
 2012,12,2011/2012,64,US National,Season peak percentage,2.4
@@ -4544,7 +4577,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,12,2011/2012,64,US National,4 wk ahead,1.4
 2012,12,2011/2012,64,HHS Region 1,Season onset,none
 2012,12,2011/2012,64,HHS Region 1,Season peak week,52
-2012,12,2011/2012,64,HHS Region 1,Season peak week,8
 2012,12,2011/2012,64,HHS Region 1,Season peak percentage,1
 2012,12,2011/2012,64,HHS Region 1,1 wk ahead,0.6
 2012,12,2011/2012,64,HHS Region 1,2 wk ahead,0.8
@@ -4555,7 +4587,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,12,2011/2012,64,HHS Region 2,Season peak percentage,1.4
 2012,12,2011/2012,64,HHS Region 2,1 wk ahead,1.1
 2012,12,2011/2012,64,HHS Region 2,2 wk ahead,1.3
-2012,12,2011/2012,64,HHS Region 2,3 wk ahead,1.2
+2012,12,2011/2012,64,HHS Region 2,3 wk ahead,1.1
 2012,12,2011/2012,64,HHS Region 2,4 wk ahead,1.1
 2012,12,2011/2012,64,HHS Region 3,Season onset,none
 2012,12,2011/2012,64,HHS Region 3,Season peak week,52
@@ -4570,29 +4602,29 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,12,2011/2012,64,HHS Region 4,Season peak percentage,2.3
 2012,12,2011/2012,64,HHS Region 4,1 wk ahead,1.7
 2012,12,2011/2012,64,HHS Region 4,2 wk ahead,1.6
-2012,12,2011/2012,64,HHS Region 4,3 wk ahead,1.5
+2012,12,2011/2012,64,HHS Region 4,3 wk ahead,1.4
 2012,12,2011/2012,64,HHS Region 4,4 wk ahead,1.4
 2012,12,2011/2012,64,HHS Region 5,Season onset,7
 2012,12,2011/2012,64,HHS Region 5,Season peak week,11
 2012,12,2011/2012,64,HHS Region 5,Season peak percentage,2.4
-2012,12,2011/2012,64,HHS Region 5,1 wk ahead,1.4
+2012,12,2011/2012,64,HHS Region 5,1 wk ahead,1.3
 2012,12,2011/2012,64,HHS Region 5,2 wk ahead,1.4
 2012,12,2011/2012,64,HHS Region 5,3 wk ahead,1.2
 2012,12,2011/2012,64,HHS Region 5,4 wk ahead,1
 2012,12,2011/2012,64,HHS Region 6,Season onset,none
 2012,12,2011/2012,64,HHS Region 6,Season peak week,11
-2012,12,2011/2012,64,HHS Region 6,Season peak percentage,4.2
+2012,12,2011/2012,64,HHS Region 6,Season peak percentage,4.1
 2012,12,2011/2012,64,HHS Region 6,1 wk ahead,2.6
-2012,12,2011/2012,64,HHS Region 6,2 wk ahead,2.3
+2012,12,2011/2012,64,HHS Region 6,2 wk ahead,2.4
 2012,12,2011/2012,64,HHS Region 6,3 wk ahead,1.9
 2012,12,2011/2012,64,HHS Region 6,4 wk ahead,2
 2012,12,2011/2012,64,HHS Region 7,Season onset,5
 2012,12,2011/2012,64,HHS Region 7,Season peak week,9
-2012,12,2011/2012,64,HHS Region 7,Season peak percentage,3.5
+2012,12,2011/2012,64,HHS Region 7,Season peak percentage,3.4
 2012,12,2011/2012,64,HHS Region 7,1 wk ahead,1.2
 2012,12,2011/2012,64,HHS Region 7,2 wk ahead,0.9
 2012,12,2011/2012,64,HHS Region 7,3 wk ahead,0.8
-2012,12,2011/2012,64,HHS Region 7,4 wk ahead,0.7
+2012,12,2011/2012,64,HHS Region 7,4 wk ahead,0.8
 2012,12,2011/2012,64,HHS Region 8,Season onset,none
 2012,12,2011/2012,64,HHS Region 8,Season peak week,11
 2012,12,2011/2012,64,HHS Region 8,Season peak percentage,2.2
@@ -4602,18 +4634,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,12,2011/2012,64,HHS Region 8,4 wk ahead,0.9
 2012,12,2011/2012,64,HHS Region 9,Season onset,none
 2012,12,2011/2012,64,HHS Region 9,Season peak week,52
+2012,12,2011/2012,64,HHS Region 9,Season peak week,8
 2012,12,2011/2012,64,HHS Region 9,Season peak percentage,3.7
-2012,12,2011/2012,64,HHS Region 9,1 wk ahead,3.3
-2012,12,2011/2012,64,HHS Region 9,2 wk ahead,2.6
+2012,12,2011/2012,64,HHS Region 9,1 wk ahead,3.4
+2012,12,2011/2012,64,HHS Region 9,2 wk ahead,2.7
 2012,12,2011/2012,64,HHS Region 9,3 wk ahead,2.6
 2012,12,2011/2012,64,HHS Region 9,4 wk ahead,2
-2012,12,2011/2012,64,HHS Region 10,Season onset,10
-2012,12,2011/2012,64,HHS Region 10,Season peak week,11
-2012,12,2011/2012,64,HHS Region 10,Season peak percentage,2.7
-2012,12,2011/2012,64,HHS Region 10,1 wk ahead,1.9
-2012,12,2011/2012,64,HHS Region 10,2 wk ahead,1.8
-2012,12,2011/2012,64,HHS Region 10,3 wk ahead,2.1
-2012,12,2011/2012,64,HHS Region 10,4 wk ahead,2.1
+2012,12,2011/2012,64,HHS Region 10,Season onset,none
+2012,12,2011/2012,64,HHS Region 10,Season peak week,12
+2012,12,2011/2012,64,HHS Region 10,Season peak percentage,2.2
+2012,12,2011/2012,64,HHS Region 10,1 wk ahead,1.8
+2012,12,2011/2012,64,HHS Region 10,2 wk ahead,1.6
+2012,12,2011/2012,64,HHS Region 10,3 wk ahead,1.9
+2012,12,2011/2012,64,HHS Region 10,4 wk ahead,1.6
 2012,13,2011/2012,65,US National,Season onset,none
 2012,13,2011/2012,65,US National,Season peak week,11
 2012,13,2011/2012,65,US National,Season peak percentage,2.4
@@ -4623,7 +4656,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,13,2011/2012,65,US National,4 wk ahead,1.3
 2012,13,2011/2012,65,HHS Region 1,Season onset,none
 2012,13,2011/2012,65,HHS Region 1,Season peak week,52
-2012,13,2011/2012,65,HHS Region 1,Season peak week,8
 2012,13,2011/2012,65,HHS Region 1,Season peak percentage,1
 2012,13,2011/2012,65,HHS Region 1,1 wk ahead,0.8
 2012,13,2011/2012,65,HHS Region 1,2 wk ahead,0.9
@@ -4633,22 +4665,22 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,13,2011/2012,65,HHS Region 2,Season peak week,49
 2012,13,2011/2012,65,HHS Region 2,Season peak percentage,1.4
 2012,13,2011/2012,65,HHS Region 2,1 wk ahead,1.3
-2012,13,2011/2012,65,HHS Region 2,2 wk ahead,1.2
+2012,13,2011/2012,65,HHS Region 2,2 wk ahead,1.1
 2012,13,2011/2012,65,HHS Region 2,3 wk ahead,1.1
-2012,13,2011/2012,65,HHS Region 2,4 wk ahead,1
+2012,13,2011/2012,65,HHS Region 2,4 wk ahead,0.9
 2012,13,2011/2012,65,HHS Region 3,Season onset,none
 2012,13,2011/2012,65,HHS Region 3,Season peak week,52
 2012,13,2011/2012,65,HHS Region 3,Season peak percentage,2.1
 2012,13,2011/2012,65,HHS Region 3,1 wk ahead,1.3
 2012,13,2011/2012,65,HHS Region 3,2 wk ahead,1.2
 2012,13,2011/2012,65,HHS Region 3,3 wk ahead,1.1
-2012,13,2011/2012,65,HHS Region 3,4 wk ahead,1
+2012,13,2011/2012,65,HHS Region 3,4 wk ahead,1.1
 2012,13,2011/2012,65,HHS Region 4,Season onset,none
 2012,13,2011/2012,65,HHS Region 4,Season peak week,52
 2012,13,2011/2012,65,HHS Region 4,Season peak week,10
 2012,13,2011/2012,65,HHS Region 4,Season peak percentage,2.3
 2012,13,2011/2012,65,HHS Region 4,1 wk ahead,1.6
-2012,13,2011/2012,65,HHS Region 4,2 wk ahead,1.5
+2012,13,2011/2012,65,HHS Region 4,2 wk ahead,1.4
 2012,13,2011/2012,65,HHS Region 4,3 wk ahead,1.4
 2012,13,2011/2012,65,HHS Region 4,4 wk ahead,1.3
 2012,13,2011/2012,65,HHS Region 5,Season onset,7
@@ -4660,17 +4692,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,13,2011/2012,65,HHS Region 5,4 wk ahead,0.9
 2012,13,2011/2012,65,HHS Region 6,Season onset,none
 2012,13,2011/2012,65,HHS Region 6,Season peak week,11
-2012,13,2011/2012,65,HHS Region 6,Season peak percentage,4.2
-2012,13,2011/2012,65,HHS Region 6,1 wk ahead,2.3
+2012,13,2011/2012,65,HHS Region 6,Season peak percentage,4.1
+2012,13,2011/2012,65,HHS Region 6,1 wk ahead,2.4
 2012,13,2011/2012,65,HHS Region 6,2 wk ahead,1.9
 2012,13,2011/2012,65,HHS Region 6,3 wk ahead,2
 2012,13,2011/2012,65,HHS Region 6,4 wk ahead,1.9
 2012,13,2011/2012,65,HHS Region 7,Season onset,5
 2012,13,2011/2012,65,HHS Region 7,Season peak week,9
-2012,13,2011/2012,65,HHS Region 7,Season peak percentage,3.5
+2012,13,2011/2012,65,HHS Region 7,Season peak percentage,3.4
 2012,13,2011/2012,65,HHS Region 7,1 wk ahead,0.9
 2012,13,2011/2012,65,HHS Region 7,2 wk ahead,0.8
-2012,13,2011/2012,65,HHS Region 7,3 wk ahead,0.7
+2012,13,2011/2012,65,HHS Region 7,3 wk ahead,0.8
 2012,13,2011/2012,65,HHS Region 7,4 wk ahead,0.7
 2012,13,2011/2012,65,HHS Region 8,Season onset,none
 2012,13,2011/2012,65,HHS Region 8,Season peak week,11
@@ -4681,18 +4713,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,13,2011/2012,65,HHS Region 8,4 wk ahead,0.9
 2012,13,2011/2012,65,HHS Region 9,Season onset,none
 2012,13,2011/2012,65,HHS Region 9,Season peak week,52
+2012,13,2011/2012,65,HHS Region 9,Season peak week,8
 2012,13,2011/2012,65,HHS Region 9,Season peak percentage,3.7
-2012,13,2011/2012,65,HHS Region 9,1 wk ahead,2.6
+2012,13,2011/2012,65,HHS Region 9,1 wk ahead,2.7
 2012,13,2011/2012,65,HHS Region 9,2 wk ahead,2.6
 2012,13,2011/2012,65,HHS Region 9,3 wk ahead,2
-2012,13,2011/2012,65,HHS Region 9,4 wk ahead,2
-2012,13,2011/2012,65,HHS Region 10,Season onset,10
-2012,13,2011/2012,65,HHS Region 10,Season peak week,11
-2012,13,2011/2012,65,HHS Region 10,Season peak percentage,2.7
-2012,13,2011/2012,65,HHS Region 10,1 wk ahead,1.8
-2012,13,2011/2012,65,HHS Region 10,2 wk ahead,2.1
-2012,13,2011/2012,65,HHS Region 10,3 wk ahead,2.1
-2012,13,2011/2012,65,HHS Region 10,4 wk ahead,1.8
+2012,13,2011/2012,65,HHS Region 9,4 wk ahead,1.9
+2012,13,2011/2012,65,HHS Region 10,Season onset,none
+2012,13,2011/2012,65,HHS Region 10,Season peak week,12
+2012,13,2011/2012,65,HHS Region 10,Season peak percentage,2.2
+2012,13,2011/2012,65,HHS Region 10,1 wk ahead,1.6
+2012,13,2011/2012,65,HHS Region 10,2 wk ahead,1.9
+2012,13,2011/2012,65,HHS Region 10,3 wk ahead,1.6
+2012,13,2011/2012,65,HHS Region 10,4 wk ahead,1.4
 2012,14,2011/2012,66,US National,Season onset,none
 2012,14,2011/2012,66,US National,Season peak week,11
 2012,14,2011/2012,66,US National,Season peak percentage,2.4
@@ -4702,7 +4735,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,14,2011/2012,66,US National,4 wk ahead,1.5
 2012,14,2011/2012,66,HHS Region 1,Season onset,none
 2012,14,2011/2012,66,HHS Region 1,Season peak week,52
-2012,14,2011/2012,66,HHS Region 1,Season peak week,8
 2012,14,2011/2012,66,HHS Region 1,Season peak percentage,1
 2012,14,2011/2012,66,HHS Region 1,1 wk ahead,0.9
 2012,14,2011/2012,66,HHS Region 1,2 wk ahead,0.8
@@ -4711,22 +4743,22 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,14,2011/2012,66,HHS Region 2,Season onset,none
 2012,14,2011/2012,66,HHS Region 2,Season peak week,49
 2012,14,2011/2012,66,HHS Region 2,Season peak percentage,1.4
-2012,14,2011/2012,66,HHS Region 2,1 wk ahead,1.2
+2012,14,2011/2012,66,HHS Region 2,1 wk ahead,1.1
 2012,14,2011/2012,66,HHS Region 2,2 wk ahead,1.1
-2012,14,2011/2012,66,HHS Region 2,3 wk ahead,1
+2012,14,2011/2012,66,HHS Region 2,3 wk ahead,0.9
 2012,14,2011/2012,66,HHS Region 2,4 wk ahead,1
 2012,14,2011/2012,66,HHS Region 3,Season onset,none
 2012,14,2011/2012,66,HHS Region 3,Season peak week,52
 2012,14,2011/2012,66,HHS Region 3,Season peak percentage,2.1
 2012,14,2011/2012,66,HHS Region 3,1 wk ahead,1.2
 2012,14,2011/2012,66,HHS Region 3,2 wk ahead,1.1
-2012,14,2011/2012,66,HHS Region 3,3 wk ahead,1
+2012,14,2011/2012,66,HHS Region 3,3 wk ahead,1.1
 2012,14,2011/2012,66,HHS Region 3,4 wk ahead,1.3
 2012,14,2011/2012,66,HHS Region 4,Season onset,none
 2012,14,2011/2012,66,HHS Region 4,Season peak week,52
 2012,14,2011/2012,66,HHS Region 4,Season peak week,10
 2012,14,2011/2012,66,HHS Region 4,Season peak percentage,2.3
-2012,14,2011/2012,66,HHS Region 4,1 wk ahead,1.5
+2012,14,2011/2012,66,HHS Region 4,1 wk ahead,1.4
 2012,14,2011/2012,66,HHS Region 4,2 wk ahead,1.4
 2012,14,2011/2012,66,HHS Region 4,3 wk ahead,1.3
 2012,14,2011/2012,66,HHS Region 4,4 wk ahead,1.5
@@ -4736,19 +4768,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,14,2011/2012,66,HHS Region 5,1 wk ahead,1.2
 2012,14,2011/2012,66,HHS Region 5,2 wk ahead,1
 2012,14,2011/2012,66,HHS Region 5,3 wk ahead,0.9
-2012,14,2011/2012,66,HHS Region 5,4 wk ahead,1.1
+2012,14,2011/2012,66,HHS Region 5,4 wk ahead,1
 2012,14,2011/2012,66,HHS Region 6,Season onset,none
 2012,14,2011/2012,66,HHS Region 6,Season peak week,11
-2012,14,2011/2012,66,HHS Region 6,Season peak percentage,4.2
+2012,14,2011/2012,66,HHS Region 6,Season peak percentage,4.1
 2012,14,2011/2012,66,HHS Region 6,1 wk ahead,1.9
 2012,14,2011/2012,66,HHS Region 6,2 wk ahead,2
 2012,14,2011/2012,66,HHS Region 6,3 wk ahead,1.9
 2012,14,2011/2012,66,HHS Region 6,4 wk ahead,1.9
 2012,14,2011/2012,66,HHS Region 7,Season onset,5
 2012,14,2011/2012,66,HHS Region 7,Season peak week,9
-2012,14,2011/2012,66,HHS Region 7,Season peak percentage,3.5
+2012,14,2011/2012,66,HHS Region 7,Season peak percentage,3.4
 2012,14,2011/2012,66,HHS Region 7,1 wk ahead,0.8
-2012,14,2011/2012,66,HHS Region 7,2 wk ahead,0.7
+2012,14,2011/2012,66,HHS Region 7,2 wk ahead,0.8
 2012,14,2011/2012,66,HHS Region 7,3 wk ahead,0.7
 2012,14,2011/2012,66,HHS Region 7,4 wk ahead,0.8
 2012,14,2011/2012,66,HHS Region 8,Season onset,none
@@ -4760,18 +4792,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,14,2011/2012,66,HHS Region 8,4 wk ahead,0.9
 2012,14,2011/2012,66,HHS Region 9,Season onset,none
 2012,14,2011/2012,66,HHS Region 9,Season peak week,52
+2012,14,2011/2012,66,HHS Region 9,Season peak week,8
 2012,14,2011/2012,66,HHS Region 9,Season peak percentage,3.7
 2012,14,2011/2012,66,HHS Region 9,1 wk ahead,2.6
 2012,14,2011/2012,66,HHS Region 9,2 wk ahead,2
-2012,14,2011/2012,66,HHS Region 9,3 wk ahead,2
-2012,14,2011/2012,66,HHS Region 9,4 wk ahead,2.4
-2012,14,2011/2012,66,HHS Region 10,Season onset,10
-2012,14,2011/2012,66,HHS Region 10,Season peak week,11
-2012,14,2011/2012,66,HHS Region 10,Season peak percentage,2.7
-2012,14,2011/2012,66,HHS Region 10,1 wk ahead,2.1
-2012,14,2011/2012,66,HHS Region 10,2 wk ahead,2.1
-2012,14,2011/2012,66,HHS Region 10,3 wk ahead,1.8
-2012,14,2011/2012,66,HHS Region 10,4 wk ahead,2.1
+2012,14,2011/2012,66,HHS Region 9,3 wk ahead,1.9
+2012,14,2011/2012,66,HHS Region 9,4 wk ahead,2.1
+2012,14,2011/2012,66,HHS Region 10,Season onset,none
+2012,14,2011/2012,66,HHS Region 10,Season peak week,12
+2012,14,2011/2012,66,HHS Region 10,Season peak percentage,2.2
+2012,14,2011/2012,66,HHS Region 10,1 wk ahead,1.9
+2012,14,2011/2012,66,HHS Region 10,2 wk ahead,1.6
+2012,14,2011/2012,66,HHS Region 10,3 wk ahead,1.4
+2012,14,2011/2012,66,HHS Region 10,4 wk ahead,1.4
 2012,15,2011/2012,67,US National,Season onset,none
 2012,15,2011/2012,67,US National,Season peak week,11
 2012,15,2011/2012,67,US National,Season peak percentage,2.4
@@ -4781,7 +4814,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,15,2011/2012,67,US National,4 wk ahead,1.4
 2012,15,2011/2012,67,HHS Region 1,Season onset,none
 2012,15,2011/2012,67,HHS Region 1,Season peak week,52
-2012,15,2011/2012,67,HHS Region 1,Season peak week,8
 2012,15,2011/2012,67,HHS Region 1,Season peak percentage,1
 2012,15,2011/2012,67,HHS Region 1,1 wk ahead,0.8
 2012,15,2011/2012,67,HHS Region 1,2 wk ahead,0.6
@@ -4791,14 +4823,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,15,2011/2012,67,HHS Region 2,Season peak week,49
 2012,15,2011/2012,67,HHS Region 2,Season peak percentage,1.4
 2012,15,2011/2012,67,HHS Region 2,1 wk ahead,1.1
-2012,15,2011/2012,67,HHS Region 2,2 wk ahead,1
+2012,15,2011/2012,67,HHS Region 2,2 wk ahead,0.9
 2012,15,2011/2012,67,HHS Region 2,3 wk ahead,1
 2012,15,2011/2012,67,HHS Region 2,4 wk ahead,0.9
 2012,15,2011/2012,67,HHS Region 3,Season onset,none
 2012,15,2011/2012,67,HHS Region 3,Season peak week,52
 2012,15,2011/2012,67,HHS Region 3,Season peak percentage,2.1
 2012,15,2011/2012,67,HHS Region 3,1 wk ahead,1.1
-2012,15,2011/2012,67,HHS Region 3,2 wk ahead,1
+2012,15,2011/2012,67,HHS Region 3,2 wk ahead,1.1
 2012,15,2011/2012,67,HHS Region 3,3 wk ahead,1.3
 2012,15,2011/2012,67,HHS Region 3,4 wk ahead,1.5
 2012,15,2011/2012,67,HHS Region 4,Season onset,none
@@ -4814,22 +4846,22 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,15,2011/2012,67,HHS Region 5,Season peak percentage,2.4
 2012,15,2011/2012,67,HHS Region 5,1 wk ahead,1
 2012,15,2011/2012,67,HHS Region 5,2 wk ahead,0.9
-2012,15,2011/2012,67,HHS Region 5,3 wk ahead,1.1
+2012,15,2011/2012,67,HHS Region 5,3 wk ahead,1
 2012,15,2011/2012,67,HHS Region 5,4 wk ahead,1
 2012,15,2011/2012,67,HHS Region 6,Season onset,none
 2012,15,2011/2012,67,HHS Region 6,Season peak week,11
-2012,15,2011/2012,67,HHS Region 6,Season peak percentage,4.2
+2012,15,2011/2012,67,HHS Region 6,Season peak percentage,4.1
 2012,15,2011/2012,67,HHS Region 6,1 wk ahead,2
 2012,15,2011/2012,67,HHS Region 6,2 wk ahead,1.9
 2012,15,2011/2012,67,HHS Region 6,3 wk ahead,1.9
 2012,15,2011/2012,67,HHS Region 6,4 wk ahead,1.9
 2012,15,2011/2012,67,HHS Region 7,Season onset,5
 2012,15,2011/2012,67,HHS Region 7,Season peak week,9
-2012,15,2011/2012,67,HHS Region 7,Season peak percentage,3.5
-2012,15,2011/2012,67,HHS Region 7,1 wk ahead,0.7
+2012,15,2011/2012,67,HHS Region 7,Season peak percentage,3.4
+2012,15,2011/2012,67,HHS Region 7,1 wk ahead,0.8
 2012,15,2011/2012,67,HHS Region 7,2 wk ahead,0.7
 2012,15,2011/2012,67,HHS Region 7,3 wk ahead,0.8
-2012,15,2011/2012,67,HHS Region 7,4 wk ahead,0.2
+2012,15,2011/2012,67,HHS Region 7,4 wk ahead,0.7
 2012,15,2011/2012,67,HHS Region 8,Season onset,none
 2012,15,2011/2012,67,HHS Region 8,Season peak week,11
 2012,15,2011/2012,67,HHS Region 8,Season peak percentage,2.2
@@ -4839,18 +4871,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,15,2011/2012,67,HHS Region 8,4 wk ahead,0.8
 2012,15,2011/2012,67,HHS Region 9,Season onset,none
 2012,15,2011/2012,67,HHS Region 9,Season peak week,52
+2012,15,2011/2012,67,HHS Region 9,Season peak week,8
 2012,15,2011/2012,67,HHS Region 9,Season peak percentage,3.7
 2012,15,2011/2012,67,HHS Region 9,1 wk ahead,2
-2012,15,2011/2012,67,HHS Region 9,2 wk ahead,2
-2012,15,2011/2012,67,HHS Region 9,3 wk ahead,2.4
-2012,15,2011/2012,67,HHS Region 9,4 wk ahead,2.4
-2012,15,2011/2012,67,HHS Region 10,Season onset,10
-2012,15,2011/2012,67,HHS Region 10,Season peak week,11
-2012,15,2011/2012,67,HHS Region 10,Season peak percentage,2.7
-2012,15,2011/2012,67,HHS Region 10,1 wk ahead,2.1
-2012,15,2011/2012,67,HHS Region 10,2 wk ahead,1.8
-2012,15,2011/2012,67,HHS Region 10,3 wk ahead,2.1
-2012,15,2011/2012,67,HHS Region 10,4 wk ahead,1.9
+2012,15,2011/2012,67,HHS Region 9,2 wk ahead,1.9
+2012,15,2011/2012,67,HHS Region 9,3 wk ahead,2.1
+2012,15,2011/2012,67,HHS Region 9,4 wk ahead,2
+2012,15,2011/2012,67,HHS Region 10,Season onset,none
+2012,15,2011/2012,67,HHS Region 10,Season peak week,12
+2012,15,2011/2012,67,HHS Region 10,Season peak percentage,2.2
+2012,15,2011/2012,67,HHS Region 10,1 wk ahead,1.6
+2012,15,2011/2012,67,HHS Region 10,2 wk ahead,1.4
+2012,15,2011/2012,67,HHS Region 10,3 wk ahead,1.4
+2012,15,2011/2012,67,HHS Region 10,4 wk ahead,1.1
 2012,16,2011/2012,68,US National,Season onset,none
 2012,16,2011/2012,68,US National,Season peak week,11
 2012,16,2011/2012,68,US National,Season peak percentage,2.4
@@ -4860,7 +4893,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,16,2011/2012,68,US National,4 wk ahead,1.3
 2012,16,2011/2012,68,HHS Region 1,Season onset,none
 2012,16,2011/2012,68,HHS Region 1,Season peak week,52
-2012,16,2011/2012,68,HHS Region 1,Season peak week,8
 2012,16,2011/2012,68,HHS Region 1,Season peak percentage,1
 2012,16,2011/2012,68,HHS Region 1,1 wk ahead,0.6
 2012,16,2011/2012,68,HHS Region 1,2 wk ahead,0.5
@@ -4869,17 +4901,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,16,2011/2012,68,HHS Region 2,Season onset,none
 2012,16,2011/2012,68,HHS Region 2,Season peak week,49
 2012,16,2011/2012,68,HHS Region 2,Season peak percentage,1.4
-2012,16,2011/2012,68,HHS Region 2,1 wk ahead,1
+2012,16,2011/2012,68,HHS Region 2,1 wk ahead,0.9
 2012,16,2011/2012,68,HHS Region 2,2 wk ahead,1
 2012,16,2011/2012,68,HHS Region 2,3 wk ahead,0.9
 2012,16,2011/2012,68,HHS Region 2,4 wk ahead,0.9
 2012,16,2011/2012,68,HHS Region 3,Season onset,none
 2012,16,2011/2012,68,HHS Region 3,Season peak week,52
 2012,16,2011/2012,68,HHS Region 3,Season peak percentage,2.1
-2012,16,2011/2012,68,HHS Region 3,1 wk ahead,1
+2012,16,2011/2012,68,HHS Region 3,1 wk ahead,1.1
 2012,16,2011/2012,68,HHS Region 3,2 wk ahead,1.3
 2012,16,2011/2012,68,HHS Region 3,3 wk ahead,1.5
-2012,16,2011/2012,68,HHS Region 3,4 wk ahead,1.2
+2012,16,2011/2012,68,HHS Region 3,4 wk ahead,1
 2012,16,2011/2012,68,HHS Region 4,Season onset,none
 2012,16,2011/2012,68,HHS Region 4,Season peak week,52
 2012,16,2011/2012,68,HHS Region 4,Season peak week,10
@@ -4887,28 +4919,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,16,2011/2012,68,HHS Region 4,1 wk ahead,1.3
 2012,16,2011/2012,68,HHS Region 4,2 wk ahead,1.5
 2012,16,2011/2012,68,HHS Region 4,3 wk ahead,1.4
-2012,16,2011/2012,68,HHS Region 4,4 wk ahead,1.1
+2012,16,2011/2012,68,HHS Region 4,4 wk ahead,1.4
 2012,16,2011/2012,68,HHS Region 5,Season onset,7
 2012,16,2011/2012,68,HHS Region 5,Season peak week,11
 2012,16,2011/2012,68,HHS Region 5,Season peak percentage,2.4
 2012,16,2011/2012,68,HHS Region 5,1 wk ahead,0.9
-2012,16,2011/2012,68,HHS Region 5,2 wk ahead,1.1
+2012,16,2011/2012,68,HHS Region 5,2 wk ahead,1
 2012,16,2011/2012,68,HHS Region 5,3 wk ahead,1
 2012,16,2011/2012,68,HHS Region 5,4 wk ahead,0.8
 2012,16,2011/2012,68,HHS Region 6,Season onset,none
 2012,16,2011/2012,68,HHS Region 6,Season peak week,11
-2012,16,2011/2012,68,HHS Region 6,Season peak percentage,4.2
+2012,16,2011/2012,68,HHS Region 6,Season peak percentage,4.1
 2012,16,2011/2012,68,HHS Region 6,1 wk ahead,1.9
 2012,16,2011/2012,68,HHS Region 6,2 wk ahead,1.9
 2012,16,2011/2012,68,HHS Region 6,3 wk ahead,1.9
 2012,16,2011/2012,68,HHS Region 6,4 wk ahead,1.9
 2012,16,2011/2012,68,HHS Region 7,Season onset,5
 2012,16,2011/2012,68,HHS Region 7,Season peak week,9
-2012,16,2011/2012,68,HHS Region 7,Season peak percentage,3.5
+2012,16,2011/2012,68,HHS Region 7,Season peak percentage,3.4
 2012,16,2011/2012,68,HHS Region 7,1 wk ahead,0.7
 2012,16,2011/2012,68,HHS Region 7,2 wk ahead,0.8
-2012,16,2011/2012,68,HHS Region 7,3 wk ahead,0.2
-2012,16,2011/2012,68,HHS Region 7,4 wk ahead,0.2
+2012,16,2011/2012,68,HHS Region 7,3 wk ahead,0.7
+2012,16,2011/2012,68,HHS Region 7,4 wk ahead,0.5
 2012,16,2011/2012,68,HHS Region 8,Season onset,none
 2012,16,2011/2012,68,HHS Region 8,Season peak week,11
 2012,16,2011/2012,68,HHS Region 8,Season peak percentage,2.2
@@ -4918,18 +4950,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,16,2011/2012,68,HHS Region 8,4 wk ahead,0.8
 2012,16,2011/2012,68,HHS Region 9,Season onset,none
 2012,16,2011/2012,68,HHS Region 9,Season peak week,52
+2012,16,2011/2012,68,HHS Region 9,Season peak week,8
 2012,16,2011/2012,68,HHS Region 9,Season peak percentage,3.7
-2012,16,2011/2012,68,HHS Region 9,1 wk ahead,2
-2012,16,2011/2012,68,HHS Region 9,2 wk ahead,2.4
-2012,16,2011/2012,68,HHS Region 9,3 wk ahead,2.4
-2012,16,2011/2012,68,HHS Region 9,4 wk ahead,0.6
-2012,16,2011/2012,68,HHS Region 10,Season onset,10
-2012,16,2011/2012,68,HHS Region 10,Season peak week,11
-2012,16,2011/2012,68,HHS Region 10,Season peak percentage,2.7
-2012,16,2011/2012,68,HHS Region 10,1 wk ahead,1.8
-2012,16,2011/2012,68,HHS Region 10,2 wk ahead,2.1
-2012,16,2011/2012,68,HHS Region 10,3 wk ahead,1.9
-2012,16,2011/2012,68,HHS Region 10,4 wk ahead,1.6
+2012,16,2011/2012,68,HHS Region 9,1 wk ahead,1.9
+2012,16,2011/2012,68,HHS Region 9,2 wk ahead,2.1
+2012,16,2011/2012,68,HHS Region 9,3 wk ahead,2
+2012,16,2011/2012,68,HHS Region 9,4 wk ahead,1.9
+2012,16,2011/2012,68,HHS Region 10,Season onset,none
+2012,16,2011/2012,68,HHS Region 10,Season peak week,12
+2012,16,2011/2012,68,HHS Region 10,Season peak percentage,2.2
+2012,16,2011/2012,68,HHS Region 10,1 wk ahead,1.4
+2012,16,2011/2012,68,HHS Region 10,2 wk ahead,1.4
+2012,16,2011/2012,68,HHS Region 10,3 wk ahead,1.1
+2012,16,2011/2012,68,HHS Region 10,4 wk ahead,0.9
 2012,17,2011/2012,69,US National,Season onset,none
 2012,17,2011/2012,69,US National,Season peak week,11
 2012,17,2011/2012,69,US National,Season peak percentage,2.4
@@ -4939,7 +4972,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,17,2011/2012,69,US National,4 wk ahead,1.3
 2012,17,2011/2012,69,HHS Region 1,Season onset,none
 2012,17,2011/2012,69,HHS Region 1,Season peak week,52
-2012,17,2011/2012,69,HHS Region 1,Season peak week,8
 2012,17,2011/2012,69,HHS Region 1,Season peak percentage,1
 2012,17,2011/2012,69,HHS Region 1,1 wk ahead,0.5
 2012,17,2011/2012,69,HHS Region 1,2 wk ahead,0.6
@@ -4957,7 +4989,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,17,2011/2012,69,HHS Region 3,Season peak percentage,2.1
 2012,17,2011/2012,69,HHS Region 3,1 wk ahead,1.3
 2012,17,2011/2012,69,HHS Region 3,2 wk ahead,1.5
-2012,17,2011/2012,69,HHS Region 3,3 wk ahead,1.2
+2012,17,2011/2012,69,HHS Region 3,3 wk ahead,1
 2012,17,2011/2012,69,HHS Region 3,4 wk ahead,1.1
 2012,17,2011/2012,69,HHS Region 4,Season onset,none
 2012,17,2011/2012,69,HHS Region 4,Season peak week,52
@@ -4965,28 +4997,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,17,2011/2012,69,HHS Region 4,Season peak percentage,2.3
 2012,17,2011/2012,69,HHS Region 4,1 wk ahead,1.5
 2012,17,2011/2012,69,HHS Region 4,2 wk ahead,1.4
-2012,17,2011/2012,69,HHS Region 4,3 wk ahead,1.1
+2012,17,2011/2012,69,HHS Region 4,3 wk ahead,1.4
 2012,17,2011/2012,69,HHS Region 4,4 wk ahead,1.5
 2012,17,2011/2012,69,HHS Region 5,Season onset,7
 2012,17,2011/2012,69,HHS Region 5,Season peak week,11
 2012,17,2011/2012,69,HHS Region 5,Season peak percentage,2.4
-2012,17,2011/2012,69,HHS Region 5,1 wk ahead,1.1
+2012,17,2011/2012,69,HHS Region 5,1 wk ahead,1
 2012,17,2011/2012,69,HHS Region 5,2 wk ahead,1
 2012,17,2011/2012,69,HHS Region 5,3 wk ahead,0.8
 2012,17,2011/2012,69,HHS Region 5,4 wk ahead,0.7
 2012,17,2011/2012,69,HHS Region 6,Season onset,none
 2012,17,2011/2012,69,HHS Region 6,Season peak week,11
-2012,17,2011/2012,69,HHS Region 6,Season peak percentage,4.2
+2012,17,2011/2012,69,HHS Region 6,Season peak percentage,4.1
 2012,17,2011/2012,69,HHS Region 6,1 wk ahead,1.9
 2012,17,2011/2012,69,HHS Region 6,2 wk ahead,1.9
 2012,17,2011/2012,69,HHS Region 6,3 wk ahead,1.9
 2012,17,2011/2012,69,HHS Region 6,4 wk ahead,1.9
 2012,17,2011/2012,69,HHS Region 7,Season onset,5
 2012,17,2011/2012,69,HHS Region 7,Season peak week,9
-2012,17,2011/2012,69,HHS Region 7,Season peak percentage,3.5
+2012,17,2011/2012,69,HHS Region 7,Season peak percentage,3.4
 2012,17,2011/2012,69,HHS Region 7,1 wk ahead,0.8
-2012,17,2011/2012,69,HHS Region 7,2 wk ahead,0.2
-2012,17,2011/2012,69,HHS Region 7,3 wk ahead,0.2
+2012,17,2011/2012,69,HHS Region 7,2 wk ahead,0.7
+2012,17,2011/2012,69,HHS Region 7,3 wk ahead,0.5
 2012,17,2011/2012,69,HHS Region 7,4 wk ahead,0.4
 2012,17,2011/2012,69,HHS Region 8,Season onset,none
 2012,17,2011/2012,69,HHS Region 8,Season peak week,11
@@ -4997,17 +5029,18 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,17,2011/2012,69,HHS Region 8,4 wk ahead,0.6
 2012,17,2011/2012,69,HHS Region 9,Season onset,none
 2012,17,2011/2012,69,HHS Region 9,Season peak week,52
+2012,17,2011/2012,69,HHS Region 9,Season peak week,8
 2012,17,2011/2012,69,HHS Region 9,Season peak percentage,3.7
-2012,17,2011/2012,69,HHS Region 9,1 wk ahead,2.4
-2012,17,2011/2012,69,HHS Region 9,2 wk ahead,2.4
-2012,17,2011/2012,69,HHS Region 9,3 wk ahead,0.6
+2012,17,2011/2012,69,HHS Region 9,1 wk ahead,2.1
+2012,17,2011/2012,69,HHS Region 9,2 wk ahead,2
+2012,17,2011/2012,69,HHS Region 9,3 wk ahead,1.9
 2012,17,2011/2012,69,HHS Region 9,4 wk ahead,2
-2012,17,2011/2012,69,HHS Region 10,Season onset,10
-2012,17,2011/2012,69,HHS Region 10,Season peak week,11
-2012,17,2011/2012,69,HHS Region 10,Season peak percentage,2.7
-2012,17,2011/2012,69,HHS Region 10,1 wk ahead,2.1
-2012,17,2011/2012,69,HHS Region 10,2 wk ahead,1.9
-2012,17,2011/2012,69,HHS Region 10,3 wk ahead,1.6
+2012,17,2011/2012,69,HHS Region 10,Season onset,none
+2012,17,2011/2012,69,HHS Region 10,Season peak week,12
+2012,17,2011/2012,69,HHS Region 10,Season peak percentage,2.2
+2012,17,2011/2012,69,HHS Region 10,1 wk ahead,1.4
+2012,17,2011/2012,69,HHS Region 10,2 wk ahead,1.1
+2012,17,2011/2012,69,HHS Region 10,3 wk ahead,0.9
 2012,17,2011/2012,69,HHS Region 10,4 wk ahead,0.7
 2012,18,2011/2012,70,US National,Season onset,none
 2012,18,2011/2012,70,US National,Season peak week,11
@@ -5018,7 +5051,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,18,2011/2012,70,US National,4 wk ahead,1.3
 2012,18,2011/2012,70,HHS Region 1,Season onset,none
 2012,18,2011/2012,70,HHS Region 1,Season peak week,52
-2012,18,2011/2012,70,HHS Region 1,Season peak week,8
 2012,18,2011/2012,70,HHS Region 1,Season peak percentage,1
 2012,18,2011/2012,70,HHS Region 1,1 wk ahead,0.6
 2012,18,2011/2012,70,HHS Region 1,2 wk ahead,0.5
@@ -5035,7 +5067,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,18,2011/2012,70,HHS Region 3,Season peak week,52
 2012,18,2011/2012,70,HHS Region 3,Season peak percentage,2.1
 2012,18,2011/2012,70,HHS Region 3,1 wk ahead,1.5
-2012,18,2011/2012,70,HHS Region 3,2 wk ahead,1.2
+2012,18,2011/2012,70,HHS Region 3,2 wk ahead,1
 2012,18,2011/2012,70,HHS Region 3,3 wk ahead,1.1
 2012,18,2011/2012,70,HHS Region 3,4 wk ahead,0.7
 2012,18,2011/2012,70,HHS Region 4,Season onset,none
@@ -5043,7 +5075,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,18,2011/2012,70,HHS Region 4,Season peak week,10
 2012,18,2011/2012,70,HHS Region 4,Season peak percentage,2.3
 2012,18,2011/2012,70,HHS Region 4,1 wk ahead,1.4
-2012,18,2011/2012,70,HHS Region 4,2 wk ahead,1.1
+2012,18,2011/2012,70,HHS Region 4,2 wk ahead,1.4
 2012,18,2011/2012,70,HHS Region 4,3 wk ahead,1.5
 2012,18,2011/2012,70,HHS Region 4,4 wk ahead,1.7
 2012,18,2011/2012,70,HHS Region 5,Season onset,7
@@ -5055,16 +5087,16 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,18,2011/2012,70,HHS Region 5,4 wk ahead,0.8
 2012,18,2011/2012,70,HHS Region 6,Season onset,none
 2012,18,2011/2012,70,HHS Region 6,Season peak week,11
-2012,18,2011/2012,70,HHS Region 6,Season peak percentage,4.2
+2012,18,2011/2012,70,HHS Region 6,Season peak percentage,4.1
 2012,18,2011/2012,70,HHS Region 6,1 wk ahead,1.9
 2012,18,2011/2012,70,HHS Region 6,2 wk ahead,1.9
 2012,18,2011/2012,70,HHS Region 6,3 wk ahead,1.9
 2012,18,2011/2012,70,HHS Region 6,4 wk ahead,2.2
 2012,18,2011/2012,70,HHS Region 7,Season onset,5
 2012,18,2011/2012,70,HHS Region 7,Season peak week,9
-2012,18,2011/2012,70,HHS Region 7,Season peak percentage,3.5
-2012,18,2011/2012,70,HHS Region 7,1 wk ahead,0.2
-2012,18,2011/2012,70,HHS Region 7,2 wk ahead,0.2
+2012,18,2011/2012,70,HHS Region 7,Season peak percentage,3.4
+2012,18,2011/2012,70,HHS Region 7,1 wk ahead,0.7
+2012,18,2011/2012,70,HHS Region 7,2 wk ahead,0.5
 2012,18,2011/2012,70,HHS Region 7,3 wk ahead,0.4
 2012,18,2011/2012,70,HHS Region 7,4 wk ahead,0.3
 2012,18,2011/2012,70,HHS Region 8,Season onset,none
@@ -5076,16 +5108,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,18,2011/2012,70,HHS Region 8,4 wk ahead,0.8
 2012,18,2011/2012,70,HHS Region 9,Season onset,none
 2012,18,2011/2012,70,HHS Region 9,Season peak week,52
+2012,18,2011/2012,70,HHS Region 9,Season peak week,8
 2012,18,2011/2012,70,HHS Region 9,Season peak percentage,3.7
-2012,18,2011/2012,70,HHS Region 9,1 wk ahead,2.4
-2012,18,2011/2012,70,HHS Region 9,2 wk ahead,0.6
+2012,18,2011/2012,70,HHS Region 9,1 wk ahead,2
+2012,18,2011/2012,70,HHS Region 9,2 wk ahead,1.9
 2012,18,2011/2012,70,HHS Region 9,3 wk ahead,2
 2012,18,2011/2012,70,HHS Region 9,4 wk ahead,2
-2012,18,2011/2012,70,HHS Region 10,Season onset,10
-2012,18,2011/2012,70,HHS Region 10,Season peak week,11
-2012,18,2011/2012,70,HHS Region 10,Season peak percentage,2.7
-2012,18,2011/2012,70,HHS Region 10,1 wk ahead,1.9
-2012,18,2011/2012,70,HHS Region 10,2 wk ahead,1.6
+2012,18,2011/2012,70,HHS Region 10,Season onset,none
+2012,18,2011/2012,70,HHS Region 10,Season peak week,12
+2012,18,2011/2012,70,HHS Region 10,Season peak percentage,2.2
+2012,18,2011/2012,70,HHS Region 10,1 wk ahead,1.1
+2012,18,2011/2012,70,HHS Region 10,2 wk ahead,0.9
 2012,18,2011/2012,70,HHS Region 10,3 wk ahead,0.7
 2012,18,2011/2012,70,HHS Region 10,4 wk ahead,0.7
 2012,19,2011/2012,71,US National,Season onset,none
@@ -5097,7 +5130,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,19,2011/2012,71,US National,4 wk ahead,1.2
 2012,19,2011/2012,71,HHS Region 1,Season onset,none
 2012,19,2011/2012,71,HHS Region 1,Season peak week,52
-2012,19,2011/2012,71,HHS Region 1,Season peak week,8
 2012,19,2011/2012,71,HHS Region 1,Season peak percentage,1
 2012,19,2011/2012,71,HHS Region 1,1 wk ahead,0.5
 2012,19,2011/2012,71,HHS Region 1,2 wk ahead,0.6
@@ -5113,7 +5145,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,19,2011/2012,71,HHS Region 3,Season onset,none
 2012,19,2011/2012,71,HHS Region 3,Season peak week,52
 2012,19,2011/2012,71,HHS Region 3,Season peak percentage,2.1
-2012,19,2011/2012,71,HHS Region 3,1 wk ahead,1.2
+2012,19,2011/2012,71,HHS Region 3,1 wk ahead,1
 2012,19,2011/2012,71,HHS Region 3,2 wk ahead,1.1
 2012,19,2011/2012,71,HHS Region 3,3 wk ahead,0.7
 2012,19,2011/2012,71,HHS Region 3,4 wk ahead,1.3
@@ -5121,7 +5153,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,19,2011/2012,71,HHS Region 4,Season peak week,52
 2012,19,2011/2012,71,HHS Region 4,Season peak week,10
 2012,19,2011/2012,71,HHS Region 4,Season peak percentage,2.3
-2012,19,2011/2012,71,HHS Region 4,1 wk ahead,1.1
+2012,19,2011/2012,71,HHS Region 4,1 wk ahead,1.4
 2012,19,2011/2012,71,HHS Region 4,2 wk ahead,1.5
 2012,19,2011/2012,71,HHS Region 4,3 wk ahead,1.7
 2012,19,2011/2012,71,HHS Region 4,4 wk ahead,1.5
@@ -5134,15 +5166,15 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,19,2011/2012,71,HHS Region 5,4 wk ahead,0.6
 2012,19,2011/2012,71,HHS Region 6,Season onset,none
 2012,19,2011/2012,71,HHS Region 6,Season peak week,11
-2012,19,2011/2012,71,HHS Region 6,Season peak percentage,4.2
+2012,19,2011/2012,71,HHS Region 6,Season peak percentage,4.1
 2012,19,2011/2012,71,HHS Region 6,1 wk ahead,1.9
 2012,19,2011/2012,71,HHS Region 6,2 wk ahead,1.9
 2012,19,2011/2012,71,HHS Region 6,3 wk ahead,2.2
 2012,19,2011/2012,71,HHS Region 6,4 wk ahead,1.5
 2012,19,2011/2012,71,HHS Region 7,Season onset,5
 2012,19,2011/2012,71,HHS Region 7,Season peak week,9
-2012,19,2011/2012,71,HHS Region 7,Season peak percentage,3.5
-2012,19,2011/2012,71,HHS Region 7,1 wk ahead,0.2
+2012,19,2011/2012,71,HHS Region 7,Season peak percentage,3.4
+2012,19,2011/2012,71,HHS Region 7,1 wk ahead,0.5
 2012,19,2011/2012,71,HHS Region 7,2 wk ahead,0.4
 2012,19,2011/2012,71,HHS Region 7,3 wk ahead,0.3
 2012,19,2011/2012,71,HHS Region 7,4 wk ahead,0.1
@@ -5155,15 +5187,16 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,19,2011/2012,71,HHS Region 8,4 wk ahead,0.7
 2012,19,2011/2012,71,HHS Region 9,Season onset,none
 2012,19,2011/2012,71,HHS Region 9,Season peak week,52
+2012,19,2011/2012,71,HHS Region 9,Season peak week,8
 2012,19,2011/2012,71,HHS Region 9,Season peak percentage,3.7
-2012,19,2011/2012,71,HHS Region 9,1 wk ahead,0.6
+2012,19,2011/2012,71,HHS Region 9,1 wk ahead,1.9
 2012,19,2011/2012,71,HHS Region 9,2 wk ahead,2
 2012,19,2011/2012,71,HHS Region 9,3 wk ahead,2
 2012,19,2011/2012,71,HHS Region 9,4 wk ahead,1.7
-2012,19,2011/2012,71,HHS Region 10,Season onset,10
-2012,19,2011/2012,71,HHS Region 10,Season peak week,11
-2012,19,2011/2012,71,HHS Region 10,Season peak percentage,2.7
-2012,19,2011/2012,71,HHS Region 10,1 wk ahead,1.6
+2012,19,2011/2012,71,HHS Region 10,Season onset,none
+2012,19,2011/2012,71,HHS Region 10,Season peak week,12
+2012,19,2011/2012,71,HHS Region 10,Season peak percentage,2.2
+2012,19,2011/2012,71,HHS Region 10,1 wk ahead,0.9
 2012,19,2011/2012,71,HHS Region 10,2 wk ahead,0.7
 2012,19,2011/2012,71,HHS Region 10,3 wk ahead,0.7
 2012,19,2011/2012,71,HHS Region 10,4 wk ahead,0.6
@@ -5176,7 +5209,6 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,20,2011/2012,72,US National,4 wk ahead,1.1
 2012,20,2011/2012,72,HHS Region 1,Season onset,none
 2012,20,2011/2012,72,HHS Region 1,Season peak week,52
-2012,20,2011/2012,72,HHS Region 1,Season peak week,8
 2012,20,2011/2012,72,HHS Region 1,Season peak percentage,1
 2012,20,2011/2012,72,HHS Region 1,1 wk ahead,0.6
 2012,20,2011/2012,72,HHS Region 1,2 wk ahead,0.6
@@ -5213,14 +5245,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,20,2011/2012,72,HHS Region 5,4 wk ahead,0.5
 2012,20,2011/2012,72,HHS Region 6,Season onset,none
 2012,20,2011/2012,72,HHS Region 6,Season peak week,11
-2012,20,2011/2012,72,HHS Region 6,Season peak percentage,4.2
+2012,20,2011/2012,72,HHS Region 6,Season peak percentage,4.1
 2012,20,2011/2012,72,HHS Region 6,1 wk ahead,1.9
 2012,20,2011/2012,72,HHS Region 6,2 wk ahead,2.2
 2012,20,2011/2012,72,HHS Region 6,3 wk ahead,1.5
 2012,20,2011/2012,72,HHS Region 6,4 wk ahead,1.3
 2012,20,2011/2012,72,HHS Region 7,Season onset,5
 2012,20,2011/2012,72,HHS Region 7,Season peak week,9
-2012,20,2011/2012,72,HHS Region 7,Season peak percentage,3.5
+2012,20,2011/2012,72,HHS Region 7,Season peak percentage,3.4
 2012,20,2011/2012,72,HHS Region 7,1 wk ahead,0.4
 2012,20,2011/2012,72,HHS Region 7,2 wk ahead,0.3
 2012,20,2011/2012,72,HHS Region 7,3 wk ahead,0.1
@@ -5234,14 +5266,15 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,20,2011/2012,72,HHS Region 8,4 wk ahead,0.6
 2012,20,2011/2012,72,HHS Region 9,Season onset,none
 2012,20,2011/2012,72,HHS Region 9,Season peak week,52
+2012,20,2011/2012,72,HHS Region 9,Season peak week,8
 2012,20,2011/2012,72,HHS Region 9,Season peak percentage,3.7
 2012,20,2011/2012,72,HHS Region 9,1 wk ahead,2
 2012,20,2011/2012,72,HHS Region 9,2 wk ahead,2
 2012,20,2011/2012,72,HHS Region 9,3 wk ahead,1.7
 2012,20,2011/2012,72,HHS Region 9,4 wk ahead,1.6
-2012,20,2011/2012,72,HHS Region 10,Season onset,10
-2012,20,2011/2012,72,HHS Region 10,Season peak week,11
-2012,20,2011/2012,72,HHS Region 10,Season peak percentage,2.7
+2012,20,2011/2012,72,HHS Region 10,Season onset,none
+2012,20,2011/2012,72,HHS Region 10,Season peak week,12
+2012,20,2011/2012,72,HHS Region 10,Season peak percentage,2.2
 2012,20,2011/2012,72,HHS Region 10,1 wk ahead,0.7
 2012,20,2011/2012,72,HHS Region 10,2 wk ahead,0.7
 2012,20,2011/2012,72,HHS Region 10,3 wk ahead,0.6
@@ -5270,7 +5303,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,40,2012/2013,40,HHS Region 3,Season onset,49
 2012,40,2012/2013,40,HHS Region 3,Season peak week,52
 2012,40,2012/2013,40,HHS Region 3,Season peak percentage,7.1
-2012,40,2012/2013,40,HHS Region 3,1 wk ahead,1.3
+2012,40,2012/2013,40,HHS Region 3,1 wk ahead,1.1
 2012,40,2012/2013,40,HHS Region 3,2 wk ahead,1.1
 2012,40,2012/2013,40,HHS Region 3,3 wk ahead,1.1
 2012,40,2012/2013,40,HHS Region 3,4 wk ahead,1.3
@@ -5284,10 +5317,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,40,2012/2013,40,HHS Region 5,Season onset,47
 2012,40,2012/2013,40,HHS Region 5,Season peak week,52
 2012,40,2012/2013,40,HHS Region 5,Season peak percentage,5.7
-2012,40,2012/2013,40,HHS Region 5,1 wk ahead,0.9
+2012,40,2012/2013,40,HHS Region 5,1 wk ahead,1
 2012,40,2012/2013,40,HHS Region 5,2 wk ahead,1
-2012,40,2012/2013,40,HHS Region 5,3 wk ahead,0.9
-2012,40,2012/2013,40,HHS Region 5,4 wk ahead,1
+2012,40,2012/2013,40,HHS Region 5,3 wk ahead,1
+2012,40,2012/2013,40,HHS Region 5,4 wk ahead,1.1
 2012,40,2012/2013,40,HHS Region 6,Season onset,47
 2012,40,2012/2013,40,HHS Region 6,Season peak week,52
 2012,40,2012/2013,40,HHS Region 6,Season peak percentage,9.3
@@ -5297,9 +5330,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,40,2012/2013,40,HHS Region 6,4 wk ahead,2.5
 2012,40,2012/2013,40,HHS Region 7,Season onset,47
 2012,40,2012/2013,40,HHS Region 7,Season peak week,52
-2012,40,2012/2013,40,HHS Region 7,Season peak percentage,6.8
+2012,40,2012/2013,40,HHS Region 7,Season peak percentage,6.7
 2012,40,2012/2013,40,HHS Region 7,1 wk ahead,1.1
-2012,40,2012/2013,40,HHS Region 7,2 wk ahead,1.3
+2012,40,2012/2013,40,HHS Region 7,2 wk ahead,1.4
 2012,40,2012/2013,40,HHS Region 7,3 wk ahead,1.3
 2012,40,2012/2013,40,HHS Region 7,4 wk ahead,1.5
 2012,40,2012/2013,40,HHS Region 8,Season onset,50
@@ -5363,8 +5396,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,41,2012/2013,41,HHS Region 5,Season peak week,52
 2012,41,2012/2013,41,HHS Region 5,Season peak percentage,5.7
 2012,41,2012/2013,41,HHS Region 5,1 wk ahead,1
-2012,41,2012/2013,41,HHS Region 5,2 wk ahead,0.9
-2012,41,2012/2013,41,HHS Region 5,3 wk ahead,1
+2012,41,2012/2013,41,HHS Region 5,2 wk ahead,1
+2012,41,2012/2013,41,HHS Region 5,3 wk ahead,1.1
 2012,41,2012/2013,41,HHS Region 5,4 wk ahead,1.1
 2012,41,2012/2013,41,HHS Region 6,Season onset,47
 2012,41,2012/2013,41,HHS Region 6,Season peak week,52
@@ -5375,8 +5408,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,41,2012/2013,41,HHS Region 6,4 wk ahead,2.9
 2012,41,2012/2013,41,HHS Region 7,Season onset,47
 2012,41,2012/2013,41,HHS Region 7,Season peak week,52
-2012,41,2012/2013,41,HHS Region 7,Season peak percentage,6.8
-2012,41,2012/2013,41,HHS Region 7,1 wk ahead,1.3
+2012,41,2012/2013,41,HHS Region 7,Season peak percentage,6.7
+2012,41,2012/2013,41,HHS Region 7,1 wk ahead,1.4
 2012,41,2012/2013,41,HHS Region 7,2 wk ahead,1.3
 2012,41,2012/2013,41,HHS Region 7,3 wk ahead,1.5
 2012,41,2012/2013,41,HHS Region 7,4 wk ahead,1.6
@@ -5440,8 +5473,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,42,2012/2013,42,HHS Region 5,Season onset,47
 2012,42,2012/2013,42,HHS Region 5,Season peak week,52
 2012,42,2012/2013,42,HHS Region 5,Season peak percentage,5.7
-2012,42,2012/2013,42,HHS Region 5,1 wk ahead,0.9
-2012,42,2012/2013,42,HHS Region 5,2 wk ahead,1
+2012,42,2012/2013,42,HHS Region 5,1 wk ahead,1
+2012,42,2012/2013,42,HHS Region 5,2 wk ahead,1.1
 2012,42,2012/2013,42,HHS Region 5,3 wk ahead,1.1
 2012,42,2012/2013,42,HHS Region 5,4 wk ahead,1.2
 2012,42,2012/2013,42,HHS Region 6,Season onset,47
@@ -5453,7 +5486,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,42,2012/2013,42,HHS Region 6,4 wk ahead,2.9
 2012,42,2012/2013,42,HHS Region 7,Season onset,47
 2012,42,2012/2013,42,HHS Region 7,Season peak week,52
-2012,42,2012/2013,42,HHS Region 7,Season peak percentage,6.8
+2012,42,2012/2013,42,HHS Region 7,Season peak percentage,6.7
 2012,42,2012/2013,42,HHS Region 7,1 wk ahead,1.3
 2012,42,2012/2013,42,HHS Region 7,2 wk ahead,1.5
 2012,42,2012/2013,42,HHS Region 7,3 wk ahead,1.6
@@ -5507,7 +5540,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,43,2012/2013,43,HHS Region 3,1 wk ahead,1.3
 2012,43,2012/2013,43,HHS Region 3,2 wk ahead,1.3
 2012,43,2012/2013,43,HHS Region 3,3 wk ahead,1.3
-2012,43,2012/2013,43,HHS Region 3,4 wk ahead,1.8
+2012,43,2012/2013,43,HHS Region 3,4 wk ahead,1.7
 2012,43,2012/2013,43,HHS Region 4,Season onset,47
 2012,43,2012/2013,43,HHS Region 4,Season peak week,52
 2012,43,2012/2013,43,HHS Region 4,Season peak percentage,6.3
@@ -5518,7 +5551,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,43,2012/2013,43,HHS Region 5,Season onset,47
 2012,43,2012/2013,43,HHS Region 5,Season peak week,52
 2012,43,2012/2013,43,HHS Region 5,Season peak percentage,5.7
-2012,43,2012/2013,43,HHS Region 5,1 wk ahead,1
+2012,43,2012/2013,43,HHS Region 5,1 wk ahead,1.1
 2012,43,2012/2013,43,HHS Region 5,2 wk ahead,1.1
 2012,43,2012/2013,43,HHS Region 5,3 wk ahead,1.2
 2012,43,2012/2013,43,HHS Region 5,4 wk ahead,1.6
@@ -5531,7 +5564,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,43,2012/2013,43,HHS Region 6,4 wk ahead,4.4
 2012,43,2012/2013,43,HHS Region 7,Season onset,47
 2012,43,2012/2013,43,HHS Region 7,Season peak week,52
-2012,43,2012/2013,43,HHS Region 7,Season peak percentage,6.8
+2012,43,2012/2013,43,HHS Region 7,Season peak percentage,6.7
 2012,43,2012/2013,43,HHS Region 7,1 wk ahead,1.5
 2012,43,2012/2013,43,HHS Region 7,2 wk ahead,1.6
 2012,43,2012/2013,43,HHS Region 7,3 wk ahead,2
@@ -5550,7 +5583,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,43,2012/2013,43,HHS Region 9,1 wk ahead,2.1
 2012,43,2012/2013,43,HHS Region 9,2 wk ahead,2.2
 2012,43,2012/2013,43,HHS Region 9,3 wk ahead,2.2
-2012,43,2012/2013,43,HHS Region 9,4 wk ahead,2.3
+2012,43,2012/2013,43,HHS Region 9,4 wk ahead,2.4
 2012,43,2012/2013,43,HHS Region 10,Season onset,50
 2012,43,2012/2013,43,HHS Region 10,Season peak week,4
 2012,43,2012/2013,43,HHS Region 10,Season peak percentage,3.7
@@ -5584,7 +5617,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,44,2012/2013,44,HHS Region 3,Season peak percentage,7.1
 2012,44,2012/2013,44,HHS Region 3,1 wk ahead,1.3
 2012,44,2012/2013,44,HHS Region 3,2 wk ahead,1.3
-2012,44,2012/2013,44,HHS Region 3,3 wk ahead,1.8
+2012,44,2012/2013,44,HHS Region 3,3 wk ahead,1.7
 2012,44,2012/2013,44,HHS Region 3,4 wk ahead,1.6
 2012,44,2012/2013,44,HHS Region 4,Season onset,47
 2012,44,2012/2013,44,HHS Region 4,Season peak week,52
@@ -5609,7 +5642,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,44,2012/2013,44,HHS Region 6,4 wk ahead,3.7
 2012,44,2012/2013,44,HHS Region 7,Season onset,47
 2012,44,2012/2013,44,HHS Region 7,Season peak week,52
-2012,44,2012/2013,44,HHS Region 7,Season peak percentage,6.8
+2012,44,2012/2013,44,HHS Region 7,Season peak percentage,6.7
 2012,44,2012/2013,44,HHS Region 7,1 wk ahead,1.6
 2012,44,2012/2013,44,HHS Region 7,2 wk ahead,2
 2012,44,2012/2013,44,HHS Region 7,3 wk ahead,2.3
@@ -5627,8 +5660,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,44,2012/2013,44,HHS Region 9,Season peak percentage,5.6
 2012,44,2012/2013,44,HHS Region 9,1 wk ahead,2.2
 2012,44,2012/2013,44,HHS Region 9,2 wk ahead,2.2
-2012,44,2012/2013,44,HHS Region 9,3 wk ahead,2.3
-2012,44,2012/2013,44,HHS Region 9,4 wk ahead,2.1
+2012,44,2012/2013,44,HHS Region 9,3 wk ahead,2.4
+2012,44,2012/2013,44,HHS Region 9,4 wk ahead,2.2
 2012,44,2012/2013,44,HHS Region 10,Season onset,50
 2012,44,2012/2013,44,HHS Region 10,Season peak week,4
 2012,44,2012/2013,44,HHS Region 10,Season peak percentage,3.7
@@ -5661,7 +5694,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,45,2012/2013,45,HHS Region 3,Season peak week,52
 2012,45,2012/2013,45,HHS Region 3,Season peak percentage,7.1
 2012,45,2012/2013,45,HHS Region 3,1 wk ahead,1.3
-2012,45,2012/2013,45,HHS Region 3,2 wk ahead,1.8
+2012,45,2012/2013,45,HHS Region 3,2 wk ahead,1.7
 2012,45,2012/2013,45,HHS Region 3,3 wk ahead,1.6
 2012,45,2012/2013,45,HHS Region 3,4 wk ahead,2.5
 2012,45,2012/2013,45,HHS Region 4,Season onset,47
@@ -5684,10 +5717,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,45,2012/2013,45,HHS Region 6,1 wk ahead,2.9
 2012,45,2012/2013,45,HHS Region 6,2 wk ahead,4.4
 2012,45,2012/2013,45,HHS Region 6,3 wk ahead,3.7
-2012,45,2012/2013,45,HHS Region 6,4 wk ahead,4.7
+2012,45,2012/2013,45,HHS Region 6,4 wk ahead,4.6
 2012,45,2012/2013,45,HHS Region 7,Season onset,47
 2012,45,2012/2013,45,HHS Region 7,Season peak week,52
-2012,45,2012/2013,45,HHS Region 7,Season peak percentage,6.8
+2012,45,2012/2013,45,HHS Region 7,Season peak percentage,6.7
 2012,45,2012/2013,45,HHS Region 7,1 wk ahead,2
 2012,45,2012/2013,45,HHS Region 7,2 wk ahead,2.3
 2012,45,2012/2013,45,HHS Region 7,3 wk ahead,2.2
@@ -5704,9 +5737,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,45,2012/2013,45,HHS Region 9,Season peak week,4
 2012,45,2012/2013,45,HHS Region 9,Season peak percentage,5.6
 2012,45,2012/2013,45,HHS Region 9,1 wk ahead,2.2
-2012,45,2012/2013,45,HHS Region 9,2 wk ahead,2.3
-2012,45,2012/2013,45,HHS Region 9,3 wk ahead,2.1
-2012,45,2012/2013,45,HHS Region 9,4 wk ahead,2.1
+2012,45,2012/2013,45,HHS Region 9,2 wk ahead,2.4
+2012,45,2012/2013,45,HHS Region 9,3 wk ahead,2.2
+2012,45,2012/2013,45,HHS Region 9,4 wk ahead,2.2
 2012,45,2012/2013,45,HHS Region 10,Season onset,50
 2012,45,2012/2013,45,HHS Region 10,Season peak week,4
 2012,45,2012/2013,45,HHS Region 10,Season peak percentage,3.7
@@ -5738,7 +5771,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,46,2012/2013,46,HHS Region 3,Season onset,49
 2012,46,2012/2013,46,HHS Region 3,Season peak week,52
 2012,46,2012/2013,46,HHS Region 3,Season peak percentage,7.1
-2012,46,2012/2013,46,HHS Region 3,1 wk ahead,1.8
+2012,46,2012/2013,46,HHS Region 3,1 wk ahead,1.7
 2012,46,2012/2013,46,HHS Region 3,2 wk ahead,1.6
 2012,46,2012/2013,46,HHS Region 3,3 wk ahead,2.5
 2012,46,2012/2013,46,HHS Region 3,4 wk ahead,3.4
@@ -5748,7 +5781,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,46,2012/2013,46,HHS Region 4,1 wk ahead,2.8
 2012,46,2012/2013,46,HHS Region 4,2 wk ahead,2.7
 2012,46,2012/2013,46,HHS Region 4,3 wk ahead,4.2
-2012,46,2012/2013,46,HHS Region 4,4 wk ahead,4.6
+2012,46,2012/2013,46,HHS Region 4,4 wk ahead,4.7
 2012,46,2012/2013,46,HHS Region 5,Season onset,47
 2012,46,2012/2013,46,HHS Region 5,Season peak week,52
 2012,46,2012/2013,46,HHS Region 5,Season peak percentage,5.7
@@ -5761,11 +5794,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,46,2012/2013,46,HHS Region 6,Season peak percentage,9.3
 2012,46,2012/2013,46,HHS Region 6,1 wk ahead,4.4
 2012,46,2012/2013,46,HHS Region 6,2 wk ahead,3.7
-2012,46,2012/2013,46,HHS Region 6,3 wk ahead,4.7
+2012,46,2012/2013,46,HHS Region 6,3 wk ahead,4.6
 2012,46,2012/2013,46,HHS Region 6,4 wk ahead,5.6
 2012,46,2012/2013,46,HHS Region 7,Season onset,47
 2012,46,2012/2013,46,HHS Region 7,Season peak week,52
-2012,46,2012/2013,46,HHS Region 7,Season peak percentage,6.8
+2012,46,2012/2013,46,HHS Region 7,Season peak percentage,6.7
 2012,46,2012/2013,46,HHS Region 7,1 wk ahead,2.3
 2012,46,2012/2013,46,HHS Region 7,2 wk ahead,2.2
 2012,46,2012/2013,46,HHS Region 7,3 wk ahead,2.3
@@ -5781,10 +5814,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,46,2012/2013,46,HHS Region 9,Season onset,2
 2012,46,2012/2013,46,HHS Region 9,Season peak week,4
 2012,46,2012/2013,46,HHS Region 9,Season peak percentage,5.6
-2012,46,2012/2013,46,HHS Region 9,1 wk ahead,2.3
-2012,46,2012/2013,46,HHS Region 9,2 wk ahead,2.1
-2012,46,2012/2013,46,HHS Region 9,3 wk ahead,2.1
-2012,46,2012/2013,46,HHS Region 9,4 wk ahead,2.4
+2012,46,2012/2013,46,HHS Region 9,1 wk ahead,2.4
+2012,46,2012/2013,46,HHS Region 9,2 wk ahead,2.2
+2012,46,2012/2013,46,HHS Region 9,3 wk ahead,2.2
+2012,46,2012/2013,46,HHS Region 9,4 wk ahead,2.5
 2012,46,2012/2013,46,HHS Region 10,Season onset,50
 2012,46,2012/2013,46,HHS Region 10,Season peak week,4
 2012,46,2012/2013,46,HHS Region 10,Season peak percentage,3.7
@@ -5825,7 +5858,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,47,2012/2013,47,HHS Region 4,Season peak percentage,6.3
 2012,47,2012/2013,47,HHS Region 4,1 wk ahead,2.7
 2012,47,2012/2013,47,HHS Region 4,2 wk ahead,4.2
-2012,47,2012/2013,47,HHS Region 4,3 wk ahead,4.6
+2012,47,2012/2013,47,HHS Region 4,3 wk ahead,4.7
 2012,47,2012/2013,47,HHS Region 4,4 wk ahead,5
 2012,47,2012/2013,47,HHS Region 5,Season onset,47
 2012,47,2012/2013,47,HHS Region 5,Season peak week,52
@@ -5838,16 +5871,16 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,47,2012/2013,47,HHS Region 6,Season peak week,52
 2012,47,2012/2013,47,HHS Region 6,Season peak percentage,9.3
 2012,47,2012/2013,47,HHS Region 6,1 wk ahead,3.7
-2012,47,2012/2013,47,HHS Region 6,2 wk ahead,4.7
+2012,47,2012/2013,47,HHS Region 6,2 wk ahead,4.6
 2012,47,2012/2013,47,HHS Region 6,3 wk ahead,5.6
 2012,47,2012/2013,47,HHS Region 6,4 wk ahead,7.2
 2012,47,2012/2013,47,HHS Region 7,Season onset,47
 2012,47,2012/2013,47,HHS Region 7,Season peak week,52
-2012,47,2012/2013,47,HHS Region 7,Season peak percentage,6.8
+2012,47,2012/2013,47,HHS Region 7,Season peak percentage,6.7
 2012,47,2012/2013,47,HHS Region 7,1 wk ahead,2.2
 2012,47,2012/2013,47,HHS Region 7,2 wk ahead,2.3
 2012,47,2012/2013,47,HHS Region 7,3 wk ahead,2.8
-2012,47,2012/2013,47,HHS Region 7,4 wk ahead,4
+2012,47,2012/2013,47,HHS Region 7,4 wk ahead,4.1
 2012,47,2012/2013,47,HHS Region 8,Season onset,50
 2012,47,2012/2013,47,HHS Region 8,Season peak week,52
 2012,47,2012/2013,47,HHS Region 8,Season peak week,3
@@ -5859,10 +5892,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,47,2012/2013,47,HHS Region 9,Season onset,2
 2012,47,2012/2013,47,HHS Region 9,Season peak week,4
 2012,47,2012/2013,47,HHS Region 9,Season peak percentage,5.6
-2012,47,2012/2013,47,HHS Region 9,1 wk ahead,2.1
-2012,47,2012/2013,47,HHS Region 9,2 wk ahead,2.1
-2012,47,2012/2013,47,HHS Region 9,3 wk ahead,2.4
-2012,47,2012/2013,47,HHS Region 9,4 wk ahead,3
+2012,47,2012/2013,47,HHS Region 9,1 wk ahead,2.2
+2012,47,2012/2013,47,HHS Region 9,2 wk ahead,2.2
+2012,47,2012/2013,47,HHS Region 9,3 wk ahead,2.5
+2012,47,2012/2013,47,HHS Region 9,4 wk ahead,3.1
 2012,47,2012/2013,47,HHS Region 10,Season onset,50
 2012,47,2012/2013,47,HHS Region 10,Season peak week,4
 2012,47,2012/2013,47,HHS Region 10,Season peak percentage,3.7
@@ -5902,7 +5935,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,48,2012/2013,48,HHS Region 4,Season peak week,52
 2012,48,2012/2013,48,HHS Region 4,Season peak percentage,6.3
 2012,48,2012/2013,48,HHS Region 4,1 wk ahead,4.2
-2012,48,2012/2013,48,HHS Region 4,2 wk ahead,4.6
+2012,48,2012/2013,48,HHS Region 4,2 wk ahead,4.7
 2012,48,2012/2013,48,HHS Region 4,3 wk ahead,5
 2012,48,2012/2013,48,HHS Region 4,4 wk ahead,6.3
 2012,48,2012/2013,48,HHS Region 5,Season onset,47
@@ -5915,17 +5948,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,48,2012/2013,48,HHS Region 6,Season onset,47
 2012,48,2012/2013,48,HHS Region 6,Season peak week,52
 2012,48,2012/2013,48,HHS Region 6,Season peak percentage,9.3
-2012,48,2012/2013,48,HHS Region 6,1 wk ahead,4.7
+2012,48,2012/2013,48,HHS Region 6,1 wk ahead,4.6
 2012,48,2012/2013,48,HHS Region 6,2 wk ahead,5.6
 2012,48,2012/2013,48,HHS Region 6,3 wk ahead,7.2
 2012,48,2012/2013,48,HHS Region 6,4 wk ahead,9.3
 2012,48,2012/2013,48,HHS Region 7,Season onset,47
 2012,48,2012/2013,48,HHS Region 7,Season peak week,52
-2012,48,2012/2013,48,HHS Region 7,Season peak percentage,6.8
+2012,48,2012/2013,48,HHS Region 7,Season peak percentage,6.7
 2012,48,2012/2013,48,HHS Region 7,1 wk ahead,2.3
 2012,48,2012/2013,48,HHS Region 7,2 wk ahead,2.8
-2012,48,2012/2013,48,HHS Region 7,3 wk ahead,4
-2012,48,2012/2013,48,HHS Region 7,4 wk ahead,6.8
+2012,48,2012/2013,48,HHS Region 7,3 wk ahead,4.1
+2012,48,2012/2013,48,HHS Region 7,4 wk ahead,6.7
 2012,48,2012/2013,48,HHS Region 8,Season onset,50
 2012,48,2012/2013,48,HHS Region 8,Season peak week,52
 2012,48,2012/2013,48,HHS Region 8,Season peak week,3
@@ -5937,9 +5970,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,48,2012/2013,48,HHS Region 9,Season onset,2
 2012,48,2012/2013,48,HHS Region 9,Season peak week,4
 2012,48,2012/2013,48,HHS Region 9,Season peak percentage,5.6
-2012,48,2012/2013,48,HHS Region 9,1 wk ahead,2.1
-2012,48,2012/2013,48,HHS Region 9,2 wk ahead,2.4
-2012,48,2012/2013,48,HHS Region 9,3 wk ahead,3
+2012,48,2012/2013,48,HHS Region 9,1 wk ahead,2.2
+2012,48,2012/2013,48,HHS Region 9,2 wk ahead,2.5
+2012,48,2012/2013,48,HHS Region 9,3 wk ahead,3.1
 2012,48,2012/2013,48,HHS Region 9,4 wk ahead,4.8
 2012,48,2012/2013,48,HHS Region 10,Season onset,50
 2012,48,2012/2013,48,HHS Region 10,Season peak week,4
@@ -5979,7 +6012,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,49,2012/2013,49,HHS Region 4,Season onset,47
 2012,49,2012/2013,49,HHS Region 4,Season peak week,52
 2012,49,2012/2013,49,HHS Region 4,Season peak percentage,6.3
-2012,49,2012/2013,49,HHS Region 4,1 wk ahead,4.6
+2012,49,2012/2013,49,HHS Region 4,1 wk ahead,4.7
 2012,49,2012/2013,49,HHS Region 4,2 wk ahead,5
 2012,49,2012/2013,49,HHS Region 4,3 wk ahead,6.3
 2012,49,2012/2013,49,HHS Region 4,4 wk ahead,4.5
@@ -5999,10 +6032,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,49,2012/2013,49,HHS Region 6,4 wk ahead,7.7
 2012,49,2012/2013,49,HHS Region 7,Season onset,47
 2012,49,2012/2013,49,HHS Region 7,Season peak week,52
-2012,49,2012/2013,49,HHS Region 7,Season peak percentage,6.8
+2012,49,2012/2013,49,HHS Region 7,Season peak percentage,6.7
 2012,49,2012/2013,49,HHS Region 7,1 wk ahead,2.8
-2012,49,2012/2013,49,HHS Region 7,2 wk ahead,4
-2012,49,2012/2013,49,HHS Region 7,3 wk ahead,6.8
+2012,49,2012/2013,49,HHS Region 7,2 wk ahead,4.1
+2012,49,2012/2013,49,HHS Region 7,3 wk ahead,6.7
 2012,49,2012/2013,49,HHS Region 7,4 wk ahead,5.8
 2012,49,2012/2013,49,HHS Region 8,Season onset,50
 2012,49,2012/2013,49,HHS Region 8,Season peak week,52
@@ -6015,8 +6048,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,49,2012/2013,49,HHS Region 9,Season onset,2
 2012,49,2012/2013,49,HHS Region 9,Season peak week,4
 2012,49,2012/2013,49,HHS Region 9,Season peak percentage,5.6
-2012,49,2012/2013,49,HHS Region 9,1 wk ahead,2.4
-2012,49,2012/2013,49,HHS Region 9,2 wk ahead,3
+2012,49,2012/2013,49,HHS Region 9,1 wk ahead,2.5
+2012,49,2012/2013,49,HHS Region 9,2 wk ahead,3.1
 2012,49,2012/2013,49,HHS Region 9,3 wk ahead,4.8
 2012,49,2012/2013,49,HHS Region 9,4 wk ahead,3.4
 2012,49,2012/2013,49,HHS Region 10,Season onset,50
@@ -6077,9 +6110,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,50,2012/2013,50,HHS Region 6,4 wk ahead,7.3
 2012,50,2012/2013,50,HHS Region 7,Season onset,47
 2012,50,2012/2013,50,HHS Region 7,Season peak week,52
-2012,50,2012/2013,50,HHS Region 7,Season peak percentage,6.8
-2012,50,2012/2013,50,HHS Region 7,1 wk ahead,4
-2012,50,2012/2013,50,HHS Region 7,2 wk ahead,6.8
+2012,50,2012/2013,50,HHS Region 7,Season peak percentage,6.7
+2012,50,2012/2013,50,HHS Region 7,1 wk ahead,4.1
+2012,50,2012/2013,50,HHS Region 7,2 wk ahead,6.7
 2012,50,2012/2013,50,HHS Region 7,3 wk ahead,5.8
 2012,50,2012/2013,50,HHS Region 7,4 wk ahead,5.1
 2012,50,2012/2013,50,HHS Region 8,Season onset,50
@@ -6089,11 +6122,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,50,2012/2013,50,HHS Region 8,1 wk ahead,3.2
 2012,50,2012/2013,50,HHS Region 8,2 wk ahead,4.1
 2012,50,2012/2013,50,HHS Region 8,3 wk ahead,3.7
-2012,50,2012/2013,50,HHS Region 8,4 wk ahead,3.9
+2012,50,2012/2013,50,HHS Region 8,4 wk ahead,4
 2012,50,2012/2013,50,HHS Region 9,Season onset,2
 2012,50,2012/2013,50,HHS Region 9,Season peak week,4
 2012,50,2012/2013,50,HHS Region 9,Season peak percentage,5.6
-2012,50,2012/2013,50,HHS Region 9,1 wk ahead,3
+2012,50,2012/2013,50,HHS Region 9,1 wk ahead,3.1
 2012,50,2012/2013,50,HHS Region 9,2 wk ahead,4.8
 2012,50,2012/2013,50,HHS Region 9,3 wk ahead,3.4
 2012,50,2012/2013,50,HHS Region 9,4 wk ahead,3.5
@@ -6155,8 +6188,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,51,2012/2013,51,HHS Region 6,4 wk ahead,7.4
 2012,51,2012/2013,51,HHS Region 7,Season onset,47
 2012,51,2012/2013,51,HHS Region 7,Season peak week,52
-2012,51,2012/2013,51,HHS Region 7,Season peak percentage,6.8
-2012,51,2012/2013,51,HHS Region 7,1 wk ahead,6.8
+2012,51,2012/2013,51,HHS Region 7,Season peak percentage,6.7
+2012,51,2012/2013,51,HHS Region 7,1 wk ahead,6.7
 2012,51,2012/2013,51,HHS Region 7,2 wk ahead,5.8
 2012,51,2012/2013,51,HHS Region 7,3 wk ahead,5.1
 2012,51,2012/2013,51,HHS Region 7,4 wk ahead,5.2
@@ -6166,7 +6199,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,51,2012/2013,51,HHS Region 8,Season peak percentage,4.1
 2012,51,2012/2013,51,HHS Region 8,1 wk ahead,4.1
 2012,51,2012/2013,51,HHS Region 8,2 wk ahead,3.7
-2012,51,2012/2013,51,HHS Region 8,3 wk ahead,3.9
+2012,51,2012/2013,51,HHS Region 8,3 wk ahead,4
 2012,51,2012/2013,51,HHS Region 8,4 wk ahead,4.1
 2012,51,2012/2013,51,HHS Region 9,Season onset,2
 2012,51,2012/2013,51,HHS Region 9,Season peak week,4
@@ -6233,7 +6266,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,52,2012/2013,52,HHS Region 6,4 wk ahead,7.1
 2012,52,2012/2013,52,HHS Region 7,Season onset,47
 2012,52,2012/2013,52,HHS Region 7,Season peak week,52
-2012,52,2012/2013,52,HHS Region 7,Season peak percentage,6.8
+2012,52,2012/2013,52,HHS Region 7,Season peak percentage,6.7
 2012,52,2012/2013,52,HHS Region 7,1 wk ahead,5.8
 2012,52,2012/2013,52,HHS Region 7,2 wk ahead,5.1
 2012,52,2012/2013,52,HHS Region 7,3 wk ahead,5.2
@@ -6243,7 +6276,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2012,52,2012/2013,52,HHS Region 8,Season peak week,3
 2012,52,2012/2013,52,HHS Region 8,Season peak percentage,4.1
 2012,52,2012/2013,52,HHS Region 8,1 wk ahead,3.7
-2012,52,2012/2013,52,HHS Region 8,2 wk ahead,3.9
+2012,52,2012/2013,52,HHS Region 8,2 wk ahead,4
 2012,52,2012/2013,52,HHS Region 8,3 wk ahead,4.1
 2012,52,2012/2013,52,HHS Region 8,4 wk ahead,4
 2012,52,2012/2013,52,HHS Region 9,Season onset,2
@@ -6311,16 +6344,16 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,1,2012/2013,53,HHS Region 6,4 wk ahead,5.8
 2013,1,2012/2013,53,HHS Region 7,Season onset,47
 2013,1,2012/2013,53,HHS Region 7,Season peak week,52
-2013,1,2012/2013,53,HHS Region 7,Season peak percentage,6.8
+2013,1,2012/2013,53,HHS Region 7,Season peak percentage,6.7
 2013,1,2012/2013,53,HHS Region 7,1 wk ahead,5.1
 2013,1,2012/2013,53,HHS Region 7,2 wk ahead,5.2
 2013,1,2012/2013,53,HHS Region 7,3 wk ahead,5.3
-2013,1,2012/2013,53,HHS Region 7,4 wk ahead,5.1
+2013,1,2012/2013,53,HHS Region 7,4 wk ahead,5.2
 2013,1,2012/2013,53,HHS Region 8,Season onset,50
 2013,1,2012/2013,53,HHS Region 8,Season peak week,52
 2013,1,2012/2013,53,HHS Region 8,Season peak week,3
 2013,1,2012/2013,53,HHS Region 8,Season peak percentage,4.1
-2013,1,2012/2013,53,HHS Region 8,1 wk ahead,3.9
+2013,1,2012/2013,53,HHS Region 8,1 wk ahead,4
 2013,1,2012/2013,53,HHS Region 8,2 wk ahead,4.1
 2013,1,2012/2013,53,HHS Region 8,3 wk ahead,4
 2013,1,2012/2013,53,HHS Region 8,4 wk ahead,3.4
@@ -6389,10 +6422,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,2,2012/2013,54,HHS Region 6,4 wk ahead,4.5
 2013,2,2012/2013,54,HHS Region 7,Season onset,47
 2013,2,2012/2013,54,HHS Region 7,Season peak week,52
-2013,2,2012/2013,54,HHS Region 7,Season peak percentage,6.8
+2013,2,2012/2013,54,HHS Region 7,Season peak percentage,6.7
 2013,2,2012/2013,54,HHS Region 7,1 wk ahead,5.2
 2013,2,2012/2013,54,HHS Region 7,2 wk ahead,5.3
-2013,2,2012/2013,54,HHS Region 7,3 wk ahead,5.1
+2013,2,2012/2013,54,HHS Region 7,3 wk ahead,5.2
 2013,2,2012/2013,54,HHS Region 7,4 wk ahead,4.3
 2013,2,2012/2013,54,HHS Region 8,Season onset,50
 2013,2,2012/2013,54,HHS Region 8,Season peak week,52
@@ -6467,9 +6500,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,3,2012/2013,55,HHS Region 6,4 wk ahead,3.9
 2013,3,2012/2013,55,HHS Region 7,Season onset,47
 2013,3,2012/2013,55,HHS Region 7,Season peak week,52
-2013,3,2012/2013,55,HHS Region 7,Season peak percentage,6.8
+2013,3,2012/2013,55,HHS Region 7,Season peak percentage,6.7
 2013,3,2012/2013,55,HHS Region 7,1 wk ahead,5.3
-2013,3,2012/2013,55,HHS Region 7,2 wk ahead,5.1
+2013,3,2012/2013,55,HHS Region 7,2 wk ahead,5.2
 2013,3,2012/2013,55,HHS Region 7,3 wk ahead,4.3
 2013,3,2012/2013,55,HHS Region 7,4 wk ahead,3.4
 2013,3,2012/2013,55,HHS Region 8,Season onset,50
@@ -6545,8 +6578,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,4,2012/2013,56,HHS Region 6,4 wk ahead,3.3
 2013,4,2012/2013,56,HHS Region 7,Season onset,47
 2013,4,2012/2013,56,HHS Region 7,Season peak week,52
-2013,4,2012/2013,56,HHS Region 7,Season peak percentage,6.8
-2013,4,2012/2013,56,HHS Region 7,1 wk ahead,5.1
+2013,4,2012/2013,56,HHS Region 7,Season peak percentage,6.7
+2013,4,2012/2013,56,HHS Region 7,1 wk ahead,5.2
 2013,4,2012/2013,56,HHS Region 7,2 wk ahead,4.3
 2013,4,2012/2013,56,HHS Region 7,3 wk ahead,3.4
 2013,4,2012/2013,56,HHS Region 7,4 wk ahead,3.1
@@ -6564,7 +6597,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,4,2012/2013,56,HHS Region 9,1 wk ahead,5.5
 2013,4,2012/2013,56,HHS Region 9,2 wk ahead,4.8
 2013,4,2012/2013,56,HHS Region 9,3 wk ahead,4.5
-2013,4,2012/2013,56,HHS Region 9,4 wk ahead,3.9
+2013,4,2012/2013,56,HHS Region 9,4 wk ahead,3.8
 2013,4,2012/2013,56,HHS Region 10,Season onset,50
 2013,4,2012/2013,56,HHS Region 10,Season peak week,4
 2013,4,2012/2013,56,HHS Region 10,Season peak percentage,3.7
@@ -6623,7 +6656,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,5,2012/2013,57,HHS Region 6,4 wk ahead,3.2
 2013,5,2012/2013,57,HHS Region 7,Season onset,47
 2013,5,2012/2013,57,HHS Region 7,Season peak week,52
-2013,5,2012/2013,57,HHS Region 7,Season peak percentage,6.8
+2013,5,2012/2013,57,HHS Region 7,Season peak percentage,6.7
 2013,5,2012/2013,57,HHS Region 7,1 wk ahead,4.3
 2013,5,2012/2013,57,HHS Region 7,2 wk ahead,3.4
 2013,5,2012/2013,57,HHS Region 7,3 wk ahead,3.1
@@ -6641,7 +6674,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,5,2012/2013,57,HHS Region 9,Season peak percentage,5.6
 2013,5,2012/2013,57,HHS Region 9,1 wk ahead,4.8
 2013,5,2012/2013,57,HHS Region 9,2 wk ahead,4.5
-2013,5,2012/2013,57,HHS Region 9,3 wk ahead,3.9
+2013,5,2012/2013,57,HHS Region 9,3 wk ahead,3.8
 2013,5,2012/2013,57,HHS Region 9,4 wk ahead,3.5
 2013,5,2012/2013,57,HHS Region 10,Season onset,50
 2013,5,2012/2013,57,HHS Region 10,Season peak week,4
@@ -6698,10 +6731,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,6,2012/2013,58,HHS Region 6,1 wk ahead,3.9
 2013,6,2012/2013,58,HHS Region 6,2 wk ahead,3.3
 2013,6,2012/2013,58,HHS Region 6,3 wk ahead,3.2
-2013,6,2012/2013,58,HHS Region 6,4 wk ahead,3.2
+2013,6,2012/2013,58,HHS Region 6,4 wk ahead,3.1
 2013,6,2012/2013,58,HHS Region 7,Season onset,47
 2013,6,2012/2013,58,HHS Region 7,Season peak week,52
-2013,6,2012/2013,58,HHS Region 7,Season peak percentage,6.8
+2013,6,2012/2013,58,HHS Region 7,Season peak percentage,6.7
 2013,6,2012/2013,58,HHS Region 7,1 wk ahead,3.4
 2013,6,2012/2013,58,HHS Region 7,2 wk ahead,3.1
 2013,6,2012/2013,58,HHS Region 7,3 wk ahead,2.4
@@ -6718,7 +6751,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,6,2012/2013,58,HHS Region 9,Season peak week,4
 2013,6,2012/2013,58,HHS Region 9,Season peak percentage,5.6
 2013,6,2012/2013,58,HHS Region 9,1 wk ahead,4.5
-2013,6,2012/2013,58,HHS Region 9,2 wk ahead,3.9
+2013,6,2012/2013,58,HHS Region 9,2 wk ahead,3.8
 2013,6,2012/2013,58,HHS Region 9,3 wk ahead,3.5
 2013,6,2012/2013,58,HHS Region 9,4 wk ahead,3.6
 2013,6,2012/2013,58,HHS Region 10,Season onset,50
@@ -6755,7 +6788,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,7,2012/2013,59,HHS Region 3,1 wk ahead,2.6
 2013,7,2012/2013,59,HHS Region 3,2 wk ahead,2.6
 2013,7,2012/2013,59,HHS Region 3,3 wk ahead,2.7
-2013,7,2012/2013,59,HHS Region 3,4 wk ahead,2.7
+2013,7,2012/2013,59,HHS Region 3,4 wk ahead,2.6
 2013,7,2012/2013,59,HHS Region 4,Season onset,47
 2013,7,2012/2013,59,HHS Region 4,Season peak week,52
 2013,7,2012/2013,59,HHS Region 4,Season peak percentage,6.3
@@ -6775,11 +6808,11 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,7,2012/2013,59,HHS Region 6,Season peak percentage,9.3
 2013,7,2012/2013,59,HHS Region 6,1 wk ahead,3.3
 2013,7,2012/2013,59,HHS Region 6,2 wk ahead,3.2
-2013,7,2012/2013,59,HHS Region 6,3 wk ahead,3.2
+2013,7,2012/2013,59,HHS Region 6,3 wk ahead,3.1
 2013,7,2012/2013,59,HHS Region 6,4 wk ahead,3
 2013,7,2012/2013,59,HHS Region 7,Season onset,47
 2013,7,2012/2013,59,HHS Region 7,Season peak week,52
-2013,7,2012/2013,59,HHS Region 7,Season peak percentage,6.8
+2013,7,2012/2013,59,HHS Region 7,Season peak percentage,6.7
 2013,7,2012/2013,59,HHS Region 7,1 wk ahead,3.1
 2013,7,2012/2013,59,HHS Region 7,2 wk ahead,2.4
 2013,7,2012/2013,59,HHS Region 7,3 wk ahead,2.3
@@ -6795,7 +6828,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,7,2012/2013,59,HHS Region 9,Season onset,2
 2013,7,2012/2013,59,HHS Region 9,Season peak week,4
 2013,7,2012/2013,59,HHS Region 9,Season peak percentage,5.6
-2013,7,2012/2013,59,HHS Region 9,1 wk ahead,3.9
+2013,7,2012/2013,59,HHS Region 9,1 wk ahead,3.8
 2013,7,2012/2013,59,HHS Region 9,2 wk ahead,3.5
 2013,7,2012/2013,59,HHS Region 9,3 wk ahead,3.6
 2013,7,2012/2013,59,HHS Region 9,4 wk ahead,3.1
@@ -6826,14 +6859,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,8,2012/2013,60,HHS Region 2,1 wk ahead,2.8
 2013,8,2012/2013,60,HHS Region 2,2 wk ahead,3
 2013,8,2012/2013,60,HHS Region 2,3 wk ahead,2.9
-2013,8,2012/2013,60,HHS Region 2,4 wk ahead,2.6
+2013,8,2012/2013,60,HHS Region 2,4 wk ahead,2.5
 2013,8,2012/2013,60,HHS Region 3,Season onset,49
 2013,8,2012/2013,60,HHS Region 3,Season peak week,52
 2013,8,2012/2013,60,HHS Region 3,Season peak percentage,7.1
 2013,8,2012/2013,60,HHS Region 3,1 wk ahead,2.6
 2013,8,2012/2013,60,HHS Region 3,2 wk ahead,2.7
-2013,8,2012/2013,60,HHS Region 3,3 wk ahead,2.7
-2013,8,2012/2013,60,HHS Region 3,4 wk ahead,2.3
+2013,8,2012/2013,60,HHS Region 3,3 wk ahead,2.6
+2013,8,2012/2013,60,HHS Region 3,4 wk ahead,2.2
 2013,8,2012/2013,60,HHS Region 4,Season onset,47
 2013,8,2012/2013,60,HHS Region 4,Season peak week,52
 2013,8,2012/2013,60,HHS Region 4,Season peak percentage,6.3
@@ -6852,12 +6885,12 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,8,2012/2013,60,HHS Region 6,Season peak week,52
 2013,8,2012/2013,60,HHS Region 6,Season peak percentage,9.3
 2013,8,2012/2013,60,HHS Region 6,1 wk ahead,3.2
-2013,8,2012/2013,60,HHS Region 6,2 wk ahead,3.2
+2013,8,2012/2013,60,HHS Region 6,2 wk ahead,3.1
 2013,8,2012/2013,60,HHS Region 6,3 wk ahead,3
 2013,8,2012/2013,60,HHS Region 6,4 wk ahead,2.6
 2013,8,2012/2013,60,HHS Region 7,Season onset,47
 2013,8,2012/2013,60,HHS Region 7,Season peak week,52
-2013,8,2012/2013,60,HHS Region 7,Season peak percentage,6.8
+2013,8,2012/2013,60,HHS Region 7,Season peak percentage,6.7
 2013,8,2012/2013,60,HHS Region 7,1 wk ahead,2.4
 2013,8,2012/2013,60,HHS Region 7,2 wk ahead,2.3
 2013,8,2012/2013,60,HHS Region 7,3 wk ahead,1.9
@@ -6903,14 +6936,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,9,2012/2013,61,HHS Region 2,Season peak percentage,5.5
 2013,9,2012/2013,61,HHS Region 2,1 wk ahead,3
 2013,9,2012/2013,61,HHS Region 2,2 wk ahead,2.9
-2013,9,2012/2013,61,HHS Region 2,3 wk ahead,2.6
+2013,9,2012/2013,61,HHS Region 2,3 wk ahead,2.5
 2013,9,2012/2013,61,HHS Region 2,4 wk ahead,2.2
 2013,9,2012/2013,61,HHS Region 3,Season onset,49
 2013,9,2012/2013,61,HHS Region 3,Season peak week,52
 2013,9,2012/2013,61,HHS Region 3,Season peak percentage,7.1
 2013,9,2012/2013,61,HHS Region 3,1 wk ahead,2.7
-2013,9,2012/2013,61,HHS Region 3,2 wk ahead,2.7
-2013,9,2012/2013,61,HHS Region 3,3 wk ahead,2.3
+2013,9,2012/2013,61,HHS Region 3,2 wk ahead,2.6
+2013,9,2012/2013,61,HHS Region 3,3 wk ahead,2.2
 2013,9,2012/2013,61,HHS Region 3,4 wk ahead,2.1
 2013,9,2012/2013,61,HHS Region 4,Season onset,47
 2013,9,2012/2013,61,HHS Region 4,Season peak week,52
@@ -6929,13 +6962,13 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,9,2012/2013,61,HHS Region 6,Season onset,47
 2013,9,2012/2013,61,HHS Region 6,Season peak week,52
 2013,9,2012/2013,61,HHS Region 6,Season peak percentage,9.3
-2013,9,2012/2013,61,HHS Region 6,1 wk ahead,3.2
+2013,9,2012/2013,61,HHS Region 6,1 wk ahead,3.1
 2013,9,2012/2013,61,HHS Region 6,2 wk ahead,3
 2013,9,2012/2013,61,HHS Region 6,3 wk ahead,2.6
 2013,9,2012/2013,61,HHS Region 6,4 wk ahead,2.3
 2013,9,2012/2013,61,HHS Region 7,Season onset,47
 2013,9,2012/2013,61,HHS Region 7,Season peak week,52
-2013,9,2012/2013,61,HHS Region 7,Season peak percentage,6.8
+2013,9,2012/2013,61,HHS Region 7,Season peak percentage,6.7
 2013,9,2012/2013,61,HHS Region 7,1 wk ahead,2.3
 2013,9,2012/2013,61,HHS Region 7,2 wk ahead,1.9
 2013,9,2012/2013,61,HHS Region 7,3 wk ahead,1.5
@@ -6947,14 +6980,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,9,2012/2013,61,HHS Region 8,1 wk ahead,1.8
 2013,9,2012/2013,61,HHS Region 8,2 wk ahead,1.8
 2013,9,2012/2013,61,HHS Region 8,3 wk ahead,1.2
-2013,9,2012/2013,61,HHS Region 8,4 wk ahead,1.3
+2013,9,2012/2013,61,HHS Region 8,4 wk ahead,1.2
 2013,9,2012/2013,61,HHS Region 9,Season onset,2
 2013,9,2012/2013,61,HHS Region 9,Season peak week,4
 2013,9,2012/2013,61,HHS Region 9,Season peak percentage,5.6
 2013,9,2012/2013,61,HHS Region 9,1 wk ahead,3.6
 2013,9,2012/2013,61,HHS Region 9,2 wk ahead,3.1
 2013,9,2012/2013,61,HHS Region 9,3 wk ahead,2.9
-2013,9,2012/2013,61,HHS Region 9,4 wk ahead,2.9
+2013,9,2012/2013,61,HHS Region 9,4 wk ahead,2.6
 2013,9,2012/2013,61,HHS Region 10,Season onset,50
 2013,9,2012/2013,61,HHS Region 10,Season peak week,4
 2013,9,2012/2013,61,HHS Region 10,Season peak percentage,3.7
@@ -6980,14 +7013,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,10,2012/2013,62,HHS Region 2,Season peak week,52
 2013,10,2012/2013,62,HHS Region 2,Season peak percentage,5.5
 2013,10,2012/2013,62,HHS Region 2,1 wk ahead,2.9
-2013,10,2012/2013,62,HHS Region 2,2 wk ahead,2.6
+2013,10,2012/2013,62,HHS Region 2,2 wk ahead,2.5
 2013,10,2012/2013,62,HHS Region 2,3 wk ahead,2.2
-2013,10,2012/2013,62,HHS Region 2,4 wk ahead,2
+2013,10,2012/2013,62,HHS Region 2,4 wk ahead,1.9
 2013,10,2012/2013,62,HHS Region 3,Season onset,49
 2013,10,2012/2013,62,HHS Region 3,Season peak week,52
 2013,10,2012/2013,62,HHS Region 3,Season peak percentage,7.1
-2013,10,2012/2013,62,HHS Region 3,1 wk ahead,2.7
-2013,10,2012/2013,62,HHS Region 3,2 wk ahead,2.3
+2013,10,2012/2013,62,HHS Region 3,1 wk ahead,2.6
+2013,10,2012/2013,62,HHS Region 3,2 wk ahead,2.2
 2013,10,2012/2013,62,HHS Region 3,3 wk ahead,2.1
 2013,10,2012/2013,62,HHS Region 3,4 wk ahead,1.7
 2013,10,2012/2013,62,HHS Region 4,Season onset,47
@@ -7003,7 +7036,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,10,2012/2013,62,HHS Region 5,1 wk ahead,2.1
 2013,10,2012/2013,62,HHS Region 5,2 wk ahead,1.8
 2013,10,2012/2013,62,HHS Region 5,3 wk ahead,1.6
-2013,10,2012/2013,62,HHS Region 5,4 wk ahead,1.3
+2013,10,2012/2013,62,HHS Region 5,4 wk ahead,1.4
 2013,10,2012/2013,62,HHS Region 6,Season onset,47
 2013,10,2012/2013,62,HHS Region 6,Season peak week,52
 2013,10,2012/2013,62,HHS Region 6,Season peak percentage,9.3
@@ -7013,7 +7046,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,10,2012/2013,62,HHS Region 6,4 wk ahead,2.2
 2013,10,2012/2013,62,HHS Region 7,Season onset,47
 2013,10,2012/2013,62,HHS Region 7,Season peak week,52
-2013,10,2012/2013,62,HHS Region 7,Season peak percentage,6.8
+2013,10,2012/2013,62,HHS Region 7,Season peak percentage,6.7
 2013,10,2012/2013,62,HHS Region 7,1 wk ahead,1.9
 2013,10,2012/2013,62,HHS Region 7,2 wk ahead,1.5
 2013,10,2012/2013,62,HHS Region 7,3 wk ahead,1.5
@@ -7024,15 +7057,15 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,10,2012/2013,62,HHS Region 8,Season peak percentage,4.1
 2013,10,2012/2013,62,HHS Region 8,1 wk ahead,1.8
 2013,10,2012/2013,62,HHS Region 8,2 wk ahead,1.2
-2013,10,2012/2013,62,HHS Region 8,3 wk ahead,1.3
+2013,10,2012/2013,62,HHS Region 8,3 wk ahead,1.2
 2013,10,2012/2013,62,HHS Region 8,4 wk ahead,1.2
 2013,10,2012/2013,62,HHS Region 9,Season onset,2
 2013,10,2012/2013,62,HHS Region 9,Season peak week,4
 2013,10,2012/2013,62,HHS Region 9,Season peak percentage,5.6
 2013,10,2012/2013,62,HHS Region 9,1 wk ahead,3.1
 2013,10,2012/2013,62,HHS Region 9,2 wk ahead,2.9
-2013,10,2012/2013,62,HHS Region 9,3 wk ahead,2.9
-2013,10,2012/2013,62,HHS Region 9,4 wk ahead,2.4
+2013,10,2012/2013,62,HHS Region 9,3 wk ahead,2.6
+2013,10,2012/2013,62,HHS Region 9,4 wk ahead,2.2
 2013,10,2012/2013,62,HHS Region 10,Season onset,50
 2013,10,2012/2013,62,HHS Region 10,Season peak week,4
 2013,10,2012/2013,62,HHS Region 10,Season peak percentage,3.7
@@ -7057,14 +7090,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,11,2012/2013,63,HHS Region 2,Season onset,48
 2013,11,2012/2013,63,HHS Region 2,Season peak week,52
 2013,11,2012/2013,63,HHS Region 2,Season peak percentage,5.5
-2013,11,2012/2013,63,HHS Region 2,1 wk ahead,2.6
+2013,11,2012/2013,63,HHS Region 2,1 wk ahead,2.5
 2013,11,2012/2013,63,HHS Region 2,2 wk ahead,2.2
-2013,11,2012/2013,63,HHS Region 2,3 wk ahead,2
+2013,11,2012/2013,63,HHS Region 2,3 wk ahead,1.9
 2013,11,2012/2013,63,HHS Region 2,4 wk ahead,1.6
 2013,11,2012/2013,63,HHS Region 3,Season onset,49
 2013,11,2012/2013,63,HHS Region 3,Season peak week,52
 2013,11,2012/2013,63,HHS Region 3,Season peak percentage,7.1
-2013,11,2012/2013,63,HHS Region 3,1 wk ahead,2.3
+2013,11,2012/2013,63,HHS Region 3,1 wk ahead,2.2
 2013,11,2012/2013,63,HHS Region 3,2 wk ahead,2.1
 2013,11,2012/2013,63,HHS Region 3,3 wk ahead,1.7
 2013,11,2012/2013,63,HHS Region 3,4 wk ahead,1.5
@@ -7080,8 +7113,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,11,2012/2013,63,HHS Region 5,Season peak percentage,5.7
 2013,11,2012/2013,63,HHS Region 5,1 wk ahead,1.8
 2013,11,2012/2013,63,HHS Region 5,2 wk ahead,1.6
-2013,11,2012/2013,63,HHS Region 5,3 wk ahead,1.3
-2013,11,2012/2013,63,HHS Region 5,4 wk ahead,1.1
+2013,11,2012/2013,63,HHS Region 5,3 wk ahead,1.4
+2013,11,2012/2013,63,HHS Region 5,4 wk ahead,1.2
 2013,11,2012/2013,63,HHS Region 6,Season onset,47
 2013,11,2012/2013,63,HHS Region 6,Season peak week,52
 2013,11,2012/2013,63,HHS Region 6,Season peak percentage,9.3
@@ -7091,7 +7124,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,11,2012/2013,63,HHS Region 6,4 wk ahead,2.1
 2013,11,2012/2013,63,HHS Region 7,Season onset,47
 2013,11,2012/2013,63,HHS Region 7,Season peak week,52
-2013,11,2012/2013,63,HHS Region 7,Season peak percentage,6.8
+2013,11,2012/2013,63,HHS Region 7,Season peak percentage,6.7
 2013,11,2012/2013,63,HHS Region 7,1 wk ahead,1.5
 2013,11,2012/2013,63,HHS Region 7,2 wk ahead,1.5
 2013,11,2012/2013,63,HHS Region 7,3 wk ahead,1.1
@@ -7101,16 +7134,16 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,11,2012/2013,63,HHS Region 8,Season peak week,3
 2013,11,2012/2013,63,HHS Region 8,Season peak percentage,4.1
 2013,11,2012/2013,63,HHS Region 8,1 wk ahead,1.2
-2013,11,2012/2013,63,HHS Region 8,2 wk ahead,1.3
+2013,11,2012/2013,63,HHS Region 8,2 wk ahead,1.2
 2013,11,2012/2013,63,HHS Region 8,3 wk ahead,1.2
 2013,11,2012/2013,63,HHS Region 8,4 wk ahead,1
 2013,11,2012/2013,63,HHS Region 9,Season onset,2
 2013,11,2012/2013,63,HHS Region 9,Season peak week,4
 2013,11,2012/2013,63,HHS Region 9,Season peak percentage,5.6
 2013,11,2012/2013,63,HHS Region 9,1 wk ahead,2.9
-2013,11,2012/2013,63,HHS Region 9,2 wk ahead,2.9
-2013,11,2012/2013,63,HHS Region 9,3 wk ahead,2.4
-2013,11,2012/2013,63,HHS Region 9,4 wk ahead,2
+2013,11,2012/2013,63,HHS Region 9,2 wk ahead,2.6
+2013,11,2012/2013,63,HHS Region 9,3 wk ahead,2.2
+2013,11,2012/2013,63,HHS Region 9,4 wk ahead,1.9
 2013,11,2012/2013,63,HHS Region 10,Season onset,50
 2013,11,2012/2013,63,HHS Region 10,Season peak week,4
 2013,11,2012/2013,63,HHS Region 10,Season peak percentage,3.7
@@ -7136,7 +7169,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,12,2012/2013,64,HHS Region 2,Season peak week,52
 2013,12,2012/2013,64,HHS Region 2,Season peak percentage,5.5
 2013,12,2012/2013,64,HHS Region 2,1 wk ahead,2.2
-2013,12,2012/2013,64,HHS Region 2,2 wk ahead,2
+2013,12,2012/2013,64,HHS Region 2,2 wk ahead,1.9
 2013,12,2012/2013,64,HHS Region 2,3 wk ahead,1.6
 2013,12,2012/2013,64,HHS Region 2,4 wk ahead,1.4
 2013,12,2012/2013,64,HHS Region 3,Season onset,49
@@ -7157,19 +7190,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,12,2012/2013,64,HHS Region 5,Season peak week,52
 2013,12,2012/2013,64,HHS Region 5,Season peak percentage,5.7
 2013,12,2012/2013,64,HHS Region 5,1 wk ahead,1.6
-2013,12,2012/2013,64,HHS Region 5,2 wk ahead,1.3
-2013,12,2012/2013,64,HHS Region 5,3 wk ahead,1.1
-2013,12,2012/2013,64,HHS Region 5,4 wk ahead,1
+2013,12,2012/2013,64,HHS Region 5,2 wk ahead,1.4
+2013,12,2012/2013,64,HHS Region 5,3 wk ahead,1.2
+2013,12,2012/2013,64,HHS Region 5,4 wk ahead,1.1
 2013,12,2012/2013,64,HHS Region 6,Season onset,47
 2013,12,2012/2013,64,HHS Region 6,Season peak week,52
 2013,12,2012/2013,64,HHS Region 6,Season peak percentage,9.3
 2013,12,2012/2013,64,HHS Region 6,1 wk ahead,2.3
 2013,12,2012/2013,64,HHS Region 6,2 wk ahead,2.2
 2013,12,2012/2013,64,HHS Region 6,3 wk ahead,2.1
-2013,12,2012/2013,64,HHS Region 6,4 wk ahead,1.9
+2013,12,2012/2013,64,HHS Region 6,4 wk ahead,2
 2013,12,2012/2013,64,HHS Region 7,Season onset,47
 2013,12,2012/2013,64,HHS Region 7,Season peak week,52
-2013,12,2012/2013,64,HHS Region 7,Season peak percentage,6.8
+2013,12,2012/2013,64,HHS Region 7,Season peak percentage,6.7
 2013,12,2012/2013,64,HHS Region 7,1 wk ahead,1.5
 2013,12,2012/2013,64,HHS Region 7,2 wk ahead,1.1
 2013,12,2012/2013,64,HHS Region 7,3 wk ahead,1
@@ -7178,17 +7211,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,12,2012/2013,64,HHS Region 8,Season peak week,52
 2013,12,2012/2013,64,HHS Region 8,Season peak week,3
 2013,12,2012/2013,64,HHS Region 8,Season peak percentage,4.1
-2013,12,2012/2013,64,HHS Region 8,1 wk ahead,1.3
+2013,12,2012/2013,64,HHS Region 8,1 wk ahead,1.2
 2013,12,2012/2013,64,HHS Region 8,2 wk ahead,1.2
 2013,12,2012/2013,64,HHS Region 8,3 wk ahead,1
 2013,12,2012/2013,64,HHS Region 8,4 wk ahead,1
 2013,12,2012/2013,64,HHS Region 9,Season onset,2
 2013,12,2012/2013,64,HHS Region 9,Season peak week,4
 2013,12,2012/2013,64,HHS Region 9,Season peak percentage,5.6
-2013,12,2012/2013,64,HHS Region 9,1 wk ahead,2.9
-2013,12,2012/2013,64,HHS Region 9,2 wk ahead,2.4
-2013,12,2012/2013,64,HHS Region 9,3 wk ahead,2
-2013,12,2012/2013,64,HHS Region 9,4 wk ahead,1.8
+2013,12,2012/2013,64,HHS Region 9,1 wk ahead,2.6
+2013,12,2012/2013,64,HHS Region 9,2 wk ahead,2.2
+2013,12,2012/2013,64,HHS Region 9,3 wk ahead,1.9
+2013,12,2012/2013,64,HHS Region 9,4 wk ahead,1.7
 2013,12,2012/2013,64,HHS Region 10,Season onset,50
 2013,12,2012/2013,64,HHS Region 10,Season peak week,4
 2013,12,2012/2013,64,HHS Region 10,Season peak percentage,3.7
@@ -7213,7 +7246,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,13,2012/2013,65,HHS Region 2,Season onset,48
 2013,13,2012/2013,65,HHS Region 2,Season peak week,52
 2013,13,2012/2013,65,HHS Region 2,Season peak percentage,5.5
-2013,13,2012/2013,65,HHS Region 2,1 wk ahead,2
+2013,13,2012/2013,65,HHS Region 2,1 wk ahead,1.9
 2013,13,2012/2013,65,HHS Region 2,2 wk ahead,1.6
 2013,13,2012/2013,65,HHS Region 2,3 wk ahead,1.4
 2013,13,2012/2013,65,HHS Region 2,4 wk ahead,1.5
@@ -7230,28 +7263,28 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,13,2012/2013,65,HHS Region 4,1 wk ahead,1.4
 2013,13,2012/2013,65,HHS Region 4,2 wk ahead,1.2
 2013,13,2012/2013,65,HHS Region 4,3 wk ahead,1
-2013,13,2012/2013,65,HHS Region 4,4 wk ahead,0.8
+2013,13,2012/2013,65,HHS Region 4,4 wk ahead,0.9
 2013,13,2012/2013,65,HHS Region 5,Season onset,47
 2013,13,2012/2013,65,HHS Region 5,Season peak week,52
 2013,13,2012/2013,65,HHS Region 5,Season peak percentage,5.7
-2013,13,2012/2013,65,HHS Region 5,1 wk ahead,1.3
-2013,13,2012/2013,65,HHS Region 5,2 wk ahead,1.1
-2013,13,2012/2013,65,HHS Region 5,3 wk ahead,1
-2013,13,2012/2013,65,HHS Region 5,4 wk ahead,0.9
+2013,13,2012/2013,65,HHS Region 5,1 wk ahead,1.4
+2013,13,2012/2013,65,HHS Region 5,2 wk ahead,1.2
+2013,13,2012/2013,65,HHS Region 5,3 wk ahead,1.1
+2013,13,2012/2013,65,HHS Region 5,4 wk ahead,1
 2013,13,2012/2013,65,HHS Region 6,Season onset,47
 2013,13,2012/2013,65,HHS Region 6,Season peak week,52
 2013,13,2012/2013,65,HHS Region 6,Season peak percentage,9.3
 2013,13,2012/2013,65,HHS Region 6,1 wk ahead,2.2
 2013,13,2012/2013,65,HHS Region 6,2 wk ahead,2.1
-2013,13,2012/2013,65,HHS Region 6,3 wk ahead,1.9
-2013,13,2012/2013,65,HHS Region 6,4 wk ahead,1.8
+2013,13,2012/2013,65,HHS Region 6,3 wk ahead,2
+2013,13,2012/2013,65,HHS Region 6,4 wk ahead,1.9
 2013,13,2012/2013,65,HHS Region 7,Season onset,47
 2013,13,2012/2013,65,HHS Region 7,Season peak week,52
-2013,13,2012/2013,65,HHS Region 7,Season peak percentage,6.8
+2013,13,2012/2013,65,HHS Region 7,Season peak percentage,6.7
 2013,13,2012/2013,65,HHS Region 7,1 wk ahead,1.1
 2013,13,2012/2013,65,HHS Region 7,2 wk ahead,1
 2013,13,2012/2013,65,HHS Region 7,3 wk ahead,0.9
-2013,13,2012/2013,65,HHS Region 7,4 wk ahead,0.7
+2013,13,2012/2013,65,HHS Region 7,4 wk ahead,0.9
 2013,13,2012/2013,65,HHS Region 8,Season onset,50
 2013,13,2012/2013,65,HHS Region 8,Season peak week,52
 2013,13,2012/2013,65,HHS Region 8,Season peak week,3
@@ -7263,10 +7296,10 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,13,2012/2013,65,HHS Region 9,Season onset,2
 2013,13,2012/2013,65,HHS Region 9,Season peak week,4
 2013,13,2012/2013,65,HHS Region 9,Season peak percentage,5.6
-2013,13,2012/2013,65,HHS Region 9,1 wk ahead,2.4
-2013,13,2012/2013,65,HHS Region 9,2 wk ahead,2
-2013,13,2012/2013,65,HHS Region 9,3 wk ahead,1.8
-2013,13,2012/2013,65,HHS Region 9,4 wk ahead,1.8
+2013,13,2012/2013,65,HHS Region 9,1 wk ahead,2.2
+2013,13,2012/2013,65,HHS Region 9,2 wk ahead,1.9
+2013,13,2012/2013,65,HHS Region 9,3 wk ahead,1.7
+2013,13,2012/2013,65,HHS Region 9,4 wk ahead,1.6
 2013,13,2012/2013,65,HHS Region 10,Season onset,50
 2013,13,2012/2013,65,HHS Region 10,Season peak week,4
 2013,13,2012/2013,65,HHS Region 10,Season peak percentage,3.7
@@ -7301,35 +7334,35 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,14,2012/2013,66,HHS Region 3,1 wk ahead,1.5
 2013,14,2012/2013,66,HHS Region 3,2 wk ahead,1.1
 2013,14,2012/2013,66,HHS Region 3,3 wk ahead,1.1
-2013,14,2012/2013,66,HHS Region 3,4 wk ahead,1.3
+2013,14,2012/2013,66,HHS Region 3,4 wk ahead,1.1
 2013,14,2012/2013,66,HHS Region 4,Season onset,47
 2013,14,2012/2013,66,HHS Region 4,Season peak week,52
 2013,14,2012/2013,66,HHS Region 4,Season peak percentage,6.3
 2013,14,2012/2013,66,HHS Region 4,1 wk ahead,1.2
 2013,14,2012/2013,66,HHS Region 4,2 wk ahead,1
-2013,14,2012/2013,66,HHS Region 4,3 wk ahead,0.8
+2013,14,2012/2013,66,HHS Region 4,3 wk ahead,0.9
 2013,14,2012/2013,66,HHS Region 4,4 wk ahead,0.7
 2013,14,2012/2013,66,HHS Region 5,Season onset,47
 2013,14,2012/2013,66,HHS Region 5,Season peak week,52
 2013,14,2012/2013,66,HHS Region 5,Season peak percentage,5.7
-2013,14,2012/2013,66,HHS Region 5,1 wk ahead,1.1
-2013,14,2012/2013,66,HHS Region 5,2 wk ahead,1
-2013,14,2012/2013,66,HHS Region 5,3 wk ahead,0.9
+2013,14,2012/2013,66,HHS Region 5,1 wk ahead,1.2
+2013,14,2012/2013,66,HHS Region 5,2 wk ahead,1.1
+2013,14,2012/2013,66,HHS Region 5,3 wk ahead,1
 2013,14,2012/2013,66,HHS Region 5,4 wk ahead,0.8
 2013,14,2012/2013,66,HHS Region 6,Season onset,47
 2013,14,2012/2013,66,HHS Region 6,Season peak week,52
 2013,14,2012/2013,66,HHS Region 6,Season peak percentage,9.3
 2013,14,2012/2013,66,HHS Region 6,1 wk ahead,2.1
-2013,14,2012/2013,66,HHS Region 6,2 wk ahead,1.9
-2013,14,2012/2013,66,HHS Region 6,3 wk ahead,1.8
-2013,14,2012/2013,66,HHS Region 6,4 wk ahead,1.6
+2013,14,2012/2013,66,HHS Region 6,2 wk ahead,2
+2013,14,2012/2013,66,HHS Region 6,3 wk ahead,1.9
+2013,14,2012/2013,66,HHS Region 6,4 wk ahead,1.7
 2013,14,2012/2013,66,HHS Region 7,Season onset,47
 2013,14,2012/2013,66,HHS Region 7,Season peak week,52
-2013,14,2012/2013,66,HHS Region 7,Season peak percentage,6.8
+2013,14,2012/2013,66,HHS Region 7,Season peak percentage,6.7
 2013,14,2012/2013,66,HHS Region 7,1 wk ahead,1
 2013,14,2012/2013,66,HHS Region 7,2 wk ahead,0.9
-2013,14,2012/2013,66,HHS Region 7,3 wk ahead,0.7
-2013,14,2012/2013,66,HHS Region 7,4 wk ahead,0.6
+2013,14,2012/2013,66,HHS Region 7,3 wk ahead,0.9
+2013,14,2012/2013,66,HHS Region 7,4 wk ahead,0.8
 2013,14,2012/2013,66,HHS Region 8,Season onset,50
 2013,14,2012/2013,66,HHS Region 8,Season peak week,52
 2013,14,2012/2013,66,HHS Region 8,Season peak week,3
@@ -7341,17 +7374,17 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,14,2012/2013,66,HHS Region 9,Season onset,2
 2013,14,2012/2013,66,HHS Region 9,Season peak week,4
 2013,14,2012/2013,66,HHS Region 9,Season peak percentage,5.6
-2013,14,2012/2013,66,HHS Region 9,1 wk ahead,2
-2013,14,2012/2013,66,HHS Region 9,2 wk ahead,1.8
-2013,14,2012/2013,66,HHS Region 9,3 wk ahead,1.8
-2013,14,2012/2013,66,HHS Region 9,4 wk ahead,1.5
+2013,14,2012/2013,66,HHS Region 9,1 wk ahead,1.9
+2013,14,2012/2013,66,HHS Region 9,2 wk ahead,1.7
+2013,14,2012/2013,66,HHS Region 9,3 wk ahead,1.6
+2013,14,2012/2013,66,HHS Region 9,4 wk ahead,1.6
 2013,14,2012/2013,66,HHS Region 10,Season onset,50
 2013,14,2012/2013,66,HHS Region 10,Season peak week,4
 2013,14,2012/2013,66,HHS Region 10,Season peak percentage,3.7
 2013,14,2012/2013,66,HHS Region 10,1 wk ahead,0.4
 2013,14,2012/2013,66,HHS Region 10,2 wk ahead,0.4
 2013,14,2012/2013,66,HHS Region 10,3 wk ahead,0.4
-2013,14,2012/2013,66,HHS Region 10,4 wk ahead,0.5
+2013,14,2012/2013,66,HHS Region 10,4 wk ahead,0.4
 2013,15,2012/2013,67,US National,Season onset,47
 2013,15,2012/2013,67,US National,Season peak week,52
 2013,15,2012/2013,67,US National,Season peak percentage,6.1
@@ -7378,36 +7411,36 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,15,2012/2013,67,HHS Region 3,Season peak percentage,7.1
 2013,15,2012/2013,67,HHS Region 3,1 wk ahead,1.1
 2013,15,2012/2013,67,HHS Region 3,2 wk ahead,1.1
-2013,15,2012/2013,67,HHS Region 3,3 wk ahead,1.3
-2013,15,2012/2013,67,HHS Region 3,4 wk ahead,1.1
+2013,15,2012/2013,67,HHS Region 3,3 wk ahead,1.1
+2013,15,2012/2013,67,HHS Region 3,4 wk ahead,1.3
 2013,15,2012/2013,67,HHS Region 4,Season onset,47
 2013,15,2012/2013,67,HHS Region 4,Season peak week,52
 2013,15,2012/2013,67,HHS Region 4,Season peak percentage,6.3
 2013,15,2012/2013,67,HHS Region 4,1 wk ahead,1
-2013,15,2012/2013,67,HHS Region 4,2 wk ahead,0.8
+2013,15,2012/2013,67,HHS Region 4,2 wk ahead,0.9
 2013,15,2012/2013,67,HHS Region 4,3 wk ahead,0.7
 2013,15,2012/2013,67,HHS Region 4,4 wk ahead,0.6
 2013,15,2012/2013,67,HHS Region 5,Season onset,47
 2013,15,2012/2013,67,HHS Region 5,Season peak week,52
 2013,15,2012/2013,67,HHS Region 5,Season peak percentage,5.7
-2013,15,2012/2013,67,HHS Region 5,1 wk ahead,1
-2013,15,2012/2013,67,HHS Region 5,2 wk ahead,0.9
+2013,15,2012/2013,67,HHS Region 5,1 wk ahead,1.1
+2013,15,2012/2013,67,HHS Region 5,2 wk ahead,1
 2013,15,2012/2013,67,HHS Region 5,3 wk ahead,0.8
-2013,15,2012/2013,67,HHS Region 5,4 wk ahead,0.8
+2013,15,2012/2013,67,HHS Region 5,4 wk ahead,0.9
 2013,15,2012/2013,67,HHS Region 6,Season onset,47
 2013,15,2012/2013,67,HHS Region 6,Season peak week,52
 2013,15,2012/2013,67,HHS Region 6,Season peak percentage,9.3
-2013,15,2012/2013,67,HHS Region 6,1 wk ahead,1.9
-2013,15,2012/2013,67,HHS Region 6,2 wk ahead,1.8
-2013,15,2012/2013,67,HHS Region 6,3 wk ahead,1.6
+2013,15,2012/2013,67,HHS Region 6,1 wk ahead,2
+2013,15,2012/2013,67,HHS Region 6,2 wk ahead,1.9
+2013,15,2012/2013,67,HHS Region 6,3 wk ahead,1.7
 2013,15,2012/2013,67,HHS Region 6,4 wk ahead,1.7
 2013,15,2012/2013,67,HHS Region 7,Season onset,47
 2013,15,2012/2013,67,HHS Region 7,Season peak week,52
-2013,15,2012/2013,67,HHS Region 7,Season peak percentage,6.8
+2013,15,2012/2013,67,HHS Region 7,Season peak percentage,6.7
 2013,15,2012/2013,67,HHS Region 7,1 wk ahead,0.9
-2013,15,2012/2013,67,HHS Region 7,2 wk ahead,0.7
-2013,15,2012/2013,67,HHS Region 7,3 wk ahead,0.6
-2013,15,2012/2013,67,HHS Region 7,4 wk ahead,0.5
+2013,15,2012/2013,67,HHS Region 7,2 wk ahead,0.9
+2013,15,2012/2013,67,HHS Region 7,3 wk ahead,0.8
+2013,15,2012/2013,67,HHS Region 7,4 wk ahead,0.8
 2013,15,2012/2013,67,HHS Region 8,Season onset,50
 2013,15,2012/2013,67,HHS Region 8,Season peak week,52
 2013,15,2012/2013,67,HHS Region 8,Season peak week,3
@@ -7419,16 +7452,16 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,15,2012/2013,67,HHS Region 9,Season onset,2
 2013,15,2012/2013,67,HHS Region 9,Season peak week,4
 2013,15,2012/2013,67,HHS Region 9,Season peak percentage,5.6
-2013,15,2012/2013,67,HHS Region 9,1 wk ahead,1.8
-2013,15,2012/2013,67,HHS Region 9,2 wk ahead,1.8
-2013,15,2012/2013,67,HHS Region 9,3 wk ahead,1.5
-2013,15,2012/2013,67,HHS Region 9,4 wk ahead,0.9
+2013,15,2012/2013,67,HHS Region 9,1 wk ahead,1.7
+2013,15,2012/2013,67,HHS Region 9,2 wk ahead,1.6
+2013,15,2012/2013,67,HHS Region 9,3 wk ahead,1.6
+2013,15,2012/2013,67,HHS Region 9,4 wk ahead,1.5
 2013,15,2012/2013,67,HHS Region 10,Season onset,50
 2013,15,2012/2013,67,HHS Region 10,Season peak week,4
 2013,15,2012/2013,67,HHS Region 10,Season peak percentage,3.7
 2013,15,2012/2013,67,HHS Region 10,1 wk ahead,0.4
 2013,15,2012/2013,67,HHS Region 10,2 wk ahead,0.4
-2013,15,2012/2013,67,HHS Region 10,3 wk ahead,0.5
+2013,15,2012/2013,67,HHS Region 10,3 wk ahead,0.4
 2013,15,2012/2013,67,HHS Region 10,4 wk ahead,0.2
 2013,16,2012/2013,68,US National,Season onset,47
 2013,16,2012/2013,68,US National,Season peak week,52
@@ -7450,42 +7483,42 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,16,2012/2013,68,HHS Region 2,1 wk ahead,1.5
 2013,16,2012/2013,68,HHS Region 2,2 wk ahead,1.4
 2013,16,2012/2013,68,HHS Region 2,3 wk ahead,1.3
-2013,16,2012/2013,68,HHS Region 2,4 wk ahead,0.9
+2013,16,2012/2013,68,HHS Region 2,4 wk ahead,1.3
 2013,16,2012/2013,68,HHS Region 3,Season onset,49
 2013,16,2012/2013,68,HHS Region 3,Season peak week,52
 2013,16,2012/2013,68,HHS Region 3,Season peak percentage,7.1
 2013,16,2012/2013,68,HHS Region 3,1 wk ahead,1.1
-2013,16,2012/2013,68,HHS Region 3,2 wk ahead,1.3
-2013,16,2012/2013,68,HHS Region 3,3 wk ahead,1.1
-2013,16,2012/2013,68,HHS Region 3,4 wk ahead,1
+2013,16,2012/2013,68,HHS Region 3,2 wk ahead,1.1
+2013,16,2012/2013,68,HHS Region 3,3 wk ahead,1.3
+2013,16,2012/2013,68,HHS Region 3,4 wk ahead,1.1
 2013,16,2012/2013,68,HHS Region 4,Season onset,47
 2013,16,2012/2013,68,HHS Region 4,Season peak week,52
 2013,16,2012/2013,68,HHS Region 4,Season peak percentage,6.3
-2013,16,2012/2013,68,HHS Region 4,1 wk ahead,0.8
+2013,16,2012/2013,68,HHS Region 4,1 wk ahead,0.9
 2013,16,2012/2013,68,HHS Region 4,2 wk ahead,0.7
 2013,16,2012/2013,68,HHS Region 4,3 wk ahead,0.6
 2013,16,2012/2013,68,HHS Region 4,4 wk ahead,0.8
 2013,16,2012/2013,68,HHS Region 5,Season onset,47
 2013,16,2012/2013,68,HHS Region 5,Season peak week,52
 2013,16,2012/2013,68,HHS Region 5,Season peak percentage,5.7
-2013,16,2012/2013,68,HHS Region 5,1 wk ahead,0.9
+2013,16,2012/2013,68,HHS Region 5,1 wk ahead,1
 2013,16,2012/2013,68,HHS Region 5,2 wk ahead,0.8
-2013,16,2012/2013,68,HHS Region 5,3 wk ahead,0.8
-2013,16,2012/2013,68,HHS Region 5,4 wk ahead,0.8
+2013,16,2012/2013,68,HHS Region 5,3 wk ahead,0.9
+2013,16,2012/2013,68,HHS Region 5,4 wk ahead,0.9
 2013,16,2012/2013,68,HHS Region 6,Season onset,47
 2013,16,2012/2013,68,HHS Region 6,Season peak week,52
 2013,16,2012/2013,68,HHS Region 6,Season peak percentage,9.3
-2013,16,2012/2013,68,HHS Region 6,1 wk ahead,1.8
-2013,16,2012/2013,68,HHS Region 6,2 wk ahead,1.6
+2013,16,2012/2013,68,HHS Region 6,1 wk ahead,1.9
+2013,16,2012/2013,68,HHS Region 6,2 wk ahead,1.7
 2013,16,2012/2013,68,HHS Region 6,3 wk ahead,1.7
 2013,16,2012/2013,68,HHS Region 6,4 wk ahead,1.6
 2013,16,2012/2013,68,HHS Region 7,Season onset,47
 2013,16,2012/2013,68,HHS Region 7,Season peak week,52
-2013,16,2012/2013,68,HHS Region 7,Season peak percentage,6.8
-2013,16,2012/2013,68,HHS Region 7,1 wk ahead,0.7
-2013,16,2012/2013,68,HHS Region 7,2 wk ahead,0.6
-2013,16,2012/2013,68,HHS Region 7,3 wk ahead,0.5
-2013,16,2012/2013,68,HHS Region 7,4 wk ahead,0.3
+2013,16,2012/2013,68,HHS Region 7,Season peak percentage,6.7
+2013,16,2012/2013,68,HHS Region 7,1 wk ahead,0.9
+2013,16,2012/2013,68,HHS Region 7,2 wk ahead,0.8
+2013,16,2012/2013,68,HHS Region 7,3 wk ahead,0.8
+2013,16,2012/2013,68,HHS Region 7,4 wk ahead,0.6
 2013,16,2012/2013,68,HHS Region 8,Season onset,50
 2013,16,2012/2013,68,HHS Region 8,Season peak week,52
 2013,16,2012/2013,68,HHS Region 8,Season peak week,3
@@ -7493,19 +7526,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,16,2012/2013,68,HHS Region 8,1 wk ahead,1
 2013,16,2012/2013,68,HHS Region 8,2 wk ahead,1
 2013,16,2012/2013,68,HHS Region 8,3 wk ahead,0.9
-2013,16,2012/2013,68,HHS Region 8,4 wk ahead,0.8
+2013,16,2012/2013,68,HHS Region 8,4 wk ahead,0.7
 2013,16,2012/2013,68,HHS Region 9,Season onset,2
 2013,16,2012/2013,68,HHS Region 9,Season peak week,4
 2013,16,2012/2013,68,HHS Region 9,Season peak percentage,5.6
-2013,16,2012/2013,68,HHS Region 9,1 wk ahead,1.8
-2013,16,2012/2013,68,HHS Region 9,2 wk ahead,1.5
-2013,16,2012/2013,68,HHS Region 9,3 wk ahead,0.9
-2013,16,2012/2013,68,HHS Region 9,4 wk ahead,0.6
+2013,16,2012/2013,68,HHS Region 9,1 wk ahead,1.6
+2013,16,2012/2013,68,HHS Region 9,2 wk ahead,1.6
+2013,16,2012/2013,68,HHS Region 9,3 wk ahead,1.5
+2013,16,2012/2013,68,HHS Region 9,4 wk ahead,1.6
 2013,16,2012/2013,68,HHS Region 10,Season onset,50
 2013,16,2012/2013,68,HHS Region 10,Season peak week,4
 2013,16,2012/2013,68,HHS Region 10,Season peak percentage,3.7
 2013,16,2012/2013,68,HHS Region 10,1 wk ahead,0.4
-2013,16,2012/2013,68,HHS Region 10,2 wk ahead,0.5
+2013,16,2012/2013,68,HHS Region 10,2 wk ahead,0.4
 2013,16,2012/2013,68,HHS Region 10,3 wk ahead,0.2
 2013,16,2012/2013,68,HHS Region 10,4 wk ahead,0.3
 2013,17,2012/2013,69,US National,Season onset,47
@@ -7527,14 +7560,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,17,2012/2013,69,HHS Region 2,Season peak percentage,5.5
 2013,17,2012/2013,69,HHS Region 2,1 wk ahead,1.4
 2013,17,2012/2013,69,HHS Region 2,2 wk ahead,1.3
-2013,17,2012/2013,69,HHS Region 2,3 wk ahead,0.9
+2013,17,2012/2013,69,HHS Region 2,3 wk ahead,1.3
 2013,17,2012/2013,69,HHS Region 2,4 wk ahead,1
 2013,17,2012/2013,69,HHS Region 3,Season onset,49
 2013,17,2012/2013,69,HHS Region 3,Season peak week,52
 2013,17,2012/2013,69,HHS Region 3,Season peak percentage,7.1
-2013,17,2012/2013,69,HHS Region 3,1 wk ahead,1.3
-2013,17,2012/2013,69,HHS Region 3,2 wk ahead,1.1
-2013,17,2012/2013,69,HHS Region 3,3 wk ahead,1
+2013,17,2012/2013,69,HHS Region 3,1 wk ahead,1.1
+2013,17,2012/2013,69,HHS Region 3,2 wk ahead,1.3
+2013,17,2012/2013,69,HHS Region 3,3 wk ahead,1.1
 2013,17,2012/2013,69,HHS Region 3,4 wk ahead,1.1
 2013,17,2012/2013,69,HHS Region 4,Season onset,47
 2013,17,2012/2013,69,HHS Region 4,Season peak week,52
@@ -7547,22 +7580,22 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,17,2012/2013,69,HHS Region 5,Season peak week,52
 2013,17,2012/2013,69,HHS Region 5,Season peak percentage,5.7
 2013,17,2012/2013,69,HHS Region 5,1 wk ahead,0.8
-2013,17,2012/2013,69,HHS Region 5,2 wk ahead,0.8
-2013,17,2012/2013,69,HHS Region 5,3 wk ahead,0.8
+2013,17,2012/2013,69,HHS Region 5,2 wk ahead,0.9
+2013,17,2012/2013,69,HHS Region 5,3 wk ahead,0.9
 2013,17,2012/2013,69,HHS Region 5,4 wk ahead,0.8
 2013,17,2012/2013,69,HHS Region 6,Season onset,47
 2013,17,2012/2013,69,HHS Region 6,Season peak week,52
 2013,17,2012/2013,69,HHS Region 6,Season peak percentage,9.3
-2013,17,2012/2013,69,HHS Region 6,1 wk ahead,1.6
+2013,17,2012/2013,69,HHS Region 6,1 wk ahead,1.7
 2013,17,2012/2013,69,HHS Region 6,2 wk ahead,1.7
 2013,17,2012/2013,69,HHS Region 6,3 wk ahead,1.6
 2013,17,2012/2013,69,HHS Region 6,4 wk ahead,1.5
 2013,17,2012/2013,69,HHS Region 7,Season onset,47
 2013,17,2012/2013,69,HHS Region 7,Season peak week,52
-2013,17,2012/2013,69,HHS Region 7,Season peak percentage,6.8
-2013,17,2012/2013,69,HHS Region 7,1 wk ahead,0.6
-2013,17,2012/2013,69,HHS Region 7,2 wk ahead,0.5
-2013,17,2012/2013,69,HHS Region 7,3 wk ahead,0.3
+2013,17,2012/2013,69,HHS Region 7,Season peak percentage,6.7
+2013,17,2012/2013,69,HHS Region 7,1 wk ahead,0.8
+2013,17,2012/2013,69,HHS Region 7,2 wk ahead,0.8
+2013,17,2012/2013,69,HHS Region 7,3 wk ahead,0.6
 2013,17,2012/2013,69,HHS Region 7,4 wk ahead,0.7
 2013,17,2012/2013,69,HHS Region 8,Season onset,50
 2013,17,2012/2013,69,HHS Region 8,Season peak week,52
@@ -7570,19 +7603,19 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,17,2012/2013,69,HHS Region 8,Season peak percentage,4.1
 2013,17,2012/2013,69,HHS Region 8,1 wk ahead,1
 2013,17,2012/2013,69,HHS Region 8,2 wk ahead,0.9
-2013,17,2012/2013,69,HHS Region 8,3 wk ahead,0.8
+2013,17,2012/2013,69,HHS Region 8,3 wk ahead,0.7
 2013,17,2012/2013,69,HHS Region 8,4 wk ahead,0.8
 2013,17,2012/2013,69,HHS Region 9,Season onset,2
 2013,17,2012/2013,69,HHS Region 9,Season peak week,4
 2013,17,2012/2013,69,HHS Region 9,Season peak percentage,5.6
-2013,17,2012/2013,69,HHS Region 9,1 wk ahead,1.5
-2013,17,2012/2013,69,HHS Region 9,2 wk ahead,0.9
-2013,17,2012/2013,69,HHS Region 9,3 wk ahead,0.6
+2013,17,2012/2013,69,HHS Region 9,1 wk ahead,1.6
+2013,17,2012/2013,69,HHS Region 9,2 wk ahead,1.5
+2013,17,2012/2013,69,HHS Region 9,3 wk ahead,1.6
 2013,17,2012/2013,69,HHS Region 9,4 wk ahead,1.4
 2013,17,2012/2013,69,HHS Region 10,Season onset,50
 2013,17,2012/2013,69,HHS Region 10,Season peak week,4
 2013,17,2012/2013,69,HHS Region 10,Season peak percentage,3.7
-2013,17,2012/2013,69,HHS Region 10,1 wk ahead,0.5
+2013,17,2012/2013,69,HHS Region 10,1 wk ahead,0.4
 2013,17,2012/2013,69,HHS Region 10,2 wk ahead,0.2
 2013,17,2012/2013,69,HHS Region 10,3 wk ahead,0.3
 2013,17,2012/2013,69,HHS Region 10,4 wk ahead,0.3
@@ -7604,14 +7637,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,18,2012/2013,70,HHS Region 2,Season peak week,52
 2013,18,2012/2013,70,HHS Region 2,Season peak percentage,5.5
 2013,18,2012/2013,70,HHS Region 2,1 wk ahead,1.3
-2013,18,2012/2013,70,HHS Region 2,2 wk ahead,0.9
+2013,18,2012/2013,70,HHS Region 2,2 wk ahead,1.3
 2013,18,2012/2013,70,HHS Region 2,3 wk ahead,1
 2013,18,2012/2013,70,HHS Region 2,4 wk ahead,1.4
 2013,18,2012/2013,70,HHS Region 3,Season onset,49
 2013,18,2012/2013,70,HHS Region 3,Season peak week,52
 2013,18,2012/2013,70,HHS Region 3,Season peak percentage,7.1
-2013,18,2012/2013,70,HHS Region 3,1 wk ahead,1.1
-2013,18,2012/2013,70,HHS Region 3,2 wk ahead,1
+2013,18,2012/2013,70,HHS Region 3,1 wk ahead,1.3
+2013,18,2012/2013,70,HHS Region 3,2 wk ahead,1.1
 2013,18,2012/2013,70,HHS Region 3,3 wk ahead,1.1
 2013,18,2012/2013,70,HHS Region 3,4 wk ahead,1.3
 2013,18,2012/2013,70,HHS Region 4,Season onset,47
@@ -7624,8 +7657,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,18,2012/2013,70,HHS Region 5,Season onset,47
 2013,18,2012/2013,70,HHS Region 5,Season peak week,52
 2013,18,2012/2013,70,HHS Region 5,Season peak percentage,5.7
-2013,18,2012/2013,70,HHS Region 5,1 wk ahead,0.8
-2013,18,2012/2013,70,HHS Region 5,2 wk ahead,0.8
+2013,18,2012/2013,70,HHS Region 5,1 wk ahead,0.9
+2013,18,2012/2013,70,HHS Region 5,2 wk ahead,0.9
 2013,18,2012/2013,70,HHS Region 5,3 wk ahead,0.8
 2013,18,2012/2013,70,HHS Region 5,4 wk ahead,1
 2013,18,2012/2013,70,HHS Region 6,Season onset,47
@@ -7637,9 +7670,9 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,18,2012/2013,70,HHS Region 6,4 wk ahead,1.5
 2013,18,2012/2013,70,HHS Region 7,Season onset,47
 2013,18,2012/2013,70,HHS Region 7,Season peak week,52
-2013,18,2012/2013,70,HHS Region 7,Season peak percentage,6.8
-2013,18,2012/2013,70,HHS Region 7,1 wk ahead,0.5
-2013,18,2012/2013,70,HHS Region 7,2 wk ahead,0.3
+2013,18,2012/2013,70,HHS Region 7,Season peak percentage,6.7
+2013,18,2012/2013,70,HHS Region 7,1 wk ahead,0.8
+2013,18,2012/2013,70,HHS Region 7,2 wk ahead,0.6
 2013,18,2012/2013,70,HHS Region 7,3 wk ahead,0.7
 2013,18,2012/2013,70,HHS Region 7,4 wk ahead,0.8
 2013,18,2012/2013,70,HHS Region 8,Season onset,50
@@ -7647,14 +7680,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,18,2012/2013,70,HHS Region 8,Season peak week,3
 2013,18,2012/2013,70,HHS Region 8,Season peak percentage,4.1
 2013,18,2012/2013,70,HHS Region 8,1 wk ahead,0.9
-2013,18,2012/2013,70,HHS Region 8,2 wk ahead,0.8
+2013,18,2012/2013,70,HHS Region 8,2 wk ahead,0.7
 2013,18,2012/2013,70,HHS Region 8,3 wk ahead,0.8
 2013,18,2012/2013,70,HHS Region 8,4 wk ahead,0.8
 2013,18,2012/2013,70,HHS Region 9,Season onset,2
 2013,18,2012/2013,70,HHS Region 9,Season peak week,4
 2013,18,2012/2013,70,HHS Region 9,Season peak percentage,5.6
-2013,18,2012/2013,70,HHS Region 9,1 wk ahead,0.9
-2013,18,2012/2013,70,HHS Region 9,2 wk ahead,0.6
+2013,18,2012/2013,70,HHS Region 9,1 wk ahead,1.5
+2013,18,2012/2013,70,HHS Region 9,2 wk ahead,1.6
 2013,18,2012/2013,70,HHS Region 9,3 wk ahead,1.4
 2013,18,2012/2013,70,HHS Region 9,4 wk ahead,1.4
 2013,18,2012/2013,70,HHS Region 10,Season onset,50
@@ -7681,14 +7714,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,19,2012/2013,71,HHS Region 2,Season onset,48
 2013,19,2012/2013,71,HHS Region 2,Season peak week,52
 2013,19,2012/2013,71,HHS Region 2,Season peak percentage,5.5
-2013,19,2012/2013,71,HHS Region 2,1 wk ahead,0.9
+2013,19,2012/2013,71,HHS Region 2,1 wk ahead,1.3
 2013,19,2012/2013,71,HHS Region 2,2 wk ahead,1
 2013,19,2012/2013,71,HHS Region 2,3 wk ahead,1.4
 2013,19,2012/2013,71,HHS Region 2,4 wk ahead,1.1
 2013,19,2012/2013,71,HHS Region 3,Season onset,49
 2013,19,2012/2013,71,HHS Region 3,Season peak week,52
 2013,19,2012/2013,71,HHS Region 3,Season peak percentage,7.1
-2013,19,2012/2013,71,HHS Region 3,1 wk ahead,1
+2013,19,2012/2013,71,HHS Region 3,1 wk ahead,1.1
 2013,19,2012/2013,71,HHS Region 3,2 wk ahead,1.1
 2013,19,2012/2013,71,HHS Region 3,3 wk ahead,1.3
 2013,19,2012/2013,71,HHS Region 3,4 wk ahead,1
@@ -7702,7 +7735,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,19,2012/2013,71,HHS Region 5,Season onset,47
 2013,19,2012/2013,71,HHS Region 5,Season peak week,52
 2013,19,2012/2013,71,HHS Region 5,Season peak percentage,5.7
-2013,19,2012/2013,71,HHS Region 5,1 wk ahead,0.8
+2013,19,2012/2013,71,HHS Region 5,1 wk ahead,0.9
 2013,19,2012/2013,71,HHS Region 5,2 wk ahead,0.8
 2013,19,2012/2013,71,HHS Region 5,3 wk ahead,1
 2013,19,2012/2013,71,HHS Region 5,4 wk ahead,0.9
@@ -7715,8 +7748,8 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,19,2012/2013,71,HHS Region 6,4 wk ahead,1.3
 2013,19,2012/2013,71,HHS Region 7,Season onset,47
 2013,19,2012/2013,71,HHS Region 7,Season peak week,52
-2013,19,2012/2013,71,HHS Region 7,Season peak percentage,6.8
-2013,19,2012/2013,71,HHS Region 7,1 wk ahead,0.3
+2013,19,2012/2013,71,HHS Region 7,Season peak percentage,6.7
+2013,19,2012/2013,71,HHS Region 7,1 wk ahead,0.6
 2013,19,2012/2013,71,HHS Region 7,2 wk ahead,0.7
 2013,19,2012/2013,71,HHS Region 7,3 wk ahead,0.8
 2013,19,2012/2013,71,HHS Region 7,4 wk ahead,0.2
@@ -7724,14 +7757,14 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,19,2012/2013,71,HHS Region 8,Season peak week,52
 2013,19,2012/2013,71,HHS Region 8,Season peak week,3
 2013,19,2012/2013,71,HHS Region 8,Season peak percentage,4.1
-2013,19,2012/2013,71,HHS Region 8,1 wk ahead,0.8
+2013,19,2012/2013,71,HHS Region 8,1 wk ahead,0.7
 2013,19,2012/2013,71,HHS Region 8,2 wk ahead,0.8
 2013,19,2012/2013,71,HHS Region 8,3 wk ahead,0.8
 2013,19,2012/2013,71,HHS Region 8,4 wk ahead,0.7
 2013,19,2012/2013,71,HHS Region 9,Season onset,2
 2013,19,2012/2013,71,HHS Region 9,Season peak week,4
 2013,19,2012/2013,71,HHS Region 9,Season peak percentage,5.6
-2013,19,2012/2013,71,HHS Region 9,1 wk ahead,0.6
+2013,19,2012/2013,71,HHS Region 9,1 wk ahead,1.6
 2013,19,2012/2013,71,HHS Region 9,2 wk ahead,1.4
 2013,19,2012/2013,71,HHS Region 9,3 wk ahead,1.4
 2013,19,2012/2013,71,HHS Region 9,4 wk ahead,1.4
@@ -7793,7 +7826,7 @@ Year,Calendar Week,Season,Model Week,Location,Target,Valid Bin_start_incl
 2013,20,2012/2013,72,HHS Region 6,4 wk ahead,1.2
 2013,20,2012/2013,72,HHS Region 7,Season onset,47
 2013,20,2012/2013,72,HHS Region 7,Season peak week,52
-2013,20,2012/2013,72,HHS Region 7,Season peak percentage,6.8
+2013,20,2012/2013,72,HHS Region 7,Season peak percentage,6.7
 2013,20,2012/2013,72,HHS Region 7,1 wk ahead,0.7
 2013,20,2012/2013,72,HHS Region 7,2 wk ahead,0.8
 2013,20,2012/2013,72,HHS Region 7,3 wk ahead,0.2


### PR DESCRIPTION
When calculating "ground truth" / evaluation target values:
- Use issue week 28 data as ground truth, if it is available, otherwise the
  _next_ available issue as ground truth, rather than _previous_ available
  issue, as in previous related commit. This only happens from
  2010/2011--2012/2013 in the HHS Regions; issues {2011,2012,2013}28 are
  unavailable; the next available issue that deals with these seasons' data is
  201352 (instead of issues {2011,2012,2013}20 in the other direction).  A hasty
  ad-hoc evaluation suggests that this new strategy for approximating missing
  issue 28 data will have better accuracy.

The original approach is PR #204, addressing GH issue #203.